### PR TITLE
nightly cleanup 2026-03-18

### DIFF
--- a/app/components/AccessCodeInput.tsx
+++ b/app/components/AccessCodeInput.tsx
@@ -4,12 +4,11 @@ import { useRef, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 
 const CODE_LENGTH = 6;
+const EMPTY_CODE = () => Array<string>(CODE_LENGTH).fill("");
 
 export default function AccessCodeInput() {
   const router = useRouter();
-  const [values, setValues] = useState<string[]>(() =>
-    Array(CODE_LENGTH).fill(""),
-  );
+  const [values, setValues] = useState<string[]>(EMPTY_CODE);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
@@ -29,7 +28,7 @@ export default function AccessCodeInput() {
           router.push(data.redirect);
         } else {
           setError(data.error || "Invalid access code");
-          setValues(Array(CODE_LENGTH).fill(""));
+          setValues(EMPTY_CODE());
           inputRefs.current[0]?.focus();
         }
       } catch {
@@ -83,7 +82,7 @@ export default function AccessCodeInput() {
 
     if (!pasted) return;
 
-    const next = Array(CODE_LENGTH).fill("");
+    const next = EMPTY_CODE();
     for (let i = 0; i < pasted.length; i++) {
       next[i] = pasted[i];
     }

--- a/lib/providers/image/runware.ts
+++ b/lib/providers/image/runware.ts
@@ -1,6 +1,6 @@
-import { Runware } from "@runware/sdk-js";
 import type { ImageGenerateParams, ImageResult } from "@/lib/connectors/types";
 import { BaseProvider } from "../base";
+import { withRunware } from "../runware";
 
 export class RunwareImage extends BaseProvider<
   ImageGenerateParams,
@@ -14,8 +14,7 @@ export class RunwareImage extends BaseProvider<
   }
 
   async generate(params: ImageGenerateParams) {
-    const runware = new Runware({ apiKey: this.apiKey });
-    try {
+    return withRunware(this.apiKey, async (runware) => {
       const results = await runware.imageInference({
         positivePrompt: params.prompt,
         model: params.model || "runware:z-image@turbo",
@@ -34,8 +33,6 @@ export class RunwareImage extends BaseProvider<
         width: params.width || 512,
         height: params.height || 512,
       };
-    } finally {
-      runware.disconnect?.();
-    }
+    });
   }
 }

--- a/lib/providers/runware.ts
+++ b/lib/providers/runware.ts
@@ -1,0 +1,13 @@
+import { Runware } from "@runware/sdk-js";
+
+export async function withRunware<T>(
+  apiKey: string,
+  fn: (runware: InstanceType<typeof Runware>) => Promise<T>,
+): Promise<T> {
+  const runware = new Runware({ apiKey });
+  try {
+    return await fn(runware);
+  } finally {
+    runware.disconnect?.();
+  }
+}

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -1,7 +1,23 @@
-import { Runware } from "@runware/sdk-js";
-import type { VideoGenerateParams, VideoJob } from "@/lib/connectors/types";
+import type {
+  VideoGenerateParams,
+  VideoJob,
+  VideoJobStatus,
+} from "@/lib/connectors/types";
 import { BaseProvider } from "../base";
 import { awaitCompletion } from "../poll";
+import { withRunware } from "../runware";
+
+function toVideoJob(video: {
+  taskUUID: string;
+  status: string;
+  videoURL?: string;
+}): VideoJob {
+  return {
+    jobId: video.taskUUID,
+    status: video.status as VideoJobStatus,
+    resultUrl: video.videoURL,
+  };
+}
 
 export class RunwareVideo extends BaseProvider<VideoGenerateParams, VideoJob> {
   private apiKey: string;
@@ -12,8 +28,7 @@ export class RunwareVideo extends BaseProvider<VideoGenerateParams, VideoJob> {
   }
 
   async submit(params: VideoGenerateParams) {
-    const runware = new Runware({ apiKey: this.apiKey });
-    try {
+    return withRunware(this.apiKey, async (runware) => {
       const result = await runware.videoInference({
         positivePrompt: params.prompt,
         model: params.model || "bytedance:2@2",
@@ -25,18 +40,8 @@ export class RunwareVideo extends BaseProvider<VideoGenerateParams, VideoJob> {
       });
 
       const video = Array.isArray(result) ? result[0] : result;
-      return {
-        jobId: video.taskUUID,
-        status: video.status as
-          | "queued"
-          | "processing"
-          | "completed"
-          | "failed",
-        resultUrl: video.videoURL,
-      };
-    } finally {
-      runware.disconnect?.();
-    }
+      return toVideoJob(video);
+    });
   }
 
   async generate(params: VideoGenerateParams): Promise<VideoJob> {
@@ -45,8 +50,7 @@ export class RunwareVideo extends BaseProvider<VideoGenerateParams, VideoJob> {
   }
 
   async poll(jobId: string) {
-    const runware = new Runware({ apiKey: this.apiKey });
-    try {
+    return withRunware(this.apiKey, async (runware) => {
       const results = await runware.getResponse<{
         taskUUID: string;
         status: string;
@@ -55,18 +59,7 @@ export class RunwareVideo extends BaseProvider<VideoGenerateParams, VideoJob> {
 
       const video = results?.[0];
       if (!video) throw new Error("Job not found");
-
-      return {
-        jobId: video.taskUUID,
-        status: video.status as
-          | "queued"
-          | "processing"
-          | "completed"
-          | "failed",
-        resultUrl: video.videoURL,
-      };
-    } finally {
-      runware.disconnect?.();
-    }
+      return toVideoJob(video);
+    });
   }
 }


### PR DESCRIPTION
Automated nightly code cleanup

- Extract `withRunware()` lifecycle helper to eliminate repeated connect/disconnect pattern (3 occurrences → 1)
- Deduplicate Runware video job mapping into `toVideoJob()` helper
- Use existing `VideoJobStatus` type instead of inline union
- Extract `EMPTY_CODE()` factory in AccessCodeInput (3 occurrences → 1)