### PR TITLE
show queue progress bar in player slot when busy

### DIFF
--- a/app/components/video/QueueProgressBar.module.css
+++ b/app/components/video/QueueProgressBar.module.css
@@ -1,0 +1,6 @@
+.fill {
+	height: 100%;
+	background-color: rgb(139 92 246);
+	box-shadow: 0 0 4px rgba(139, 92, 246, 0.5);
+	transition: width 300ms ease-out;
+}

--- a/app/components/video/QueueProgressBar.tsx
+++ b/app/components/video/QueueProgressBar.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState, useSyncExternalStore } from "react";
+import { generationQueue } from "@/lib/generation/queue";
+import styles from "./QueueProgressBar.module.css";
+
+export function QueueProgressBar() {
+	const active = useSyncExternalStore(
+		generationQueue.subscribe,
+		generationQueue.getActiveCount,
+		() => 0,
+	);
+	const [peak, setPeak] = useState(0);
+	if (active > peak) setPeak(active);
+	else if (active === 0 && peak !== 0) setPeak(0);
+	const done = peak - active;
+	const pct = peak === 0 ? 0 : (done / peak) * 100;
+
+	return (
+		<div className="shimmer-surface flex aspect-video w-full items-center justify-center">
+			<div className="flex w-2/3 max-w-md flex-col items-center gap-2">
+				<div
+					className="h-1.5 w-full overflow-hidden rounded-full bg-white/10"
+					role="progressbar"
+					aria-valuemin={0}
+					aria-valuemax={peak || 1}
+					aria-valuenow={done}
+					aria-label="Generation progress"
+				>
+					<div className={styles.fill} style={{ width: `${pct}%` }} />
+				</div>
+				<div className="text-xs text-white/60 tabular-nums">
+					{peak === 0 ? "Preparing…" : `${done} of ${peak} generated`}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/app/components/video/VideoPanel.tsx
+++ b/app/components/video/VideoPanel.tsx
@@ -3,6 +3,7 @@
 import { useLayout } from "./VideoLayoutContext";
 import { VideoPreview } from "./VideoPreview";
 import { RenderControls } from "./RenderControls";
+import { QueueProgressBar } from "./QueueProgressBar";
 
 export function VideoPanel() {
 	const { layout, ready, playerKey } = useLayout();
@@ -14,7 +15,7 @@ export function VideoPanel() {
 				{layout && ready ? (
 					<VideoPreview key={playerKey} layout={layout} />
 				) : layout ? (
-					<div className="shimmer-surface aspect-video w-full" />
+					<QueueProgressBar />
 				) : (
 					<div className="flex aspect-video items-center justify-center text-sm text-white/40">
 						Generate assets to see the video preview

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -80,6 +80,14 @@ export class GenerationQueue {
 		return false;
 	};
 
+	getActiveCount = (): number => {
+		let active = 0;
+		for (const snap of this.state.values()) {
+			if (snap.status === "queued" || snap.status === "generating") active++;
+		}
+		return active;
+	};
+
 	private isInQueue(id: string): boolean {
 		const s = this.state.get(id)?.status;
 		return s === "queued" || s === "generating";


### PR DESCRIPTION
## Summary
- Replaces the bare `shimmer-surface` placeholder in `VideoPanel` with a new `QueueProgressBar` that shows determinate "X of Y generated" progress while the generation queue is busy.
- New self-contained component subscribes to `generationQueue` directly via `useSyncExternalStore`; tracks peak active job count locally so the bar fills smoothly as jobs complete and resets between batches.
- Adds `getActiveCount()` to the queue (primitive return so the snapshot stays referentially stable).

## Test plan
- [ ] `npm run dev`, generate a script, click "Generate & Preview" — bar appears in the player slot, fills from 0 to 100% as jobs complete, then transitions to the Remotion player.
- [ ] Mid-batch, regenerate one element from the canvas — bar reappears with a new peak and clears when the queue empties.
- [ ] CI: lint, format, typecheck, tests all green.