### PR TITLE
Extract shared stream-to-buffer utility from ElevenLabs providers

### DIFF
--- a/lib/providers/music/elevenlabs.ts
+++ b/lib/providers/music/elevenlabs.ts
@@ -1,6 +1,7 @@
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
 import type { MusicGenerateParams } from "@/lib/connectors/types";
 import { BaseProvider } from "../base";
+import { streamToBuffer } from "../stream";
 
 export class ElevenLabsMusic extends BaseProvider<
   MusicGenerateParams,
@@ -21,22 +22,6 @@ export class ElevenLabsMusic extends BaseProvider<
       outputFormat: "mp3_22050_32",
     });
 
-    const chunks: Uint8Array[] = [];
-    const reader = stream.getReader();
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      chunks.push(value);
-    }
-
-    const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
-    const buffer = new Uint8Array(totalLength);
-    let offset = 0;
-    for (const chunk of chunks) {
-      buffer.set(chunk, offset);
-      offset += chunk.length;
-    }
-
-    return buffer.buffer as ArrayBuffer;
+    return streamToBuffer(stream);
   }
 }

--- a/lib/providers/sfx/elevenlabs.ts
+++ b/lib/providers/sfx/elevenlabs.ts
@@ -1,6 +1,7 @@
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
 import type { SFXGenerateParams } from "@/lib/connectors/types";
 import { BaseProvider } from "../base";
+import { streamToBuffer } from "../stream";
 
 export class ElevenLabsSFX extends BaseProvider<
   SFXGenerateParams,
@@ -20,22 +21,6 @@ export class ElevenLabsSFX extends BaseProvider<
       outputFormat: "mp3_22050_32",
     });
 
-    const chunks: Uint8Array[] = [];
-    const reader = stream.getReader();
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      chunks.push(value);
-    }
-
-    const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
-    const buffer = new Uint8Array(totalLength);
-    let offset = 0;
-    for (const chunk of chunks) {
-      buffer.set(chunk, offset);
-      offset += chunk.length;
-    }
-
-    return buffer.buffer as ArrayBuffer;
+    return streamToBuffer(stream);
   }
 }

--- a/lib/providers/stream.ts
+++ b/lib/providers/stream.ts
@@ -1,0 +1,21 @@
+export async function streamToBuffer(
+  stream: ReadableStream<Uint8Array>,
+): Promise<ArrayBuffer> {
+  const chunks: Uint8Array[] = [];
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+
+  const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
+  const buffer = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return buffer.buffer as ArrayBuffer;
+}


### PR DESCRIPTION
## Problem

`ElevenLabsMusic` and `ElevenLabsSFX` contain identical stream-to-`ArrayBuffer` conversion code (12 lines, verbatim duplicate):

```typescript
const chunks: Uint8Array[] = [];
const reader = stream.getReader();
while (true) {
  const { done, value } = await reader.read();
  if (done) break;
  chunks.push(value);
}

const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
const buffer = new Uint8Array(totalLength);
let offset = 0;
for (const chunk of chunks) {
  buffer.set(chunk, offset);
  offset += chunk.length;
}

return buffer.buffer as ArrayBuffer;
```

## Fix

Extract into a shared `streamToBuffer` helper at `lib/providers/stream.ts`, following the same pattern as the existing `poll.ts` utility in the same directory. Both providers now call `streamToBuffer(stream)` instead of inlining the logic.

## Changes

| File | Change |
|------|--------|
| `lib/providers/stream.ts` | **New** — `streamToBuffer(stream)` helper |
| `lib/providers/music/elevenlabs.ts` | Replace inline buffer code with `streamToBuffer` call |
| `lib/providers/sfx/elevenlabs.ts` | Replace inline buffer code with `streamToBuffer` call |

Zero functional changes — purely structural.