### PR TITLE
nightly cleanup 2026-04-10

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,18 +112,20 @@ Open [http://localhost:3000](http://localhost:3000) and you should see the app.
 openslop/
 |-- app/                    # Next.js App Router pages and layouts
 |   |-- api/
+|   |   |-- render/         # Remotion video rendering endpoint (SSE progress)
 |   |   |-- v1/             # REST API (image, llm, music, sfx, tts, video)
 |   |   |-- validate-code/  # Access code validation
 |   |-- auth/               # OAuth callback handler
 |   |-- components/         # App-specific React components
 |   |   |-- canvas/         # Slate-based editor canvas (drag-and-drop, elements, plugins)
+|   |   |-- video/          # Video preview, player, and rendering UI
 |   |-- login/              # Login page
 |   |-- signup/             # Signup page
 |   |-- page.tsx            # Home / editor
 |   |-- layout.tsx          # Root layout
 |-- components/ui/          # shadcn/ui primitives
 |-- lib/                    # Shared libraries
-|   |-- api/                # Route handler helpers, logger, response utils
+|   |-- api/                # Route handler helpers, logger, SSE, response utils
 |   |-- clients/            # HTTP client for the OpenSlop API
 |   |-- components/         # Shared UI components (Waveform, etc.)
 |   |-- config/             # Global connector configuration (React context)
@@ -133,7 +135,9 @@ openslop/
 |   |-- script/             # Script context provider
 |   |-- supabase/           # Supabase client helpers (browser, server, middleware)
 |   |-- user/               # User context provider
+|   |-- video/              # Video layout engine (scene builder, element resolution)
 |   |-- utils.ts            # General utilities (cn, etc.)
+|-- remotion/               # Remotion video compositions
 |-- supabase/migrations/    # Database migrations
 |-- proxy.ts                # Auth session refresh + route protection
 ```

--- a/lib/api/__tests__/sse.test.ts
+++ b/lib/api/__tests__/sse.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { formatSSE, createSSEResponse, readSSE } from "../sse";
+
+describe("formatSSE", () => {
+  it("serializes data as a JSON SSE line", () => {
+    expect(formatSSE({ type: "done", url: "/v.mp4" })).toBe(
+      'data: {"type":"done","url":"/v.mp4"}\n\n',
+    );
+  });
+
+  it("handles string data", () => {
+    expect(formatSSE("hello")).toBe('data: "hello"\n\n');
+  });
+
+  it("handles numeric data", () => {
+    expect(formatSSE(42)).toBe("data: 42\n\n");
+  });
+
+  it("handles null", () => {
+    expect(formatSSE(null)).toBe("data: null\n\n");
+  });
+});
+
+describe("createSSEResponse", () => {
+  it("returns a Response with SSE headers", () => {
+    const response = createSSEResponse(async () => {});
+    expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+    expect(response.headers.get("Cache-Control")).toBe("no-cache");
+    expect(response.headers.get("Connection")).toBe("keep-alive");
+  });
+
+  it("has a readable body", () => {
+    const response = createSSEResponse(async () => {});
+    expect(response.body).toBeTruthy();
+  });
+
+  it("streams messages sent via the send callback", async () => {
+    const response = createSSEResponse(async (send) => {
+      await send({ phase: "bundling", progress: 0.5 });
+      await send({ phase: "rendering", progress: 1.0 });
+    });
+
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("expected readable body");
+
+    const decoder = new TextDecoder();
+    let text = "";
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+    }
+
+    expect(text).toContain('data: {"phase":"bundling","progress":0.5}\n\n');
+    expect(text).toContain('data: {"phase":"rendering","progress":1}\n\n');
+  });
+});
+
+describe("readSSE", () => {
+  function makeStream(chunks: string[]): ReadableStream {
+    const encoder = new TextEncoder();
+    return new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk));
+        }
+        controller.close();
+      },
+    });
+  }
+
+  it("parses complete SSE messages", async () => {
+    const stream = makeStream([
+      'data: {"type":"phase","progress":0.5}\n\n',
+      'data: {"type":"done","url":"/v.mp4"}\n\n',
+    ]);
+    const messages: unknown[] = [];
+    for await (const msg of readSSE(stream)) {
+      messages.push(msg);
+    }
+    expect(messages).toEqual([
+      { type: "phase", progress: 0.5 },
+      { type: "done", url: "/v.mp4" },
+    ]);
+  });
+
+  it("handles messages split across chunks", async () => {
+    const stream = makeStream([
+      'data: {"type":',
+      '"phase","pr',
+      'ogress":1}\n\ndata: {"type":"done"}\n\n',
+    ]);
+    const messages: unknown[] = [];
+    for await (const msg of readSSE(stream)) {
+      messages.push(msg);
+    }
+    expect(messages).toEqual([
+      { type: "phase", progress: 1 },
+      { type: "done" },
+    ]);
+  });
+
+  it("skips malformed JSON", async () => {
+    const stream = makeStream([
+      "data: not-json\n\n",
+      'data: {"valid":true}\n\n',
+    ]);
+    const messages: unknown[] = [];
+    for await (const msg of readSSE(stream)) {
+      messages.push(msg);
+    }
+    expect(messages).toEqual([{ valid: true }]);
+  });
+
+  it("skips event blocks that do not start with data:", async () => {
+    const stream = makeStream(["event: update\n\n", 'data: {"ok":true}\n\n']);
+    const messages: unknown[] = [];
+    for await (const msg of readSSE(stream)) {
+      messages.push(msg);
+    }
+    expect(messages).toEqual([{ ok: true }]);
+  });
+
+  it("returns nothing for an empty stream", async () => {
+    const stream = makeStream([]);
+    const messages: unknown[] = [];
+    for await (const msg of readSSE(stream)) {
+      messages.push(msg);
+    }
+    expect(messages).toEqual([]);
+  });
+
+  it("handles multiple messages in a single chunk", async () => {
+    const stream = makeStream([
+      'data: {"a":1}\n\ndata: {"b":2}\n\ndata: {"c":3}\n\n',
+    ]);
+    const messages: unknown[] = [];
+    for await (const msg of readSSE(stream)) {
+      messages.push(msg);
+    }
+    expect(messages).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }]);
+  });
+
+  it("ignores trailing incomplete message without double newline", async () => {
+    const stream = makeStream([
+      'data: {"complete":true}\n\ndata: {"incomplete":true}',
+    ]);
+    const messages: unknown[] = [];
+    for await (const msg of readSSE(stream)) {
+      messages.push(msg);
+    }
+    expect(messages).toEqual([{ complete: true }]);
+  });
+});

--- a/lib/connectors/__tests__/osml.test.ts
+++ b/lib/connectors/__tests__/osml.test.ts
@@ -2,16 +2,19 @@ import { describe, expect, it } from "vitest";
 import { osmlPlugin } from "../plugins/osml";
 
 describe("osmlPlugin", () => {
+  const beforeGenerate = osmlPlugin.beforeGenerate;
+  if (!beforeGenerate) throw new Error("expected beforeGenerate");
+
   it("injects systemPrompt when none provided", () => {
     const params = { prompt: "hello" };
-    const result = osmlPlugin.beforeGenerate!(params);
+    const result = beforeGenerate(params);
     expect(result).toHaveProperty("systemPrompt");
     expect((result as { systemPrompt: string }).systemPrompt).toBeTruthy();
   });
 
   it("preserves existing systemPrompt", () => {
     const params = { prompt: "hello", systemPrompt: "custom" };
-    const result = osmlPlugin.beforeGenerate!(params);
+    const result = beforeGenerate(params);
     expect((result as { systemPrompt: string }).systemPrompt).toBe("custom");
   });
 });

--- a/lib/connectors/__tests__/story-kernel.test.ts
+++ b/lib/connectors/__tests__/story-kernel.test.ts
@@ -26,10 +26,10 @@ describe("storyModePlugin", () => {
       provider,
     };
 
-    const result = await storyModePlugin.transformPrompt!(
-      "a knight and a dragon",
-      ctx,
-    );
+    const transformPrompt = storyModePlugin.transformPrompt;
+    if (!transformPrompt) throw new Error("expected transformPrompt");
+
+    const result = await transformPrompt("a knight and a dragon", ctx);
 
     expect(result).toContain(
       "A brave knight rescues a dragon who turns out to be friendly.",
@@ -38,7 +38,10 @@ describe("storyModePlugin", () => {
   });
 
   it("throws when no context is provided", async () => {
-    await expect(storyModePlugin.transformPrompt!("test")).rejects.toThrow(
+    const transformPrompt = storyModePlugin.transformPrompt;
+    if (!transformPrompt) throw new Error("expected transformPrompt");
+
+    await expect(transformPrompt("test")).rejects.toThrow(
       "story mode plugin requires provider context",
     );
   });

--- a/lib/generation/__tests__/queue.test.ts
+++ b/lib/generation/__tests__/queue.test.ts
@@ -337,7 +337,7 @@ describe("GenerationQueue", () => {
 
   describe("batch processing", () => {
     it("processes queued jobs after generating ones complete", async () => {
-      let resolve1: (v: { url: string }) => void;
+      let resolve1: (v: { url: string }) => void = () => {};
       const p1 = new Promise<{ url: string }>((r) => {
         resolve1 = r;
       });
@@ -357,7 +357,7 @@ describe("GenerationQueue", () => {
       expect(generationQueue.getElementSnapshot("q4").status).toBe("queued");
 
       // Complete the first job and flush microtasks
-      resolve1!({ url: "done" });
+      resolve1({ url: "done" });
       await vi.advanceTimersByTimeAsync(0);
 
       expect(generationQueue.getElementSnapshot("q1").status).toBe("idle");

--- a/lib/video/__tests__/resolve.test.ts
+++ b/lib/video/__tests__/resolve.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import { resolveElements } from "../resolve";
+import type { ElementSnapshot } from "@/lib/generation/queue";
+import type { CanvasElement } from "@/app/components/canvas/types";
+
+function makeElement(id: string, type: CanvasElement["type"]): CanvasElement {
+  return {
+    id,
+    type,
+    children: [{ id: `${id}-t`, type, text: "some prompt" }],
+  };
+}
+
+const IDLE_WITH_RESULT: ElementSnapshot = {
+  status: "idle",
+  seconds: 0,
+  result: { url: "https://example.com/asset.mp3", durationSec: 5 },
+  error: null,
+};
+
+const IDLE_NO_RESULT: ElementSnapshot = {
+  status: "idle",
+  seconds: 0,
+  result: null,
+  error: null,
+};
+
+const GENERATING: ElementSnapshot = {
+  status: "generating",
+  seconds: 3,
+  result: null,
+  error: null,
+};
+
+describe("resolveElements", () => {
+  it("returns empty array for no elements", () => {
+    const result = resolveElements([], () => IDLE_NO_RESULT);
+    expect(result).toEqual([]);
+  });
+
+  it("skips elements without results", () => {
+    const elements = [
+      makeElement("e1", "image"),
+      makeElement("e2", "narration"),
+    ];
+    const result = resolveElements(elements, () => IDLE_NO_RESULT);
+    expect(result).toEqual([]);
+  });
+
+  it("skips elements that are still generating", () => {
+    const elements = [makeElement("e1", "image")];
+    const result = resolveElements(elements, () => GENERATING);
+    expect(result).toEqual([]);
+  });
+
+  it("resolves elements with results", () => {
+    const elements = [makeElement("e1", "image")];
+    const result = resolveElements(elements, () => IDLE_WITH_RESULT);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: "e1",
+      type: "image",
+      role: "foreground",
+      layer: "visual",
+      url: "https://example.com/asset.mp3",
+      durationSec: 5,
+    });
+  });
+
+  it("maps element types to correct roles and layers", () => {
+    const types: CanvasElement["type"][] = [
+      "image",
+      "clip",
+      "narration",
+      "character",
+      "music",
+      "sound",
+    ];
+    const elements = types.map((t, i) => makeElement(`e${i}`, t));
+    const result = resolveElements(elements, () => IDLE_WITH_RESULT);
+
+    expect(result).toHaveLength(6);
+    expect(result[0]).toMatchObject({
+      type: "image",
+      role: "foreground",
+      layer: "visual",
+    });
+    expect(result[1]).toMatchObject({
+      type: "clip",
+      role: "foreground",
+      layer: "visual",
+    });
+    expect(result[2]).toMatchObject({
+      type: "narration",
+      role: "overlay",
+      layer: "audio",
+    });
+    expect(result[3]).toMatchObject({
+      type: "character",
+      role: "overlay",
+      layer: "audio",
+    });
+    expect(result[4]).toMatchObject({
+      type: "music",
+      role: "background",
+      layer: "audio",
+    });
+    expect(result[5]).toMatchObject({
+      type: "sound",
+      role: "effect",
+      layer: "audio",
+    });
+  });
+
+  it("only includes elements whose snapshots have results", () => {
+    const elements = [
+      makeElement("e1", "image"),
+      makeElement("e2", "narration"),
+      makeElement("e3", "clip"),
+    ];
+    const snapshots: Record<string, ElementSnapshot> = {
+      e1: IDLE_WITH_RESULT,
+      e2: IDLE_NO_RESULT,
+      e3: {
+        status: "idle",
+        seconds: 0,
+        result: { url: "https://example.com/clip.mp4", durationSec: 10 },
+        error: null,
+      },
+    };
+    const result = resolveElements(
+      elements,
+      (id) => snapshots[id] ?? IDLE_NO_RESULT,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("e1");
+    expect(result[1].id).toBe("e3");
+  });
+
+  it("preserves element order", () => {
+    const elements = [
+      makeElement("e3", "music"),
+      makeElement("e1", "image"),
+      makeElement("e2", "narration"),
+    ];
+    const result = resolveElements(elements, () => IDLE_WITH_RESULT);
+
+    expect(result.map((r) => r.id)).toEqual(["e3", "e1", "e2"]);
+  });
+
+  it("uses durationSec from the snapshot result", () => {
+    const elements = [makeElement("e1", "clip")];
+    const snapshot: ElementSnapshot = {
+      status: "idle",
+      seconds: 0,
+      result: { url: "https://example.com/vid.mp4", durationSec: 42 },
+      error: null,
+    };
+    const result = resolveElements(elements, () => snapshot);
+
+    expect(result[0].durationSec).toBe(42);
+    expect(result[0].url).toBe("https://example.com/vid.mp4");
+  });
+});


### PR DESCRIPTION
Automated nightly code cleanup and documentation update

**Code cleanup**
- removed non-null assertions in three test files, replaced with typed guards or safe defaults

**Docs**
- README project structure updated to include `app/api/render/`, `app/components/video/`, `lib/video/`, and `remotion/`

**Tests**
- `lib/api/__tests__/sse.test.ts` (14 tests) covering `formatSSE`, `createSSEResponse`, `readSSE` including chunked/malformed/batched streams
- `lib/video/__tests__/resolve.test.ts` (8 tests) covering role/layer mapping for all element types, skip states, and order preservation

All 275 tests pass. Lint, format, typecheck clean.