### PR TITLE
nightly cleanup 2026-04-06

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ public/assets/
 .claude/memory/
 .claude/plans/
 .gstack/
+.remotion/

--- a/app/components/AuthForm.tsx
+++ b/app/components/AuthForm.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import OnboardingCard from "./OnboardingCard";
+import EmailSentCard from "./EmailSentCard";
+import GradientButton from "./GradientButton";
+import OrDivider from "./OrDivider";
+import GoogleOAuthButton from "./GoogleOAuthButton";
+import authStyles from "@/app/styles/auth.module.css";
+
+interface AuthFormProps {
+  heading: string;
+  subtitle: string;
+  submitLabel: string;
+  sentKind?: string;
+  shouldCreateUser?: boolean;
+  otpData?: Record<string, unknown>;
+  footer?: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+export default function AuthForm({
+  heading,
+  subtitle,
+  submitLabel,
+  sentKind = "login",
+  shouldCreateUser,
+  otpData,
+  footer,
+  children,
+}: AuthFormProps) {
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState("");
+
+  const supabase = createClient();
+
+  const handleMagicLink = async (e?: React.FormEvent) => {
+    e?.preventDefault();
+    setLoading(true);
+    setError("");
+
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
+        ...(shouldCreateUser === false && { shouldCreateUser: false }),
+        ...(otpData && { data: otpData }),
+      },
+    });
+
+    if (error) {
+      setError(error.message);
+    } else {
+      setSent(true);
+    }
+    setLoading(false);
+  };
+
+  const handleGoogleAuth = async () => {
+    await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+  };
+
+  if (sent) {
+    return (
+      <EmailSentCard
+        email={email}
+        subtitle={`We sent a ${sentKind} link to ${email}`}
+        resendLabel={`Send another ${sentKind} link`}
+        loading={loading}
+        error={error}
+        onResend={() => handleMagicLink()}
+        onEditEmail={() => setSent(false)}
+      />
+    );
+  }
+
+  return (
+    <OnboardingCard heading={heading} subtitle={subtitle} footer={footer}>
+      <form onSubmit={handleMagicLink} className="w-full flex flex-col gap-3">
+        {children}
+        <input
+          type="email"
+          name="email"
+          autoComplete="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className={authStyles.input}
+          required
+        />
+        <GradientButton type="submit" disabled={loading} className="mt-1">
+          {loading ? "Sending\u2026" : submitLabel}
+        </GradientButton>
+      </form>
+
+      {error && (
+        <p aria-live="polite" className="text-red-400 text-sm text-center">
+          {error}
+        </p>
+      )}
+
+      <OrDivider />
+      <GoogleOAuthButton onClick={handleGoogleAuth} />
+    </OnboardingCard>
+  );
+}

--- a/app/components/OrbLoader.tsx
+++ b/app/components/OrbLoader.tsx
@@ -11,9 +11,6 @@ export default function OrbLoader() {
               <polygon points="25,25 75,25 50,75" fill="white" />
               <polygon points="50,25 75,75 25,75" fill="white" />
               <polygon points="35,35 65,35 50,65" fill="white" />
-              <polygon points="35,35 65,35 50,65" fill="white" />
-              <polygon points="35,35 65,35 50,65" fill="white" />
-              <polygon points="35,35 65,35 50,65" fill="white" />
             </mask>
           </defs>
         </svg>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,90 +1,12 @@
-"use client";
-
-import { useState } from "react";
-import { createClient } from "@/lib/supabase/client";
-import OnboardingCard from "../components/OnboardingCard";
-import EmailSentCard from "../components/EmailSentCard";
-import GradientButton from "../components/GradientButton";
-import OrDivider from "../components/OrDivider";
-import GoogleOAuthButton from "../components/GoogleOAuthButton";
-import authStyles from "@/app/styles/auth.module.css";
+import AuthForm from "../components/AuthForm";
 
 export default function LoginPage() {
-  const [email, setEmail] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [sent, setSent] = useState(false);
-  const [error, setError] = useState("");
-
-  const supabase = createClient();
-
-  const handleMagicLink = async (e?: React.FormEvent) => {
-    e?.preventDefault();
-    setLoading(true);
-    setError("");
-
-    const { error } = await supabase.auth.signInWithOtp({
-      email,
-      options: {
-        emailRedirectTo: `${window.location.origin}/auth/callback`,
-        shouldCreateUser: false,
-      },
-    });
-
-    if (error) {
-      setError(error.message);
-    } else {
-      setSent(true);
-    }
-    setLoading(false);
-  };
-
-  const handleGoogleLogin = async () => {
-    await supabase.auth.signInWithOAuth({
-      provider: "google",
-      options: {
-        redirectTo: `${window.location.origin}/auth/callback`,
-      },
-    });
-  };
-
-  if (sent) {
-    return (
-      <EmailSentCard
-        email={email}
-        loading={loading}
-        error={error}
-        onResend={() => handleMagicLink()}
-        onEditEmail={() => setSent(false)}
-      />
-    );
-  }
-
   return (
-    <OnboardingCard heading="Login" subtitle="Welcome back to OpenSlop">
-      <form onSubmit={handleMagicLink} className="w-full flex flex-col gap-3">
-        <input
-          type="email"
-          name="email"
-          autoComplete="email"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          className={authStyles.input}
-          required
-        />
-        <GradientButton type="submit" disabled={loading} className="mt-1">
-          {loading ? "Sending\u2026" : "Send login link"}
-        </GradientButton>
-      </form>
-
-      {error && (
-        <p aria-live="polite" className="text-red-400 text-sm text-center">
-          {error}
-        </p>
-      )}
-
-      <OrDivider />
-      <GoogleOAuthButton onClick={handleGoogleLogin} />
-    </OnboardingCard>
+    <AuthForm
+      heading="Login"
+      subtitle="Welcome back to OpenSlop"
+      submitLabel="Send login link"
+      shouldCreateUser={false}
+    />
   );
 }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,72 +1,20 @@
 "use client";
 
 import { useState } from "react";
-import { createClient } from "@/lib/supabase/client";
 import Link from "next/link";
-import OnboardingCard from "../components/OnboardingCard";
-import EmailSentCard from "../components/EmailSentCard";
-import GradientButton from "../components/GradientButton";
-import OrDivider from "../components/OrDivider";
-import GoogleOAuthButton from "../components/GoogleOAuthButton";
+import AuthForm from "../components/AuthForm";
 import authStyles from "@/app/styles/auth.module.css";
 
 export default function SignupPage() {
   const [fullName, setFullName] = useState("");
-  const [email, setEmail] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [sent, setSent] = useState(false);
-  const [error, setError] = useState("");
-
-  const supabase = createClient();
-
-  const handleMagicLink = async (e?: React.FormEvent) => {
-    e?.preventDefault();
-    setLoading(true);
-    setError("");
-
-    const { error } = await supabase.auth.signInWithOtp({
-      email,
-      options: {
-        emailRedirectTo: `${window.location.origin}/auth/callback`,
-        data: { full_name: fullName },
-      },
-    });
-
-    if (error) {
-      setError(error.message);
-    } else {
-      setSent(true);
-    }
-    setLoading(false);
-  };
-
-  const handleGoogleSignup = async () => {
-    await supabase.auth.signInWithOAuth({
-      provider: "google",
-      options: {
-        redirectTo: `${window.location.origin}/auth/callback`,
-      },
-    });
-  };
-
-  if (sent) {
-    return (
-      <EmailSentCard
-        email={email}
-        subtitle={`We sent a sign-up link to ${email}`}
-        resendLabel="Send another sign-up link"
-        loading={loading}
-        error={error}
-        onResend={() => handleMagicLink()}
-        onEditEmail={() => setSent(false)}
-      />
-    );
-  }
 
   return (
-    <OnboardingCard
+    <AuthForm
       heading="Sign up"
       subtitle="Create your account to start using OpenSlop"
+      submitLabel="Send signup link"
+      sentKind="sign-up"
+      otpData={{ full_name: fullName }}
       footer={
         <>
           Already have an account?{" "}
@@ -79,40 +27,16 @@ export default function SignupPage() {
         </>
       }
     >
-      <form onSubmit={handleMagicLink} className="w-full flex flex-col gap-3">
-        <input
-          type="text"
-          name="fullName"
-          autoComplete="name"
-          placeholder="Full Name"
-          value={fullName}
-          onChange={(e) => setFullName(e.target.value)}
-          className={authStyles.input}
-          required
-        />
-        <input
-          type="email"
-          name="email"
-          autoComplete="email"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          className={authStyles.input}
-          required
-        />
-        <GradientButton type="submit" disabled={loading} className="mt-1">
-          {loading ? "Sending\u2026" : "Send signup link"}
-        </GradientButton>
-      </form>
-
-      {error && (
-        <p aria-live="polite" className="text-red-400 text-sm text-center">
-          {error}
-        </p>
-      )}
-
-      <OrDivider />
-      <GoogleOAuthButton onClick={handleGoogleSignup} />
-    </OnboardingCard>
+      <input
+        type="text"
+        name="fullName"
+        autoComplete="name"
+        placeholder="Full Name"
+        value={fullName}
+        onChange={(e) => setFullName(e.target.value)}
+        className={authStyles.input}
+        required
+      />
+    </AuthForm>
   );
 }

--- a/lib/api/__tests__/asset-bundle.test.ts
+++ b/lib/api/__tests__/asset-bundle.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { AssetBundle } from "../asset-bundle";
+import type { BundleResponse } from "../asset-bundle";
+
+describe("AssetBundle", () => {
+  describe("buildUrl", () => {
+    beforeEach(() => {
+      AssetBundle.baseUrl = "https://blob.example.com";
+    });
+
+    it("constructs url from type, provider, and id", () => {
+      const url = AssetBundle.buildUrl("image", "runware", "abc123");
+      expect(url).toBe("https://blob.example.com/assets/image/runware/abc123");
+    });
+
+    it("handles empty baseUrl", () => {
+      AssetBundle.baseUrl = "";
+      const url = AssetBundle.buildUrl("video", "mock", "xyz");
+      expect(url).toBe("/assets/video/mock/xyz");
+    });
+  });
+
+  describe("resolve", () => {
+    it("resolves relative path against bundle url", () => {
+      const bundle = new AssetBundle(
+        "https://blob.example.com/assets/image/runware/abc",
+        {
+          version: 1,
+          type: "image",
+          createdAt: "",
+          result: { image: "output.png" },
+        },
+      );
+      expect(bundle.resolve("image")).toBe(
+        "https://blob.example.com/assets/image/runware/abc/output.png",
+      );
+    });
+
+    it("returns absolute urls as-is", () => {
+      const bundle = new AssetBundle(
+        "https://blob.example.com/assets/video/mock/xyz",
+        {
+          version: 1,
+          type: "video",
+          createdAt: "",
+          result: { video: "https://cdn.example.com/video.mp4" },
+        },
+      );
+      expect(bundle.resolve("video")).toBe("https://cdn.example.com/video.mp4");
+    });
+
+    it("throws for unknown key", () => {
+      const bundle = new AssetBundle("https://blob.example.com/x", {
+        version: 1,
+        type: "image",
+        createdAt: "",
+        result: {},
+      });
+      expect(() => bundle.resolve("missing")).toThrow('No file "missing"');
+    });
+  });
+
+  describe("fromResponse", () => {
+    beforeEach(() => {
+      AssetBundle.baseUrl = "https://blob.example.com";
+    });
+
+    it("creates bundle from a BundleResponse", () => {
+      const response: BundleResponse = {
+        id: "abc",
+        provider: "runware",
+        result: { image: "output.png" },
+      };
+      const bundle = AssetBundle.fromResponse("image", response);
+      expect(bundle.resolve("image")).toBe(
+        "https://blob.example.com/assets/image/runware/abc/output.png",
+      );
+      expect(bundle.manifest.type).toBe("image");
+      expect(bundle.manifest.version).toBe(1);
+    });
+  });
+
+  describe("fetchJson", () => {
+    beforeEach(() => {
+      AssetBundle.baseUrl = "https://blob.example.com";
+    });
+
+    it("fetches and parses JSON from resolved url", async () => {
+      const payload = { words: [{ start: 0, end: 1, text: "hello" }] };
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          json: () => Promise.resolve(payload),
+        }),
+      );
+
+      const bundle = new AssetBundle(
+        "https://blob.example.com/assets/tts/cartesia/abc",
+        {
+          version: 1,
+          type: "tts",
+          createdAt: "",
+          result: { timestamps: "timestamps.json" },
+        },
+      );
+
+      const result = await bundle.fetchJson("timestamps");
+      expect(result).toEqual(payload);
+      expect(fetch).toHaveBeenCalledWith(
+        "https://blob.example.com/assets/tts/cartesia/abc/timestamps.json",
+      );
+
+      vi.unstubAllGlobals();
+    });
+  });
+
+  describe("fromId", () => {
+    beforeEach(() => {
+      AssetBundle.baseUrl = "https://blob.example.com";
+    });
+
+    it("fetches manifest and creates bundle", async () => {
+      const manifest = {
+        version: 1,
+        type: "image",
+        createdAt: "2024-01-01",
+        result: { image: "output.png" },
+      };
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          json: () => Promise.resolve(manifest),
+        }),
+      );
+
+      const bundle = await AssetBundle.fromId("image", "runware", "abc");
+      expect(bundle.manifest).toEqual(manifest);
+      expect(bundle.resolve("image")).toBe(
+        "https://blob.example.com/assets/image/runware/abc/output.png",
+      );
+      expect(fetch).toHaveBeenCalledWith(
+        "https://blob.example.com/assets/image/runware/abc/manifest.json",
+      );
+
+      vi.unstubAllGlobals();
+    });
+  });
+
+  describe("upload", () => {
+    const putMock = vi.fn();
+
+    beforeEach(() => {
+      AssetBundle.baseUrl = "https://blob.example.com";
+      putMock.mockReset().mockResolvedValue({ url: "https://blob/stored" });
+      vi.doMock("@vercel/blob", () => ({
+        put: (...args: unknown[]) => putMock(...args),
+      }));
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("uploads files and returns BundleResponse", async () => {
+      const result = await AssetBundle.upload("image", "runware", [
+        {
+          key: "image",
+          filename: "output.png",
+          data: Buffer.from("fake-image"),
+          contentType: "image/png",
+        },
+      ]);
+
+      expect(result.provider).toBe("runware");
+      expect(result.result.image).toBe("output.png");
+      expect(result.id).toBeTruthy();
+      // 2 calls: one for the file, one for manifest.json
+      expect(putMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("stores external urls directly in result without uploading", async () => {
+      const result = await AssetBundle.upload("video", "runware", [
+        { key: "video", url: "https://cdn.example.com/video.mp4" },
+      ]);
+
+      expect(result.result.video).toBe("https://cdn.example.com/video.mp4");
+      // Only manifest upload, no file upload for external urls
+      expect(putMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/lib/clients/__tests__/openslop.test.ts
+++ b/lib/clients/__tests__/openslop.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { OpenSlopClient } from "../openslop";
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      getSession: () =>
+        Promise.resolve({
+          data: { session: { access_token: "test-token" } },
+        }),
+    },
+  }),
+}));
+
+describe("OpenSlopClient", () => {
+  let client: OpenSlopClient;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new OpenSlopClient("https://api.test.com");
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  describe("post", () => {
+    it("sends POST with auth header and JSON body", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ result: "ok" }),
+      });
+
+      const result = await client.post("/api/v1/image", { prompt: "a cat" });
+
+      expect(result).toEqual({ result: "ok" });
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.test.com/api/v1/image",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer test-token",
+          },
+          body: JSON.stringify({ prompt: "a cat" }),
+        },
+      );
+    });
+  });
+
+  describe("get", () => {
+    it("sends GET with query params", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ voices: [] }),
+      });
+
+      await client.get("/api/v1/tts/voices", { gender: "female" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.test.com/api/v1/tts/voices?gender=female",
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("omits query string when no params given", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      });
+
+      await client.get("/api/v1/tts/voices");
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.test.com/api/v1/tts/voices",
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("filters out undefined param values", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await client.get("/api/v1/tts/voices", {
+        gender: "male",
+        age: undefined as unknown as string,
+      });
+
+      const url = fetchMock.mock.calls[0][0] as string;
+      expect(url).toContain("gender=male");
+      expect(url).not.toContain("age");
+    });
+  });
+
+  describe("postStream", () => {
+    it("returns the raw response for streaming", async () => {
+      const mockResponse = { ok: true, body: "stream" };
+      fetchMock.mockResolvedValue(mockResponse);
+
+      const result = await client.postStream("/api/v1/llm", { prompt: "hi" });
+      expect(result).toBe(mockResponse);
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws with error message from JSON response", async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        json: () => Promise.resolve({ error: "prompt is required" }),
+      });
+
+      await expect(client.post("/api/v1/image", {})).rejects.toThrow(
+        "prompt is required",
+      );
+    });
+
+    it("falls back to status text when response is not JSON", async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        json: () => Promise.reject(new Error("not json")),
+      });
+
+      await expect(client.post("/api/v1/image", {})).rejects.toThrow(
+        "500 Internal Server Error",
+      );
+    });
+
+    it("falls back to status text when JSON has no error field", async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+        json: () => Promise.resolve({ message: "no access" }),
+      });
+
+      await expect(client.post("/api/v1/image", {})).rejects.toThrow(
+        "403 Forbidden",
+      );
+    });
+  });
+
+  describe("auth", () => {
+    it("omits authorization header when no session", async () => {
+      vi.resetModules();
+
+      vi.doMock("@/lib/supabase/client", () => ({
+        createClient: () => ({
+          auth: {
+            getSession: () => Promise.resolve({ data: { session: null } }),
+          },
+        }),
+      }));
+
+      const { OpenSlopClient: FreshClient } = await import("../openslop");
+      const noAuthClient = new FreshClient("https://api.test.com");
+
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await noAuthClient.post("/test", {});
+
+      const headers = fetchMock.mock.calls[0][1].headers as Record<
+        string,
+        string
+      >;
+      expect(headers.authorization).toBeUndefined();
+      expect(headers["content-type"]).toBe("application/json");
+    });
+  });
+});

--- a/lib/providers/__tests__/poll.test.ts
+++ b/lib/providers/__tests__/poll.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { awaitCompletion } from "../poll";
+import type { VideoJob, VideoJobStatus } from "@/lib/connectors/types";
+
+function makeJob(status: VideoJobStatus, url?: string): VideoJob {
+  return { jobId: "j1", status, url };
+}
+
+describe("awaitCompletion", () => {
+  it("returns immediately when job is already completed", async () => {
+    const poll = vi
+      .fn()
+      .mockResolvedValue(makeJob("completed", "https://x.com/v.mp4"));
+    const result = await awaitCompletion(poll, "j1");
+    expect(result.status).toBe("completed");
+    expect(result.url).toBe("https://x.com/v.mp4");
+    expect(poll).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns immediately when job has failed", async () => {
+    const poll = vi.fn().mockResolvedValue(makeJob("failed"));
+    const result = await awaitCompletion(poll, "j1");
+    expect(result.status).toBe("failed");
+    expect(poll).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls until job completes", async () => {
+    const poll = vi
+      .fn()
+      .mockResolvedValueOnce(makeJob("processing"))
+      .mockResolvedValueOnce(makeJob("processing"))
+      .mockResolvedValueOnce(makeJob("completed", "https://x.com/done.mp4"));
+
+    const result = await awaitCompletion(poll, "j1", 10, 5000);
+    expect(result.status).toBe("completed");
+    expect(poll).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws on timeout", async () => {
+    const poll = vi.fn().mockResolvedValue(makeJob("processing"));
+    await expect(awaitCompletion(poll, "j1", 10, 50)).rejects.toThrow(
+      "timed out",
+    );
+  });
+
+  it("passes jobId to pollFn", async () => {
+    const poll = vi.fn().mockResolvedValue(makeJob("completed"));
+    await awaitCompletion(poll, "my-job-id");
+    expect(poll).toHaveBeenCalledWith("my-job-id");
+  });
+
+  it("propagates pollFn errors", async () => {
+    const poll = vi.fn().mockRejectedValue(new Error("network error"));
+    await expect(awaitCompletion(poll, "j1")).rejects.toThrow("network error");
+  });
+});

--- a/lib/providers/__tests__/stream.test.ts
+++ b/lib/providers/__tests__/stream.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { streamToBuffer } from "../stream";
+
+function makeStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+describe("streamToBuffer", () => {
+  it("converts a single chunk stream to ArrayBuffer", async () => {
+    const data = new Uint8Array([1, 2, 3, 4]);
+    const buffer = await streamToBuffer(makeStream([data]));
+    expect(new Uint8Array(buffer)).toEqual(data);
+  });
+
+  it("concatenates multiple chunks", async () => {
+    const chunks = [
+      new Uint8Array([1, 2]),
+      new Uint8Array([3, 4, 5]),
+      new Uint8Array([6]),
+    ];
+    const buffer = await streamToBuffer(makeStream(chunks));
+    expect(new Uint8Array(buffer)).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6]));
+  });
+
+  it("returns empty buffer for empty stream", async () => {
+    const buffer = await streamToBuffer(makeStream([]));
+    expect(buffer.byteLength).toBe(0);
+  });
+
+  it("handles large chunks correctly", async () => {
+    const big = new Uint8Array(10_000).fill(42);
+    const buffer = await streamToBuffer(makeStream([big]));
+    expect(new Uint8Array(buffer).every((b) => b === 42)).toBe(true);
+    expect(buffer.byteLength).toBe(10_000);
+  });
+});


### PR DESCRIPTION
Automated nightly code cleanup and documentation update

**Changes:**
- Extract shared `AuthForm` component from login/signup pages (removes ~160 lines of duplication)
- Remove duplicate SVG polygon elements in `OrbLoader`
- Add `.remotion/` build output to `.gitignore`
- Add test suites for asset-bundle upload, openslop client, poll provider, and stream provider (all 242 tests passing)