### PR TITLE
Prevent nested scenes on paste, non-selectable previews

### DIFF
--- a/app/components/canvas/__tests__/withFlatPaste.test.ts
+++ b/app/components/canvas/__tests__/withFlatPaste.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { createEditor, Editor, Element, Transforms } from "slate";
+import { withReact } from "slate-react";
+import { withScenes } from "../plugins/withScenes";
+import { withFlatPaste } from "../plugins/withFlatPaste";
+import { withNodeId } from "../plugins/withNodeId";
+import {
+  CanvasContentElement,
+  SceneElement,
+  SCENE_TYPE,
+  CanvasEditor,
+} from "../types";
+import { isSceneElement } from "../utils/guards";
+
+function content(
+  type: CanvasContentElement["type"],
+  id: string = type,
+): CanvasContentElement {
+  return {
+    id,
+    type,
+    children: [{ id: `${id}-t`, type, text: "" }],
+  };
+}
+
+function scene(
+  children: CanvasContentElement[],
+  id: string = "s",
+): SceneElement {
+  return { id, type: SCENE_TYPE, children };
+}
+
+function makeEditor(): CanvasEditor {
+  return withNodeId(withFlatPaste(withScenes(withReact(createEditor()))));
+}
+
+function shape(editor: Editor): string[][] {
+  return editor.children.map((s) =>
+    isSceneElement(s)
+      ? s.children.map((c) => c.type)
+      : [`!${(s as Element).type}`],
+  );
+}
+
+function hasNestedScene(editor: Editor): boolean {
+  return editor.children.some(
+    (n) =>
+      isSceneElement(n) && n.children.some((c) => isSceneElement(c as Element)),
+  );
+}
+
+describe("withFlatPaste", () => {
+  it("flattens scene wrappers in pasted fragments", () => {
+    const editor = makeEditor();
+    // Seed with one scene so we have a valid selection target
+    Editor.withoutNormalizing(editor, () => {
+      Transforms.insertNodes(editor, scene([content("narration", "n0")]));
+    });
+    Editor.normalize(editor, { force: true });
+    Transforms.select(editor, Editor.end(editor, []));
+
+    editor.insertFragment([
+      scene([content("image", "i1"), content("narration", "n1")], "ps1"),
+    ]);
+
+    expect(hasNestedScene(editor)).toBe(false);
+  });
+
+  it("passes through bare content elements unchanged", () => {
+    const editor = makeEditor();
+    Editor.withoutNormalizing(editor, () => {
+      Transforms.insertNodes(editor, scene([content("narration", "n0")]));
+    });
+    Editor.normalize(editor, { force: true });
+    Transforms.select(editor, Editor.end(editor, []));
+
+    editor.insertFragment([content("sound", "snd1")]);
+
+    const types = shape(editor).flat();
+    expect(types).toContain("sound");
+    expect(hasNestedScene(editor)).toBe(false);
+  });
+
+  it("handles a mixed fragment of scenes and bare content", () => {
+    const editor = makeEditor();
+    Editor.withoutNormalizing(editor, () => {
+      Transforms.insertNodes(editor, scene([content("narration", "n0")]));
+    });
+    Editor.normalize(editor, { force: true });
+    Transforms.select(editor, Editor.end(editor, []));
+
+    editor.insertFragment([
+      scene([content("image", "i1")], "ps1"),
+      content("music", "m1"),
+      scene([content("clip", "c1")], "ps2"),
+    ]);
+
+    const types = shape(editor).flat();
+    expect(types).toContain("image");
+    expect(types).toContain("music");
+    expect(types).toContain("clip");
+    expect(hasNestedScene(editor)).toBe(false);
+  });
+});

--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -95,7 +95,7 @@ export function ElementContainer({
 
       {/* Center divider */}
       <div
-        className="relative flex-shrink-0 w-px self-stretch mx-3 sm:mx-4"
+        className="relative flex-shrink-0 w-px self-stretch mx-3 sm:mx-4 select-none"
         contentEditable={false}
         aria-hidden="true"
       >
@@ -110,7 +110,10 @@ export function ElementContainer({
       </div>
 
       {/* Right: preview */}
-      <div className="flex-1 min-w-0 flex items-center" contentEditable={false}>
+      <div
+        className="flex-1 min-w-0 flex items-center select-none"
+        contentEditable={false}
+      >
         <OutputPreview
           type={element.type}
           generating={gen.generating}

--- a/app/components/canvas/hooks/useEditorSetup.ts
+++ b/app/components/canvas/hooks/useEditorSetup.ts
@@ -2,10 +2,12 @@ import { useState } from "react";
 import { createEditor, Descendant } from "slate";
 import { withReact } from "slate-react";
 import { withHistory } from "slate-history";
+import flow from "lodash/flow";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { withNodeId } from "../plugins/withNodeId";
 import { withLayout } from "../plugins/withLayout";
 import { withScenes } from "../plugins/withScenes";
+import { withFlatPaste } from "../plugins/withFlatPaste";
 
 const initialValue: Descendant[] = [];
 
@@ -13,11 +15,14 @@ export function useEditorSetup() {
   const { connectorConfig } = useConfig();
 
   const [editor] = useState(() =>
-    withNodeId(
-      withScenes(
-        withLayout(connectorConfig)(withReact(withHistory(createEditor()))),
-      ),
-    ),
+    flow(
+      withHistory,
+      withReact,
+      withLayout(connectorConfig),
+      withScenes,
+      withFlatPaste,
+      withNodeId,
+    )(createEditor()),
   );
 
   const [value, setValue] = useState<Descendant[]>(initialValue);

--- a/app/components/canvas/plugins/withFlatPaste.ts
+++ b/app/components/canvas/plugins/withFlatPaste.ts
@@ -1,0 +1,14 @@
+import type { CanvasEditor } from "../types";
+import { isSceneElement } from "../utils/guards";
+
+export const withFlatPaste = (editor: CanvasEditor): CanvasEditor => {
+  const { insertFragment } = editor;
+
+  editor.insertFragment = (fragment) => {
+    insertFragment(
+      fragment.flatMap((n) => (isSceneElement(n) ? n.children : [n])),
+    );
+  };
+
+  return editor;
+};


### PR DESCRIPTION
## Summary
- Add `withFlatPaste` Slate plugin that unwraps scene elements from pasted fragments, preventing illegal nested scenes when users Ctrl+A → copy → paste
- Refactor `useEditorSetup` to use `lodash/flow` for a readable left-to-right plugin pipeline
- Add `select-none` to output preview and center divider so they can't be highlighted by browser text selection

## Test plan
- [x] 3 new tests in `withFlatPaste.test.ts` (scene-wrapped, bare content, mixed fragments)
- [x] All 85 existing canvas tests pass
- [x] Lint, format, typecheck clean
- [ ] Manual: add elements across scenes, Ctrl+A → Ctrl+C → Ctrl+V — no nested scenes
- [ ] Manual: output previews not highlighted on Ctrl+A or drag selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)