### PR TITLE
Reusable ResizeHandle + hide canvas actions on mobile

### DIFF
--- a/app/components/canvas/styles/sortable.module.css
+++ b/app/components/canvas/styles/sortable.module.css
@@ -48,6 +48,12 @@
 	transition: opacity 0.15s ease;
 }
 
+@media (max-width: 639px) {
+	.actions {
+		display: none;
+	}
+}
+
 .hoverTarget {
 	display: flex;
 }

--- a/app/components/video/PlayerPanel.tsx
+++ b/app/components/video/PlayerPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ResizeHandle } from "./ResizeHandle";
 import { useResize } from "./useResize";
 import { VideoPanel } from "./VideoPanel";
 
@@ -28,21 +29,11 @@ export function TopPlayerPanel() {
 			>
 				<VideoPanel />
 			</div>
-			<div
+			<ResizeHandle
+				axis="vertical"
+				resizing={resizing}
 				onMouseDown={handleMouseDown}
-				className={`relative flex h-2 w-full shrink-0 cursor-row-resize items-end justify-center ${resizing ? "select-none" : ""}`}
-			>
-				<div
-					className={`h-0.5 rounded-full transition-colors ${
-						resizing ? "bg-white/40" : "bg-white/10 hover:bg-white/25"
-					}`}
-					style={{
-						width: "100%",
-						maskImage:
-							"linear-gradient(to right, transparent, black 20%, black 80%, transparent)",
-					}}
-				/>
-			</div>
+			/>
 		</div>
 	);
 }
@@ -59,21 +50,11 @@ export function SidePlayerPanel() {
 
 	return (
 		<div className="flex shrink-0" style={{ width: size }}>
-			<div
+			<ResizeHandle
+				axis="horizontal"
+				resizing={resizing}
 				onMouseDown={handleMouseDown}
-				className={`flex h-full w-4 shrink-0 cursor-col-resize items-center justify-center ${resizing ? "select-none" : ""}`}
-			>
-				<div
-					className={`w-0.5 rounded-full transition-colors ${
-						resizing ? "bg-white/40" : "bg-white/10 hover:bg-white/25"
-					}`}
-					style={{
-						height: "100%",
-						maskImage:
-							"linear-gradient(to bottom, transparent, black 20%, black 80%, transparent)",
-					}}
-				/>
-			</div>
+			/>
 			<div className="flex flex-1 flex-col justify-center overflow-hidden p-4">
 				<VideoPanel />
 			</div>

--- a/app/components/video/ResizeHandle.tsx
+++ b/app/components/video/ResizeHandle.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+type ResizeHandleProps = {
+	axis: "vertical" | "horizontal";
+	resizing: boolean;
+	onMouseDown: (e: React.MouseEvent) => void;
+};
+
+export function ResizeHandle({
+	axis,
+	resizing,
+	onMouseDown,
+}: ResizeHandleProps) {
+	const isVertical = axis === "vertical";
+
+	return (
+		<div
+			onMouseDown={onMouseDown}
+			className={`group relative flex shrink-0 items-center justify-center ${
+				isVertical
+					? "h-2 w-full cursor-row-resize"
+					: "h-full w-4 cursor-col-resize"
+			} ${resizing ? "select-none" : ""}`}
+		>
+			<div
+				className={`absolute rounded-full transition-colors ${
+					isVertical ? "h-0.5 w-full" : "h-full w-0.5"
+				} ${resizing ? "bg-white/40" : "bg-white/10 group-hover:bg-white/25"}`}
+				style={{
+					maskImage: `linear-gradient(${
+						isVertical ? "to right" : "to bottom"
+					}, transparent, black 20%, black 80%, transparent)`,
+				}}
+			/>
+			<div
+				className={`relative rounded-full transition-colors ${
+					isVertical ? "h-1 w-6" : "h-6 w-1"
+				} ${resizing ? "bg-white/50" : "bg-white/30 group-hover:bg-white/50"}`}
+			/>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- Extract the player-panel drag handle into a single reusable `ResizeHandle` component, used by both `TopPlayerPanel` and `SidePlayerPanel`. Adds a centered grip pill, and moves the hover highlight to the full handle area (via `group-hover:`) so hovering anywhere over the 8px row / 16px column brightens both the line and the pill — not just the 2px line itself.
- Hide the canvas element action buttons on screens under 640px in `sortable.module.css`. They depend on hover and were left visible / overlapping the thumb on touch viewports.

## Test plan
- [ ] `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run test:run`, `npm run build` all pass locally
- [ ] Top-mounted player view: hovering anywhere over the handle row brightens line + pill; drag still resizes; cursor is `row-resize`
- [ ] Side-mounted player view: hovering anywhere over the handle column brightens line + pill; drag still resizes; cursor is `col-resize`
- [ ] Pill stays centered and visible at rest; `select-none` engages mid-drag
- [ ] On a viewport <640px, canvas element action buttons are hidden and don't overlap the thumb

🤖 Generated with [Claude Code](https://claude.com/claude-code)