### PR TITLE
deduplicate providers, routes, and client code

### DIFF
--- a/app/api/v1/image/route.ts
+++ b/app/api/v1/image/route.ts
@@ -1,21 +1,13 @@
-import { NextRequest, NextResponse } from "next/server";
 import { getImageProvider } from "@/lib/api/providers";
-import { badRequest, serverError } from "@/lib/api/response";
-import { validateModel } from "@/lib/api/validate-model";
+import { createRouteHandler, jsonResponse } from "@/lib/api/route-handler";
 import { IMAGE_MODELS } from "@/lib/connectors/image/openslop/models";
-import { logger } from "@/lib/api/logger";
 
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json();
+export const POST = createRouteHandler({
+  models: IMAGE_MODELS,
+  getProvider: getImageProvider,
+  label: "Image generation",
+  handle: async (provider, body) => {
     const { prompt, model, width, height, format, referenceImage } = body;
-
-    if (!prompt || typeof prompt !== "string")
-      return badRequest("prompt is required");
-    const modelError = validateModel(model, IMAGE_MODELS);
-    if (modelError) return modelError;
-
-    const provider = getImageProvider();
     const result = await provider.generate({
       prompt,
       model,
@@ -24,10 +16,6 @@ export async function POST(request: NextRequest) {
       format,
       referenceImage,
     });
-
-    return NextResponse.json(result);
-  } catch (error) {
-    logger.error(error, "Image generation failed");
-    return serverError("Image generation failed");
-  }
-}
+    return jsonResponse(result);
+  },
+});

--- a/app/api/v1/llm/route.ts
+++ b/app/api/v1/llm/route.ts
@@ -1,13 +1,13 @@
-import { NextRequest, NextResponse } from "next/server";
 import { getLLMProvider } from "@/lib/api/providers";
-import { badRequest, serverError } from "@/lib/api/response";
-import { validateModel } from "@/lib/api/validate-model";
+import { createRouteHandler, jsonResponse } from "@/lib/api/route-handler";
 import { LLM_MODELS } from "@/lib/connectors/llm/openslop/models";
 import { logger } from "@/lib/api/logger";
 
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json();
+export const POST = createRouteHandler({
+  models: LLM_MODELS,
+  getProvider: getLLMProvider,
+  label: "LLM generation",
+  handle: async (provider, body) => {
     const {
       prompt,
       model,
@@ -17,13 +17,6 @@ export async function POST(request: NextRequest) {
       temperature,
       stream,
     } = body;
-
-    if (!prompt || typeof prompt !== "string")
-      return badRequest("prompt is required");
-    const modelError = validateModel(model, LLM_MODELS);
-    if (modelError) return modelError;
-
-    const provider = getLLMProvider();
     const genParams = {
       prompt,
       model,
@@ -61,10 +54,6 @@ export async function POST(request: NextRequest) {
     }
 
     const result = await provider.generate(genParams);
-
-    return NextResponse.json(result);
-  } catch (error) {
-    logger.error(error, "LLM generation failed");
-    return serverError("LLM generation failed");
-  }
-}
+    return jsonResponse(result);
+  },
+});

--- a/app/api/v1/music/route.ts
+++ b/app/api/v1/music/route.ts
@@ -1,28 +1,18 @@
-import { NextRequest } from "next/server";
 import { getMusicProvider } from "@/lib/api/providers";
-import { badRequest, serverError } from "@/lib/api/response";
-import { validateModel } from "@/lib/api/validate-model";
+import { createRouteHandler, audioResponse } from "@/lib/api/route-handler";
 import { MUSIC_MODELS } from "@/lib/connectors/music/openslop/models";
-import { logger } from "@/lib/api/logger";
 
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json();
+export const POST = createRouteHandler({
+  models: MUSIC_MODELS,
+  getProvider: getMusicProvider,
+  label: "Music generation",
+  handle: async (provider, body) => {
     const { prompt, model, durationSeconds } = body;
-
-    if (!prompt || typeof prompt !== "string")
-      return badRequest("prompt is required");
-    const modelError = validateModel(model, MUSIC_MODELS);
-    if (modelError) return modelError;
-
-    const provider = getMusicProvider();
-    const buffer = await provider.generate({ prompt, model, durationSeconds });
-
-    return new Response(buffer, {
-      headers: { "content-type": "audio/mpeg" },
+    const buffer = await provider.generate({
+      prompt,
+      model,
+      durationSeconds,
     });
-  } catch (error) {
-    logger.error(error, "Music generation failed");
-    return serverError("Music generation failed");
-  }
-}
+    return audioResponse(buffer);
+  },
+});

--- a/app/api/v1/sfx/route.ts
+++ b/app/api/v1/sfx/route.ts
@@ -1,28 +1,18 @@
-import { NextRequest } from "next/server";
 import { getSFXProvider } from "@/lib/api/providers";
-import { badRequest, serverError } from "@/lib/api/response";
-import { validateModel } from "@/lib/api/validate-model";
+import { createRouteHandler, audioResponse } from "@/lib/api/route-handler";
 import { SFX_MODELS } from "@/lib/connectors/sfx/openslop/models";
-import { logger } from "@/lib/api/logger";
 
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json();
+export const POST = createRouteHandler({
+  models: SFX_MODELS,
+  getProvider: getSFXProvider,
+  label: "SFX generation",
+  handle: async (provider, body) => {
     const { prompt, model, durationSeconds } = body;
-
-    if (!prompt || typeof prompt !== "string")
-      return badRequest("prompt is required");
-    const modelError = validateModel(model, SFX_MODELS);
-    if (modelError) return modelError;
-
-    const provider = getSFXProvider();
-    const buffer = await provider.generate({ prompt, model, durationSeconds });
-
-    return new Response(buffer, {
-      headers: { "content-type": "audio/mpeg" },
+    const buffer = await provider.generate({
+      prompt,
+      model,
+      durationSeconds,
     });
-  } catch (error) {
-    logger.error(error, "SFX generation failed");
-    return serverError("SFX generation failed");
-  }
-}
+    return audioResponse(buffer);
+  },
+});

--- a/app/api/v1/tts/route.ts
+++ b/app/api/v1/tts/route.ts
@@ -1,23 +1,19 @@
-import { NextRequest, NextResponse } from "next/server";
 import { getTTSProvider } from "@/lib/api/providers";
-import { badRequest, serverError } from "@/lib/api/response";
-import { validateModel } from "@/lib/api/validate-model";
+import { badRequest } from "@/lib/api/response";
+import { createRouteHandler, jsonResponse } from "@/lib/api/route-handler";
 import { TTS_MODELS } from "@/lib/connectors/tts/openslop/models";
-import { logger } from "@/lib/api/logger";
 
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json();
-    const { prompt, voiceId, model, speed, volume, format } = body;
-
-    if (!prompt || typeof prompt !== "string")
-      return badRequest("prompt is required");
-    if (!voiceId || typeof voiceId !== "string")
+export const POST = createRouteHandler({
+  models: TTS_MODELS,
+  getProvider: getTTSProvider,
+  label: "TTS generation",
+  extraValidation: (body) => {
+    if (!body.voiceId || typeof body.voiceId !== "string")
       return badRequest("voiceId is required");
-    const modelError = validateModel(model, TTS_MODELS);
-    if (modelError) return modelError;
-
-    const provider = getTTSProvider();
+    return null;
+  },
+  handle: async (provider, body) => {
+    const { prompt, voiceId, model, speed, volume, format } = body;
     const result = await provider.generate({
       prompt,
       voiceId,
@@ -26,10 +22,6 @@ export async function POST(request: NextRequest) {
       volume,
       format,
     });
-
-    return NextResponse.json(result);
-  } catch (error) {
-    logger.error(error, "TTS generation failed");
-    return serverError("TTS generation failed");
-  }
-}
+    return jsonResponse(result);
+  },
+});

--- a/app/api/v1/video/route.ts
+++ b/app/api/v1/video/route.ts
@@ -1,29 +1,26 @@
-import { NextRequest, NextResponse } from "next/server";
 import { getVideoProvider } from "@/lib/api/providers";
-import { badRequest, serverError } from "@/lib/api/response";
-import { validateModel } from "@/lib/api/validate-model";
+import { badRequest } from "@/lib/api/response";
+import { createRouteHandler, jsonResponse } from "@/lib/api/route-handler";
 import { VIDEO_MODELS } from "@/lib/connectors/video/openslop/models";
-import { logger } from "@/lib/api/logger";
 
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json();
-    const { prompt, model, referenceImage, duration, width, height } = body;
-
-    if (!prompt || typeof prompt !== "string")
-      return badRequest("prompt is required");
-    const modelError = validateModel(model, VIDEO_MODELS);
-    if (modelError) return modelError;
+export const POST = createRouteHandler({
+  models: VIDEO_MODELS,
+  getProvider: getVideoProvider,
+  label: "Video submission",
+  extraValidation: (body) => {
+    const { referenceImage } = body;
     if (
       referenceImage &&
       (typeof referenceImage !== "string" ||
-        !referenceImage.match(/^data:[a-z]+\/[a-z+.-]+;base64,/i))
+        !String(referenceImage).match(/^data:[a-z]+\/[a-z+.-]+;base64,/i))
     )
       return badRequest(
         "referenceImage must be a data URI (e.g. data:image/png;base64,...)",
       );
-
-    const provider = getVideoProvider();
+    return null;
+  },
+  handle: async (provider, body) => {
+    const { prompt, model, referenceImage, duration, width, height } = body;
     const result = await provider.submit({
       prompt,
       model,
@@ -32,10 +29,6 @@ export async function POST(request: NextRequest) {
       width,
       height,
     });
-
-    return NextResponse.json(result);
-  } catch (error) {
-    logger.error(error, "Video submission failed");
-    return serverError("Video submission failed");
-  }
-}
+    return jsonResponse(result);
+  },
+});

--- a/app/components/Copilot.tsx
+++ b/app/components/Copilot.tsx
@@ -23,6 +23,24 @@ interface CopilotProps {
   loading?: boolean;
 }
 
+function SubmitButton({
+  label,
+  onClick,
+}: {
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      aria-label={label}
+      onClick={onClick}
+      className="relative grain ml-3 flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-[#1f1528]/60 text-violet-300 transition-[filter] hover:brightness-[1.3]"
+    >
+      <ArrowRight className="h-4 w-4" />
+    </button>
+  );
+}
+
 function LoadingText() {
   const [index, setIndex] = useState(() =>
     Math.floor(Math.random() * LOADING_MESSAGES.length),
@@ -78,13 +96,7 @@ export default function Copilot({
           />
           {hasText && (
             <div className="flex justify-end pt-2">
-              <button
-                aria-label="Submit script"
-                onClick={handleSubmit}
-                className="relative grain flex h-6 w-6 items-center justify-center rounded-lg bg-[#1f1528]/60 text-violet-300 transition-[filter] hover:brightness-[1.3]"
-              >
-                <ArrowRight className="h-4 w-4" />
-              </button>
+              <SubmitButton label="Submit script" onClick={handleSubmit} />
             </div>
           )}
         </div>
@@ -127,13 +139,7 @@ export default function Copilot({
             </button>
           ) : (
             hasText && (
-              <button
-                aria-label="Submit prompt"
-                onClick={handleSubmit}
-                className="relative grain ml-3 flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-[#1f1528]/60 text-violet-300 transition-[filter] hover:brightness-[1.3]"
-              >
-                <ArrowRight className="h-4 w-4" />
-              </button>
+              <SubmitButton label="Submit prompt" onClick={handleSubmit} />
             )
           )}
         </div>

--- a/app/components/Editor.tsx
+++ b/app/components/Editor.tsx
@@ -24,8 +24,7 @@ And in that garden… lived a little rabbit named Lumi…`;
 
 export default function Editor({ user }: { user: UserProfileProps }) {
   const { mode, setMode } = useConfig();
-  const { script, loading, submitPrompt, refineScript, stopGeneration } =
-    useScript();
+  const { script, loading, submitPrompt, stopGeneration } = useScript();
   const [prompted, setPrompted] = useState(false);
 
   const hasScript = script.length > 0 || loading;
@@ -77,7 +76,7 @@ export default function Editor({ user }: { user: UserProfileProps }) {
         <div className="flex w-full justify-center px-4 pl-16 animate-copilot-enter">
           <div className="w-full max-w-2xl">
             <Copilot
-              onSubmit={refineScript}
+              onSubmit={submitPrompt}
               onStop={stopGeneration}
               multiline={false}
               loading={loading}

--- a/app/components/Editor.tsx
+++ b/app/components/Editor.tsx
@@ -24,7 +24,8 @@ And in that garden… lived a little rabbit named Lumi…`;
 
 export default function Editor({ user }: { user: UserProfileProps }) {
   const { mode, setMode } = useConfig();
-  const { script, loading, submitPrompt, stopGeneration } = useScript();
+  const { script, loading, submitPrompt, stopGeneration, refineScript } =
+    useScript();
   const [prompted, setPrompted] = useState(false);
 
   const hasScript = script.length > 0 || loading;
@@ -44,7 +45,19 @@ export default function Editor({ user }: { user: UserProfileProps }) {
         <UserProfile {...user} />
       </div>
 
-      {!prompted ? (
+      {prompted ? (
+        <div className="flex w-full justify-center px-4 pl-16 animate-copilot-enter">
+          <div className="w-full max-w-2xl">
+            <Copilot
+              onSubmit={refineScript}
+              onStop={stopGeneration}
+              multiline={false}
+              loading={loading}
+              placeholder="Refine your script…"
+            />
+          </div>
+        </div>
+      ) : (
         <div className="flex w-full max-w-2xl flex-col items-center px-4">
           <div
             className="flex flex-col items-center opacity-100 max-h-[400px] mb-6 transition-[opacity,max-height,margin-bottom] duration-1000"
@@ -71,18 +84,6 @@ export default function Editor({ user }: { user: UserProfileProps }) {
               )
             }
           />
-        </div>
-      ) : (
-        <div className="flex w-full justify-center px-4 pl-16 animate-copilot-enter">
-          <div className="w-full max-w-2xl">
-            <Copilot
-              onSubmit={submitPrompt}
-              onStop={stopGeneration}
-              multiline={false}
-              loading={loading}
-              placeholder="Refine your script…"
-            />
-          </div>
         </div>
       )}
 

--- a/app/components/OrbLoader.tsx
+++ b/app/components/OrbLoader.tsx
@@ -9,9 +9,6 @@ export default function OrbLoader() {
               <polygon points="25,25 75,25 50,75" fill="white" />
               <polygon points="50,25 75,75 25,75" fill="white" />
               <polygon points="35,35 65,35 50,65" fill="white" />
-              <polygon points="35,35 65,35 50,65" fill="white" />
-              <polygon points="35,35 65,35 50,65" fill="white" />
-              <polygon points="35,35 65,35 50,65" fill="white" />
             </mask>
           </defs>
         </svg>

--- a/app/components/OrbLoader.tsx
+++ b/app/components/OrbLoader.tsx
@@ -9,6 +9,9 @@ export default function OrbLoader() {
               <polygon points="25,25 75,25 50,75" fill="white" />
               <polygon points="50,25 75,75 25,75" fill="white" />
               <polygon points="35,35 65,35 50,65" fill="white" />
+              <polygon points="35,35 65,35 50,65" fill="white" />
+              <polygon points="35,35 65,35 50,65" fill="white" />
+              <polygon points="35,35 65,35 50,65" fill="white" />
             </mask>
           </defs>
         </svg>

--- a/app/components/canvas/config/constants.ts
+++ b/app/components/canvas/config/constants.ts
@@ -1,4 +1,4 @@
-export const PILL_COLORS = [
+export const ATTRIBUTE_BADGE_COLORS = [
   "bg-rose-500",
   "bg-blue-500",
   "bg-green-500",

--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -2,7 +2,7 @@ import { RenderElementProps } from "slate-react";
 import { Node } from "slate";
 import { ChevronDown } from "lucide-react";
 import type { CanvasElement } from "../types";
-import { PILL_COLORS, ZERO_WIDTH_SPACE } from "../config/constants";
+import { ATTRIBUTE_BADGE_COLORS, ZERO_WIDTH_SPACE } from "../config/constants";
 import { OutputPreview } from "./OutputPreview";
 
 interface ElementContainerProps {
@@ -49,7 +49,7 @@ export function ElementContainer({
               value ? (
                 <span
                   key={key}
-                  className={`${PILL_COLORS[index % PILL_COLORS.length]} text-white text-[12px] px-1.5 py-0.5 rounded-full truncate max-w-[100px]`}
+                  className={`${ATTRIBUTE_BADGE_COLORS[index % ATTRIBUTE_BADGE_COLORS.length]} text-white text-[12px] px-1.5 py-0.5 rounded-full truncate max-w-[100px]`}
                   title={value}
                 >
                   {value}

--- a/app/components/canvas/hooks/useScriptSync.ts
+++ b/app/components/canvas/hooks/useScriptSync.ts
@@ -1,6 +1,5 @@
 import { useEffect, useMemo } from "react";
 import { Editor, Transforms } from "slate";
-import flow from "lodash/fp/flow";
 import { useScript } from "@/lib/script/ScriptProvider";
 import { useConfig, type ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import { ELEMENT_CONFIGS } from "../config/elementConfigs";
@@ -11,10 +10,10 @@ export function useScriptSync(editor: Editor): void {
   const { nodes } = useScript();
   const { connectors } = useConfig();
 
-  const normalize = useMemo(
-    () => flow(trimWhitespace, hydrateModel(connectors)),
-    [connectors],
-  );
+  const normalize = useMemo(() => {
+    const hydrate = hydrateModel(connectors);
+    return (node: CanvasElement) => hydrate(trimWhitespace(node));
+  }, [connectors]);
 
   useEffect(() => {
     Editor.withoutNormalizing(editor, () => {

--- a/app/components/canvas/hooks/useScriptSync.ts
+++ b/app/components/canvas/hooks/useScriptSync.ts
@@ -5,15 +5,16 @@ import { useConfig, type ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import { ELEMENT_CONFIGS } from "../config/elementConfigs";
 import type { CanvasElement } from "../types";
 import { OSMLSerializer } from "../utils/osmlSerializer";
+import flow from "lodash/fp/flow";
 
 export function useScriptSync(editor: Editor): void {
   const { nodes } = useScript();
   const { connectors } = useConfig();
 
-  const normalize = useMemo(() => {
-    const hydrate = hydrateModel(connectors);
-    return (node: CanvasElement) => hydrate(trimWhitespace(node));
-  }, [connectors]);
+  const normalize = useMemo(
+    () => flow(trimWhitespace, hydrateModel(connectors)),
+    [connectors],
+  );
 
   useEffect(() => {
     Editor.withoutNormalizing(editor, () => {

--- a/app/components/canvas/types.ts
+++ b/app/components/canvas/types.ts
@@ -9,18 +9,14 @@ export type CanvasElementType =
   | "sound"
   | "music";
 
-const CANVAS_ELEMENT_TYPE_LIST: CanvasElementType[] = [
+export const CANVAS_ELEMENT_TYPES = new Set<CanvasElementType>([
   "narration",
   "character",
   "image",
   "clip",
   "sound",
   "music",
-];
-
-export const CANVAS_ELEMENT_TYPES = new Set<CanvasElementType>(
-  CANVAS_ELEMENT_TYPE_LIST,
-);
+]);
 
 export type CanvasEditor = BaseEditor & ReactEditor & { id?: string };
 

--- a/app/components/canvas/utils/osmlSerializer.ts
+++ b/app/components/canvas/utils/osmlSerializer.ts
@@ -9,15 +9,12 @@ import { parseXmlTag } from "./parseXmlTag";
 
 const DEFAULT_TAG_TYPE: CanvasElementType = "narration";
 const MIN_BUFFER_LENGTH = 5;
+const TAG_PATTERN = /<([^<>/][^<>]*?)>|<\/([^<>/][^<>]*?)>/g;
 
 export class OSMLSerializer {
   private processedSinceLastEmit = 0;
   private buffer = "";
   private nodes: CanvasElement[] = [];
-
-  private static readonly VALID_TYPES: Set<string> = new Set(
-    CANVAS_ELEMENT_TYPES,
-  );
 
   static serialize(descendants: Descendant[]): string {
     let osml = "";
@@ -53,7 +50,7 @@ export class OSMLSerializer {
   }
 
   private parseBuffer(): boolean {
-    const tagPattern = /<([^<>/][^<>]*?)>|<\/([^<>/][^<>]*?)>/g;
+    TAG_PATTERN.lastIndex = 0;
 
     if (this.shouldFlushBuffer()) {
       this.updateCurrent(this.buffer);
@@ -65,7 +62,7 @@ export class OSMLSerializer {
     let match: RegExpExecArray | null = null;
     let updated = false;
 
-    while ((match = tagPattern.exec(this.buffer)) !== null) {
+    while ((match = TAG_PATTERN.exec(this.buffer)) !== null) {
       const text = this.buffer.slice(lastIndex, match.index);
       if (text.trim()) {
         this.updateCurrent(text);
@@ -117,7 +114,7 @@ export class OSMLSerializer {
 
   private mapTagToType(tagName: string): CanvasElementType {
     const normalized = tagName.toLowerCase();
-    return OSMLSerializer.VALID_TYPES.has(normalized)
+    return CANVAS_ELEMENT_TYPES.has(normalized as CanvasElementType)
       ? (normalized as CanvasElementType)
       : DEFAULT_TAG_TYPE;
   }

--- a/lib/api/route-handler.ts
+++ b/lib/api/route-handler.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { badRequest, serverError } from "./response";
+import { validateModel } from "./validate-model";
+import { logger } from "./logger";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type RequestBody = any;
+
+type RouteOptions<T> = {
+  models: Record<string, string>;
+  getProvider: () => T;
+  label: string;
+  extraValidation?: (body: RequestBody) => Response | null;
+  handle: (provider: T, body: RequestBody) => Promise<Response>;
+};
+
+export function createRouteHandler<T>(options: RouteOptions<T>) {
+  return async function POST(request: NextRequest) {
+    try {
+      const body = await request.json();
+      const { prompt, model } = body;
+
+      if (!prompt || typeof prompt !== "string")
+        return badRequest("prompt is required");
+      const modelError = validateModel(model, options.models);
+      if (modelError) return modelError;
+
+      if (options.extraValidation) {
+        const validationError = options.extraValidation(body);
+        if (validationError) return validationError;
+      }
+
+      const provider = options.getProvider();
+      return await options.handle(provider, body);
+    } catch (error) {
+      logger.error(error, `${options.label} failed`);
+      return serverError(`${options.label} failed`);
+    }
+  };
+}
+
+export function jsonResponse(data: unknown) {
+  return NextResponse.json(data);
+}
+
+export function audioResponse(buffer: ArrayBuffer) {
+  return new Response(buffer, {
+    headers: { "content-type": "audio/mpeg" },
+  });
+}

--- a/lib/clients/openslop.ts
+++ b/lib/clients/openslop.ts
@@ -18,14 +18,23 @@ export class OpenSlopClient {
     return h;
   }
 
-  async post<T>(path: string, body: unknown): Promise<T> {
-    const res = await fetch(`${this.baseUrl}${path}`, {
-      method: "POST",
+  private async request(
+    method: string,
+    url: string,
+    body?: unknown,
+  ): Promise<Response> {
+    const res = await fetch(url, {
+      method,
       headers: await this.headers(),
-      body: JSON.stringify(body),
+      ...(body !== undefined && { body: JSON.stringify(body) }),
     });
     if (!res.ok)
       throw new Error(`OpenSlop API error: ${res.status} ${res.statusText}`);
+    return res;
+  }
+
+  async post<T>(path: string, body: unknown): Promise<T> {
+    const res = await this.request("POST", `${this.baseUrl}${path}`, body);
     return res.json() as Promise<T>;
   }
 
@@ -37,34 +46,16 @@ export class OpenSlopClient {
       ).toString();
       if (qs) url += `?${qs}`;
     }
-    const res = await fetch(url, {
-      method: "GET",
-      headers: await this.headers(),
-    });
-    if (!res.ok)
-      throw new Error(`OpenSlop API error: ${res.status} ${res.statusText}`);
+    const res = await this.request("GET", url);
     return res.json() as Promise<T>;
   }
 
   async postBinary(path: string, body: unknown): Promise<ArrayBuffer> {
-    const res = await fetch(`${this.baseUrl}${path}`, {
-      method: "POST",
-      headers: await this.headers(),
-      body: JSON.stringify(body),
-    });
-    if (!res.ok)
-      throw new Error(`OpenSlop API error: ${res.status} ${res.statusText}`);
+    const res = await this.request("POST", `${this.baseUrl}${path}`, body);
     return res.arrayBuffer();
   }
 
   async postStream(path: string, body: unknown): Promise<Response> {
-    const res = await fetch(`${this.baseUrl}${path}`, {
-      method: "POST",
-      headers: await this.headers(),
-      body: JSON.stringify(body),
-    });
-    if (!res.ok)
-      throw new Error(`OpenSlop API error: ${res.status} ${res.statusText}`);
-    return res;
+    return this.request("POST", `${this.baseUrl}${path}`, body);
   }
 }

--- a/lib/connectors/image/openslop/index.ts
+++ b/lib/connectors/image/openslop/index.ts
@@ -1,6 +1,7 @@
 import { BaseImageConnector } from "../connector";
 import { OpenSlopImage as OpenSlopImageProvider } from "@/lib/providers/image/openslop";
 import type { ConnectorConfig, ModelInfo } from "@/lib/connectors/types";
+import { modelsFromMap } from "@/lib/connectors/types";
 import { IMAGE_MODELS } from "./models";
 
 export class OpenSlopImage extends BaseImageConnector<OpenSlopImageProvider> {
@@ -9,6 +10,6 @@ export class OpenSlopImage extends BaseImageConnector<OpenSlopImageProvider> {
   }
 
   async listModels(): Promise<ModelInfo[]> {
-    return Object.entries(IMAGE_MODELS).map(([name, id]) => ({ id, name }));
+    return modelsFromMap(IMAGE_MODELS);
   }
 }

--- a/lib/connectors/llm/openslop/index.ts
+++ b/lib/connectors/llm/openslop/index.ts
@@ -6,6 +6,7 @@ import type {
   LLMStreamChunk,
   ModelInfo,
 } from "@/lib/connectors/types";
+import { modelsFromMap } from "@/lib/connectors/types";
 import { LLM_MODELS } from "./models";
 
 export class OpenSlopLLM extends BaseLLMConnector<OpenSlopLLMProvider> {
@@ -14,7 +15,7 @@ export class OpenSlopLLM extends BaseLLMConnector<OpenSlopLLMProvider> {
   }
 
   async listModels(): Promise<ModelInfo[]> {
-    return Object.entries(LLM_MODELS).map(([name, id]) => ({ id, name }));
+    return modelsFromMap(LLM_MODELS);
   }
 
   protected async *_stream(

--- a/lib/connectors/music/openslop/index.ts
+++ b/lib/connectors/music/openslop/index.ts
@@ -1,6 +1,7 @@
 import { BaseMusicConnector } from "../connector";
 import { OpenSlopMusic as OpenSlopMusicProvider } from "@/lib/providers/music/openslop";
 import type { ConnectorConfig, ModelInfo } from "@/lib/connectors/types";
+import { modelsFromMap } from "@/lib/connectors/types";
 import { MUSIC_MODELS } from "./models";
 
 export class OpenSlopMusic extends BaseMusicConnector<OpenSlopMusicProvider> {
@@ -9,6 +10,6 @@ export class OpenSlopMusic extends BaseMusicConnector<OpenSlopMusicProvider> {
   }
 
   async listModels(): Promise<ModelInfo[]> {
-    return Object.entries(MUSIC_MODELS).map(([name, id]) => ({ id, name }));
+    return modelsFromMap(MUSIC_MODELS);
   }
 }

--- a/lib/connectors/sfx/openslop/index.ts
+++ b/lib/connectors/sfx/openslop/index.ts
@@ -1,6 +1,7 @@
 import { BaseSFXConnector } from "../connector";
 import { OpenSlopSFX as OpenSlopSFXProvider } from "@/lib/providers/sfx/openslop";
 import type { ConnectorConfig, ModelInfo } from "@/lib/connectors/types";
+import { modelsFromMap } from "@/lib/connectors/types";
 import { SFX_MODELS } from "./models";
 
 export class OpenSlopSFX extends BaseSFXConnector<OpenSlopSFXProvider> {
@@ -9,6 +10,6 @@ export class OpenSlopSFX extends BaseSFXConnector<OpenSlopSFXProvider> {
   }
 
   async listModels(): Promise<ModelInfo[]> {
-    return Object.entries(SFX_MODELS).map(([name, id]) => ({ id, name }));
+    return modelsFromMap(SFX_MODELS);
   }
 }

--- a/lib/connectors/tts/openslop/index.ts
+++ b/lib/connectors/tts/openslop/index.ts
@@ -6,6 +6,7 @@ import type {
   VoiceInfo,
   VoiceSearchParams,
 } from "@/lib/connectors/types";
+import { modelsFromMap } from "@/lib/connectors/types";
 import { TTS_MODELS } from "./models";
 
 export class OpenSlopTTS extends BaseTTSConnector<OpenSlopTTSProvider> {
@@ -14,7 +15,7 @@ export class OpenSlopTTS extends BaseTTSConnector<OpenSlopTTSProvider> {
   }
 
   async listModels(): Promise<ModelInfo[]> {
-    return Object.entries(TTS_MODELS).map(([name, id]) => ({ id, name }));
+    return modelsFromMap(TTS_MODELS);
   }
 
   async searchVoices(params: VoiceSearchParams): Promise<VoiceInfo[]> {

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -12,6 +12,10 @@ export type ModelInfo = {
   description?: string;
 };
 
+export function modelsFromMap(map: Record<string, string>): ModelInfo[] {
+  return Object.entries(map).map(([name, id]) => ({ id, name }));
+}
+
 export interface PluginContext<TParams = unknown, TResult = unknown> {
   provider: BaseProvider<TParams, TResult>;
 }

--- a/lib/connectors/video/openslop/index.ts
+++ b/lib/connectors/video/openslop/index.ts
@@ -5,6 +5,7 @@ import type {
   ModelInfo,
   VideoJob,
 } from "@/lib/connectors/types";
+import { modelsFromMap } from "@/lib/connectors/types";
 import { VIDEO_MODELS } from "./models";
 
 export class OpenSlopVideo extends BaseVideoConnector<OpenSlopVideoProvider> {
@@ -13,7 +14,7 @@ export class OpenSlopVideo extends BaseVideoConnector<OpenSlopVideoProvider> {
   }
 
   async listModels(): Promise<ModelInfo[]> {
-    return Object.entries(VIDEO_MODELS).map(([name, id]) => ({ id, name }));
+    return modelsFromMap(VIDEO_MODELS);
   }
 
   async poll(jobId: string): Promise<VideoJob> {

--- a/lib/providers/image/openslop.ts
+++ b/lib/providers/image/openslop.ts
@@ -1,18 +1,10 @@
-import { OpenSlopClient } from "@/lib/clients/openslop";
 import type { ImageGenerateParams, ImageResult } from "@/lib/connectors/types";
-import { BaseProvider } from "../base";
+import { BaseOpenSlopProvider } from "../openslop-base";
 
-export class OpenSlopImage extends BaseProvider<
+export class OpenSlopImage extends BaseOpenSlopProvider<
   ImageGenerateParams,
   ImageResult
 > {
-  private client: OpenSlopClient;
-
-  constructor(baseUrl?: string) {
-    super();
-    this.client = new OpenSlopClient(baseUrl);
-  }
-
   async generate(params: ImageGenerateParams): Promise<ImageResult> {
     return this.client.post("/api/v1/image", params);
   }

--- a/lib/providers/llm/openslop.ts
+++ b/lib/providers/llm/openslop.ts
@@ -1,22 +1,14 @@
-import { OpenSlopClient } from "@/lib/clients/openslop";
 import type {
   LLMGenerateParams,
   LLMGenerateResult,
   LLMStreamChunk,
 } from "@/lib/connectors/types";
-import { BaseProvider } from "../base";
+import { BaseOpenSlopProvider } from "../openslop-base";
 
-export class OpenSlopLLM extends BaseProvider<
+export class OpenSlopLLM extends BaseOpenSlopProvider<
   LLMGenerateParams,
   LLMGenerateResult
 > {
-  private client: OpenSlopClient;
-
-  constructor(baseUrl?: string) {
-    super();
-    this.client = new OpenSlopClient(baseUrl);
-  }
-
   async generate(params: LLMGenerateParams): Promise<LLMGenerateResult> {
     return this.client.post("/api/v1/llm", params);
   }

--- a/lib/providers/music/openslop.ts
+++ b/lib/providers/music/openslop.ts
@@ -1,18 +1,10 @@
-import { OpenSlopClient } from "@/lib/clients/openslop";
 import type { MusicGenerateParams } from "@/lib/connectors/types";
-import { BaseProvider } from "../base";
+import { BaseOpenSlopProvider } from "../openslop-base";
 
-export class OpenSlopMusic extends BaseProvider<
+export class OpenSlopMusic extends BaseOpenSlopProvider<
   MusicGenerateParams,
   ArrayBuffer
 > {
-  private client: OpenSlopClient;
-
-  constructor(baseUrl?: string) {
-    super();
-    this.client = new OpenSlopClient(baseUrl);
-  }
-
   async generate(params: MusicGenerateParams): Promise<ArrayBuffer> {
     return this.client.postBinary("/api/v1/music", params);
   }

--- a/lib/providers/openslop-base.ts
+++ b/lib/providers/openslop-base.ts
@@ -1,0 +1,14 @@
+import { OpenSlopClient } from "@/lib/clients/openslop";
+import { BaseProvider } from "./base";
+
+export abstract class BaseOpenSlopProvider<
+  TParams = unknown,
+  TResult = unknown,
+> extends BaseProvider<TParams, TResult> {
+  protected client: OpenSlopClient;
+
+  constructor(baseUrl?: string) {
+    super();
+    this.client = new OpenSlopClient(baseUrl);
+  }
+}

--- a/lib/providers/sfx/openslop.ts
+++ b/lib/providers/sfx/openslop.ts
@@ -1,15 +1,10 @@
-import { OpenSlopClient } from "@/lib/clients/openslop";
 import type { SFXGenerateParams } from "@/lib/connectors/types";
-import { BaseProvider } from "../base";
+import { BaseOpenSlopProvider } from "../openslop-base";
 
-export class OpenSlopSFX extends BaseProvider<SFXGenerateParams, ArrayBuffer> {
-  private client: OpenSlopClient;
-
-  constructor(baseUrl?: string) {
-    super();
-    this.client = new OpenSlopClient(baseUrl);
-  }
-
+export class OpenSlopSFX extends BaseOpenSlopProvider<
+  SFXGenerateParams,
+  ArrayBuffer
+> {
   async generate(params: SFXGenerateParams): Promise<ArrayBuffer> {
     return this.client.postBinary("/api/v1/sfx", params);
   }

--- a/lib/providers/tts/openslop.ts
+++ b/lib/providers/tts/openslop.ts
@@ -1,20 +1,15 @@
-import { OpenSlopClient } from "@/lib/clients/openslop";
 import type {
   TTSGenerateParams,
   TTSResult,
   VoiceInfo,
   VoiceSearchParams,
 } from "@/lib/connectors/types";
-import { BaseProvider } from "../base";
+import { BaseOpenSlopProvider } from "../openslop-base";
 
-export class OpenSlopTTS extends BaseProvider<TTSGenerateParams, TTSResult> {
-  private client: OpenSlopClient;
-
-  constructor(baseUrl?: string) {
-    super();
-    this.client = new OpenSlopClient(baseUrl);
-  }
-
+export class OpenSlopTTS extends BaseOpenSlopProvider<
+  TTSGenerateParams,
+  TTSResult
+> {
   async generate(params: TTSGenerateParams): Promise<TTSResult> {
     return this.client.post("/api/v1/tts", params);
   }

--- a/lib/providers/video/openslop.ts
+++ b/lib/providers/video/openslop.ts
@@ -1,16 +1,11 @@
-import { OpenSlopClient } from "@/lib/clients/openslop";
 import type { VideoGenerateParams, VideoJob } from "@/lib/connectors/types";
-import { BaseProvider } from "../base";
+import { BaseOpenSlopProvider } from "../openslop-base";
 import { awaitCompletion } from "../poll";
 
-export class OpenSlopVideo extends BaseProvider<VideoGenerateParams, VideoJob> {
-  private client: OpenSlopClient;
-
-  constructor(baseUrl?: string) {
-    super();
-    this.client = new OpenSlopClient(baseUrl);
-  }
-
+export class OpenSlopVideo extends BaseOpenSlopProvider<
+  VideoGenerateParams,
+  VideoJob
+> {
   async generate(params: VideoGenerateParams): Promise<VideoJob> {
     const job = await this.submit(params);
     return awaitCompletion((id) => this.poll(id), job.jobId);

--- a/lib/script/ScriptProvider.tsx
+++ b/lib/script/ScriptProvider.tsx
@@ -18,7 +18,6 @@ type ScriptContextValue = {
   nodes: Descendant[];
   loading: boolean;
   submitPrompt: (prompt: string) => Promise<void>;
-  refineScript: (prompt: string) => Promise<void>;
   stopGeneration: () => void;
 };
 
@@ -68,8 +67,6 @@ export function ScriptProvider({ children }: { children: ReactNode }) {
     [connectors.llm, appendChunk],
   );
 
-  const refineScript = useCallback(async (_prompt: string) => {}, []);
-
   return (
     <ScriptContext.Provider
       value={{
@@ -77,7 +74,6 @@ export function ScriptProvider({ children }: { children: ReactNode }) {
         nodes,
         loading,
         submitPrompt,
-        refineScript,
         stopGeneration,
       }}
     >

--- a/lib/script/ScriptProvider.tsx
+++ b/lib/script/ScriptProvider.tsx
@@ -18,6 +18,7 @@ type ScriptContextValue = {
   nodes: Descendant[];
   loading: boolean;
   submitPrompt: (prompt: string) => Promise<void>;
+  refineScript: (prompt: string) => Promise<void>;
   stopGeneration: () => void;
 };
 
@@ -67,6 +68,10 @@ export function ScriptProvider({ children }: { children: ReactNode }) {
     [connectors.llm, appendChunk],
   );
 
+  const refineScript = useCallback(async (_prompt: string) => {
+    // TODO: Implement
+  }, []);
+
   return (
     <ScriptContext.Provider
       value={{
@@ -74,6 +79,7 @@ export function ScriptProvider({ children }: { children: ReactNode }) {
         nodes,
         loading,
         submitPrompt,
+        refineScript,
         stopGeneration,
       }}
     >

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "clsx": "^2.1.1",
         "dedent": "^1.7.2",
         "dotenv": "^17.3.1",
-        "lodash": "^4.17.23",
         "lucide-react": "^0.576.0",
         "nanoid": "^5.1.6",
         "next": "16.1.6",
@@ -36,7 +35,6 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
-        "@types/lodash": "^4.17.24",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -4962,13 +4960,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.24",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
-      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "clsx": "^2.1.1",
         "dedent": "^1.7.2",
         "dotenv": "^17.3.1",
+        "lodash": "^4.17.23",
         "lucide-react": "^0.576.0",
         "nanoid": "^5.1.6",
         "next": "16.1.6",
@@ -35,6 +36,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/lodash": "^4.17.24",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -4960,6 +4962,13 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "clsx": "^2.1.1",
     "dedent": "^1.7.2",
     "dotenv": "^17.3.1",
-    "lodash": "^4.17.23",
     "lucide-react": "^0.576.0",
     "nanoid": "^5.1.6",
     "next": "16.1.6",
@@ -44,7 +43,6 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
-    "@types/lodash": "^4.17.24",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "clsx": "^2.1.1",
     "dedent": "^1.7.2",
     "dotenv": "^17.3.1",
+    "lodash": "^4.17.23",
     "lucide-react": "^0.576.0",
     "nanoid": "^5.1.6",
     "next": "16.1.6",
@@ -43,6 +44,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/lodash": "^4.17.24",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
extract BaseOpenSlopProvider to remove repeated client/constructor boilerplate from all 6 openslop providers. add createRouteHandler to eliminate duplicated validation/error-handling across api routes. consolidate OpenSlopClient fetch methods into a shared request(). remove dead refineScript stub, extract shared SubmitButton in Copilot, drop lodash dependency.