### PR TITLE
Add config context provider

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import path from "path";
 import Link from "next/link";
 import Image from "next/image";
 import { createClient } from "@/lib/supabase/server";
+import { ConfigProvider } from "@/lib/config/ConfigProvider";
 import Editor from "./components/Editor";
 import OnboardingCard from "./components/OnboardingCard";
 import AccessCodeInput from "./components/AccessCodeInput";
@@ -21,13 +22,15 @@ export default async function Home() {
 
   if (user) {
     return (
-      <Editor
-        user={{
-          email: user.email ?? "",
-          avatarUrl: user.user_metadata?.avatar_url,
-          name: user.user_metadata?.full_name,
-        }}
-      />
+      <ConfigProvider>
+        <Editor
+          user={{
+            email: user.email ?? "",
+            avatarUrl: user.user_metadata?.avatar_url,
+            name: user.user_metadata?.full_name,
+          }}
+        />
+      </ConfigProvider>
     );
   }
 

--- a/lib/config/ConfigProvider.tsx
+++ b/lib/config/ConfigProvider.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { createContext, useContext, useState, type ReactNode } from "react";
+import type { ConnectorConfig } from "@/lib/connectors/types";
+
+export type AppConfig = {
+  llm: ConnectorConfig;
+};
+
+const defaultConfig: AppConfig = {
+  llm: { provider: "openslop", apiKey: "" },
+};
+
+type ConfigContextValue = {
+  config: AppConfig;
+  setConfig: React.Dispatch<React.SetStateAction<AppConfig>>;
+};
+
+const ConfigContext = createContext<ConfigContextValue | null>(null);
+
+export function useConfig() {
+  const ctx = useContext(ConfigContext);
+  if (!ctx) throw new Error("useConfig must be used within ConfigProvider");
+  return ctx;
+}
+
+export function ConfigProvider({ children }: { children: ReactNode }) {
+  const [config, setConfig] = useState<AppConfig>(defaultConfig);
+
+  return (
+    <ConfigContext.Provider value={{ config, setConfig }}>
+      {children}
+    </ConfigContext.Provider>
+  );
+}


### PR DESCRIPTION
React context that holds app-wide config (starting with LLM connector config). Editor is wrapped in ConfigProvider.