### PR TITLE
nightly cleanup 2026-04-03

### DIFF
--- a/lib/api/__tests__/route-handler.test.ts
+++ b/lib/api/__tests__/route-handler.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { createRouteHandler, jsonResponse } from "../route-handler";
+
+vi.mock("../logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn() },
+}));
+
+function makeRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/test", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const models = { "model-a": "slug-a", "model-b": "slug-b" };
+
+function makeHandler(overrides?: {
+  extraValidation?: (body: Record<string, unknown>) => Response | null;
+  handle?: (
+    provider: string,
+    body: Record<string, unknown>,
+  ) => Promise<Response>;
+}) {
+  return createRouteHandler<string>({
+    models,
+    getProvider: () => "test-provider",
+    label: "TestRoute",
+    ...overrides,
+    handle:
+      overrides?.handle ??
+      (async (_provider, body) =>
+        jsonResponse({ ok: true, prompt: body.prompt })),
+  });
+}
+
+describe("createRouteHandler", () => {
+  it("returns 400 when prompt is missing", async () => {
+    const handler = makeHandler();
+    const res = await handler(makeRequest({}));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("prompt is required");
+  });
+
+  it("returns 400 when prompt is not a string", async () => {
+    const handler = makeHandler();
+    const res = await handler(makeRequest({ prompt: 123 }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("prompt is required");
+  });
+
+  it("returns 400 for invalid model", async () => {
+    const handler = makeHandler();
+    const res = await handler(
+      makeRequest({ prompt: "hello", model: "unknown" }),
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("Invalid model");
+    expect(json.error).toContain("model-a");
+  });
+
+  it("maps model name to slug and passes to handle", async () => {
+    const handle = vi.fn(async () => jsonResponse({ done: true }));
+    const handler = makeHandler({ handle });
+    await handler(makeRequest({ prompt: "hello", model: "model-a" }));
+
+    expect(handle).toHaveBeenCalledWith(
+      "test-provider",
+      expect.objectContaining({ prompt: "hello", model: "slug-a" }),
+    );
+  });
+
+  it("returns successful response when valid", async () => {
+    const handler = makeHandler();
+    const res = await handler(makeRequest({ prompt: "hello" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ ok: true, prompt: "hello" });
+  });
+
+  it("calls extraValidation and returns its response on failure", async () => {
+    const handler = makeHandler({
+      extraValidation: () =>
+        Response.json({ error: "custom" }, { status: 422 }),
+    });
+    const res = await handler(makeRequest({ prompt: "hello" }));
+    expect(res.status).toBe(422);
+  });
+
+  it("proceeds when extraValidation returns null", async () => {
+    const handler = makeHandler({ extraValidation: () => null });
+    const res = await handler(makeRequest({ prompt: "hello" }));
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 500 when handle throws", async () => {
+    const handler = makeHandler({
+      handle: async () => {
+        throw new Error("boom");
+      },
+    });
+    const res = await handler(makeRequest({ prompt: "hello" }));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("TestRoute failed");
+  });
+});
+
+describe("jsonResponse", () => {
+  it("returns a JSON NextResponse", async () => {
+    const res = jsonResponse({ foo: "bar" });
+    const json = await res.json();
+    expect(json).toEqual({ foo: "bar" });
+  });
+});

--- a/lib/components/Waveform.tsx
+++ b/lib/components/Waveform.tsx
@@ -168,7 +168,7 @@ export function Waveform({
         drawRef.current();
         onReady?.();
       })
-      .catch(() => {});
+      .catch((e) => console.error("Failed to decode audio:", e));
     return () => {
       cancelled = true;
       ac.close();

--- a/lib/config/__tests__/connectorUtils.test.ts
+++ b/lib/config/__tests__/connectorUtils.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { ConnectorConfig } from "@/lib/connectors/types";
+import type { ConnectorRegistry } from "../ConfigProvider";
+import { getDefaultConnector } from "../connectorUtils";
+
+function makeConfig(overrides?: Partial<ConnectorConfig>): ConnectorConfig {
+  return {
+    defaultModel: "m1",
+    models: ["m1"],
+    isDefault: false,
+    ...overrides,
+  };
+}
+
+function makeRegistry(
+  imageProviders: Record<string, ConnectorConfig>,
+): ConnectorRegistry {
+  const empty = {} as Record<string, ConnectorConfig>;
+  return {
+    llm: empty,
+    music: empty,
+    sfx: empty,
+    image: imageProviders,
+    tts: empty,
+    video: empty,
+  } as ConnectorRegistry;
+}
+
+describe("getDefaultConnector", () => {
+  it("returns the provider marked as default", () => {
+    const registry = makeRegistry({
+      providerA: makeConfig({ isDefault: false }),
+      providerB: makeConfig({ isDefault: true }),
+    });
+
+    const result = getDefaultConnector(registry, "image");
+    expect(result.provider).toBe("providerB");
+    expect(result.config.isDefault).toBe(true);
+  });
+
+  it("falls back to the first provider when none is marked default", () => {
+    const registry = makeRegistry({
+      providerA: makeConfig({ isDefault: false }),
+      providerB: makeConfig({ isDefault: false }),
+    });
+
+    const result = getDefaultConnector(registry, "image");
+    expect(result.provider).toBe("providerA");
+  });
+
+  it("returns the only provider when there is exactly one", () => {
+    const registry = makeRegistry({
+      solo: makeConfig({ isDefault: true }),
+    });
+
+    const result = getDefaultConnector(registry, "image");
+    expect(result.provider).toBe("solo");
+    expect(result.config.defaultModel).toBe("m1");
+  });
+
+  it("returns the first default when multiple are marked default", () => {
+    const registry = makeRegistry({
+      first: makeConfig({ isDefault: true, defaultModel: "x" }),
+      second: makeConfig({ isDefault: true, defaultModel: "y" }),
+    });
+
+    const result = getDefaultConnector(registry, "image");
+    expect(result.provider).toBe("first");
+    expect(result.config.defaultModel).toBe("x");
+  });
+});

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -188,6 +188,7 @@ class GenerationQueue {
       })
       .catch((err) => {
         if (controller.signal.aborted) return;
+        console.error(`Generation failed for element ${elementId}:`, err);
         this.update(elementId, {
           status: "idle",
           seconds: 0,

--- a/lib/script/ScriptProvider.tsx
+++ b/lib/script/ScriptProvider.tsx
@@ -76,7 +76,7 @@ export function ScriptProvider({ children }: { children: ReactNode }) {
   );
 
   const refineScript = useCallback(async (_prompt: string) => {
-    // TODO: Implement
+    console.warn("refineScript is not implemented yet");
   }, []);
 
   const value = useMemo<ScriptContextValue>(


### PR DESCRIPTION
Automated nightly code cleanup and documentation update

**Bug fixes:**
- Waveform: log audio decode errors instead of silently swallowing them
- Generation queue: log errors server-side before setting error state
- ScriptProvider: warn when unimplemented refineScript is called

**Tests:**
- Added 9 tests for route-handler (validation, model mapping, error handling)
- Added 4 tests for connectorUtils (default provider selection, fallbacks)
- Total: 213 tests across 32 files, all passing