### PR TITLE
show character avatar in audio result preview

### DIFF
--- a/app/components/canvas/elements/AudioPlayer.tsx
+++ b/app/components/canvas/elements/AudioPlayer.tsx
@@ -30,7 +30,7 @@ export function AudioPlayer({
 	const [duration, setDuration] = useState(0);
 
 	return (
-		<div className="flex flex-1 min-w-0 items-center gap-2">
+		<>
 			<Tooltip>
 				<TooltipTrigger asChild>
 					<button
@@ -54,7 +54,7 @@ export function AudioPlayer({
 				src={src}
 				peaksCache={peaksCache}
 				waveColor={waveColor}
-				className="flex-1 h-10 min-w-0"
+				className="flex-1 basis-[160px] min-w-0 h-10"
 				onPlay={() => setPlaying(true)}
 				onPause={() => setPlaying(false)}
 				onTimeUpdate={(t, d) => {
@@ -63,9 +63,9 @@ export function AudioPlayer({
 				}}
 				onFinish={() => setPlaying(false)}
 			/>
-			<span className="shrink-0 w-16 text-right text-[10px] tabular-nums text-white/50 overflow-hidden">
+			<span className="shrink-0 ml-auto text-[10px] tabular-nums text-white/50">
 				{formatTime(currentTime)}/{formatTime(duration)}
 			</span>
-		</div>
+		</>
 	);
 }

--- a/app/components/canvas/elements/CharacterBadge.tsx
+++ b/app/components/canvas/elements/CharacterBadge.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { User } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { useConfig } from "@/lib/config/ConfigProvider";
+import { useProjectStore } from "@/lib/project/store";
+
+export function CharacterBadge({ name }: { name?: string }) {
+	const { projectId } = useConfig();
+	const avatarUrl = useProjectStore(projectId, (state) =>
+		name ? state.metadata.characters[name]?.avatarUrl : undefined,
+	);
+	const initial = name?.trim().charAt(0).toUpperCase();
+
+	return (
+		<div className="flex items-center gap-2 shrink-0 min-w-0 max-w-[140px]">
+			<Avatar size="sm" className="bg-white/10">
+				{avatarUrl && (
+					<AvatarImage
+						src={avatarUrl}
+						alt={name ?? "Character"}
+						className="object-cover object-center"
+					/>
+				)}
+				<AvatarFallback className="bg-white/10 text-white">
+					{initial || <User className="w-3 h-3" aria-hidden="true" />}
+				</AvatarFallback>
+			</Avatar>
+			{name && (
+				<span className="truncate text-xs font-medium text-white/80">
+					{name}
+				</span>
+			)}
+		</div>
+	);
+}

--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -118,6 +118,7 @@ export function ElementContainer({
 			>
 				<OutputPreview
 					type={element.type}
+					characterName={element.customAttributes?.name}
 					generating={gen.generating}
 					queued={gen.queued}
 					seconds={gen.seconds}

--- a/app/components/canvas/elements/OutputPreview.tsx
+++ b/app/components/canvas/elements/OutputPreview.tsx
@@ -9,6 +9,7 @@ import {
 	TooltipContent,
 } from "@/components/ui/tooltip";
 import { AudioPlayer } from "./AudioPlayer";
+import { CharacterBadge } from "./CharacterBadge";
 import type { CanvasElementType } from "../types";
 import type { AssetResult } from "@/lib/connectors/types";
 import { ELEMENT_CONFIGS } from "../config/elementConfigs";
@@ -289,6 +290,7 @@ function ErrorMessage({ message }: { message: string }) {
 function AudioResult({
 	type,
 	src,
+	characterName,
 	generating,
 	queued,
 	seconds,
@@ -297,11 +299,13 @@ function AudioResult({
 }: GenerationState & {
 	type: CanvasElementType;
 	src: string;
+	characterName?: string;
 	stale: boolean;
 	onRegenerate: () => void;
 }) {
 	return (
-		<div className="group relative w-full h-16 rounded-lg overflow-hidden border border-white/10 bg-white/[0.03] flex items-center gap-1.5 px-2">
+		<div className="group relative w-full min-h-16 rounded-lg overflow-hidden border border-white/10 bg-white/[0.03] flex flex-wrap items-center gap-x-2 gap-y-1.5 px-2 py-1.5">
+			{type === "character" && <CharacterBadge name={characterName} />}
 			<RegenerateButton
 				generating={generating}
 				queued={queued}
@@ -317,6 +321,7 @@ function AudioResult({
 
 interface OutputPreviewProps {
 	type: CanvasElementType;
+	characterName?: string;
 	generating: boolean;
 	queued: boolean;
 	seconds: number;
@@ -334,7 +339,7 @@ function AudioPlaceholder({
 	error,
 	onGenerate,
 	onDiscard,
-}: Omit<OutputPreviewProps, "type" | "result" | "stale">) {
+}: Omit<OutputPreviewProps, "type" | "characterName" | "result" | "stale">) {
 	const staticRotations = useStaticRotations();
 
 	const [mask] = useState(() => {
@@ -495,6 +500,7 @@ const WAVE_COLORS: Record<CanvasElementType, string> = {
 
 export function OutputPreview({
 	type,
+	characterName,
 	generating,
 	queued,
 	seconds,
@@ -512,6 +518,7 @@ export function OutputPreview({
 				<AudioResult
 					type={type}
 					src={result.url}
+					characterName={characterName}
 					generating={generating}
 					queued={queued}
 					seconds={seconds}


### PR DESCRIPTION
## Summary
- Render a circular character avatar + name inside the audio result preview for character elements, sourced from `metadata.characters[name].avatarUrl` in the project store. Falls back to the name's initial, then a `User` icon when name is empty.
- Image uses `object-cover object-center` so it preserves aspect ratio (cropped/centered into the circle).
- Flatten the audio result row into a single `flex-wrap` container — avatar, name, regenerate button, play button, waveform, and time display are now direct siblings that wrap naturally as width shrinks (waveform shrinks first via `flex-1 basis-[160px] min-w-0`, time wraps below next, etc.). Audio placeholder unchanged.

## Test plan
- [ ] Character element with an `avatarUrl` shows the image cropped into a circle next to the name in the audio preview.
- [ ] Character element without an `avatarUrl` shows the name's first letter; with no name set, shows a `User` icon.
- [ ] Resize the canvas narrow: the audio preview row wraps gracefully (waveform shrinks, then time/play wrap below) and the card grows in height instead of overflowing.
- [ ] Non-character audio types (narration, music, sound) render unchanged.
- [ ] Audio placeholder (pre-generation) is unchanged.