### PR TITLE
move mock assets to Vercel Blob storage and remove from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ next-env.d.ts
 # Supabase CLI temp files
 supabase/.temp/
 
+# Mock assets (served from Vercel Blob)
+public/assets/
+
 # Claude Code (user-specific files only; .agents/ and .claude/skills/ are shared)
 .claude/settings.local.json
 .claude/memory/

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ ELEVENLABS_API_KEY=       # Music + SFX generation
 CARTESIA_API_KEY=         # Text-to-speech
 ```
 
+Optional (asset storage -- required when using real providers above):
+
+```
+BLOB_READ_WRITE_TOKEN=    # Vercel Blob token for storing generated assets
+NEXT_PUBLIC_BLOB_URL=     # Vercel Blob store public URL
+```
+
 4. Run the database migrations:
 
 ```bash

--- a/lib/providers/image/mock.ts
+++ b/lib/providers/image/mock.ts
@@ -3,10 +3,17 @@ import type { ImageGenerateParams } from "@/lib/connectors/types";
 import { BaseProvider } from "../base";
 import { pickRandom } from "../mock-utils";
 
+const BLOB_BASE =
+  "https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/image/mock";
+
 const MOCK_VARIANTS: BundleResponse[] = [
-  { id: "1", provider: "mock", result: { image: "output.webp" } },
-  { id: "2", provider: "mock", result: { image: "output.jpg" } },
-  { id: "3", provider: "mock", result: { image: "output.png" } },
+  {
+    id: "1",
+    provider: "mock",
+    result: { image: `${BLOB_BASE}/1/output.webp` },
+  },
+  { id: "2", provider: "mock", result: { image: `${BLOB_BASE}/2/output.jpg` } },
+  { id: "3", provider: "mock", result: { image: `${BLOB_BASE}/3/output.png` } },
 ];
 
 export class MockImage extends BaseProvider<

--- a/lib/providers/music/mock.ts
+++ b/lib/providers/music/mock.ts
@@ -3,10 +3,13 @@ import type { MusicGenerateParams } from "@/lib/connectors/types";
 import { BaseProvider } from "../base";
 import { pickRandom } from "../mock-utils";
 
+const BLOB_BASE =
+  "https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/music/mock";
+
 const MOCK_VARIANTS: BundleResponse[] = [
-  { id: "1", provider: "mock", result: { audio: "output.mp3" } },
-  { id: "2", provider: "mock", result: { audio: "output.m4a" } },
-  { id: "3", provider: "mock", result: { audio: "output.wav" } },
+  { id: "1", provider: "mock", result: { audio: `${BLOB_BASE}/1/output.mp3` } },
+  { id: "2", provider: "mock", result: { audio: `${BLOB_BASE}/2/output.m4a` } },
+  { id: "3", provider: "mock", result: { audio: `${BLOB_BASE}/3/output.wav` } },
 ];
 
 export class MockMusic extends BaseProvider<

--- a/lib/providers/sfx/mock.ts
+++ b/lib/providers/sfx/mock.ts
@@ -3,10 +3,13 @@ import type { SFXGenerateParams } from "@/lib/connectors/types";
 import { BaseProvider } from "../base";
 import { pickRandom } from "../mock-utils";
 
+const BLOB_BASE =
+  "https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/sfx/mock";
+
 const MOCK_VARIANTS: BundleResponse[] = [
-  { id: "1", provider: "mock", result: { audio: "output.mp3" } },
-  { id: "2", provider: "mock", result: { audio: "output.wav" } },
-  { id: "3", provider: "mock", result: { audio: "output.m4a" } },
+  { id: "1", provider: "mock", result: { audio: `${BLOB_BASE}/1/output.mp3` } },
+  { id: "2", provider: "mock", result: { audio: `${BLOB_BASE}/2/output.wav` } },
+  { id: "3", provider: "mock", result: { audio: `${BLOB_BASE}/3/output.m4a` } },
 ];
 
 export class MockSFX extends BaseProvider<SFXGenerateParams, BundleResponse> {

--- a/lib/providers/tts/mock.ts
+++ b/lib/providers/tts/mock.ts
@@ -7,36 +7,57 @@ import type {
 import { BaseProvider } from "../base";
 import { pickRandom } from "../mock-utils";
 
+const BLOB_BASE =
+  "https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/tts/mock";
+
 const MOCK_VARIANTS: BundleResponse[] = [
   {
     id: "1",
     provider: "mock",
-    result: { audio: "output.mp3", timestamps: "timestamps.json" },
+    result: {
+      audio: `${BLOB_BASE}/1/output.mp3`,
+      timestamps: `${BLOB_BASE}/1/timestamps.json`,
+    },
   },
   {
     id: "2",
     provider: "mock",
-    result: { audio: "output.m4a", timestamps: "timestamps.json" },
+    result: {
+      audio: `${BLOB_BASE}/2/output.m4a`,
+      timestamps: `${BLOB_BASE}/2/timestamps.json`,
+    },
   },
   {
     id: "3",
     provider: "mock",
-    result: { audio: "output.wav", timestamps: "timestamps.json" },
+    result: {
+      audio: `${BLOB_BASE}/3/output.wav`,
+      timestamps: `${BLOB_BASE}/3/timestamps.json`,
+    },
   },
   {
     id: "4",
     provider: "mock",
-    result: { audio: "output.mp3", timestamps: "timestamps.json" },
+    result: {
+      audio: `${BLOB_BASE}/4/output.mp3`,
+      timestamps: `${BLOB_BASE}/4/timestamps.json`,
+    },
   },
   {
     id: "5",
     provider: "mock",
-    result: { audio: "output.wav", timestamps: "timestamps.json" },
+    result: {
+      audio: `${BLOB_BASE}/5/output.wav`,
+      timestamps: `${BLOB_BASE}/5/timestamps.json`,
+    },
   },
   {
     id: "6",
     provider: "mock",
-    result: { audio: "output.m4a", timestamps: "timestamps.json" },
+    result: {
+      audio: `${BLOB_BASE}/6/output.m4a`,
+      timestamps: `${BLOB_BASE}/6/timestamps.json`,
+    },
   },
 ];
 


### PR DESCRIPTION
Mock assets (image, music, sfx, tts) are now served from Vercel Blob storage instead of the local public/ directory. This removes ~27MB of binary files from the repo. Video mock is unchanged (placeholder only).