### PR TITLE
fix: nightly bug fixes 2026-04-28

### DIFF
--- a/app/api/upload/image/route.ts
+++ b/app/api/upload/image/route.ts
@@ -35,6 +35,6 @@ export async function POST(request: NextRequest) {
 		},
 	]);
 
-	const url = `${AssetBundle.buildUrl("upload", "user", response.id)}/${file.name}`;
+	const url = `${AssetBundle.buildUrl("upload", "user", response.id)}/${encodeURIComponent(file.name)}`;
 	return NextResponse.json({ url });
 }

--- a/lib/clients/__tests__/openslop.test.ts
+++ b/lib/clients/__tests__/openslop.test.ts
@@ -141,6 +141,19 @@ describe("OpenSlopClient", () => {
 				"403 Forbidden",
 			);
 		});
+
+		it("falls back to status text when JSON response is a primitive", async () => {
+			fetchMock.mockResolvedValue({
+				ok: false,
+				status: 502,
+				statusText: "Bad Gateway",
+				json: () => Promise.resolve("upstream failed"),
+			});
+
+			await expect(client.post("/api/v1/image", {})).rejects.toThrow(
+				"502 Bad Gateway",
+			);
+		});
 	});
 
 	describe("auth", () => {

--- a/lib/clients/openslop.ts
+++ b/lib/clients/openslop.ts
@@ -29,9 +29,10 @@ export class OpenSlopClient {
 			...(body !== undefined && { body: JSON.stringify(body) }),
 		});
 		if (!res.ok) {
+			const fallback = `${res.status} ${res.statusText}`;
 			const message = await res.json().then(
-				(b) => b.error || `${res.status} ${res.statusText}`,
-				() => `${res.status} ${res.statusText}`,
+				(b) => (b && typeof b === "object" && b.error) || fallback,
+				() => fallback,
 			);
 			throw new Error(message);
 		}


### PR DESCRIPTION
## Summary
- Fix upload URL generation to safely encode user-provided filenames.
- Harden OpenSlop API client error parsing to avoid dropping status errors when JSON payloads are primitive or malformed.
- Add regression test coverage for primitive JSON error payload fallback behavior.

## Validation
- npm test -- --passWithNoTests
- npm run build