### PR TITLE
nightly cleanup 2026-03-22

### DIFF
--- a/app/components/canvas/__tests__/useGenerate.test.ts
+++ b/app/components/canvas/__tests__/useGenerate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, type Mock } from "vitest";
-import { generateForElement } from "../hooks/useGenerate";
+import { generateForElement } from "@/lib/generation/generateForElement";
 import * as factory from "@/lib/connectors/factory";
 
 vi.mock("@/lib/connectors/factory", () => ({

--- a/app/components/canvas/hooks/useGenerate.ts
+++ b/app/components/canvas/hooks/useGenerate.ts
@@ -4,8 +4,6 @@ import { generationQueue } from "@/lib/generation/queue";
 import type { CanvasElement } from "../types";
 import { buildGenerationJob } from "../utils/buildGenerationJob";
 
-export { generateForElement } from "@/lib/generation/generateForElement";
-
 export function useGenerate(element: CanvasElement) {
   const { connectorConfig } = useConfig();
 

--- a/app/components/canvas/hooks/useGenerateAll.ts
+++ b/app/components/canvas/hooks/useGenerateAll.ts
@@ -15,7 +15,5 @@ export function useGenerateAll(editor: Editor) {
     generationQueue.enqueueAll(jobs);
   }, [editor, connectorConfig]);
 
-  const cancelAll = useCallback(() => generationQueue.cancelAll(), []);
-
-  return { generateAll, cancelAll };
+  return { generateAll };
 }


### PR DESCRIPTION
Automated nightly code cleanup

- Remove unused cancelAll callback wrapper from useGenerateAll
- Remove barrel re-export of generateForElement from useGenerate hook
- Update test to import directly from source module

All CI checks pass (lint, format, typecheck, 149 tests).