### PR TITLE
nightly cleanup 2026-03-24

### DIFF
--- a/app/components/canvas/elements/DeleteButton.module.css
+++ b/app/components/canvas/elements/DeleteButton.module.css
@@ -9,19 +9,10 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition:
-    background-color 0.2s,
-    opacity 0.2s;
+  transition: background-color 0.2s;
   overflow: hidden;
   position: relative;
   gap: 1px;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.visible {
-  opacity: 1;
-  pointer-events: auto;
 }
 
 .icon {

--- a/app/components/canvas/elements/DeleteButton.tsx
+++ b/app/components/canvas/elements/DeleteButton.tsx
@@ -3,19 +3,13 @@ import { ReactEditor, useSlateStatic } from "slate-react";
 import type { CanvasElement } from "../types";
 import styles from "./DeleteButton.module.css";
 
-export function DeleteButton({
-  element,
-  visible,
-}: {
-  element: CanvasElement;
-  visible: boolean;
-}) {
+export function DeleteButton({ element }: { element: CanvasElement }) {
   const editor = useSlateStatic();
 
   return (
     <button
       aria-label="Delete element"
-      className={`${styles.button} ${visible ? styles.visible : ""}`}
+      className={styles.button}
       onMouseDown={(e) => {
         e.preventDefault();
         const path = ReactEditor.findPath(editor, element);

--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -1,4 +1,4 @@
-import { JSX, useCallback, useState } from "react";
+import { JSX } from "react";
 import { RenderElementProps } from "slate-react";
 import { Node } from "slate";
 import type { ProviderKey } from "@/lib/connectors/types";
@@ -31,25 +31,19 @@ export function ElementContainer({
   const config = ELEMENT_CONFIGS[element.type];
   const { model, provider } = element.customAttributes ?? {};
   const isEmpty = Node.string(element) === ZERO_WIDTH_SPACE;
-  const [isCardHovered, setIsCardHovered] = useState(false);
   const gen = useGenerate(element);
-
-  const handleMouseEnter = useCallback(() => setIsCardHovered(true), []);
-  const handleMouseLeave = useCallback(() => setIsCardHovered(false), []);
 
   return (
     <div className="flex items-stretch mb-1.5 animate-fadeInUp" {...attributes}>
       {/* Left: element card */}
       <div
-        className={`grain rounded-lg ${config.bgColor} p-2 shadow-md relative overflow-hidden flex-1 min-w-0`}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
+        className={`group/card grain rounded-lg ${config.bgColor} p-2 shadow-md relative overflow-hidden flex-1 min-w-0`}
       >
         <div
-          className="absolute top-1.5 right-1.5 z-20"
+          className="absolute top-1.5 right-1.5 z-20 opacity-0 pointer-events-none group-hover/card:opacity-100 group-hover/card:pointer-events-auto transition-opacity duration-200"
           contentEditable={false}
         >
-          <DeleteButton element={element} visible={isCardHovered} />
+          <DeleteButton element={element} />
         </div>
         <div className="relative z-10 min-w-0">
           <div

--- a/app/components/canvas/elements/OutputPreview.tsx
+++ b/app/components/canvas/elements/OutputPreview.tsx
@@ -135,17 +135,15 @@ function ResultOverlay({
   onRegenerate: () => void;
 }) {
   return (
-    <>
-      <GenerateButton
-        generating={generating}
-        queued={queued}
-        seconds={seconds}
-        onClick={onRegenerate}
-        label="Regenerate"
-        icon={<RotateCcw className="w-3 h-3" />}
-        className="absolute top-2 left-2 z-10"
-      />
-    </>
+    <GenerateButton
+      generating={generating}
+      queued={queued}
+      seconds={seconds}
+      onClick={onRegenerate}
+      label="Regenerate"
+      icon={<RotateCcw className="w-3 h-3" />}
+      className="absolute top-2 left-2 z-10"
+    />
   );
 }
 


### PR DESCRIPTION
Automated nightly code cleanup

- Replaced React hover state with CSS `group-hover` in ElementContainer (-10 lines net, eliminates unnecessary re-renders)
- Removed unnecessary React fragment in ResultOverlay (-2 lines)

All checks pass: lint, typecheck, format, and all 149 tests.