### PR TITLE
nightly cleanup 2026-04-15

### DIFF
--- a/app/components/canvas/__tests__/insertElement.test.ts
+++ b/app/components/canvas/__tests__/insertElement.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from "vitest";
+import { createEditor, Editor } from "slate";
+
+vi.mock("../config/elementConfigs", () => ({
+  ELEMENT_CONFIGS: {
+    image: {
+      type: "image",
+      connector: "image",
+      outputKind: "image",
+      label: "Image",
+      defaultAttributes: undefined,
+      visibleAttributes: {},
+    },
+    narration: {
+      type: "narration",
+      connector: "tts",
+      outputKind: "audio",
+      label: "Narration",
+      defaultAttributes: { gender: "male", accent: "american" },
+      visibleAttributes: {},
+    },
+  },
+}));
+
+vi.mock("../utils/hydrateConnectorConfig", () => ({
+  hydrateConnectorConfig: () => (node: Record<string, unknown>) => ({
+    ...node,
+    customAttributes: {
+      ...(node.customAttributes as Record<string, string> | undefined),
+      model: "test-model",
+      provider: "openslop",
+    },
+  }),
+}));
+
+import { insertElement } from "../utils/insertElement";
+import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
+
+const connectors: ConnectorRegistry = {
+  llm: {
+    openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },
+  },
+  tts: {
+    openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },
+  },
+  image: {
+    openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },
+  },
+  video: {
+    openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },
+  },
+  sfx: {
+    openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },
+  },
+  music: {
+    openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },
+  },
+};
+
+function makeEditor() {
+  const editor = createEditor();
+  editor.children = [
+    {
+      id: "scene-1",
+      type: "scene",
+      children: [
+        {
+          id: "nar-1",
+          type: "narration",
+          children: [{ id: "t1", type: "narration", text: "hello" }],
+        },
+      ],
+    },
+  ];
+  return editor;
+}
+
+describe("insertElement", () => {
+  it("inserts a node with correct type", () => {
+    const editor = makeEditor();
+    Editor.withoutNormalizing(editor, () => {
+      insertElement(editor, "narration", [0, 1], connectors);
+    });
+
+    const scene = editor.children[0] as {
+      children: Array<Record<string, unknown>>;
+    };
+    const inserted = scene.children[1];
+    expect(inserted.type).toBe("narration");
+    expect(inserted.id).toBeDefined();
+    expect(inserted.children).toBeDefined();
+  });
+
+  it("applies default attributes from element config", () => {
+    const editor = makeEditor();
+    Editor.withoutNormalizing(editor, () => {
+      insertElement(editor, "narration", [0, 1], connectors);
+    });
+
+    const scene = editor.children[0] as {
+      children: Array<Record<string, unknown>>;
+    };
+    const inserted = scene.children[1];
+    const attrs = inserted.customAttributes as Record<string, string>;
+    expect(attrs.gender).toBe("male");
+    expect(attrs.accent).toBe("american");
+  });
+
+  it("hydrates connector config (model and provider)", () => {
+    const editor = makeEditor();
+    Editor.withoutNormalizing(editor, () => {
+      insertElement(editor, "image", [0, 1], connectors);
+    });
+
+    const scene = editor.children[0] as {
+      children: Array<Record<string, unknown>>;
+    };
+    const inserted = scene.children[1];
+    const attrs = inserted.customAttributes as Record<string, string>;
+    expect(attrs.model).toBe("test-model");
+    expect(attrs.provider).toBe("openslop");
+  });
+
+  it("element without defaultAttributes gets undefined customAttributes base", () => {
+    const editor = makeEditor();
+    Editor.withoutNormalizing(editor, () => {
+      insertElement(editor, "image", [0, 1], connectors);
+    });
+
+    const scene = editor.children[0] as {
+      children: Array<Record<string, unknown>>;
+    };
+    const inserted = scene.children[1];
+    const attrs = inserted.customAttributes as Record<string, string>;
+    expect(attrs.model).toBe("test-model");
+    expect(attrs.provider).toBe("openslop");
+    expect(attrs.gender).toBeUndefined();
+  });
+});

--- a/lib/connectors/base.ts
+++ b/lib/connectors/base.ts
@@ -52,7 +52,11 @@ export abstract class BaseConnector<
       result = await runAfterGenerate(this.plugins, result, ctx);
       return result;
     } catch (error) {
-      await runOnError(this.plugins, error as Error, ctx);
+      await runOnError(
+        this.plugins,
+        error instanceof Error ? error : new Error(String(error)),
+        ctx,
+      );
       throw error;
     }
   }

--- a/lib/connectors/llm/connector.ts
+++ b/lib/connectors/llm/connector.ts
@@ -40,7 +40,11 @@ export abstract class BaseLLMConnector<
       const prepared = await this.prepareParams(params, ctx);
       yield* this._stream(prepared);
     } catch (error) {
-      await runOnError(this.plugins, error as Error, ctx);
+      await runOnError(
+        this.plugins,
+        error instanceof Error ? error : new Error(String(error)),
+        ctx,
+      );
       throw error;
     }
   }

--- a/lib/providers/__tests__/base.test.ts
+++ b/lib/providers/__tests__/base.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/api/asset-bundle");
+
+import { AssetBundle } from "@/lib/api/asset-bundle";
+import { BaseProvider, type WithMetadata } from "../base";
+import type { BundleFile } from "@/lib/api/asset-bundle";
+
+type TestParams = { prompt: string; size?: number };
+type TestRawResult = { data: string } & WithMetadata;
+
+class TestProvider extends BaseProvider<TestParams, TestRawResult> {
+  protected readonly blobConfig = { type: "test", provider: "mock" };
+  generateFn = vi.fn<(params: TestParams) => Promise<TestRawResult>>();
+
+  protected toFiles(r: TestRawResult): BundleFile[] {
+    return [
+      {
+        key: "output",
+        filename: "out.bin",
+        data: r.data,
+        contentType: "application/octet-stream",
+      },
+    ];
+  }
+
+  protected async _generate(params: TestParams): Promise<TestRawResult> {
+    return this.generateFn(params);
+  }
+}
+
+describe("BaseProvider", () => {
+  let provider: TestProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new TestProvider();
+  });
+
+  it("calls _generate then store (upload)", async () => {
+    provider.generateFn.mockResolvedValue({ data: "abc" });
+
+    const result = await provider.generate({ prompt: "hello" });
+
+    expect(provider.generateFn).toHaveBeenCalledWith({ prompt: "hello" });
+    expect(AssetBundle.upload).toHaveBeenCalledWith(
+      "test",
+      "mock",
+      [
+        {
+          key: "output",
+          filename: "out.bin",
+          data: "abc",
+          contentType: "application/octet-stream",
+        },
+      ],
+      undefined,
+    );
+    expect(result).toEqual(
+      expect.objectContaining({ provider: "mock", result: { output: "url" } }),
+    );
+  });
+
+  it("forwards metadata to upload", async () => {
+    provider.generateFn.mockResolvedValue({
+      data: "x",
+      metadata: { durationSec: 5 },
+    });
+
+    await provider.generate({ prompt: "hi" });
+
+    expect(AssetBundle.upload).toHaveBeenCalledWith(
+      "test",
+      "mock",
+      expect.any(Array),
+      { durationSec: 5 },
+    );
+  });
+
+  it("propagates _generate errors", async () => {
+    provider.generateFn.mockRejectedValue(new Error("provider down"));
+
+    await expect(provider.generate({ prompt: "fail" })).rejects.toThrow(
+      "provider down",
+    );
+    expect(AssetBundle.upload).not.toHaveBeenCalled();
+  });
+
+  it("propagates upload errors", async () => {
+    provider.generateFn.mockResolvedValue({ data: "ok" });
+    vi.mocked(AssetBundle.upload).mockRejectedValueOnce(
+      new Error("upload failed"),
+    );
+
+    await expect(provider.generate({ prompt: "x" })).rejects.toThrow(
+      "upload failed",
+    );
+  });
+});


### PR DESCRIPTION
Automated nightly code cleanup and documentation update

Changes:
- Safe error handling in base.ts and llm/connector.ts (replace unsafe casts with instanceof checks)
- New test: insertElement utility (4 tests)
- New test: BaseProvider generate/store flow (4 tests)