### PR TITLE
nightly cleanup 2026-04-27

### DIFF
--- a/lib/connectors/__tests__/reference-images.test.ts
+++ b/lib/connectors/__tests__/reference-images.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createReferenceImagesPlugin } from "../plugins/reference-images";
+import { clearProjectStore, getProjectStore } from "@/lib/project/store";
+
+const projectId = "reference-images-test-project";
+
+afterEach(() => {
+	clearProjectStore(projectId);
+});
+
+describe("createReferenceImagesPlugin", () => {
+	it("has the expected name", () => {
+		expect(createReferenceImagesPlugin(projectId).name).toBe(
+			"reference-images",
+		);
+	});
+
+	it("returns params unchanged when store and params are empty", () => {
+		const { beforeGenerate } = createReferenceImagesPlugin(projectId);
+		const params = { prompt: "a cat" };
+		expect(beforeGenerate?.(params)).toBe(params);
+	});
+
+	it("uses store images when params has none", () => {
+		getProjectStore(projectId)
+			.getState()
+			.setReferenceImages(["https://img/a.png", "https://img/b.png"]);
+		const { beforeGenerate } = createReferenceImagesPlugin(projectId);
+		expect(beforeGenerate?.({ prompt: "a cat" })).toEqual({
+			prompt: "a cat",
+			referenceImages: ["https://img/a.png", "https://img/b.png"],
+		});
+	});
+
+	it("appends store images to existing referenceImages", () => {
+		getProjectStore(projectId)
+			.getState()
+			.setReferenceImages(["https://img/store.png"]);
+		const { beforeGenerate } = createReferenceImagesPlugin(projectId);
+		expect(
+			beforeGenerate?.({
+				prompt: "a cat",
+				referenceImages: ["https://img/existing.png"],
+			}),
+		).toEqual({
+			prompt: "a cat",
+			referenceImages: ["https://img/existing.png", "https://img/store.png"],
+		});
+	});
+
+	it("preserves existing referenceImages when store is empty", () => {
+		const { beforeGenerate } = createReferenceImagesPlugin(projectId);
+		expect(
+			beforeGenerate?.({
+				prompt: "a cat",
+				referenceImages: ["https://img/existing.png"],
+			}),
+		).toEqual({
+			prompt: "a cat",
+			referenceImages: ["https://img/existing.png"],
+		});
+	});
+});


### PR DESCRIPTION
Automated nightly cleanup: added test coverage for reference-images plugin (5 tests). No code changes. All 490 tests pass.