### PR TITLE
add collapsible sidebar with glassy panel for canvas elements

### DIFF
--- a/app/components/Editor.tsx
+++ b/app/components/Editor.tsx
@@ -8,6 +8,7 @@ import ModeToggle from "./ModeToggle";
 import Copilot from "./Copilot";
 import AnimatedPlaceholder from "./AnimatedPlaceholder";
 import Canvas from "./canvas/Canvas";
+import type { UserProfileProps } from "./UserProfile";
 
 const INPUT_SCRIPT_PLACEHOLDER = `EXT. NIGHT STARRY SKY
 Soft glowing stars twinkle quietly across a deep blue sky.
@@ -21,13 +22,7 @@ there was a small glowing garden hidden on the moon.
 
 And in that garden… lived a little rabbit named Lumi…`;
 
-interface EditorUser {
-  email: string;
-  avatarUrl?: string;
-  name?: string;
-}
-
-export default function Editor({ user }: { user: EditorUser }) {
+export default function Editor({ user }: { user: UserProfileProps }) {
   const { mode, setMode } = useConfig();
   const { script, loading, submitPrompt, refineScript, stopGeneration } =
     useScript();
@@ -46,45 +41,31 @@ export default function Editor({ user }: { user: EditorUser }) {
         hasScript ? "pt-4" : "pt-[30vh]"
       }`}
     >
-      <div className="absolute top-4 left-4 sm:top-6 sm:left-6 z-[51]">
-        <UserProfile
-          email={user.email}
-          avatarUrl={user.avatarUrl}
-          name={user.name}
-        />
+      <div className="fixed top-4 left-4 z-[100]">
+        <UserProfile {...user} />
       </div>
 
-      <div
-        className={`flex w-full max-w-2xl flex-col items-center px-4 ${
-          prompted ? "pl-16 sm:pl-4" : ""
-        }`}
-      >
-        <div
-          className={`flex flex-col items-center transition-[opacity,max-height,margin-bottom] duration-1000 ${
-            prompted
-              ? "opacity-0 max-h-0 overflow-hidden mb-0 pointer-events-none"
-              : "opacity-100 max-h-[400px] mb-6"
-          }`}
-          style={{
-            transitionTimingFunction: "cubic-bezier(0.16, 1, 0.3, 1)",
-          }}
-        >
-          <h1 className="font-title text-center text-[clamp(48px,12vw,85px)] tracking-[-0.04em] leading-[0.95em] text-white/90 text-wrap-balance mb-6">
-            {mode === "prompt" ? "Describe your video" : "Paste your script"}
-          </h1>
-          <ModeToggle mode={mode} onChange={setMode} />
-        </div>
+      {!prompted ? (
+        <div className="flex w-full max-w-2xl flex-col items-center px-4">
+          <div
+            className="flex flex-col items-center opacity-100 max-h-[400px] mb-6 transition-[opacity,max-height,margin-bottom] duration-1000"
+            style={{
+              transitionTimingFunction: "cubic-bezier(0.16, 1, 0.3, 1)",
+            }}
+          >
+            <h1 className="font-title text-center text-[clamp(48px,12vw,85px)] tracking-[-0.04em] leading-[0.95em] text-white/90 text-wrap-balance mb-6">
+              {mode === "prompt" ? "Describe your video" : "Paste your script"}
+            </h1>
+            <ModeToggle mode={mode} onChange={setMode} />
+          </div>
 
-        <div className={prompted ? "w-full animate-copilot-enter" : "w-full"}>
           <Copilot
-            onSubmit={prompted ? refineScript : handleSubmit}
+            onSubmit={handleSubmit}
             onStop={stopGeneration}
-            multiline={!prompted && mode === "inputScript"}
+            multiline={mode === "inputScript"}
             loading={loading}
             placeholder={
-              prompted ? (
-                "Refine your script…"
-              ) : mode === "inputScript" ? (
+              mode === "inputScript" ? (
                 INPUT_SCRIPT_PLACEHOLDER
               ) : (
                 <AnimatedPlaceholder active />
@@ -92,7 +73,19 @@ export default function Editor({ user }: { user: EditorUser }) {
             }
           />
         </div>
-      </div>
+      ) : (
+        <div className="flex w-full justify-center px-4 pl-16 animate-copilot-enter">
+          <div className="w-full max-w-2xl">
+            <Copilot
+              onSubmit={refineScript}
+              onStop={stopGeneration}
+              multiline={false}
+              loading={loading}
+              placeholder="Refine your script…"
+            />
+          </div>
+        </div>
+      )}
 
       {prompted && (
         <div className="w-full max-w-6xl px-4 pt-6">

--- a/app/components/UserProfile.tsx
+++ b/app/components/UserProfile.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { LogOut } from "lucide-react";
 
-interface UserProfileProps {
+export interface UserProfileProps {
   email: string;
   avatarUrl?: string;
   name?: string;
@@ -37,7 +37,7 @@ export default function UserProfile({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className="relative z-[51] rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="relative z-[91] rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <Avatar className="h-9 w-9 cursor-pointer">
             {avatarUrl && <AvatarImage src={avatarUrl} alt={email} />}
@@ -52,7 +52,7 @@ export default function UserProfile({
         side="bottom"
         sideOffset={-44}
         alignOffset={-8}
-        className="w-56 origin-center rounded-3xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-105 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-105"
+        className="z-[90] w-56 origin-center rounded-3xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-105 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-105"
       >
         <div className="flex h-[52px] items-center gap-3 pl-12 pr-4">
           <span className="truncate text-sm font-medium text-white/90 pl-1">

--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Slate, Editable, RenderElementProps } from "slate-react";
 import { DndContext, DragOverlay } from "@dnd-kit/core";
 import {
@@ -13,11 +13,12 @@ import { useDragAndDrop } from "./dnd/useDragAndDrop";
 import { SortableElement } from "./dnd/SortableElement";
 import { DragOverlayContent } from "./dnd/DragOverlay";
 import { PanelItem } from "./panel/PanelItem";
-import ElementPanel from "./panel/ElementPanel";
+import Sidebar from "./panel/Sidebar";
 import { renderStoryElement } from "./elements/ElementRenderer";
 import { ELEMENT_CONFIGS } from "./config/elementConfigs";
-
 export default function Canvas() {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const toggleSidebar = useCallback(() => setSidebarOpen((prev) => !prev), []);
   const { editor, value, setValue } = useEditorSetup();
   const {
     activeId,
@@ -56,12 +57,12 @@ export default function Canvas() {
       onDragCancel={handleDragCancel}
       onDragOver={handleDragOver}
     >
-      <ElementPanel />
+      <Sidebar open={sidebarOpen} onToggle={toggleSidebar} />
 
       <Slate editor={editor} initialValue={value} onChange={setValue}>
         <SortableContext items={items} strategy={verticalListSortingStrategy}>
           <Editable
-            placeholder="Start typing your story..."
+            placeholder="Start typing your story…"
             renderElement={renderElement}
             className="font-body text-sm leading-relaxed outline-none focus-visible:ring-2 focus-visible:ring-ring"
           />

--- a/app/components/canvas/config/elementConfigs.tsx
+++ b/app/components/canvas/config/elementConfigs.tsx
@@ -24,7 +24,6 @@ export interface ElementConfig {
   icon: React.ReactNode;
   bgColor: string;
   placeholder: string;
-  panelColor: string;
   defaultAttributes?: Record<string, string>;
 }
 
@@ -37,7 +36,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
     icon: <BookOpen size={16} />,
     bgColor: "bg-slate-600",
     placeholder: "Write the narration...",
-    panelColor: "slate",
+
     defaultAttributes: {
       gender: TTSGender.Male,
       age: TTSAge.Adult,
@@ -53,7 +52,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
     icon: <User size={16} />,
     bgColor: "bg-amber-600",
     placeholder: "What does this character say?",
-    panelColor: "amber",
+
     defaultAttributes: {
       gender: TTSGender.Male,
       age: TTSAge.Adult,
@@ -69,7 +68,6 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
     icon: <ImageIcon size={16} />,
     bgColor: "bg-cyan-600",
     placeholder: "Describe the image...",
-    panelColor: "cyan",
   },
   clip: {
     id: "clip",
@@ -79,7 +77,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
     icon: <Film size={16} />,
     bgColor: "bg-indigo-600",
     placeholder: "Describe the video clip...",
-    panelColor: "indigo",
+
     defaultAttributes: {
       duration: "5s",
     },
@@ -92,7 +90,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
     icon: <Volume2 size={16} />,
     bgColor: "bg-emerald-600",
     placeholder: "Describe the sound effect...",
-    panelColor: "emerald",
+
     defaultAttributes: {
       type: SoundType.Transient,
     },
@@ -105,53 +103,5 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
     icon: <Music size={16} />,
     bgColor: "bg-violet-600",
     placeholder: "Describe the music...",
-    panelColor: "violet",
-  },
-};
-
-export const colorClasses: Record<
-  string,
-  {
-    background: string;
-    outline: string;
-    hoverBackground: string;
-    hoverOutline: string;
-  }
-> = {
-  slate: {
-    background: "bg-slate-400/30",
-    outline: "outline outline-1 outline-slate-300/60",
-    hoverBackground: "hover:bg-slate-400/50",
-    hoverOutline: "hover:outline-slate-300/80",
-  },
-  amber: {
-    background: "bg-amber-400/30",
-    outline: "outline outline-1 outline-amber-300/60",
-    hoverBackground: "hover:bg-amber-400/50",
-    hoverOutline: "hover:outline-amber-300/80",
-  },
-  cyan: {
-    background: "bg-cyan-400/30",
-    outline: "outline outline-1 outline-cyan-300/60",
-    hoverBackground: "hover:bg-cyan-400/50",
-    hoverOutline: "hover:outline-cyan-300/80",
-  },
-  indigo: {
-    background: "bg-indigo-400/30",
-    outline: "outline outline-1 outline-indigo-300/60",
-    hoverBackground: "hover:bg-indigo-400/50",
-    hoverOutline: "hover:outline-indigo-300/80",
-  },
-  emerald: {
-    background: "bg-emerald-400/30",
-    outline: "outline outline-1 outline-emerald-300/60",
-    hoverBackground: "hover:bg-emerald-400/50",
-    hoverOutline: "hover:outline-emerald-300/80",
-  },
-  violet: {
-    background: "bg-violet-400/30",
-    outline: "outline outline-1 outline-violet-300/60",
-    hoverBackground: "hover:bg-violet-400/50",
-    hoverOutline: "hover:outline-violet-300/80",
   },
 };

--- a/app/components/canvas/panel/ElementPanel.tsx
+++ b/app/components/canvas/panel/ElementPanel.tsx
@@ -3,16 +3,17 @@
 import { ELEMENT_CONFIGS } from "../config/elementConfigs";
 import { DraggablePanelItem } from "./DraggablePanelItem";
 
+const ELEMENT_LIST = Object.values(ELEMENT_CONFIGS);
+
 export default function ElementPanel() {
   return (
-    <div className="fixed left-4 top-1/2 -translate-y-1/2 z-[60] pointer-events-auto">
-      <div className="p-2 min-w-[140px]">
-        <div className="flex flex-col gap-2">
-          {Object.values(ELEMENT_CONFIGS).map((item) => (
-            <DraggablePanelItem key={item.id} item={item} />
-          ))}
-        </div>
-      </div>
+    <div className="flex flex-col gap-2">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-white/50">
+        Elements
+      </h2>
+      {ELEMENT_LIST.map((item) => (
+        <DraggablePanelItem key={item.id} item={item} />
+      ))}
     </div>
   );
 }

--- a/app/components/canvas/panel/PanelItem.tsx
+++ b/app/components/canvas/panel/PanelItem.tsx
@@ -1,5 +1,5 @@
 import { GripVertical } from "lucide-react";
-import { ElementConfig, colorClasses } from "../config/elementConfigs";
+import { ElementConfig } from "../config/elementConfigs";
 
 interface PanelItemProps extends React.HTMLAttributes<HTMLDivElement> {
   item: ElementConfig;
@@ -7,24 +7,24 @@ interface PanelItemProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export function PanelItem({ item, ref, ...props }: PanelItemProps) {
-  const { background, outline, hoverBackground, hoverOutline } =
-    colorClasses[item.panelColor];
-
   return (
-    <div
-      className={`flex items-center gap-2 px-3 py-2 rounded-md cursor-move
-        transition-[transform,background-color,outline-color] duration-200
-        ${background} ${outline} ${hoverBackground} ${hoverOutline}`}
-      ref={ref}
-      {...props}
-    >
+    <div className="flex items-center gap-2 cursor-move" ref={ref} {...props}>
       <GripVertical
         size={14}
-        className="text-muted-foreground/60 flex-shrink-0"
+        className="text-white/40 flex-shrink-0"
         aria-hidden="true"
       />
-      <span className="text-muted-foreground">{item.icon}</span>
-      <span className="text-sm font-medium">{item.label}</span>
+      <div
+        className={`grain relative overflow-hidden rounded-lg ${item.bgColor} shadow-md flex-1
+          transition-[transform,filter] duration-200 motion-reduce:transition-none hover:brightness-110`}
+      >
+        <div className="relative z-10 flex items-center gap-2 px-3 py-2">
+          <span className="text-white/80">{item.icon}</span>
+          <span className="text-sm font-medium text-white/90">
+            {item.label}
+          </span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/components/canvas/panel/Sidebar.tsx
+++ b/app/components/canvas/panel/Sidebar.tsx
@@ -12,7 +12,7 @@ export default function Sidebar({ open, onToggle }: SidebarProps) {
   return (
     <div
       className={`fixed top-0 left-0 h-full z-[80] w-[calc(14rem+2.5rem)] transition-transform duration-300 motion-reduce:transition-none ${
-        open ? "translate-x-0" : "-translate-x-52"
+        open ? "translate-x-0" : "-translate-x-52 pointer-events-none"
       }`}
     >
       <div
@@ -25,7 +25,7 @@ export default function Sidebar({ open, onToggle }: SidebarProps) {
           type="button"
           onClick={onToggle}
           aria-label={open ? "Close sidebar" : "Open sidebar"}
-          className="absolute right-2 top-16 p-1.5 rounded-md text-white/70 hover:text-white hover:bg-white/10 transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+          className="pointer-events-auto absolute right-2 top-16 p-1.5 rounded-md text-white/70 hover:text-white hover:bg-white/10 transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
         >
           <PanelLeft size={23} strokeWidth={1} aria-hidden="true" />
         </button>

--- a/app/components/canvas/panel/Sidebar.tsx
+++ b/app/components/canvas/panel/Sidebar.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { PanelLeft } from "lucide-react";
+import ElementPanel from "./ElementPanel";
+
+interface SidebarProps {
+  open: boolean;
+  onToggle: () => void;
+}
+
+export default function Sidebar({ open, onToggle }: SidebarProps) {
+  return (
+    <div
+      className={`fixed top-0 left-0 h-full z-[80] w-[calc(14rem+2.5rem)] transition-transform duration-300 motion-reduce:transition-none ${
+        open ? "translate-x-0" : "-translate-x-51"
+      }`}
+    >
+      <div
+        className={`absolute inset-0 bg-white/5 backdrop-blur-xl shadow-[4px_0_16px_rgba(0,0,0,0.3)] border-r border-white/10 transition-opacity duration-300 motion-reduce:transition-none ${
+          open ? "opacity-100" : "opacity-0"
+        }`}
+      />
+      <div className="relative pt-14 px-2">
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-label={open ? "Close sidebar" : "Open sidebar"}
+          className="absolute right-2 top-16 p-1.5 rounded-md text-white/70 hover:text-white hover:bg-white/10 transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+        >
+          <PanelLeft size={23} strokeWidth={1} aria-hidden="true" />
+        </button>
+
+        {open && (
+          <div className="mt-10 px-2">
+            <ElementPanel />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/canvas/panel/Sidebar.tsx
+++ b/app/components/canvas/panel/Sidebar.tsx
@@ -12,7 +12,7 @@ export default function Sidebar({ open, onToggle }: SidebarProps) {
   return (
     <div
       className={`fixed top-0 left-0 h-full z-[80] w-[calc(14rem+2.5rem)] transition-transform duration-300 motion-reduce:transition-none ${
-        open ? "translate-x-0" : "-translate-x-51"
+        open ? "translate-x-0" : "-translate-x-52"
       }`}
     >
       <div


### PR DESCRIPTION
replaces the fixed element panel with a slide-in sidebar. panel items now match canvas card styling (grain, solid bg, shadow). user profile z-index bumped to stay above sidebar. editor layout split into conditional branches for pre/post prompt.