### PR TITLE
Add BaseProvider, provider-aware plugins, and story kernel plugin

### DIFF
--- a/lib/connectors/__tests__/base.test.ts
+++ b/lib/connectors/__tests__/base.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, it } from "vitest";
+import { BaseProvider } from "@/lib/providers/base";
 import { BaseConnector } from "../base";
 import type { ConnectorConfig, ConnectorType, ModelInfo } from "../types";
+
+class MockProvider extends BaseProvider {
+  async generate(): Promise<unknown> {
+    return {};
+  }
+}
 
 class TestConnector extends BaseConnector {
   readonly type: ConnectorType = "llm";
   async listModels(): Promise<ModelInfo[]> {
     return [{ id: "test", name: "Test" }];
-  }
-  protected async _generate(): Promise<unknown> {
-    return {};
   }
 }
 
@@ -20,27 +24,30 @@ describe("BaseConnector", () => {
   };
 
   it("init is a no-op by default", async () => {
-    const c = new TestConnector(config);
+    const c = new TestConnector(new MockProvider(), config);
     await expect(c.init()).resolves.toBeUndefined();
   });
 
   it("validate returns true by default", async () => {
-    const c = new TestConnector(config);
+    const c = new TestConnector(new MockProvider(), config);
     await expect(c.validate()).resolves.toBe(true);
   });
 
   it("destroy is a no-op by default", async () => {
-    const c = new TestConnector(config);
+    const c = new TestConnector(new MockProvider(), config);
     await expect(c.destroy()).resolves.toBeUndefined();
   });
 
   it("extracts plugins from config", () => {
-    const c = new TestConnector(config);
+    const c = new TestConnector(new MockProvider(), config);
     expect((c as unknown as { plugins: unknown[] }).plugins).toHaveLength(1);
   });
 
   it("defaults plugins to empty array", () => {
-    const c = new TestConnector({ provider: "test", apiKey: "key" });
+    const c = new TestConnector(new MockProvider(), {
+      provider: "test",
+      apiKey: "key",
+    });
     expect((c as unknown as { plugins: unknown[] }).plugins).toEqual([]);
   });
 });

--- a/lib/connectors/__tests__/openslop-providers.test.ts
+++ b/lib/connectors/__tests__/openslop-providers.test.ts
@@ -133,16 +133,24 @@ describe("OpenSlop connectors (via providers)", () => {
     expect(voices[0].id).toBe("v1");
   });
 
-  it("Video: generate submits job", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      jsonResponse({ jobId: "j1", status: "processing" }),
-    );
+  it("Video: generate submits and polls job", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse({ jobId: "j1", status: "processing" }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          jobId: "j1",
+          status: "completed",
+          resultUrl: "https://v.mp4",
+        }),
+      );
 
     const c = new OpenSlopVideo(config);
     const job = await c.generate({ prompt: "sunset" });
 
     expect(job.jobId).toBe("j1");
-    expect(job.status).toBe("processing");
+    expect(job.status).toBe("completed");
   });
 
   it("Video: poll returns job status", async () => {

--- a/lib/connectors/__tests__/story-kernel.test.ts
+++ b/lib/connectors/__tests__/story-kernel.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { BaseProvider } from "@/lib/providers/base";
+import { storyKernelPlugin } from "../plugins/story-kernel";
+import type {
+  LLMGenerateParams,
+  LLMGenerateResult,
+  PluginContext,
+} from "../types";
+
+class MockLLMProvider extends BaseProvider<
+  LLMGenerateParams,
+  LLMGenerateResult
+> {
+  async generate(): Promise<LLMGenerateResult> {
+    return {
+      text: "A brave knight rescues a dragon who turns out to be friendly.",
+      model: "test",
+    };
+  }
+}
+
+describe("storyKernelPlugin", () => {
+  it("calls provider to generate a story outline and rewrites the prompt", async () => {
+    const provider = new MockLLMProvider();
+    const ctx: PluginContext<LLMGenerateParams, LLMGenerateResult> = {
+      provider,
+    };
+
+    const result = await storyKernelPlugin.transformPrompt!(
+      "a knight and a dragon",
+      ctx,
+    );
+
+    expect(result).toContain(
+      "A brave knight rescues a dragon who turns out to be friendly.",
+    );
+    expect(result).toContain("5th-grade reading level");
+  });
+
+  it("throws when no context is provided", async () => {
+    await expect(storyKernelPlugin.transformPrompt!("test")).rejects.toThrow(
+      "kernel plugin requires provider context",
+    );
+  });
+});

--- a/lib/connectors/__tests__/video.test.ts
+++ b/lib/connectors/__tests__/video.test.ts
@@ -9,7 +9,8 @@ function mockJsonResponse(data: unknown) {
   });
 }
 
-const jobResponse = {
+const submitResponse = { jobId: "j1", status: "processing" };
+const completedResponse = {
   jobId: "j1",
   status: "completed",
   resultUrl: "https://v.mp4",
@@ -18,12 +19,13 @@ const jobResponse = {
 describe("BaseVideoConnector", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      mockJsonResponse(jobResponse),
-    );
   });
 
   it("generates a video job", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(submitResponse))
+      .mockResolvedValueOnce(mockJsonResponse(completedResponse));
+
     const connector = new OpenSlopVideo({ provider: "openslop", apiKey: "" });
     const result = await connector.generate({ prompt: "a sunset" });
     expect(result.status).toBe("completed");
@@ -31,7 +33,7 @@ describe("BaseVideoConnector", () => {
   });
 
   it("polls a job", async () => {
-    vi.mocked(fetch).mockResolvedValue(
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
       mockJsonResponse({ jobId: "job-123", status: "completed" }),
     );
     const connector = new OpenSlopVideo({ provider: "openslop", apiKey: "" });
@@ -41,6 +43,10 @@ describe("BaseVideoConnector", () => {
   });
 
   it("runs plugins in order", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(submitResponse))
+      .mockResolvedValueOnce(mockJsonResponse(completedResponse));
+
     const order: string[] = [];
     const plugin: ConnectorPlugin = {
       name: "tracker",
@@ -67,7 +73,7 @@ describe("BaseVideoConnector", () => {
   });
 
   it("runs onError plugin on failure", async () => {
-    vi.mocked(fetch).mockRejectedValue(new Error("video failed"));
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("video failed"));
     const errors: string[] = [];
 
     const connector = new OpenSlopVideo({

--- a/lib/connectors/base.ts
+++ b/lib/connectors/base.ts
@@ -1,3 +1,4 @@
+import type { BaseProvider } from "@/lib/providers/base";
 import {
   runAfterGenerate,
   runBeforeGenerate,
@@ -10,16 +11,23 @@ import type {
   ConnectorPlugin,
   ConnectorType,
   ModelInfo,
+  PluginContext,
 } from "./types";
 
 export abstract class BaseConnector<
   TParams extends { prompt: string } = { prompt: string },
   TResult = unknown,
+  TProvider extends BaseProvider<TParams, TResult> = BaseProvider<
+    TParams,
+    TResult
+  >,
 > implements Connector {
   abstract readonly type: ConnectorType;
   protected plugins: ConnectorPlugin[];
+  protected provider: TProvider;
 
-  constructor(protected config: ConnectorConfig) {
+  constructor(provider: TProvider, config: ConnectorConfig) {
+    this.provider = provider;
     this.plugins = config.plugins ?? [];
   }
 
@@ -32,20 +40,24 @@ export abstract class BaseConnector<
   abstract listModels(): Promise<ModelInfo[]>;
 
   async generate(params: TParams): Promise<TResult> {
+    const ctx: PluginContext<TParams, TResult> = { provider: this.provider };
     try {
-      const prompt = await runTransformPrompt(this.plugins, params.prompt);
-      const transformed = await runBeforeGenerate(this.plugins, {
-        ...params,
-        prompt,
-      });
+      const prompt = await runTransformPrompt(this.plugins, params.prompt, ctx);
+      const transformed = await runBeforeGenerate(
+        this.plugins,
+        { ...params, prompt },
+        ctx,
+      );
       let result = await this._generate(transformed);
-      result = await runAfterGenerate(this.plugins, result);
+      result = await runAfterGenerate(this.plugins, result, ctx);
       return result;
     } catch (error) {
-      await runOnError(this.plugins, error as Error);
+      await runOnError(this.plugins, error as Error, ctx);
       throw error;
     }
   }
 
-  protected abstract _generate(params: TParams): Promise<TResult>;
+  protected async _generate(params: TParams): Promise<TResult> {
+    return this.provider.generate(params);
+  }
 }

--- a/lib/connectors/image/connector.ts
+++ b/lib/connectors/image/connector.ts
@@ -1,3 +1,4 @@
+import type { BaseProvider } from "@/lib/providers/base";
 import { BaseConnector } from "../base";
 import type {
   ImageConnector,
@@ -5,13 +6,12 @@ import type {
   ImageResult,
 } from "../types";
 
-export abstract class BaseImageConnector
-  extends BaseConnector<ImageGenerateParams, ImageResult>
+export abstract class BaseImageConnector<
+  TProvider extends BaseProvider<ImageGenerateParams, ImageResult> =
+    BaseProvider<ImageGenerateParams, ImageResult>,
+>
+  extends BaseConnector<ImageGenerateParams, ImageResult, TProvider>
   implements ImageConnector
 {
   readonly type = "image" as const;
-
-  protected abstract _generate(
-    params: ImageGenerateParams,
-  ): Promise<ImageResult>;
 }

--- a/lib/connectors/image/openslop/index.ts
+++ b/lib/connectors/image/openslop/index.ts
@@ -1,26 +1,14 @@
 import { BaseImageConnector } from "../connector";
 import { OpenSlopImage as OpenSlopImageProvider } from "@/lib/providers/image/openslop";
-import type {
-  ConnectorConfig,
-  ImageGenerateParams,
-  ImageResult,
-  ModelInfo,
-} from "@/lib/connectors/types";
+import type { ConnectorConfig, ModelInfo } from "@/lib/connectors/types";
 import { IMAGE_MODELS } from "./models";
 
-export class OpenSlopImage extends BaseImageConnector {
-  private provider: OpenSlopImageProvider;
-
+export class OpenSlopImage extends BaseImageConnector<OpenSlopImageProvider> {
   constructor(config: ConnectorConfig) {
-    super(config);
-    this.provider = new OpenSlopImageProvider(config.baseUrl);
+    super(new OpenSlopImageProvider(config.baseUrl), config);
   }
 
   async listModels(): Promise<ModelInfo[]> {
     return IMAGE_MODELS.map((id) => ({ id, name: id }));
-  }
-
-  protected async _generate(params: ImageGenerateParams): Promise<ImageResult> {
-    return this.provider.generate(params);
   }
 }

--- a/lib/connectors/llm/connector.ts
+++ b/lib/connectors/llm/connector.ts
@@ -1,3 +1,4 @@
+import type { BaseProvider } from "@/lib/providers/base";
 import { BaseConnector } from "../base";
 import type {
   LLMConnector,
@@ -6,15 +7,14 @@ import type {
   LLMStreamChunk,
 } from "../types";
 
-export abstract class BaseLLMConnector
-  extends BaseConnector<LLMGenerateParams, LLMGenerateResult>
+export abstract class BaseLLMConnector<
+  TProvider extends BaseProvider<LLMGenerateParams, LLMGenerateResult> =
+    BaseProvider<LLMGenerateParams, LLMGenerateResult>,
+>
+  extends BaseConnector<LLMGenerateParams, LLMGenerateResult, TProvider>
   implements LLMConnector
 {
   readonly type = "llm" as const;
-
-  protected abstract _generate(
-    params: LLMGenerateParams,
-  ): Promise<LLMGenerateResult>;
 
   abstract stream(params: LLMGenerateParams): AsyncGenerator<LLMStreamChunk>;
 }

--- a/lib/connectors/llm/openslop/index.ts
+++ b/lib/connectors/llm/openslop/index.ts
@@ -3,28 +3,18 @@ import { OpenSlopLLM as OpenSlopLLMProvider } from "@/lib/providers/llm/openslop
 import type {
   ConnectorConfig,
   LLMGenerateParams,
-  LLMGenerateResult,
   LLMStreamChunk,
   ModelInfo,
 } from "@/lib/connectors/types";
 import { LLM_MODELS } from "./models";
 
-export class OpenSlopLLM extends BaseLLMConnector {
-  private provider: OpenSlopLLMProvider;
-
+export class OpenSlopLLM extends BaseLLMConnector<OpenSlopLLMProvider> {
   constructor(config: ConnectorConfig) {
-    super(config);
-    this.provider = new OpenSlopLLMProvider(config.baseUrl);
+    super(new OpenSlopLLMProvider(config.baseUrl), config);
   }
 
   async listModels(): Promise<ModelInfo[]> {
     return LLM_MODELS.map((id) => ({ id, name: id }));
-  }
-
-  protected async _generate(
-    params: LLMGenerateParams,
-  ): Promise<LLMGenerateResult> {
-    return this.provider.generate(params);
   }
 
   async *stream(params: LLMGenerateParams): AsyncGenerator<LLMStreamChunk> {

--- a/lib/connectors/music/connector.ts
+++ b/lib/connectors/music/connector.ts
@@ -1,13 +1,13 @@
+import type { BaseProvider } from "@/lib/providers/base";
 import { BaseConnector } from "../base";
 import type { MusicConnector, MusicGenerateParams } from "../types";
 
-export abstract class BaseMusicConnector
-  extends BaseConnector<MusicGenerateParams, ArrayBuffer>
+export abstract class BaseMusicConnector<
+  TProvider extends BaseProvider<MusicGenerateParams, ArrayBuffer> =
+    BaseProvider<MusicGenerateParams, ArrayBuffer>,
+>
+  extends BaseConnector<MusicGenerateParams, ArrayBuffer, TProvider>
   implements MusicConnector
 {
   readonly type = "music" as const;
-
-  protected abstract _generate(
-    params: MusicGenerateParams,
-  ): Promise<ArrayBuffer>;
 }

--- a/lib/connectors/music/openslop/index.ts
+++ b/lib/connectors/music/openslop/index.ts
@@ -1,25 +1,14 @@
 import { BaseMusicConnector } from "../connector";
 import { OpenSlopMusic as OpenSlopMusicProvider } from "@/lib/providers/music/openslop";
-import type {
-  ConnectorConfig,
-  ModelInfo,
-  MusicGenerateParams,
-} from "@/lib/connectors/types";
+import type { ConnectorConfig, ModelInfo } from "@/lib/connectors/types";
 import { MUSIC_MODELS } from "./models";
 
-export class OpenSlopMusic extends BaseMusicConnector {
-  private provider: OpenSlopMusicProvider;
-
+export class OpenSlopMusic extends BaseMusicConnector<OpenSlopMusicProvider> {
   constructor(config: ConnectorConfig) {
-    super(config);
-    this.provider = new OpenSlopMusicProvider(config.baseUrl);
+    super(new OpenSlopMusicProvider(config.baseUrl), config);
   }
 
   async listModels(): Promise<ModelInfo[]> {
     return MUSIC_MODELS.map((id) => ({ id, name: id }));
-  }
-
-  protected async _generate(params: MusicGenerateParams): Promise<ArrayBuffer> {
-    return this.provider.generate(params);
   }
 }

--- a/lib/connectors/plugins.ts
+++ b/lib/connectors/plugins.ts
@@ -1,13 +1,14 @@
-import type { ConnectorPlugin } from "./types";
+import type { ConnectorPlugin, PluginContext } from "./types";
 
 export async function runBeforeGenerate<T>(
   plugins: ConnectorPlugin[],
   params: T,
+  ctx?: PluginContext,
 ): Promise<T> {
   let result = params;
   for (const plugin of plugins) {
     if (plugin.beforeGenerate) {
-      result = (await plugin.beforeGenerate(result)) as T;
+      result = (await plugin.beforeGenerate(result, ctx)) as T;
     }
   }
   return result;
@@ -16,11 +17,12 @@ export async function runBeforeGenerate<T>(
 export async function runAfterGenerate<T>(
   plugins: ConnectorPlugin[],
   result: T,
+  ctx?: PluginContext,
 ): Promise<T> {
   let current = result;
   for (const plugin of plugins) {
     if (plugin.afterGenerate) {
-      current = (await plugin.afterGenerate(current)) as T;
+      current = (await plugin.afterGenerate(current, ctx)) as T;
     }
   }
   return current;
@@ -29,11 +31,12 @@ export async function runAfterGenerate<T>(
 export async function runTransformPrompt(
   plugins: ConnectorPlugin[],
   prompt: string,
+  ctx?: PluginContext,
 ): Promise<string> {
   let current = prompt;
   for (const plugin of plugins) {
     if (plugin.transformPrompt) {
-      current = await plugin.transformPrompt(current);
+      current = await plugin.transformPrompt(current, ctx);
     }
   }
   return current;
@@ -42,10 +45,11 @@ export async function runTransformPrompt(
 export async function runOnError(
   plugins: ConnectorPlugin[],
   error: Error,
+  ctx?: PluginContext,
 ): Promise<void> {
   for (const plugin of plugins) {
     if (plugin.onError) {
-      await plugin.onError(error);
+      await plugin.onError(error, ctx);
     }
   }
 }

--- a/lib/connectors/plugins/story-kernel.ts
+++ b/lib/connectors/plugins/story-kernel.ts
@@ -1,0 +1,21 @@
+import dedent from "dedent";
+import type {
+  LLMGenerateParams,
+  LLMGenerateResult,
+  LLMPlugin,
+  PluginContext,
+} from "../types";
+
+export const storyKernelPlugin: LLMPlugin = {
+  name: "storyKernel",
+  async transformPrompt(
+    prompt: string,
+    ctx?: PluginContext<LLMGenerateParams, LLMGenerateResult>,
+  ) {
+    if (!ctx) throw new Error("kernel plugin requires provider context");
+    const { text: kernel } = await ctx.provider.generate({
+      prompt: dedent`Briefly outline an engaging story with a high-concept premise, characters, themes, conflict, twists, and a resolution. The story should be about the following: ${prompt}`,
+    });
+    return dedent`Write a complete, engaging, and simple story for a 5th-grade reading level about the following: ${kernel}`;
+  },
+};

--- a/lib/connectors/sfx/connector.ts
+++ b/lib/connectors/sfx/connector.ts
@@ -1,11 +1,15 @@
+import type { BaseProvider } from "@/lib/providers/base";
 import { BaseConnector } from "../base";
 import type { SFXConnector, SFXGenerateParams } from "../types";
 
-export abstract class BaseSFXConnector
-  extends BaseConnector<SFXGenerateParams, ArrayBuffer>
+export abstract class BaseSFXConnector<
+  TProvider extends BaseProvider<SFXGenerateParams, ArrayBuffer> = BaseProvider<
+    SFXGenerateParams,
+    ArrayBuffer
+  >,
+>
+  extends BaseConnector<SFXGenerateParams, ArrayBuffer, TProvider>
   implements SFXConnector
 {
   readonly type = "sfx" as const;
-
-  protected abstract _generate(params: SFXGenerateParams): Promise<ArrayBuffer>;
 }

--- a/lib/connectors/sfx/openslop/index.ts
+++ b/lib/connectors/sfx/openslop/index.ts
@@ -1,25 +1,14 @@
 import { BaseSFXConnector } from "../connector";
 import { OpenSlopSFX as OpenSlopSFXProvider } from "@/lib/providers/sfx/openslop";
-import type {
-  ConnectorConfig,
-  ModelInfo,
-  SFXGenerateParams,
-} from "@/lib/connectors/types";
+import type { ConnectorConfig, ModelInfo } from "@/lib/connectors/types";
 import { SFX_MODELS } from "./models";
 
-export class OpenSlopSFX extends BaseSFXConnector {
-  private provider: OpenSlopSFXProvider;
-
+export class OpenSlopSFX extends BaseSFXConnector<OpenSlopSFXProvider> {
   constructor(config: ConnectorConfig) {
-    super(config);
-    this.provider = new OpenSlopSFXProvider(config.baseUrl);
+    super(new OpenSlopSFXProvider(config.baseUrl), config);
   }
 
   async listModels(): Promise<ModelInfo[]> {
     return SFX_MODELS.map((id) => ({ id, name: id }));
-  }
-
-  protected async _generate(params: SFXGenerateParams): Promise<ArrayBuffer> {
-    return this.provider.generate(params);
   }
 }

--- a/lib/connectors/tts/connector.ts
+++ b/lib/connectors/tts/connector.ts
@@ -1,3 +1,4 @@
+import type { BaseProvider } from "@/lib/providers/base";
 import { BaseConnector } from "../base";
 import type {
   TTSConnector,
@@ -7,13 +8,16 @@ import type {
   VoiceSearchParams,
 } from "../types";
 
-export abstract class BaseTTSConnector
-  extends BaseConnector<TTSGenerateParams, TTSResult>
+export abstract class BaseTTSConnector<
+  TProvider extends BaseProvider<TTSGenerateParams, TTSResult> = BaseProvider<
+    TTSGenerateParams,
+    TTSResult
+  >,
+>
+  extends BaseConnector<TTSGenerateParams, TTSResult, TProvider>
   implements TTSConnector
 {
   readonly type = "tts" as const;
-
-  protected abstract _generate(params: TTSGenerateParams): Promise<TTSResult>;
 
   abstract searchVoices(params: VoiceSearchParams): Promise<VoiceInfo[]>;
 }

--- a/lib/connectors/tts/openslop/index.ts
+++ b/lib/connectors/tts/openslop/index.ts
@@ -3,27 +3,18 @@ import { OpenSlopTTS as OpenSlopTTSProvider } from "@/lib/providers/tts/openslop
 import type {
   ConnectorConfig,
   ModelInfo,
-  TTSGenerateParams,
-  TTSResult,
   VoiceInfo,
   VoiceSearchParams,
 } from "@/lib/connectors/types";
 import { TTS_MODELS } from "./models";
 
-export class OpenSlopTTS extends BaseTTSConnector {
-  private provider: OpenSlopTTSProvider;
-
+export class OpenSlopTTS extends BaseTTSConnector<OpenSlopTTSProvider> {
   constructor(config: ConnectorConfig) {
-    super(config);
-    this.provider = new OpenSlopTTSProvider(config.baseUrl);
+    super(new OpenSlopTTSProvider(config.baseUrl), config);
   }
 
   async listModels(): Promise<ModelInfo[]> {
     return TTS_MODELS.map((id) => ({ id, name: id }));
-  }
-
-  protected async _generate(params: TTSGenerateParams): Promise<TTSResult> {
-    return this.provider.generate(params);
   }
 
   async searchVoices(params: VoiceSearchParams): Promise<VoiceInfo[]> {

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -1,3 +1,5 @@
+import type { BaseProvider } from "@/lib/providers/base";
+
 export type ConnectorType = "llm" | "music" | "sfx" | "image" | "tts" | "video";
 
 export type ProviderKey = "openslop";
@@ -10,12 +12,28 @@ export type ModelInfo = {
   description?: string;
 };
 
+export interface PluginContext<TParams = unknown, TResult = unknown> {
+  provider: BaseProvider<TParams, TResult>;
+}
+
 export interface ConnectorPlugin<TParams = unknown, TResult = unknown> {
   name: string;
-  beforeGenerate?(params: TParams): TParams | Promise<TParams>;
-  afterGenerate?(result: TResult): TResult | Promise<TResult>;
-  transformPrompt?(prompt: string): string | Promise<string>;
-  onError?(error: Error): void | Promise<void>;
+  beforeGenerate?(
+    params: TParams,
+    ctx?: PluginContext<TParams, TResult>,
+  ): TParams | Promise<TParams>;
+  afterGenerate?(
+    result: TResult,
+    ctx?: PluginContext<TParams, TResult>,
+  ): TResult | Promise<TResult>;
+  transformPrompt?(
+    prompt: string,
+    ctx?: PluginContext<TParams, TResult>,
+  ): string | Promise<string>;
+  onError?(
+    error: Error,
+    ctx?: PluginContext<TParams, TResult>,
+  ): void | Promise<void>;
 }
 
 export interface ConnectorConfig {

--- a/lib/connectors/video/connector.ts
+++ b/lib/connectors/video/connector.ts
@@ -1,13 +1,17 @@
+import type { BaseProvider } from "@/lib/providers/base";
 import { BaseConnector } from "../base";
 import type { VideoConnector, VideoGenerateParams, VideoJob } from "../types";
 
-export abstract class BaseVideoConnector
-  extends BaseConnector<VideoGenerateParams, VideoJob>
+export abstract class BaseVideoConnector<
+  TProvider extends BaseProvider<VideoGenerateParams, VideoJob> = BaseProvider<
+    VideoGenerateParams,
+    VideoJob
+  >,
+>
+  extends BaseConnector<VideoGenerateParams, VideoJob, TProvider>
   implements VideoConnector
 {
   readonly type = "video" as const;
-
-  protected abstract _generate(params: VideoGenerateParams): Promise<VideoJob>;
 
   abstract poll(jobId: string): Promise<VideoJob>;
 }

--- a/lib/connectors/video/openslop/index.ts
+++ b/lib/connectors/video/openslop/index.ts
@@ -3,25 +3,17 @@ import { OpenSlopVideo as OpenSlopVideoProvider } from "@/lib/providers/video/op
 import type {
   ConnectorConfig,
   ModelInfo,
-  VideoGenerateParams,
   VideoJob,
 } from "@/lib/connectors/types";
 import { VIDEO_MODELS } from "./models";
 
-export class OpenSlopVideo extends BaseVideoConnector {
-  private provider: OpenSlopVideoProvider;
-
+export class OpenSlopVideo extends BaseVideoConnector<OpenSlopVideoProvider> {
   constructor(config: ConnectorConfig) {
-    super(config);
-    this.provider = new OpenSlopVideoProvider(config.baseUrl);
+    super(new OpenSlopVideoProvider(config.baseUrl), config);
   }
 
   async listModels(): Promise<ModelInfo[]> {
     return VIDEO_MODELS.map((id) => ({ id, name: id }));
-  }
-
-  protected async _generate(params: VideoGenerateParams): Promise<VideoJob> {
-    return this.provider.submit(params);
   }
 
   async poll(jobId: string): Promise<VideoJob> {

--- a/lib/providers/base.ts
+++ b/lib/providers/base.ts
@@ -1,0 +1,3 @@
+export abstract class BaseProvider<TParams = unknown, TResult = unknown> {
+  abstract generate(params: TParams): Promise<TResult>;
+}

--- a/lib/providers/image/openslop.ts
+++ b/lib/providers/image/openslop.ts
@@ -1,10 +1,15 @@
 import { OpenSlopClient } from "@/lib/clients/openslop";
 import type { ImageGenerateParams, ImageResult } from "@/lib/connectors/types";
+import { BaseProvider } from "../base";
 
-export class OpenSlopImage {
+export class OpenSlopImage extends BaseProvider<
+  ImageGenerateParams,
+  ImageResult
+> {
   private client: OpenSlopClient;
 
   constructor(baseUrl?: string) {
+    super();
     this.client = new OpenSlopClient(baseUrl);
   }
 

--- a/lib/providers/image/runware.ts
+++ b/lib/providers/image/runware.ts
@@ -1,10 +1,15 @@
 import { Runware } from "@runware/sdk-js";
-import type { ImageGenerateParams } from "@/lib/connectors/types";
+import type { ImageGenerateParams, ImageResult } from "@/lib/connectors/types";
+import { BaseProvider } from "../base";
 
-export class RunwareImage {
+export class RunwareImage extends BaseProvider<
+  ImageGenerateParams,
+  ImageResult
+> {
   private apiKey: string;
 
   constructor(apiKey: string) {
+    super();
     this.apiKey = apiKey;
   }
 

--- a/lib/providers/llm/anthropic.ts
+++ b/lib/providers/llm/anthropic.ts
@@ -1,10 +1,18 @@
 import Anthropic from "@anthropic-ai/sdk";
-import type { LLMGenerateParams } from "@/lib/connectors/types";
+import type {
+  LLMGenerateParams,
+  LLMGenerateResult,
+} from "@/lib/connectors/types";
+import { BaseProvider } from "../base";
 
-export class AnthropicLLM {
+export class AnthropicLLM extends BaseProvider<
+  LLMGenerateParams,
+  LLMGenerateResult
+> {
   private client: Anthropic;
 
   constructor(apiKey: string) {
+    super();
     this.client = new Anthropic({ apiKey });
   }
 

--- a/lib/providers/llm/openslop.ts
+++ b/lib/providers/llm/openslop.ts
@@ -4,11 +4,16 @@ import type {
   LLMGenerateResult,
   LLMStreamChunk,
 } from "@/lib/connectors/types";
+import { BaseProvider } from "../base";
 
-export class OpenSlopLLM {
+export class OpenSlopLLM extends BaseProvider<
+  LLMGenerateParams,
+  LLMGenerateResult
+> {
   private client: OpenSlopClient;
 
   constructor(baseUrl?: string) {
+    super();
     this.client = new OpenSlopClient(baseUrl);
   }
 

--- a/lib/providers/music/elevenlabs.ts
+++ b/lib/providers/music/elevenlabs.ts
@@ -1,10 +1,15 @@
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
 import type { MusicGenerateParams } from "@/lib/connectors/types";
+import { BaseProvider } from "../base";
 
-export class ElevenLabsMusic {
+export class ElevenLabsMusic extends BaseProvider<
+  MusicGenerateParams,
+  ArrayBuffer
+> {
   private client: ElevenLabsClient;
 
   constructor(apiKey: string) {
+    super();
     this.client = new ElevenLabsClient({ apiKey });
   }
 

--- a/lib/providers/music/openslop.ts
+++ b/lib/providers/music/openslop.ts
@@ -1,10 +1,15 @@
 import { OpenSlopClient } from "@/lib/clients/openslop";
 import type { MusicGenerateParams } from "@/lib/connectors/types";
+import { BaseProvider } from "../base";
 
-export class OpenSlopMusic {
+export class OpenSlopMusic extends BaseProvider<
+  MusicGenerateParams,
+  ArrayBuffer
+> {
   private client: OpenSlopClient;
 
   constructor(baseUrl?: string) {
+    super();
     this.client = new OpenSlopClient(baseUrl);
   }
 

--- a/lib/providers/poll.ts
+++ b/lib/providers/poll.ts
@@ -1,0 +1,16 @@
+import type { VideoJob } from "@/lib/connectors/types";
+
+export async function awaitCompletion(
+  pollFn: (jobId: string) => Promise<VideoJob>,
+  jobId: string,
+  intervalMs = 1000,
+  timeoutMs = 300_000,
+): Promise<VideoJob> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const job = await pollFn(jobId);
+    if (job.status === "completed" || job.status === "failed") return job;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`Video job ${jobId} timed out after ${timeoutMs}ms`);
+}

--- a/lib/providers/sfx/elevenlabs.ts
+++ b/lib/providers/sfx/elevenlabs.ts
@@ -1,10 +1,15 @@
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
 import type { SFXGenerateParams } from "@/lib/connectors/types";
+import { BaseProvider } from "../base";
 
-export class ElevenLabsSFX {
+export class ElevenLabsSFX extends BaseProvider<
+  SFXGenerateParams,
+  ArrayBuffer
+> {
   private client: ElevenLabsClient;
 
   constructor(apiKey: string) {
+    super();
     this.client = new ElevenLabsClient({ apiKey });
   }
 

--- a/lib/providers/sfx/openslop.ts
+++ b/lib/providers/sfx/openslop.ts
@@ -1,10 +1,12 @@
 import { OpenSlopClient } from "@/lib/clients/openslop";
 import type { SFXGenerateParams } from "@/lib/connectors/types";
+import { BaseProvider } from "../base";
 
-export class OpenSlopSFX {
+export class OpenSlopSFX extends BaseProvider<SFXGenerateParams, ArrayBuffer> {
   private client: OpenSlopClient;
 
   constructor(baseUrl?: string) {
+    super();
     this.client = new OpenSlopClient(baseUrl);
   }
 

--- a/lib/providers/tts/cartesia.ts
+++ b/lib/providers/tts/cartesia.ts
@@ -2,14 +2,17 @@ import Cartesia from "@cartesia/cartesia-js";
 import type {
   TextTimestamp,
   TTSGenerateParams,
+  TTSResult,
   VoiceInfo,
   VoiceSearchParams,
 } from "@/lib/connectors/types";
+import { BaseProvider } from "../base";
 
-export class CartesiaTTS {
+export class CartesiaTTS extends BaseProvider<TTSGenerateParams, TTSResult> {
   private client: Cartesia;
 
   constructor(apiKey: string) {
+    super();
     this.client = new Cartesia({ apiKey });
   }
 

--- a/lib/providers/tts/openslop.ts
+++ b/lib/providers/tts/openslop.ts
@@ -5,11 +5,13 @@ import type {
   VoiceInfo,
   VoiceSearchParams,
 } from "@/lib/connectors/types";
+import { BaseProvider } from "../base";
 
-export class OpenSlopTTS {
+export class OpenSlopTTS extends BaseProvider<TTSGenerateParams, TTSResult> {
   private client: OpenSlopClient;
 
   constructor(baseUrl?: string) {
+    super();
     this.client = new OpenSlopClient(baseUrl);
   }
 

--- a/lib/providers/video/openslop.ts
+++ b/lib/providers/video/openslop.ts
@@ -1,11 +1,19 @@
 import { OpenSlopClient } from "@/lib/clients/openslop";
 import type { VideoGenerateParams, VideoJob } from "@/lib/connectors/types";
+import { BaseProvider } from "../base";
+import { awaitCompletion } from "../poll";
 
-export class OpenSlopVideo {
+export class OpenSlopVideo extends BaseProvider<VideoGenerateParams, VideoJob> {
   private client: OpenSlopClient;
 
   constructor(baseUrl?: string) {
+    super();
     this.client = new OpenSlopClient(baseUrl);
+  }
+
+  async generate(params: VideoGenerateParams): Promise<VideoJob> {
+    const job = await this.submit(params);
+    return awaitCompletion((id) => this.poll(id), job.jobId);
   }
 
   async submit(params: VideoGenerateParams): Promise<VideoJob> {

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -1,10 +1,13 @@
 import { Runware } from "@runware/sdk-js";
-import type { VideoGenerateParams } from "@/lib/connectors/types";
+import type { VideoGenerateParams, VideoJob } from "@/lib/connectors/types";
+import { BaseProvider } from "../base";
+import { awaitCompletion } from "../poll";
 
-export class RunwareVideo {
+export class RunwareVideo extends BaseProvider<VideoGenerateParams, VideoJob> {
   private apiKey: string;
 
   constructor(apiKey: string) {
+    super();
     this.apiKey = apiKey;
   }
 
@@ -34,6 +37,11 @@ export class RunwareVideo {
     } finally {
       runware.disconnect?.();
     }
+  }
+
+  async generate(params: VideoGenerateParams): Promise<VideoJob> {
+    const job = await this.submit(params);
+    return awaitCompletion((id) => this.poll(id), job.jobId);
   }
 
   async poll(jobId: string) {


### PR DESCRIPTION
Introduces a BaseProvider abstract class that all 12 providers extend, moves provider ownership into BaseConnector, passes a PluginContext to plugin hooks so plugins can access the provider, and adds a story kernel plugin that makes a preliminary LLM call to outline a story before the main generation.