### PR TITLE
add project-level context via zustand

### DIFF
--- a/lib/config/ConfigProvider.tsx
+++ b/lib/config/ConfigProvider.tsx
@@ -55,7 +55,11 @@ const initialConnectorConfig: ConnectorRegistry = {
 	music: openslopConfig("Slop Music v1", MUSIC_MODELS),
 };
 
+// TODO: replace with real project ID after projects rollout
+const MOCK_PROJECT_ID = "00000000-0000-4000-8000-000000000001";
+
 type ConfigContextValue = {
+	projectId: string;
 	connectorConfig: ConnectorRegistry;
 	composerMode: ComposerMode;
 	setConnectorConfig: React.Dispatch<React.SetStateAction<ConnectorRegistry>>;
@@ -71,6 +75,7 @@ export function useConfig() {
 }
 
 export function ConfigProvider({ children }: { children: ReactNode }) {
+	const projectId = MOCK_PROJECT_ID;
 	const [connectorConfig, setConnectorConfig] = useState<ConnectorRegistry>(
 		initialConnectorConfig,
 	);
@@ -90,12 +95,13 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
 
 	const value = useMemo<ConfigContextValue>(
 		() => ({
+			projectId,
 			connectorConfig: configWithModePlugins,
 			composerMode,
 			setConnectorConfig,
 			setComposerMode,
 		}),
-		[configWithModePlugins, composerMode],
+		[projectId, configWithModePlugins, composerMode],
 	);
 
 	return (

--- a/lib/project/store.ts
+++ b/lib/project/store.ts
@@ -1,0 +1,38 @@
+import { createStore, type StoreApi } from "zustand/vanilla";
+import { useStore } from "zustand";
+
+export type ProjectContext = {
+	outline: string;
+	characterBibleUrl: string;
+	setOutline: (outline: string) => void;
+	setCharacterBibleUrl: (url: string) => void;
+};
+
+export type ProjectStore = StoreApi<ProjectContext>;
+
+const stores = new Map<string, ProjectStore>();
+
+export function getProjectStore(projectId: string): ProjectStore {
+	let store = stores.get(projectId);
+	if (!store) {
+		store = createStore<ProjectContext>((set) => ({
+			outline: "",
+			characterBibleUrl: "",
+			setOutline: (outline) => set({ outline }),
+			setCharacterBibleUrl: (characterBibleUrl) => set({ characterBibleUrl }),
+		}));
+		stores.set(projectId, store);
+	}
+	return store;
+}
+
+export function clearProjectStore(projectId: string) {
+	stores.delete(projectId);
+}
+
+export function useProjectStore<T>(
+	projectId: string,
+	selector: (state: ProjectContext) => T,
+): T {
+	return useStore(getProjectStore(projectId), selector);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
 				"slate-history": "^0.113.1",
 				"slate-react": "^0.123.0",
 				"tailwind-merge": "^3.5.0",
-				"zod": "^4.3.6"
+				"zod": "^4.3.6",
+				"zustand": "^5.0.12"
 			},
 			"devDependencies": {
 				"@tailwindcss/postcss": "^4",
@@ -17252,6 +17253,35 @@
 			},
 			"peerDependencies": {
 				"zod": "^3.25.0 || ^4.0.0"
+			}
+		},
+		"node_modules/zustand": {
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+			"integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			},
+			"peerDependencies": {
+				"@types/react": ">=18.0.0",
+				"immer": ">=9.0.6",
+				"react": ">=18.0.0",
+				"use-sync-external-store": ">=1.2.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"immer": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"use-sync-external-store": {
+					"optional": true
+				}
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
 		"slate-history": "^0.113.1",
 		"slate-react": "^0.123.0",
 		"tailwind-merge": "^3.5.0",
-		"zod": "^4.3.6"
+		"zod": "^4.3.6",
+		"zustand": "^5.0.12"
 	},
 	"devDependencies": {
 		"@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
- Add `zustand` dependency and create per-project vanilla stores at `lib/project/store.ts`
- Store-per-project pattern via `getProjectStore(projectId)` for use outside React, `useProjectStore` hook for React components
- Each project context holds `outline` and `characterBibleUrl` fields with setters
- Mock project ID exposed via `ConfigProvider` for downstream consumers

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run test:run` — all 428 tests pass
- [ ] Verify `getProjectStore("some-id")` returns a store with correct initial state
- [ ] Verify `useProjectStore` reactively updates in React components