### PR TITLE
refactor: nightly maintainability 2026-04-28

### DIFF
--- a/app/components/canvas/elements/ForegroundPreview.tsx
+++ b/app/components/canvas/elements/ForegroundPreview.tsx
@@ -1,6 +1,3 @@
-import { useState } from "react";
-import Image from "next/image";
-import { Skeleton } from "@/components/ui/skeleton";
 import type { CanvasContentElement } from "../types";
 import { ELEMENT_CONFIGS } from "../config/elementConfigs";
 import { useGenerate } from "../hooks/useGenerate";
@@ -9,6 +6,7 @@ import {
 	useStaticRotations,
 	StaleIndicator,
 } from "./OutputPreview";
+import { MediaWithSkeleton } from "./MediaWithSkeleton";
 import loaderStyles from "./OutputPreview.module.css";
 
 export function ForegroundPreview({
@@ -17,7 +15,6 @@ export function ForegroundPreview({
 	element: CanvasContentElement;
 }) {
 	const { result, generating, stale, generate } = useGenerate(element);
-	const [loaded, setLoaded] = useState(false);
 	const { outputKind } = ELEMENT_CONFIGS[element.type];
 	const staticRotations = useStaticRotations();
 
@@ -38,25 +35,11 @@ export function ForegroundPreview({
 
 	return (
 		<div className={`relative w-full h-full rounded-lg overflow-hidden border`}>
-			{outputKind === "image" ? (
-				<Image
-					src={result.url}
-					alt="Scene preview"
-					fill
-					className="object-cover"
-					unoptimized
-					onLoad={() => setLoaded(true)}
-				/>
-			) : (
-				<video
-					src={result.url}
-					className="w-full h-full object-cover pointer-events-none"
-					onLoadedData={() => setLoaded(true)}
-				/>
-			)}
-			{!loaded && (
-				<Skeleton className="absolute inset-0 animate-none shimmer-surface" />
-			)}
+			<MediaWithSkeleton
+				outputKind={outputKind}
+				src={result.url}
+				alt="Scene preview"
+			/>
 			{stale && <StaleIndicator onClick={generate} />}
 		</div>
 	);

--- a/app/components/canvas/elements/MediaWithSkeleton.tsx
+++ b/app/components/canvas/elements/MediaWithSkeleton.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import Image from "next/image";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { ResultKind } from "../types";
+
+interface MediaWithSkeletonProps {
+	outputKind: ResultKind;
+	src: string;
+	alt: string;
+	videoInteractive?: boolean;
+}
+
+export function MediaWithSkeleton({
+	outputKind,
+	src,
+	alt,
+	videoInteractive = false,
+}: MediaWithSkeletonProps) {
+	const [loaded, setLoaded] = useState(false);
+
+	return (
+		<>
+			{outputKind === "image" ? (
+				<Image
+					src={src}
+					alt={alt}
+					fill
+					className="object-cover"
+					unoptimized
+					onLoad={() => setLoaded(true)}
+				/>
+			) : (
+				<video
+					src={src}
+					controls={videoInteractive}
+					className={
+						videoInteractive
+							? "w-full h-full object-cover"
+							: "w-full h-full object-cover pointer-events-none"
+					}
+					onLoadedData={() => setLoaded(true)}
+				/>
+			)}
+			{!loaded && (
+				<Skeleton className="absolute inset-0 animate-none shimmer-surface" />
+			)}
+		</>
+	);
+}

--- a/app/components/canvas/elements/OutputPreview.tsx
+++ b/app/components/canvas/elements/OutputPreview.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
-import Image from "next/image";
 import { X as XIcon, Wand2, RotateCcw, AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Skeleton } from "@/components/ui/skeleton";
 import {
 	Tooltip,
 	TooltipTrigger,
@@ -10,6 +8,7 @@ import {
 } from "@/components/ui/tooltip";
 import { AudioPlayer } from "./AudioPlayer";
 import { CharacterBadge } from "./CharacterBadge";
+import { MediaWithSkeleton } from "./MediaWithSkeleton";
 import type { CanvasElementType } from "../types";
 import type { AssetResult } from "@/lib/connectors/types";
 import { ELEMENT_CONFIGS } from "../config/elementConfigs";
@@ -443,32 +442,16 @@ function MediaPreview({
 	stale: boolean;
 	onRegenerate: () => void;
 }) {
-	const [loaded, setLoaded] = useState(false);
-
 	return (
 		<div
 			className={`group relative w-full aspect-video rounded-lg overflow-hidden border ${borderColor}`}
 		>
-			{outputKind === "image" ? (
-				<Image
-					src={url}
-					alt="Generated"
-					fill
-					className="object-cover"
-					unoptimized
-					onLoad={() => setLoaded(true)}
-				/>
-			) : (
-				<video
-					src={url}
-					controls
-					className="w-full h-full object-cover"
-					onLoadedData={() => setLoaded(true)}
-				/>
-			)}
-			{!loaded && (
-				<Skeleton className="absolute inset-0 animate-none shimmer-surface" />
-			)}
+			<MediaWithSkeleton
+				outputKind={outputKind}
+				src={url}
+				alt="Generated"
+				videoInteractive
+			/>
 			<ResultOverlay
 				generating={generating}
 				queued={queued}

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -37,6 +37,9 @@ const EMPTY_SNAPSHOT: ElementSnapshot = {
 	resultInputs: null,
 };
 
+const isActive = (status: ElementSnapshot["status"]) =>
+	status === "queued" || status === "generating";
+
 export class GenerationQueue {
 	private state = new Map<string, ElementSnapshot>();
 	private pending: GenerationJob[] = [];
@@ -75,7 +78,7 @@ export class GenerationQueue {
 
 	isBusy = (): boolean => {
 		for (const snap of this.state.values()) {
-			if (snap.status === "queued" || snap.status === "generating") return true;
+			if (isActive(snap.status)) return true;
 		}
 		return false;
 	};
@@ -83,14 +86,14 @@ export class GenerationQueue {
 	getActiveCount = (): number => {
 		let active = 0;
 		for (const snap of this.state.values()) {
-			if (snap.status === "queued" || snap.status === "generating") active++;
+			if (isActive(snap.status)) active++;
 		}
 		return active;
 	};
 
 	private isInQueue(id: string): boolean {
 		const s = this.state.get(id)?.status;
-		return s === "queued" || s === "generating";
+		return s !== undefined && isActive(s);
 	}
 
 	private update(id: string, patch: Partial<ElementSnapshot>) {


### PR DESCRIPTION
## Summary
- extract shared media+skeleton preview into reusable component
- simplify queue status checks with a shared active-status predicate
- preserve behavior while reducing duplication across canvas previews

## Test plan
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm test -- --passWithNoTests