### PR TITLE
Per-scene collapse/expand with compact storyboard view

### DIFF
--- a/app/components/PostPromptView.tsx
+++ b/app/components/PostPromptView.tsx
@@ -4,7 +4,7 @@ import { useCallback, useRef, useState } from "react";
 import { useScript } from "@/lib/script/ScriptProvider";
 import Copilot from "./Copilot";
 import Canvas, { type CanvasHandle } from "./canvas/Canvas";
-import { SparklesIcon } from "./canvas/elements/OutputPreview";
+import { Clapperboard } from "lucide-react";
 import { TopPlayerPanel, SidePlayerPanel } from "./video/PlayerPanel";
 import {
   PlayerPositionProvider,
@@ -49,11 +49,11 @@ function PostPromptViewInner() {
               showPlayer();
             }}
             className={`${genStyles.btn} shrink-0 transition-opacity ${loading ? "" : "opacity-80 hover:opacity-100"}`}
-            aria-label="Generate All"
+            aria-label="Generate & Preview"
             disabled={loading}
           >
-            <SparklesIcon />
-            <span className="hidden sm:inline">Generate All</span>
+            <Clapperboard className={genStyles.svg} />
+            <span className="hidden sm:inline">Generate & Preview</span>
           </button>
         </div>
       </div>
@@ -62,7 +62,10 @@ function PostPromptViewInner() {
         {visible && isTop && <TopPlayerPanel />}
 
         <div className="flex min-h-0 flex-1 overflow-hidden">
-          <div className="flex-1 overflow-y-auto scrollbar-gutter-stable">
+          <div
+            className="flex-1 overflow-y-auto"
+            style={{ scrollbarGutter: "stable" }}
+          >
             <div className="pointer-events-none sticky top-0 z-10 -mb-8 h-8 backdrop-blur-sm [mask-image:linear-gradient(to_bottom,black,transparent)]" />
             <div className="mx-auto max-w-6xl px-4 pt-4">
               <Canvas ref={canvasRef} onStructureChange={setStructureKey} />

--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -30,6 +30,7 @@ import Sidebar from "./panel/Sidebar";
 import { renderCanvasElement } from "./elements/ElementContainer";
 import { getContentElements } from "./utils/nodeUtils";
 import { PreviewCacheProvider } from "./PreviewCacheContext";
+import { ViewModeProvider } from "./ViewModeContext";
 
 export interface CanvasHandle {
   generateAll: () => void;
@@ -114,36 +115,40 @@ export default function Canvas({
   }, [editor, activeId]);
 
   return (
-    <PreviewCacheProvider>
-      <DragTransferContext.Provider value={dragTransfer}>
-        <DndContext
-          sensors={sensors}
-          collisionDetection={pointerWithin}
-          onDragStart={handleDragStart}
-          onDragOver={handleDragOver}
-          onDragEnd={handleDragEnd}
-          onDragCancel={handleDragCancel}
-        >
-          <Sidebar />
+    <ViewModeProvider sceneIds={sceneItems}>
+      <PreviewCacheProvider>
+        <DragTransferContext.Provider value={dragTransfer}>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={pointerWithin}
+            onDragStart={handleDragStart}
+            onDragOver={handleDragOver}
+            onDragEnd={handleDragEnd}
+            onDragCancel={handleDragCancel}
+          >
+            <Sidebar />
 
-          <Slate editor={editor} initialValue={value} onChange={setValue}>
-            <SortableContext
-              items={sceneItems}
-              strategy={verticalListSortingStrategy}
-            >
-              <Editable
-                placeholder="Start typing your story…"
-                renderElement={renderElement}
-                onKeyDown={handleKeyDown}
-                className="font-body text-sm leading-relaxed outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              />
-            </SortableContext>
-            <DragOverlay>
-              {activeElement && <DragOverlayContent element={activeElement} />}
-            </DragOverlay>
-          </Slate>
-        </DndContext>
-      </DragTransferContext.Provider>
-    </PreviewCacheProvider>
+            <Slate editor={editor} initialValue={value} onChange={setValue}>
+              <SortableContext
+                items={sceneItems}
+                strategy={verticalListSortingStrategy}
+              >
+                <Editable
+                  placeholder="Start typing your story…"
+                  renderElement={renderElement}
+                  onKeyDown={handleKeyDown}
+                  className="font-body text-sm leading-relaxed outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                />
+              </SortableContext>
+              <DragOverlay>
+                {activeElement && (
+                  <DragOverlayContent element={activeElement} />
+                )}
+              </DragOverlay>
+            </Slate>
+          </DndContext>
+        </DragTransferContext.Provider>
+      </PreviewCacheProvider>
+    </ViewModeProvider>
   );
 }

--- a/app/components/canvas/ViewModeContext.tsx
+++ b/app/components/canvas/ViewModeContext.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  type ReactNode,
+} from "react";
+
+type ViewModeValue = {
+  isCollapsed: (sceneId: string) => boolean;
+  toggle: (sceneId: string) => void;
+  expandAll: () => void;
+  collapseAll: () => void;
+};
+
+const ViewModeContext = createContext<ViewModeValue>({
+  isCollapsed: () => false,
+  toggle: () => {},
+  expandAll: () => {},
+  collapseAll: () => {},
+});
+
+export function ViewModeProvider({
+  sceneIds,
+  children,
+}: {
+  sceneIds: string[];
+  children: ReactNode;
+}) {
+  const [collapsedScenes, setCollapsedScenes] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const isCollapsed = useCallback(
+    (sceneId: string) => collapsedScenes.has(sceneId),
+    [collapsedScenes],
+  );
+
+  const toggle = useCallback((sceneId: string) => {
+    setCollapsedScenes((prev) => {
+      const next = new Set(prev);
+      if (next.has(sceneId)) next.delete(sceneId);
+      else next.add(sceneId);
+      return next;
+    });
+  }, []);
+
+  const expandAll = useCallback(() => {
+    setCollapsedScenes(new Set());
+  }, []);
+
+  const collapseAll = useCallback(() => {
+    setCollapsedScenes(new Set(sceneIds));
+  }, [sceneIds]);
+
+  return (
+    <ViewModeContext value={{ isCollapsed, toggle, expandAll, collapseAll }}>
+      {children}
+    </ViewModeContext>
+  );
+}
+
+export function useViewMode() {
+  return useContext(ViewModeContext);
+}

--- a/app/components/canvas/dnd/SortableContent.tsx
+++ b/app/components/canvas/dnd/SortableContent.tsx
@@ -9,6 +9,7 @@ import type {
 } from "../types";
 import { ELEMENT_LIST } from "../config/elementConfigs";
 import { insertElement } from "../utils/insertElement";
+import { useViewMode } from "../ViewModeContext";
 import { SortableItem } from "./SortableItem";
 import { useDragTransfer } from "./DragTransferContext";
 import type { InsertOption } from "./SortableActions";
@@ -36,9 +37,11 @@ export function SortableContent({
   const editor = useSlateStatic();
   const { connectorConfig } = useConfig();
   const transfer = useDragTransfer();
+  const { isCollapsed } = useViewMode();
 
   const path = ReactEditor.findPath(editor, element);
   const sceneId = (Node.parent(editor, path) as SceneElement).id;
+  const collapsed = isCollapsed(sceneId);
 
   const insertGap =
     sceneId === transfer?.toSceneId &&
@@ -66,8 +69,9 @@ export function SortableContent({
       sceneId={sceneId}
       sortableType="content"
       wrapperStyle={wrapperStyle}
-      insertOptions={INSERT_OPTIONS}
-      onInsert={handleInsert}
+      insertOptions={collapsed ? undefined : INSERT_OPTIONS}
+      onInsert={collapsed ? undefined : handleInsert}
+      disabled={collapsed}
       attributes={attributes}
       element={element}
       renderElement={renderElement}

--- a/app/components/canvas/dnd/SortableItem.tsx
+++ b/app/components/canvas/dnd/SortableItem.tsx
@@ -13,6 +13,7 @@ interface SortableItemProps {
   wrapperStyle?: React.CSSProperties;
   insertOptions?: InsertOption<CanvasElementType>[];
   onInsert?: (type: CanvasElementType) => void;
+  disabled?: boolean;
   attributes: RenderElementProps["attributes"];
   element: CanvasElement;
   children: React.ReactNode;
@@ -26,6 +27,7 @@ export function SortableItem({
   wrapperStyle,
   insertOptions,
   onInsert,
+  disabled,
   attributes,
   element,
   children,
@@ -42,6 +44,7 @@ export function SortableItem({
   } = useSortable({
     id: element.id,
     data: { type: sortableType, sceneId },
+    disabled,
   });
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -62,17 +65,19 @@ export function SortableItem({
         <div
           className={`${styles.hoverTarget} align-middle${isMenuOpen ? ` ${styles.menuOpen}` : ""}`}
         >
-          <div
-            className={`self-center ${styles.actions}`}
-            contentEditable={false}
-          >
-            <SortableActions
-              options={insertOptions}
-              onInsert={onInsert}
-              listeners={listeners}
-              onMenuOpenChange={setIsMenuOpen}
-            />
-          </div>
+          {!disabled && (
+            <div
+              className={`self-center ${styles.actions}`}
+              contentEditable={false}
+            >
+              <SortableActions
+                options={insertOptions}
+                onInsert={onInsert}
+                listeners={listeners}
+                onMenuOpenChange={setIsMenuOpen}
+              />
+            </div>
+          )}
           <div>{renderElement({ attributes, children, element })}</div>
         </div>
       </div>

--- a/app/components/canvas/dnd/useDragAndDrop.ts
+++ b/app/components/canvas/dnd/useDragAndDrop.ts
@@ -19,7 +19,7 @@ export function useDragAndDrop(editor: Editor, value: Descendant[]) {
 
   const sensors = useSensors(useSensor(PointerSensor), useSensor(TouchSensor));
 
-  const sceneItems = useMemo<UniqueIdentifier[]>(
+  const sceneItems = useMemo<string[]>(
     () => value.filter(isSceneElement).map((s) => s.id),
     [value],
   );
@@ -54,7 +54,6 @@ export function useDragAndDrop(editor: Editor, value: Descendant[]) {
       const atIndex = isSceneElement(overNode)
         ? overNode.children.length
         : overPath[overPath.length - 1];
-
       setDragTransfer({
         itemId: active.id as string,
         fromSceneId,

--- a/app/components/canvas/elements/CompactElement.tsx
+++ b/app/components/canvas/elements/CompactElement.tsx
@@ -1,0 +1,41 @@
+import { RenderElementProps } from "slate-react";
+import { Node } from "slate";
+import type { CanvasContentElement } from "../types";
+import { ELEMENT_CONFIGS } from "../config/elementConfigs";
+
+export function CompactElement({
+  attributes,
+  element,
+  children,
+}: {
+  attributes: RenderElementProps["attributes"];
+  element: CanvasContentElement;
+  children: React.ReactNode;
+}) {
+  const config = ELEMENT_CONFIGS[element.type];
+  const text = Node.string(element).trim();
+
+  return (
+    <div
+      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 animate-fadeInUp"
+      contentEditable={false}
+      {...attributes}
+    >
+      <span
+        className={`flex items-center gap-1 rounded-full ${config.bgColor} px-1.5 py-0.5 text-white`}
+        contentEditable={false}
+      >
+        {config.icon}
+      </span>
+      {text && (
+        <span
+          className="truncate text-xs text-white/60 max-w-[800px]"
+          contentEditable={false}
+        >
+          {text}
+        </span>
+      )}
+      <span className="hidden">{children}</span>
+    </div>
+  );
+}

--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -1,15 +1,17 @@
 import { JSX } from "react";
-import { RenderElementProps } from "slate-react";
+import { RenderElementProps, ReactEditor, useSlateStatic } from "slate-react";
 import { Node } from "slate";
 import type { ProviderKey } from "@/lib/connectors/types";
-import type { CanvasContentElement } from "../types";
+import type { CanvasContentElement, SceneElement } from "../types";
 import { isSceneElement } from "../utils/guards";
 import { ZERO_WIDTH_SPACE } from "../config/constants";
 import { ELEMENT_CONFIGS } from "../config/elementConfigs";
 import { useGenerate } from "../hooks/useGenerate";
+import { useViewMode } from "../ViewModeContext";
 import { OutputPreview } from "./OutputPreview";
 import { ModelSelector } from "./ModelSelector";
 import { DeleteButton } from "./DeleteButton";
+import { CompactElement } from "./CompactElement";
 import { SceneContainer } from "./SceneContainer";
 
 const ATTRIBUTE_UNITS: Record<string, string> = { duration: "s" };
@@ -129,6 +131,24 @@ export function ElementContainer({
   );
 }
 
+function ContentElement(
+  props: RenderElementProps & { element: CanvasContentElement },
+) {
+  const editor = useSlateStatic();
+  const { isCollapsed } = useViewMode();
+  const path = ReactEditor.findPath(editor, props.element);
+  const sceneId = (Node.parent(editor, path) as SceneElement).id;
+
+  if (isCollapsed(sceneId)) {
+    return (
+      <CompactElement attributes={props.attributes} element={props.element}>
+        {props.children}
+      </CompactElement>
+    );
+  }
+  return <ElementContainer {...props} element={props.element} />;
+}
+
 export const renderCanvasElement = (props: RenderElementProps): JSX.Element => {
   if (isSceneElement(props.element)) {
     return (
@@ -137,5 +157,5 @@ export const renderCanvasElement = (props: RenderElementProps): JSX.Element => {
       </SceneContainer>
     );
   }
-  return <ElementContainer {...props} element={props.element} />;
+  return <ContentElement {...props} element={props.element} />;
 };

--- a/app/components/canvas/elements/ForegroundPreview.tsx
+++ b/app/components/canvas/elements/ForegroundPreview.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import Image from "next/image";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { CanvasContentElement } from "../types";
+import { ELEMENT_CONFIGS } from "../config/elementConfigs";
+import { useGenerate } from "../hooks/useGenerate";
+import { PlaceholderBalls, useStaticRotations } from "./OutputPreview";
+import loaderStyles from "./OutputPreview.module.css";
+
+export function ForegroundPreview({
+  element,
+}: {
+  element: CanvasContentElement;
+}) {
+  const { result, generating } = useGenerate(element);
+  const [loaded, setLoaded] = useState(false);
+  const { outputKind } = ELEMENT_CONFIGS[element.type];
+  const staticRotations = useStaticRotations();
+
+  if (!result) {
+    return (
+      <div
+        className={`relative w-full h-full rounded-lg overflow-hidden border bg-white/[0.03]`}
+      >
+        <div className={loaderStyles.containerLoader} aria-hidden="true">
+          <PlaceholderBalls
+            generating={generating}
+            staticRotations={staticRotations}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`relative w-full h-full rounded-lg overflow-hidden border`}>
+      {outputKind === "image" ? (
+        <Image
+          src={result.url}
+          alt="Scene preview"
+          fill
+          className="object-cover"
+          unoptimized
+          onLoad={() => setLoaded(true)}
+        />
+      ) : (
+        <video
+          src={result.url}
+          className="w-full h-full object-cover pointer-events-none"
+          onLoadedData={() => setLoaded(true)}
+        />
+      )}
+      {!loaded && (
+        <Skeleton className="absolute inset-0 animate-none shimmer-surface" />
+      )}
+    </div>
+  );
+}

--- a/app/components/canvas/elements/OutputPreview.tsx
+++ b/app/components/canvas/elements/OutputPreview.tsx
@@ -222,7 +222,7 @@ function buildSoundwaveMask(bars: number[]) {
   )}")`;
 }
 
-function PlaceholderBalls({
+export function PlaceholderBalls({
   generating,
   staticRotations,
 }: {
@@ -257,7 +257,7 @@ function PlaceholderBalls({
   );
 }
 
-function useStaticRotations() {
+export function useStaticRotations() {
   const [rotations] = useState(() =>
     PLACEHOLDER_BALLS.map(() => Math.floor(Math.random() * 360)),
   );

--- a/app/components/canvas/elements/SceneContainer.tsx
+++ b/app/components/canvas/elements/SceneContainer.tsx
@@ -1,19 +1,27 @@
-import { useMemo } from "react";
+import { Children, useMemo } from "react";
 import { RenderElementProps } from "slate-react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import {
   SortableContext,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import type { SceneElement } from "../types";
+import { isForeground } from "../utils/guards";
 import { useDragTransfer } from "../dnd/DragTransferContext";
+import { useSceneIndex } from "../hooks/useSceneIndex";
+import { useViewMode } from "../ViewModeContext";
+import { DeleteButton } from "./DeleteButton";
+import { ForegroundPreview } from "./ForegroundPreview";
 
-export function SceneContainer({
-  attributes,
-  element,
-  children,
-}: Pick<RenderElementProps, "attributes" | "children"> & {
+const COLLAPSED_MAX_VISIBLE = 3;
+
+interface SceneProps {
+  attributes: RenderElementProps["attributes"];
   element: SceneElement;
-}) {
+  children: React.ReactNode;
+}
+
+function useSceneState(element: SceneElement) {
   const childIds = useMemo(
     () => element.children.map((c) => c.id),
     [element.children],
@@ -24,19 +32,131 @@ export function SceneContainer({
     transfer &&
     element.id === transfer.toSceneId &&
     element.id !== transfer.fromSceneId;
-  const appendToEnd = isDropTarget && transfer.atIndex >= childIds.length;
+
+  return {
+    childIds,
+    sceneIndex: useSceneIndex(element.id),
+    dropPadding: {
+      paddingBottom:
+        isDropTarget && transfer.atIndex >= childIds.length
+          ? "3rem"
+          : undefined,
+      transition: "padding-bottom 200ms ease",
+    } as React.CSSProperties,
+  };
+}
+
+function SceneHeader({
+  sceneIndex,
+  collapsed,
+  onToggle,
+  element,
+}: {
+  sceneIndex: number;
+  collapsed: boolean;
+  onToggle: () => void;
+  element: SceneElement;
+}) {
+  const Icon = collapsed ? ChevronRight : ChevronDown;
+  return (
+    <div
+      className="flex items-center gap-1 select-none text-[10px] text-white/40 font-medium mb-3 h-5"
+      contentEditable={false}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        className="opacity-0 group-hover/scene:opacity-100 transition-opacity duration-200 p-0.5 -ml-1 rounded hover:bg-white/10"
+        aria-label={collapsed ? "Expand scene" : "Collapse scene"}
+      >
+        <Icon size={12} />
+      </button>
+      Scene {sceneIndex}
+      <div className="opacity-0 group-hover/scene:opacity-100 transition-opacity duration-200 p-1">
+        <DeleteButton element={element} />
+      </div>
+    </div>
+  );
+}
+
+function CollapsedScene({ attributes, element, children }: SceneProps) {
+  const { sceneIndex, dropPadding } = useSceneState(element);
+  const { toggle } = useViewMode();
+
+  const foregroundElement = useMemo(
+    () => element.children.find(isForeground) ?? null,
+    [element.children],
+  );
+
+  const childArray = Children.toArray(children);
+  const overflowCount = Math.max(0, childArray.length - COLLAPSED_MAX_VISIBLE);
 
   return (
     <div
       {...attributes}
-      style={{
-        paddingBottom: appendToEnd ? "3rem" : undefined,
-        transition: "padding-bottom 200ms ease",
-      }}
+      className="group/scene relative h-32"
+      style={dropPadding}
     >
+      <div className="flex flex-col h-full pr-[calc(8rem+0.75rem)]">
+        <SceneHeader
+          sceneIndex={sceneIndex}
+          collapsed
+          onToggle={() => toggle(element.id)}
+          element={element}
+        />
+        <div className="flex flex-col gap-0.5 flex-1 min-h-0 overflow-hidden transition-all duration-300 ease-out motion-reduce:transition-none">
+          {childArray.slice(0, COLLAPSED_MAX_VISIBLE)}
+          {overflowCount > 0 && (
+            <div className="hidden">
+              {childArray.slice(COLLAPSED_MAX_VISIBLE)}
+            </div>
+          )}
+        </div>
+        {overflowCount > 0 && (
+          <span
+            className="text-[10px] text-white/30 pl-1 select-none shrink-0 text-left"
+            contentEditable={false}
+          >
+            +{overflowCount} more
+          </span>
+        )}
+      </div>
+      {foregroundElement && (
+        <div
+          className="absolute right-0 top-0 bottom-0 w-32 select-none"
+          contentEditable={false}
+        >
+          <ForegroundPreview element={foregroundElement} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ExpandedScene({ attributes, element, children }: SceneProps) {
+  const { childIds, sceneIndex, dropPadding } = useSceneState(element);
+  const { toggle } = useViewMode();
+
+  return (
+    <div {...attributes} className="group/scene" style={dropPadding}>
+      <SceneHeader
+        sceneIndex={sceneIndex}
+        collapsed={false}
+        onToggle={() => toggle(element.id)}
+        element={element}
+      />
       <SortableContext items={childIds} strategy={verticalListSortingStrategy}>
         {children}
       </SortableContext>
     </div>
+  );
+}
+
+export function SceneContainer(props: SceneProps) {
+  const { isCollapsed } = useViewMode();
+  return isCollapsed(props.element.id) ? (
+    <CollapsedScene {...props} />
+  ) : (
+    <ExpandedScene {...props} />
   );
 }

--- a/app/components/canvas/hooks/useSceneIndex.ts
+++ b/app/components/canvas/hooks/useSceneIndex.ts
@@ -1,0 +1,10 @@
+import { useSlateStatic } from "slate-react";
+import { isSceneElement } from "../utils/guards";
+
+export function useSceneIndex(sceneId: string): number {
+  const editor = useSlateStatic();
+  const index = editor.children.findIndex(
+    (node) => isSceneElement(node) && node.id === sceneId,
+  );
+  return index + 1;
+}

--- a/app/components/canvas/panel/Sidebar.tsx
+++ b/app/components/canvas/panel/Sidebar.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { PanelLeft } from "lucide-react";
 import UserProfile from "@/app/components/UserProfile";
 import PlayerPositionPanel from "./PlayerPositionPanel";
+import ViewModePanel from "./ViewModePanel";
 
 export default function Sidebar() {
   const [open, setOpen] = useState(false);
@@ -36,8 +37,9 @@ export default function Sidebar() {
           </button>
 
           {open && (
-            <div className="mt-10 px-2">
+            <div className="mt-10 px-2 flex flex-col gap-4">
               <PlayerPositionPanel />
+              <ViewModePanel />
             </div>
           )}
         </div>

--- a/app/components/canvas/panel/ViewModePanel.tsx
+++ b/app/components/canvas/panel/ViewModePanel.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { ChevronsDownUp, ChevronsUpDown } from "lucide-react";
+import { useViewMode } from "../ViewModeContext";
+
+export default function ViewModePanel() {
+  const { expandAll, collapseAll } = useViewMode();
+
+  const btnClass =
+    "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-white/30 hover:text-white/50 transition-colors";
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-white/50">
+        Scenes
+      </h2>
+      <button type="button" onClick={expandAll} className={btnClass}>
+        <ChevronsUpDown size={16} strokeWidth={1.5} />
+        Expand All
+      </button>
+      <button type="button" onClick={collapseAll} className={btnClass}>
+        <ChevronsDownUp size={16} strokeWidth={1.5} />
+        Collapse All
+      </button>
+    </div>
+  );
+}

--- a/app/components/canvas/utils/guards.ts
+++ b/app/components/canvas/utils/guards.ts
@@ -4,17 +4,15 @@ import {
   FOREGROUND_TYPES,
   SCENE_TYPE,
   type CanvasContentElement,
-  type CanvasElement,
   type CanvasElementType,
   type SceneElement,
 } from "../types";
 
 export const isSceneElement = (n: unknown): n is SceneElement =>
-  Element.isElement(n) && (n as CanvasElement).type === SCENE_TYPE;
+  Element.isElement(n) && n.type === SCENE_TYPE;
 
 export const isContentElement = (n: unknown): n is CanvasContentElement =>
-  Element.isElement(n) &&
-  CANVAS_ELEMENT_TYPES.has((n as CanvasElement).type as CanvasElementType);
+  Element.isElement(n) && CANVAS_ELEMENT_TYPES.has(n.type as CanvasElementType);
 
 export const isForeground = (n: unknown): n is CanvasContentElement =>
   isContentElement(n) && FOREGROUND_TYPES.has(n.type);

--- a/app/components/video/VideoLayoutContext.tsx
+++ b/app/components/video/VideoLayoutContext.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { createContext, use, useMemo, type ReactNode } from "react";
+import {
+  createContext,
+  use,
+  useMemo,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
 import type { Editor } from "slate";
 import { generationQueue } from "@/lib/generation/queue";
 import type { VideoLayout } from "@/lib/video/types";
@@ -29,7 +35,12 @@ export function VideoLayoutProvider({
   children: ReactNode;
 }) {
   const layout = useVideoLayout(getEditor, structureKey);
-  const ready = useAssetPrefetch(layout);
+  const prefetched = useAssetPrefetch(layout);
+  const busy = useSyncExternalStore(
+    generationQueue.subscribe,
+    generationQueue.isBusy,
+  );
+  const ready = prefetched && !busy;
   const playerKey = `${structureKey}-${generationQueue.getResultVersion()}`;
   const value = useMemo(
     () => ({ layout, ready, playerKey }),

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -55,6 +55,13 @@ class GenerationQueue {
 
   getResultVersion = () => this._resultVersion;
 
+  isBusy = (): boolean => {
+    for (const snap of this.state.values()) {
+      if (snap.status === "queued" || snap.status === "generating") return true;
+    }
+    return false;
+  };
+
   private isInQueue(id: string): boolean {
     const s = this.state.get(id)?.status;
     return s === "queued" || s === "generating";


### PR DESCRIPTION
## Summary
- Scenes can be individually collapsed/expanded via a chevron toggle in the scene header (visible on hover)
- Collapsed scenes show compact element chips (icon + truncated text), overflow count, and foreground output preview
- Sidebar panel provides "Expand All" / "Collapse All" bulk actions
- Scene numbers and delete buttons visible in both modes on hover
- Foreground preview absolutely positioned to prevent DnD layout shifts
- Element-level DnD disabled in collapsed scenes; scene-level DnD always available
- Fixed `scrollbar-gutter: stable` (was a non-functional Tailwind class)

## Test plan
- [ ] Toggle individual scenes between collapsed/expanded via chevron icon
- [ ] Verify compact element chips show icon + truncated text
- [ ] Verify overflow count (`+N more`) appears when elements exceed limit
- [ ] Verify foreground preview shows generated image/video or placeholder orbs
- [ ] Verify "Expand All" / "Collapse All" in sidebar work correctly
- [ ] Drag content elements between scenes (expanded and collapsed)
- [ ] Drag scenes to reorder
- [ ] Verify scene numbers update correctly after reorder
- [ ] Verify delete button works on scenes in both modes (with undo/redo)
- [ ] Verify no layout shift on foreground preview during drag operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)