### PR TITLE
nightly cleanup 2026-04-19

### DIFF
--- a/lib/providers/image/mock.ts
+++ b/lib/providers/image/mock.ts
@@ -1,37 +1,26 @@
-import type { BundleResponse } from "@/lib/api/asset-bundle";
 import type { ImageGenerateParams } from "@/lib/connectors/types";
-import { BaseProvider } from "../base";
-import { pickRandom } from "../mock-utils";
+import { MockProvider } from "../mock-base";
 
 const BLOB_BASE =
   "https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/image/mock";
 
-const MOCK_VARIANTS: BundleResponse[] = [
-  {
-    id: "1",
-    provider: "mock",
-    result: { image: `${BLOB_BASE}/1/output.webp` },
-  },
-  { id: "2", provider: "mock", result: { image: `${BLOB_BASE}/2/output.jpg` } },
-  { id: "3", provider: "mock", result: { image: `${BLOB_BASE}/3/output.png` } },
-];
-
-export class MockImage extends BaseProvider<
-  ImageGenerateParams,
-  BundleResponse
-> {
-  protected readonly blobConfig = { type: "image", provider: "mock" };
-
-  protected toFiles() {
-    return [];
-  }
-
-  protected async store(result: BundleResponse) {
-    return result;
-  }
-
-  protected async _generate(): Promise<BundleResponse> {
-    await new Promise((r) => setTimeout(r, 2000 + Math.random() * 2000));
-    return pickRandom(MOCK_VARIANTS);
-  }
+export class MockImage extends MockProvider<ImageGenerateParams> {
+  protected readonly delayMs = 2000;
+  protected readonly variants = [
+    {
+      id: "1",
+      provider: "mock",
+      result: { image: `${BLOB_BASE}/1/output.webp` },
+    },
+    {
+      id: "2",
+      provider: "mock",
+      result: { image: `${BLOB_BASE}/2/output.jpg` },
+    },
+    {
+      id: "3",
+      provider: "mock",
+      result: { image: `${BLOB_BASE}/3/output.png` },
+    },
+  ];
 }

--- a/lib/providers/mock-base.ts
+++ b/lib/providers/mock-base.ts
@@ -1,0 +1,30 @@
+import type { BundleResponse } from "@/lib/api/asset-bundle";
+import { BaseProvider } from "./base";
+import { pickRandom } from "./mock-utils";
+
+export abstract class MockProvider<TParams> extends BaseProvider<
+  TParams,
+  BundleResponse,
+  BundleResponse
+> {
+  protected abstract readonly variants: BundleResponse[];
+  protected readonly delayMs: number = 0;
+  protected readonly blobConfig = { type: "mock", provider: "mock" };
+
+  protected toFiles() {
+    return [];
+  }
+
+  protected async store(result: BundleResponse) {
+    return result;
+  }
+
+  protected async _generate(): Promise<BundleResponse> {
+    if (this.delayMs > 0) {
+      await new Promise((r) =>
+        setTimeout(r, this.delayMs + Math.random() * this.delayMs),
+      );
+    }
+    return pickRandom(this.variants);
+  }
+}

--- a/lib/providers/music/mock.ts
+++ b/lib/providers/music/mock.ts
@@ -1,48 +1,29 @@
-import type { BundleResponse } from "@/lib/api/asset-bundle";
 import type { MusicGenerateParams } from "@/lib/connectors/types";
-import { BaseProvider } from "../base";
-import { pickRandom } from "../mock-utils";
+import { MockProvider } from "../mock-base";
 
 const BLOB_BASE =
   "https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/music/mock";
 
-const MOCK_VARIANTS: BundleResponse[] = [
-  {
-    id: "1",
-    provider: "mock",
-    result: { audio: `${BLOB_BASE}/1/output.mp3` },
-    metadata: { durationSec: 30 },
-  },
-  {
-    id: "2",
-    provider: "mock",
-    result: { audio: `${BLOB_BASE}/2/output.m4a` },
-    metadata: { durationSec: 188 },
-  },
-  {
-    id: "3",
-    provider: "mock",
-    result: { audio: `${BLOB_BASE}/3/output.wav` },
-    metadata: { durationSec: 60 },
-  },
-];
-
-export class MockMusic extends BaseProvider<
-  MusicGenerateParams,
-  BundleResponse
-> {
-  protected readonly blobConfig = { type: "music", provider: "mock" };
-
-  protected toFiles() {
-    return [];
-  }
-
-  protected async store(result: BundleResponse) {
-    return result;
-  }
-
-  protected async _generate(): Promise<BundleResponse> {
-    await new Promise((r) => setTimeout(r, 2000 + Math.random() * 2000));
-    return pickRandom(MOCK_VARIANTS);
-  }
+export class MockMusic extends MockProvider<MusicGenerateParams> {
+  protected readonly delayMs = 2000;
+  protected readonly variants = [
+    {
+      id: "1",
+      provider: "mock",
+      result: { audio: `${BLOB_BASE}/1/output.mp3` },
+      metadata: { durationSec: 30 },
+    },
+    {
+      id: "2",
+      provider: "mock",
+      result: { audio: `${BLOB_BASE}/2/output.m4a` },
+      metadata: { durationSec: 188 },
+    },
+    {
+      id: "3",
+      provider: "mock",
+      result: { audio: `${BLOB_BASE}/3/output.wav` },
+      metadata: { durationSec: 60 },
+    },
+  ];
 }

--- a/lib/providers/sfx/mock.ts
+++ b/lib/providers/sfx/mock.ts
@@ -1,44 +1,28 @@
-import type { BundleResponse } from "@/lib/api/asset-bundle";
 import type { SFXGenerateParams } from "@/lib/connectors/types";
-import { BaseProvider } from "../base";
-import { pickRandom } from "../mock-utils";
+import { MockProvider } from "../mock-base";
 
 const BLOB_BASE =
   "https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/sfx/mock";
 
-const MOCK_VARIANTS: BundleResponse[] = [
-  {
-    id: "1",
-    provider: "mock",
-    result: { audio: `${BLOB_BASE}/1/output.mp3` },
-    metadata: { durationSec: 22 },
-  },
-  {
-    id: "2",
-    provider: "mock",
-    result: { audio: `${BLOB_BASE}/2/output.wav` },
-    metadata: { durationSec: 19 },
-  },
-  {
-    id: "3",
-    provider: "mock",
-    result: { audio: `${BLOB_BASE}/3/output.m4a` },
-    metadata: { durationSec: 2 },
-  },
-];
-
-export class MockSFX extends BaseProvider<SFXGenerateParams, BundleResponse> {
-  protected readonly blobConfig = { type: "sfx", provider: "mock" };
-
-  protected toFiles() {
-    return [];
-  }
-
-  protected async store(result: BundleResponse) {
-    return result;
-  }
-
-  protected async _generate(): Promise<BundleResponse> {
-    return pickRandom(MOCK_VARIANTS);
-  }
+export class MockSFX extends MockProvider<SFXGenerateParams> {
+  protected readonly variants = [
+    {
+      id: "1",
+      provider: "mock",
+      result: { audio: `${BLOB_BASE}/1/output.mp3` },
+      metadata: { durationSec: 22 },
+    },
+    {
+      id: "2",
+      provider: "mock",
+      result: { audio: `${BLOB_BASE}/2/output.wav` },
+      metadata: { durationSec: 19 },
+    },
+    {
+      id: "3",
+      provider: "mock",
+      result: { audio: `${BLOB_BASE}/3/output.m4a` },
+      metadata: { durationSec: 2 },
+    },
+  ];
 }

--- a/lib/providers/tts/mock.ts
+++ b/lib/providers/tts/mock.ts
@@ -1,86 +1,70 @@
-import type { BundleResponse } from "@/lib/api/asset-bundle";
 import type {
   TTSGenerateParams,
   VoiceInfo,
   VoiceSearchParams,
 } from "@/lib/connectors/types";
-import { BaseProvider } from "../base";
-import { pickRandom } from "../mock-utils";
+import { MockProvider } from "../mock-base";
 
 const BLOB_BASE =
   "https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/tts/mock";
 
-const MOCK_VARIANTS: BundleResponse[] = [
-  {
-    id: "1",
-    provider: "mock",
-    result: {
-      audio: `${BLOB_BASE}/1/output.mp3`,
-      timestamps: `${BLOB_BASE}/1/timestamps.json`,
+export class MockTTS extends MockProvider<TTSGenerateParams> {
+  protected readonly variants = [
+    {
+      id: "1",
+      provider: "mock",
+      result: {
+        audio: `${BLOB_BASE}/1/output.mp3`,
+        timestamps: `${BLOB_BASE}/1/timestamps.json`,
+      },
+      metadata: { durationSec: 10 },
     },
-    metadata: { durationSec: 10 },
-  },
-  {
-    id: "2",
-    provider: "mock",
-    result: {
-      audio: `${BLOB_BASE}/2/output.m4a`,
-      timestamps: `${BLOB_BASE}/2/timestamps.json`,
+    {
+      id: "2",
+      provider: "mock",
+      result: {
+        audio: `${BLOB_BASE}/2/output.m4a`,
+        timestamps: `${BLOB_BASE}/2/timestamps.json`,
+      },
+      metadata: { durationSec: 18 },
     },
-    metadata: { durationSec: 18 },
-  },
-  {
-    id: "3",
-    provider: "mock",
-    result: {
-      audio: `${BLOB_BASE}/3/output.wav`,
-      timestamps: `${BLOB_BASE}/3/timestamps.json`,
+    {
+      id: "3",
+      provider: "mock",
+      result: {
+        audio: `${BLOB_BASE}/3/output.wav`,
+        timestamps: `${BLOB_BASE}/3/timestamps.json`,
+      },
+      metadata: { durationSec: 25 },
     },
-    metadata: { durationSec: 25 },
-  },
-  {
-    id: "4",
-    provider: "mock",
-    result: {
-      audio: `${BLOB_BASE}/4/output.mp3`,
-      timestamps: `${BLOB_BASE}/4/timestamps.json`,
+    {
+      id: "4",
+      provider: "mock",
+      result: {
+        audio: `${BLOB_BASE}/4/output.mp3`,
+        timestamps: `${BLOB_BASE}/4/timestamps.json`,
+      },
+      metadata: { durationSec: 8 },
     },
-    metadata: { durationSec: 8 },
-  },
-  {
-    id: "5",
-    provider: "mock",
-    result: {
-      audio: `${BLOB_BASE}/5/output.wav`,
-      timestamps: `${BLOB_BASE}/5/timestamps.json`,
+    {
+      id: "5",
+      provider: "mock",
+      result: {
+        audio: `${BLOB_BASE}/5/output.wav`,
+        timestamps: `${BLOB_BASE}/5/timestamps.json`,
+      },
+      metadata: { durationSec: 21 },
     },
-    metadata: { durationSec: 21 },
-  },
-  {
-    id: "6",
-    provider: "mock",
-    result: {
-      audio: `${BLOB_BASE}/6/output.m4a`,
-      timestamps: `${BLOB_BASE}/6/timestamps.json`,
+    {
+      id: "6",
+      provider: "mock",
+      result: {
+        audio: `${BLOB_BASE}/6/output.m4a`,
+        timestamps: `${BLOB_BASE}/6/timestamps.json`,
+      },
+      metadata: { durationSec: 6 },
     },
-    metadata: { durationSec: 6 },
-  },
-];
-
-export class MockTTS extends BaseProvider<TTSGenerateParams, BundleResponse> {
-  protected readonly blobConfig = { type: "tts", provider: "mock" };
-
-  protected toFiles() {
-    return [];
-  }
-
-  protected async store(result: BundleResponse) {
-    return result;
-  }
-
-  protected async _generate(): Promise<BundleResponse> {
-    return pickRandom(MOCK_VARIANTS);
-  }
+  ];
 
   async search(_params: VoiceSearchParams): Promise<VoiceInfo[]> {
     return [


### PR DESCRIPTION
Automated nightly code cleanup.

**Changes:** Extracted shared `MockProvider` base class from 4 mock providers (image, music, sfx, tts). Deduplicates identical boilerplate into `lib/providers/mock-base.ts`. Each mock now declares only its unique variants and optional delay. Net -32 lines.

All 379 tests pass. Typecheck/lint/format clean.