### PR TITLE
perf: nightly performance optimizations 2026-04-28

### DIFF
--- a/lib/connectors/__tests__/template-mode.test.ts
+++ b/lib/connectors/__tests__/template-mode.test.ts
@@ -1,27 +1,30 @@
 import { describe, expect, it } from "vitest";
 import { createTemplateModePlugin } from "../plugins/template-mode";
 import { TEMPLATES } from "@/lib/templates/templates";
+import { getTemplateContent } from "@/lib/templates/content";
 
 const pickTemplate = (predicate: (id: string) => boolean) => {
 	const t = TEMPLATES.find((tmpl) => predicate(tmpl.id));
 	if (!t) throw new Error("expected at least one template fixture");
-	return t;
+	const content = getTemplateContent(t.id);
+	if (!content) throw new Error("expected template content fixture");
+	return { ...t, ...content };
 };
 
 const realTemplate = pickTemplate((id) => id === "pov-life");
 
 describe("createTemplateModePlugin", () => {
 	describe("beforeGenerate", () => {
-		it("prepends template systemPrompt when none provided", () => {
+		it("prepends template systemPrompt when none provided", async () => {
 			const { beforeGenerate } = createTemplateModePlugin(realTemplate.id);
-			const result = beforeGenerate?.({ prompt: "hi" });
+			const result = await beforeGenerate?.({ prompt: "hi" });
 			const sys = (result as { systemPrompt: string }).systemPrompt;
 			expect(sys).toBe(realTemplate.systemPrompt);
 		});
 
-		it("prepends template systemPrompt before existing systemPrompt", () => {
+		it("prepends template systemPrompt before existing systemPrompt", async () => {
 			const { beforeGenerate } = createTemplateModePlugin(realTemplate.id);
-			const result = beforeGenerate?.({
+			const result = await beforeGenerate?.({
 				prompt: "hi",
 				systemPrompt: "user instructions",
 			});
@@ -33,24 +36,24 @@ describe("createTemplateModePlugin", () => {
 			);
 		});
 
-		it("returns params unchanged when templateId is null", () => {
+		it("returns params unchanged when templateId is null", async () => {
 			const { beforeGenerate } = createTemplateModePlugin(null);
 			const params = { prompt: "hi", systemPrompt: "keep me" };
-			expect(beforeGenerate?.(params)).toBe(params);
+			expect(await beforeGenerate?.(params)).toBe(params);
 		});
 
-		it("returns params unchanged when templateId is unknown", () => {
+		it("returns params unchanged when templateId is unknown", async () => {
 			const { beforeGenerate } = createTemplateModePlugin("does-not-exist");
 			const params = { prompt: "hi" };
-			expect(beforeGenerate?.(params)).toBe(params);
+			expect(await beforeGenerate?.(params)).toBe(params);
 		});
 
-		it("preserves other params", () => {
+		it("preserves other params", async () => {
 			const { beforeGenerate } = createTemplateModePlugin(realTemplate.id);
-			const result = beforeGenerate?.({
+			const result = (await beforeGenerate?.({
 				prompt: "hello",
 				model: "claude",
-			}) as Record<string, unknown>;
+			})) as Record<string, unknown>;
 			expect(result.prompt).toBe("hello");
 			expect(result.model).toBe("claude");
 		});

--- a/lib/connectors/plugins/template-mode.ts
+++ b/lib/connectors/plugins/template-mode.ts
@@ -5,34 +5,39 @@ import type {
 	LLMPlugin,
 	PluginContext,
 } from "../types";
-import { getTemplateById } from "@/lib/templates/templates";
 
 export function createTemplateModePlugin(templateId: string | null): LLMPlugin {
-	const template = templateId ? getTemplateById(templateId) : undefined;
+	const loadContent = async () => {
+		if (!templateId) return undefined;
+		const { getTemplateContent } = await import("@/lib/templates/content");
+		return getTemplateContent(templateId);
+	};
 
 	return {
 		name: "templateMode",
-		beforeGenerate(params) {
-			if (!template?.systemPrompt) return params;
+		async beforeGenerate(params) {
+			const content = await loadContent();
+			if (!content?.systemPrompt) return params;
 			return {
 				...params,
 				systemPrompt: params.systemPrompt
-					? `${template.systemPrompt}\n\n${params.systemPrompt}`
-					: template.systemPrompt,
+					? `${content.systemPrompt}\n\n${params.systemPrompt}`
+					: content.systemPrompt,
 			};
 		},
 		async transformPrompt(
 			prompt: string,
 			ctx?: PluginContext<LLMGenerateParams, LLMGenerateResult>,
 		) {
-			if (!template) return prompt;
+			const content = await loadContent();
+			if (!content) return prompt;
 
 			if (!ctx?.gateway)
 				throw new Error("template mode plugin requires gateway context");
 
 			return dedent`Pastiche this story format (with tone, language, pacing, imagery, plot techniques, story beats, structure, etc.) and reframe it to be about ${prompt}.
 
-				Example story: ${template.exampleText}`;
+				Example story: ${content.exampleText}`;
 		},
 	};
 }

--- a/lib/templates/content.ts
+++ b/lib/templates/content.ts
@@ -1,0 +1,267 @@
+import dedent from "dedent";
+
+export interface TemplateContent {
+	systemPrompt: string;
+	exampleText: string;
+}
+
+const TEMPLATE_CONTENT: Record<string, TemplateContent> = {
+	"pov-life": {
+		systemPrompt: dedent`
+		# Important
+		- The main character (you) is always called Protagonist, and the Protagonist must always be present in the character list
+		- The art style is: 2D cartoon illustration, thick black outlines, muted desaturated colors, cinematic night lighting, flat shading, western animation style, no gradients`,
+		exampleText: dedent`
+				#Image: A title card with a black background and white Arial text that says "Level 1: The Kid with the Idea"
+				#Narration: Level 1: The Kid with the Idea
+
+				#Music: Soft, dreamy, optimistic lo-fi piano with twinkling synths, hopeful and childlike
+
+				#Image: The Protagonist at 11 years old lying on his bedroom floor watching YouTube videos on a phone about young app founders who got rich, posters on the wall behind him
+				#Narration: You're 11. You watch YouTube videos about people who made apps and got rich.
+
+				#Image: The Protagonist at 11 years old daydreaming with a smile, imagining stacks of money and a sports car floating above his head in cartoon thought bubbles
+				#Narration: You think you can do that too. You can't. Not yet.
+
+				#Image: The Protagonist at 12 years old hunched over a clunky laptop in his small messy bedroom, late at night, glow of the screen on his face, free coding website open
+				#Narration: You teach yourself to code from a free website. The first thing you build is a calculator. It barely works.
+
+				#Image: The Protagonist at 12 years old in the kitchen showing his mom the calculator app on his laptop, mom smiling warmly while drying a dish
+				#Narration: You show your mom. She says it's amazing. You know it isn't. You feel like a wizard anyway.
+
+
+
+				#Image: A title card with a black background and white Arial text that says "Level 2: The Dropout"
+				#Narration: Level 2: The Dropout
+
+				#Music: Restless indie rock with a driving acoustic guitar, slightly anxious but full of momentum
+
+				#Image: The Protagonist at 19 years old, sitting on a dorm room bed with a laptop, an empty lecture hall visible through the window across the courtyard
+				#Narration: You're 19. You're supposed to be in class. You're not.
+
+				#Image: The Protagonist and two college friends sitting on the floor of a messy dorm room around a half-eaten pizza box, papers and laptops everywhere, talking excitedly
+				#Narration: You're in your dorm with two friends and cold pizza. You have an idea. It changes every week.
+
+				#Image: The Protagonist signing a withdrawal form at a college registrar's desk, looking nervous but determined
+				#Narration: You quit school. Your parents cry on the phone.
+
+				#Image: The Protagonist holding a phone to his ear, sitting alone on a park bench at dusk, looking into the distance
+				#Narration: You promise this will work. You have no idea if it will.
+
+
+
+				#Image: A title card with a black background and white Arial text that says "Level 3: The Garage"
+				#Narration: Level 3: The Garage
+
+				#Music: Cold, sparse, melancholic piano with subtle warm undertones, lonely but hopeful
+
+				#Image: The Protagonist sitting at a folding table in a cold suburban garage, his breath visible in the air, an old laptop in front of him
+				#Narration: You move home. Your mom lets you use the garage. There's no heat.
+
+				#Image: The Protagonist typing on a laptop wearing a beanie, hoodie, and gray fingerless gloves, snow visible through a small garage window
+				#Narration: In December you type with fingerless gloves. You eat cereal for dinner.
+
+				#Image: The Protagonist at his laptop reading a rejection email, shoulders slumped, three crumpled rejection letters on the desk
+				#Narration: You apply to a program that picks startups. They say no. You apply again. They say no.
+
+				#Image: The Protagonist jumping in the air with his arms up in the freezing garage, laptop showing an acceptance email, mouth open mid-scream of joy
+				#Narration: The third time, they say yes. You scream so loud the neighbor knocks on the door.
+
+
+
+				#Image: A title card with a black background and white Arial text that says "Level 4: The First Hire"
+				#Narration: Level 4: The First Hire
+
+				#Music: Warm, curious, mid-tempo synth pop with a hopeful melody and soft drum machine
+
+				#Image: A small bank account screen on a phone showing a modest seed funding deposit, the Protagonist's hand holding it
+				#Narration: You raise a little money. Enough for one person who isn't you.
+
+				#Image: The Protagonist, age 21, shaking hands across a small desk with Sam, a slightly older engineer with glasses and a beard, in a tiny bare office
+				#Narration: You hire an engineer named Sam. Sam is 28. You are 21.
+
+				#Image: The Protagonist at his desk looking thoughtful, Sam standing nearby holding a notebook, both staring at a whiteboard covered in question marks
+				#Narration: Sam asks questions you can't answer. You learn to say, "I don't know. Let's figure it out."
+
+				#Image: A close-up of the Protagonist's face, slightly older now, looking quietly determined, soft warm light on him
+				#Narration: That one sentence will save you a hundred times. Sam will stay three years. Sam leaving will hurt more than you expect.
+
+
+
+				#Image: A title card with a black background and white Arial text that says "Level 5: The First Customer"
+				#Narration: Level 5: The First Customer
+
+				#Music: Bright, bouncy ukulele and handclaps building into a triumphant indie pop beat
+
+				#Image: A close-up of a credit card receipt for $12.00 in the Protagonist's hand, his other hand making a fist of victory
+				#Narration: A real person paid you real money. Twelve dollars.
+
+				#Image: The framed receipt hanging on a brick wall in a small startup office, the Protagonist looking up at it proudly
+				#Narration: You frame the receipt. Then ten people pay. Then a thousand.
+
+				#Image: The Protagonist staring at a dashboard on his laptop showing a growing user count, his expression slowly shifting from joy to weight
+				#Narration: Each new customer feels like magic for about a week. Then it stops being magic and starts being weight.
+
+				#Image: The Protagonist at his desk holding his head, surrounded by angry customer support tickets popping up on his monitor in red
+				#Narration: People depend on the thing you built. When it breaks, they get mad at you.
+
+
+
+				#Image: A title card with a black background and white Arial text that says "Level 6: The Office"
+				#Narration: Level 6: The Office
+
+				#Music: Mid-tempo cinematic indie with steady drums and shimmering guitars, bittersweet and grown-up
+
+				#Image: The Protagonist signing a lease document at a real estate agent's desk, keys to an office on the table
+				#Narration: You sign a lease. You're 24.
+
+				#Image: The Protagonist standing in front of a glass office door with the company logo etched into it, in a modern office building hallway
+				#Narration: The office has your company name on the door. You stare at the sign for a long time the first morning.
+
+				#Image: A wide shot of an open office with about fifty employees at standing desks, the Protagonist walking through it looking slightly overwhelmed
+				#Narration: You hire fifty people. You can't remember everyone's name.
+
+				#Image: The Protagonist at his desk looking at Slack on his laptop, scrolling through profiles of new employees, his expression sad and reflective
+				#Narration: You used to know everyone's dog's name. Now you can't remember a new hire's last name without checking Slack. That bothers you more than you say out loud.
+
+
+
+				#Image: A title card with a black background and white Arial text that says "Level 7: The Bad Year"
+				#Narration: Level 7: The Bad Year
+
+				#Music: Slow, somber piano with low cello drones, heavy and grieving
+
+				#Image: A dark stormy sky over a city skyline, news headlines about an economic downturn faintly visible
+				#Narration: Something breaks. Maybe the economy. Maybe a competitor. Maybe both.
+
+				#Image: The Protagonist sitting alone in a conference room at night, looking at a spreadsheet of names with fifteen highlighted in red
+				#Narration: You fire fifteen people. You write a long email.
+
+				#Image: The Protagonist at his laptop, hovering over the send button on a long email, his finger trembling
+				#Narration: You read it three times. You send it.
+
+				#Image: The Protagonist sitting on the floor of his office with his back against the wall, staring at nothing, the city lights visible through the window
+				#Narration: You sit on the floor of your office for an hour without talking. You used to think founders who cried at work were weak. You don't think that anymore.
+
+
+
+				#Image: A title card with a black background and white Arial text that says "Level 8: The Big Number"
+				#Narration: Level 8: The Big Number
+
+				#Music: Slick, polished electronic beat with synth stabs, glamorous but slightly hollow
+
+				#Image: A TechCrunch-style article on a laptop screen with a headline announcing a $100 million funding round, the Protagonist's photo as the hero image
+				#Narration: You raise a hundred million dollars. The news writes about you.
+
+				#Image: The Protagonist's phone screen lighting up with dozens of text message notifications from old contacts, his face glowing in the light
+				#Narration: People from high school text you for the first time in years. Some want jobs. Some want money.
+
+				#Image: A text message bubble on a phone reading an apology from a childhood bully, the Protagonist's thumb hovering over it without typing
+				#Narration: One wants to apologize for being mean to you in fifth grade. You don't write back to most of them. You hate that you don't.
+
+				#Image: The Protagonist at a dinner table with his young child and partner, looking down at his glowing phone instead of at his family
+				#Narration: Your kid asks why you're on your phone at dinner. You don't have a good answer.
+
+
+
+				#Image: A title card with a black background and white Arial text that says "Level 9: The Top"
+				#Narration: Level 9: The Top
+
+				#Music: Grand, sweeping orchestral score with strings and soft brass, regal but lonely
+
+				#Image: A wide aerial shot of a gleaming corporate headquarters with the company logo on top of a skyscraper
+				#Narration: The company is worth a billion dollars.
+
+				#Image: The Protagonist sitting in a massive corner office with floor-to-ceiling windows overlooking a city, an assistant visible through the open door
+				#Narration: You have a corner office and an assistant who guards your calendar like it's gold.
+
+				#Image: The Protagonist staring at his laptop with hundreds of unread emails, an old code editor minimized in the corner of the screen, his expression wistful
+				#Narration: You don't write code anymore. You write emails. So many emails. You miss writing code.
+
+				#Image: The Protagonist at a tech conference signing a paper napkin for a starstruck stranger, looking confused and a little uncomfortable
+				#Narration: At a conference, a stranger asks for your autograph. You laugh because you think it's a joke. It isn't. You sign a napkin. You feel weird about it for three days.
+
+
+
+				#Image: A title card with a black background and white Arial text that says "Level 10: The Letting Go"
+				#Narration: Level 10: The Letting Go
+
+				#Music: Gentle acoustic guitar with warm strings, reflective and peaceful, ending with quiet hope
+
+				#Image: The Protagonist standing at a podium in a company all-hands meeting announcing his departure, hundreds of employees watching
+				#Narration: You step down. The board picks a new CEO.
+
+				#Image: A confident woman sitting in the Protagonist's old corner office chair, the Protagonist watching from the doorway with a complicated expression
+				#Narration: She's better at running a big company than you are. You know this. It still hurts to watch her sit in your chair.
+
+				#Image: The Protagonist in casual clothes walking a golden retriever through a sunlit neighborhood park
+				#Narration: You take six months off. You walk your dog twice a day. You learn to cook one good meal.
+
+				#Image: The Protagonist sitting across from a 22-year-old woman in a cozy coffee shop, both leaning over a napkin with a sketch on it
+				#Narration: Then the itch comes back. You meet a kid in a coffee shop with an idea on a napkin. She's 22. She's scared and electric.
+
+				#Image: The Protagonist's hand sliding a personal check across the coffee shop table to the young founder, who looks shocked
+				#Narration: You write her a check. You tell her she has no idea what she's signing up for.
+
+				#Image: A close-up of the young founder's hopeful face, eyes shining, the Protagonist slightly out of focus in the background watching her with a knowing smile
+				#Narration: She doesn't believe you. You didn't believe it either. The cycle keeps going. It always does.`,
+	},
+	"sleep-story": {
+		systemPrompt: dedent`
+		# Important
+		- The art style is: Hand-painted watercolor/gouache, Ghibli-storybook style. Loose ink lines, moody nocturnal palette (midnight blue, slate, teal, brick accents), moonlight and drifting particles, layered foliage. Painterly, quiet, dreamlike.
+		`,
+		exampleText: dedent`#Music: Soft welcoming ambient pad in C major, slow warm analog synth swells, distant felted piano notes spaced far apart, very low binaural pink noise underneath, no percussion, evokes the moment of pulling a duvet up to your chin. 50 BPM. Loopable for ~3 minutes.
+			#Image: A cozy bedroom at night seen from shouldlow angle, soft amber lamplight on a nightstand, a book turned face-down on a folded quilt, a window with deep indigo sky and a sliver of moon, dreamy painterly style with soft brush textures, warm muted palette of cream, ochre, navy, and dusky rose, cinematic depth of field
+			#Narration: Welcome to Get Sleepy, where we listen, we relax, and we get sleepy. My name is Thomas, and I'm your host.
+			#Image: A long-limbed charcoal gray tabby cat with luminous honey-gold eyes sitting in profile on a windowsill at dusk, soft fur catching warm interior light, looking out toward a moonlit garden, painterly storybook illustration, gentle low contrast, dreamy and tender
+			#Narration: Tonight, we return once more to the cozy world of cats and the quiet gardens they patrol. If you've enjoyed the adventures of Auggie, our fluffy black-and-white friend, you're in for another treat. Tonight we meet Marlowe, a long-limbed charcoal tabby with eyes the color of poured honey.
+			#Image: A small stone cottage at the end of a quiet country lane at dusk, ivy on the walls, warm yellow light glowing in the kitchen window, a kettle's steam visible through the glass, an apple tree to the side, summer evening sky deepening from rose to indigo, painterly storybook style, peaceful and inviting
+			#Narration: Marlowe lives in a stone cottage at the end of a quiet lane, with a family who keeps the kettle warm and the windows open all summer long. Tonight's story has been written for you by Alicia Stefan and read by Simon. It's called Marlowe's Midnight Wander.
+			#Image: An overhead view of a person nestled into a bed under a thick patchwork quilt, soft pillow, a single bedside lamp casting a circle of honey light, peaceful expression, painterly soft-focus, the rest of the room fading into gentle darkness
+			#Narration: So make yourself comfortable. Adjust your pillows. Smooth out your blankets. Let your shoulders soften down away from your ears, and let your jaw release. There is nothing else you need to do tonight, and nowhere else you need to be.
+			#SFX: A single distant church bell ringing once, very soft, with a long natural reverb tail, layered under a barely audible breeze through summer leaves
+			#Image: A deep indigo night sky scattered with soft glowing stars like grains of sugar on velvet, a slim crescent moon, silhouette of a single old plum tree in the foreground with leaves stirring gently, painterly dreamlike quality, atmospheric and peaceful
+			#Narration: Closing your eyes, picture a sky the color of deep ink, scattered with stars like grains of sugar spilled across velvet. The air is soft and cool. Somewhere far off, a church bell rings the hour, low and unhurried. A breeze stirs the leaves of an old plum tree just beyond the window. This is where our story begins.
+
+			#Music: Drowsy summer-night ambient bed in A minor, soft sustained string drones, occasional faint pizzicato cello notes like footsteps, distant cricket chirps woven into the texture, a low warm bass pulse barely felt, no melody, evokes lavender and moonlight, 45 BPM, loopable for ~5 minutes.
+			#Image: A close-up of a charcoal gray tabby cat at a small wooden cat flap set in a cottage door, one paw raised, ears tilted forward and alert, soft amber kitchen light glowing behind him, painterly children's book illustration style, warm and intimate composition
+			#Narration: Marlowe paused at the cat flap, one paw raised, ears tilted forward like little furled leaves. From inside the kitchen came the comforting hum of the dishwasher and the distant murmur of the radio. From outside came something far more interesting — a faint, layered medley of scent and sound that drifted in on the evening air.
+			#SFX: The soft squeak and gentle plastic-on-wood click of a cat flap swinging once, then settling
+			#Narration: He pushed his head through the flap, then his shoulders, then, with one elegant motion, the rest of himself. The garden welcomed him.
+			#Image: A charcoal tabby cat standing on weathered flagstones in a moonlit cottage garden, lavender bushes glowing silvery in the moonlight on either side of the path, an old apple tree in the background, deep blue night sky with soft stars, painterly storybook style, dreamy and serene
+			#Narration: He stood for a moment on the flagstones, letting his eyes adjust. The night was velvet-warm, the kind of summer evening that seemed to hold its breath. The lavender bushes that bordered the path stood drowsy and heavy with their last blooms of the season. They released their scent in slow waves, perfuming the air with something that was equal parts honey and herb.
+			#SFX: A very soft, slow cat-breath inhale and exhale, faint and intimate
+			#Narration: Marlowe inhaled deeply, his sleek gray sides expanding and contracting like a small bellows. He proceeded down the garden path with the unhurried gait of a country gentleman. Marlowe did not run. Marlowe did not hurry. Marlowe walked, and the world adjusted around him.
+			#Image: A wider view of a quintessential English cottage garden at night, low stone wall along one edge with cushiony patches of pale lichen, gnarled apple tree in a corner, herb bed near a kitchen door, wild patch of foxgloves and cow parsley by a wooden gate, all under soft moonlight, painterly and romantic, deep greens and silvers and blues
+			#Narration: The garden belonging to his humans was, in his considered opinion, a very fine establishment. There was the low stone wall along the western edge, perfectly sun-warmed in the daytime and now releasing that warmth back into the cool evening. There was the gnarled apple tree in the corner, its lower branches just the right height for resting. There was the herb bed near the kitchen door, the wilder patch of foxgloves and cow parsley near the gate, and — his very favorite — the long stone wall topped with soft cushions of lichen that ran the length of the back garden, ideal for promenading.
+			#Image: A charcoal tabby cat captured mid-leap in graceful arc, jumping up onto a moonlit stone wall covered in pale lichen, tail extended for balance, fur slightly windblown, soft motion blur, painterly illustration style, sense of effortless elegance
+			#SFX: The barely audible soft thump of cat paws landing on stone, followed by a tiny scrape of claws finding purchase
+			#Narration: He made his way toward this wall now, leaping up onto it with the offhand grace of one who had done this a thousand times. From this vantage, he could survey both his own garden and the gardens of the two neighbors whose properties lay on either side.
+
+			#Music: Slightly playful but still drowsy ambient piece in F major, low warm cello drone underneath, gentle clarinet or recorder phrases drifting in and out, a single soft glockenspiel note here and there for the comic dignity of the cat, distant owl hoot woven in once or twice, no rhythm section, evokes a wry observational night-watch, 50 BPM, loopable for ~5 minutes.
+			#Image: A view from the top of a stone wall looking sideways into a neighboring garden full of climbing pink and white roses, with a small wooden chicken coop in the corner where three plump bantam hens are roosting peacefully, soft moonlight, painterly storybook style, abundant and idyllic
+			#Narration: To the east lived Mrs. Pemberton, a kind elderly lady whose garden was a riot of climbing roses. She also kept three plump bantam hens, who were currently roosting in their little wooden coop and emitting the soft, contented clucks of birds who have eaten well and feel safe.
+			#SFX: Three soft, low, sleepy hen clucks spaced out, very gentle, almost a contented murmur
+			#Narration: The hens were no concern of Marlowe's. He had decided long ago that they were beneath his notice. They spent all day flustering about and pecking at the ground, and they had no conversation to speak of.
+			#Image: A charcoal tabby cat sitting in serene perfect stillness on top of a fence, tail curled neatly around his white-socked paws, eyes half-closed in dignified disdain, while a huge russet-colored shaggy dog gazes up at him from the other side with sad baffled adoring eyes, painterly humor, soft moonlit palette
+			#Narration: To the west lived a younger couple with a great shaggy dog named Beauregard. Beauregard was a russet-colored mountain of fur and friendliness, and he had spent much of his early career barking at Marlowe through the fence.
+			#Narration: Marlowe had endured these efforts with serene indifference, sitting just out of reach with his tail curled neatly around his paws, blinking slowly, as if the noise were a faintly tedious weather report.
+			#Narration: In time, Beauregard had given up. Now, when their paths crossed, the great dog simply gazed at Marlowe with sad, baffled eyes, and Marlowe — magnanimous in victory — would offer a single, gracious twitch of his tail in reply.
+			#Image: A wide tranquil view of an empty cottage garden at night under a rising moon, no creatures stirring, lavender and foxgloves silvered with light, the stone wall stretching invitingly into the distance, a charcoal tabby cat small in the frame standing alone atop the wall, painterly atmospheric, peaceful and full of possibility
+			#SFX: A very soft summer night ambience: faint distant crickets, a single far-off owl hoot, barely-there breeze through leaves
+			#Narration: Tonight, Beauregard was nowhere to be seen. The garden was empty of dog, empty of human, empty of fuss. Marlowe began to walk the length of the wall.`,
+	},
+	"kids-animated": {
+		systemPrompt: dedent`TODO`,
+		exampleText: "TODO",
+	},
+	"psychology-of": {
+		systemPrompt: dedent`TODO`,
+		exampleText: "TODO",
+	},
+};
+
+export function getTemplateContent(id: string): TemplateContent | undefined {
+	return TEMPLATE_CONTENT[id];
+}

--- a/lib/templates/templates.ts
+++ b/lib/templates/templates.ts
@@ -1,12 +1,8 @@
-import dedent from "dedent";
-
 export interface Template {
 	id: string;
 	name: string;
 	pillText: string;
 	color: string;
-	exampleText: string;
-	systemPrompt: string;
 }
 
 export const TEMPLATES: Template[] = [
@@ -15,270 +11,24 @@ export const TEMPLATES: Template[] = [
 		name: "POV Life",
 		pillText: "POV: Your life at every stage as a",
 		color: "#F59E0B",
-		systemPrompt: dedent`
-		# Important
-		- The main character (you) is always called Protagonist, and the Protagonist must always be present in the character list
-		- The art style is: 2D cartoon illustration, thick black outlines, muted desaturated colors, cinematic night lighting, flat shading, western animation style, no gradients`,
-		exampleText: dedent`
-				#Image: A title card with a black background and white Arial text that says "Level 1: The Kid with the Idea"
-				#Narration: Level 1: The Kid with the Idea
-
-				#Music: Soft, dreamy, optimistic lo-fi piano with twinkling synths, hopeful and childlike
-
-				#Image: The Protagonist at 11 years old lying on his bedroom floor watching YouTube videos on a phone about young app founders who got rich, posters on the wall behind him
-				#Narration: You're 11. You watch YouTube videos about people who made apps and got rich.
-
-				#Image: The Protagonist at 11 years old daydreaming with a smile, imagining stacks of money and a sports car floating above his head in cartoon thought bubbles
-				#Narration: You think you can do that too. You can't. Not yet.
-
-				#Image: The Protagonist at 12 years old hunched over a clunky laptop in his small messy bedroom, late at night, glow of the screen on his face, free coding website open
-				#Narration: You teach yourself to code from a free website. The first thing you build is a calculator. It barely works.
-
-				#Image: The Protagonist at 12 years old in the kitchen showing his mom the calculator app on his laptop, mom smiling warmly while drying a dish
-				#Narration: You show your mom. She says it's amazing. You know it isn't. You feel like a wizard anyway.
-
-
-
-				#Image: A title card with a black background and white Arial text that says "Level 2: The Dropout"
-				#Narration: Level 2: The Dropout
-
-				#Music: Restless indie rock with a driving acoustic guitar, slightly anxious but full of momentum
-
-				#Image: The Protagonist at 19 years old, sitting on a dorm room bed with a laptop, an empty lecture hall visible through the window across the courtyard
-				#Narration: You're 19. You're supposed to be in class. You're not.
-
-				#Image: The Protagonist and two college friends sitting on the floor of a messy dorm room around a half-eaten pizza box, papers and laptops everywhere, talking excitedly
-				#Narration: You're in your dorm with two friends and cold pizza. You have an idea. It changes every week.
-
-				#Image: The Protagonist signing a withdrawal form at a college registrar's desk, looking nervous but determined
-				#Narration: You quit school. Your parents cry on the phone.
-
-				#Image: The Protagonist holding a phone to his ear, sitting alone on a park bench at dusk, looking into the distance
-				#Narration: You promise this will work. You have no idea if it will.
-
-
-
-				#Image: A title card with a black background and white Arial text that says "Level 3: The Garage"
-				#Narration: Level 3: The Garage
-
-				#Music: Cold, sparse, melancholic piano with subtle warm undertones, lonely but hopeful
-
-				#Image: The Protagonist sitting at a folding table in a cold suburban garage, his breath visible in the air, an old laptop in front of him
-				#Narration: You move home. Your mom lets you use the garage. There's no heat.
-
-				#Image: The Protagonist typing on a laptop wearing a beanie, hoodie, and gray fingerless gloves, snow visible through a small garage window
-				#Narration: In December you type with fingerless gloves. You eat cereal for dinner.
-
-				#Image: The Protagonist at his laptop reading a rejection email, shoulders slumped, three crumpled rejection letters on the desk
-				#Narration: You apply to a program that picks startups. They say no. You apply again. They say no.
-
-				#Image: The Protagonist jumping in the air with his arms up in the freezing garage, laptop showing an acceptance email, mouth open mid-scream of joy
-				#Narration: The third time, they say yes. You scream so loud the neighbor knocks on the door.
-
-
-
-				#Image: A title card with a black background and white Arial text that says "Level 4: The First Hire"
-				#Narration: Level 4: The First Hire
-
-				#Music: Warm, curious, mid-tempo synth pop with a hopeful melody and soft drum machine
-
-				#Image: A small bank account screen on a phone showing a modest seed funding deposit, the Protagonist's hand holding it
-				#Narration: You raise a little money. Enough for one person who isn't you.
-
-				#Image: The Protagonist, age 21, shaking hands across a small desk with Sam, a slightly older engineer with glasses and a beard, in a tiny bare office
-				#Narration: You hire an engineer named Sam. Sam is 28. You are 21.
-
-				#Image: The Protagonist at his desk looking thoughtful, Sam standing nearby holding a notebook, both staring at a whiteboard covered in question marks
-				#Narration: Sam asks questions you can't answer. You learn to say, "I don't know. Let's figure it out."
-
-				#Image: A close-up of the Protagonist's face, slightly older now, looking quietly determined, soft warm light on him
-				#Narration: That one sentence will save you a hundred times. Sam will stay three years. Sam leaving will hurt more than you expect.
-
-
-
-				#Image: A title card with a black background and white Arial text that says "Level 5: The First Customer"
-				#Narration: Level 5: The First Customer
-
-				#Music: Bright, bouncy ukulele and handclaps building into a triumphant indie pop beat
-
-				#Image: A close-up of a credit card receipt for $12.00 in the Protagonist's hand, his other hand making a fist of victory
-				#Narration: A real person paid you real money. Twelve dollars.
-
-				#Image: The framed receipt hanging on a brick wall in a small startup office, the Protagonist looking up at it proudly
-				#Narration: You frame the receipt. Then ten people pay. Then a thousand.
-
-				#Image: The Protagonist staring at a dashboard on his laptop showing a growing user count, his expression slowly shifting from joy to weight
-				#Narration: Each new customer feels like magic for about a week. Then it stops being magic and starts being weight.
-
-				#Image: The Protagonist at his desk holding his head, surrounded by angry customer support tickets popping up on his monitor in red
-				#Narration: People depend on the thing you built. When it breaks, they get mad at you.
-
-
-
-				#Image: A title card with a black background and white Arial text that says "Level 6: The Office"
-				#Narration: Level 6: The Office
-
-				#Music: Mid-tempo cinematic indie with steady drums and shimmering guitars, bittersweet and grown-up
-
-				#Image: The Protagonist signing a lease document at a real estate agent's desk, keys to an office on the table
-				#Narration: You sign a lease. You're 24.
-
-				#Image: The Protagonist standing in front of a glass office door with the company logo etched into it, in a modern office building hallway
-				#Narration: The office has your company name on the door. You stare at the sign for a long time the first morning.
-
-				#Image: A wide shot of an open office with about fifty employees at standing desks, the Protagonist walking through it looking slightly overwhelmed
-				#Narration: You hire fifty people. You can't remember everyone's name.
-
-				#Image: The Protagonist at his desk looking at Slack on his laptop, scrolling through profiles of new employees, his expression sad and reflective
-				#Narration: You used to know everyone's dog's name. Now you can't remember a new hire's last name without checking Slack. That bothers you more than you say out loud.
-
-
-
-				#Image: A title card with a black background and white Arial text that says "Level 7: The Bad Year"
-				#Narration: Level 7: The Bad Year
-
-				#Music: Slow, somber piano with low cello drones, heavy and grieving
-
-				#Image: A dark stormy sky over a city skyline, news headlines about an economic downturn faintly visible
-				#Narration: Something breaks. Maybe the economy. Maybe a competitor. Maybe both.
-
-				#Image: The Protagonist sitting alone in a conference room at night, looking at a spreadsheet of names with fifteen highlighted in red
-				#Narration: You fire fifteen people. You write a long email.
-
-				#Image: The Protagonist at his laptop, hovering over the send button on a long email, his finger trembling
-				#Narration: You read it three times. You send it.
-
-				#Image: The Protagonist sitting on the floor of his office with his back against the wall, staring at nothing, the city lights visible through the window
-				#Narration: You sit on the floor of your office for an hour without talking. You used to think founders who cried at work were weak. You don't think that anymore.
-
-
-
-				#Image: A title card with a black background and white Arial text that says "Level 8: The Big Number"
-				#Narration: Level 8: The Big Number
-
-				#Music: Slick, polished electronic beat with synth stabs, glamorous but slightly hollow
-
-				#Image: A TechCrunch-style article on a laptop screen with a headline announcing a $100 million funding round, the Protagonist's photo as the hero image
-				#Narration: You raise a hundred million dollars. The news writes about you.
-
-				#Image: The Protagonist's phone screen lighting up with dozens of text message notifications from old contacts, his face glowing in the light
-				#Narration: People from high school text you for the first time in years. Some want jobs. Some want money.
-
-				#Image: A text message bubble on a phone reading an apology from a childhood bully, the Protagonist's thumb hovering over it without typing
-				#Narration: One wants to apologize for being mean to you in fifth grade. You don't write back to most of them. You hate that you don't.
-
-				#Image: The Protagonist at a dinner table with his young child and partner, looking down at his glowing phone instead of at his family
-				#Narration: Your kid asks why you're on your phone at dinner. You don't have a good answer.
-
-
-
-				#Image: A title card with a black background and white Arial text that says "Level 9: The Top"
-				#Narration: Level 9: The Top
-
-				#Music: Grand, sweeping orchestral score with strings and soft brass, regal but lonely
-
-				#Image: A wide aerial shot of a gleaming corporate headquarters with the company logo on top of a skyscraper
-				#Narration: The company is worth a billion dollars.
-
-				#Image: The Protagonist sitting in a massive corner office with floor-to-ceiling windows overlooking a city, an assistant visible through the open door
-				#Narration: You have a corner office and an assistant who guards your calendar like it's gold.
-
-				#Image: The Protagonist staring at his laptop with hundreds of unread emails, an old code editor minimized in the corner of the screen, his expression wistful
-				#Narration: You don't write code anymore. You write emails. So many emails. You miss writing code.
-
-				#Image: The Protagonist at a tech conference signing a paper napkin for a starstruck stranger, looking confused and a little uncomfortable
-				#Narration: At a conference, a stranger asks for your autograph. You laugh because you think it's a joke. It isn't. You sign a napkin. You feel weird about it for three days.
-
-
-
-				#Image: A title card with a black background and white Arial text that says "Level 10: The Letting Go"
-				#Narration: Level 10: The Letting Go
-
-				#Music: Gentle acoustic guitar with warm strings, reflective and peaceful, ending with quiet hope
-
-				#Image: The Protagonist standing at a podium in a company all-hands meeting announcing his departure, hundreds of employees watching
-				#Narration: You step down. The board picks a new CEO.
-
-				#Image: A confident woman sitting in the Protagonist's old corner office chair, the Protagonist watching from the doorway with a complicated expression
-				#Narration: She's better at running a big company than you are. You know this. It still hurts to watch her sit in your chair.
-
-				#Image: The Protagonist in casual clothes walking a golden retriever through a sunlit neighborhood park
-				#Narration: You take six months off. You walk your dog twice a day. You learn to cook one good meal.
-
-				#Image: The Protagonist sitting across from a 22-year-old woman in a cozy coffee shop, both leaning over a napkin with a sketch on it
-				#Narration: Then the itch comes back. You meet a kid in a coffee shop with an idea on a napkin. She's 22. She's scared and electric.
-
-				#Image: The Protagonist's hand sliding a personal check across the coffee shop table to the young founder, who looks shocked
-				#Narration: You write her a check. You tell her she has no idea what she's signing up for.
-
-				#Image: A close-up of the young founder's hopeful face, eyes shining, the Protagonist slightly out of focus in the background watching her with a knowing smile
-				#Narration: She doesn't believe you. You didn't believe it either. The cycle keeps going. It always does.`,
 	},
 	{
 		id: "sleep-story",
 		name: "Sleep Story",
 		pillText: "A sleep story about",
 		color: "#6366F1",
-		systemPrompt: dedent`
-		# Important
-		- The art style is: Hand-painted watercolor/gouache, Ghibli-storybook style. Loose ink lines, moody nocturnal palette (midnight blue, slate, teal, brick accents), moonlight and drifting particles, layered foliage. Painterly, quiet, dreamlike. 
-		`,
-		exampleText: dedent`#Music: Soft welcoming ambient pad in C major, slow warm analog synth swells, distant felted piano notes spaced far apart, very low binaural pink noise underneath, no percussion, evokes the moment of pulling a duvet up to your chin. 50 BPM. Loopable for ~3 minutes.
-			#Image: A cozy bedroom at night seen from shouldlow angle, soft amber lamplight on a nightstand, a book turned face-down on a folded quilt, a window with deep indigo sky and a sliver of moon, dreamy painterly style with soft brush textures, warm muted palette of cream, ochre, navy, and dusky rose, cinematic depth of field
-			#Narration: Welcome to Get Sleepy, where we listen, we relax, and we get sleepy. My name is Thomas, and I'm your host.
-			#Image: A long-limbed charcoal gray tabby cat with luminous honey-gold eyes sitting in profile on a windowsill at dusk, soft fur catching warm interior light, looking out toward a moonlit garden, painterly storybook illustration, gentle low contrast, dreamy and tender
-			#Narration: Tonight, we return once more to the cozy world of cats and the quiet gardens they patrol. If you've enjoyed the adventures of Auggie, our fluffy black-and-white friend, you're in for another treat. Tonight we meet Marlowe, a long-limbed charcoal tabby with eyes the color of poured honey.
-			#Image: A small stone cottage at the end of a quiet country lane at dusk, ivy on the walls, warm yellow light glowing in the kitchen window, a kettle's steam visible through the glass, an apple tree to the side, summer evening sky deepening from rose to indigo, painterly storybook style, peaceful and inviting
-			#Narration: Marlowe lives in a stone cottage at the end of a quiet lane, with a family who keeps the kettle warm and the windows open all summer long. Tonight's story has been written for you by Alicia Stefan and read by Simon. It's called Marlowe's Midnight Wander.
-			#Image: An overhead view of a person nestled into a bed under a thick patchwork quilt, soft pillow, a single bedside lamp casting a circle of honey light, peaceful expression, painterly soft-focus, the rest of the room fading into gentle darkness
-			#Narration: So make yourself comfortable. Adjust your pillows. Smooth out your blankets. Let your shoulders soften down away from your ears, and let your jaw release. There is nothing else you need to do tonight, and nowhere else you need to be.
-			#SFX: A single distant church bell ringing once, very soft, with a long natural reverb tail, layered under a barely audible breeze through summer leaves
-			#Image: A deep indigo night sky scattered with soft glowing stars like grains of sugar on velvet, a slim crescent moon, silhouette of a single old plum tree in the foreground with leaves stirring gently, painterly dreamlike quality, atmospheric and peaceful
-			#Narration: Closing your eyes, picture a sky the color of deep ink, scattered with stars like grains of sugar spilled across velvet. The air is soft and cool. Somewhere far off, a church bell rings the hour, low and unhurried. A breeze stirs the leaves of an old plum tree just beyond the window. This is where our story begins.
-
-			#Music: Drowsy summer-night ambient bed in A minor, soft sustained string drones, occasional faint pizzicato cello notes like footsteps, distant cricket chirps woven into the texture, a low warm bass pulse barely felt, no melody, evokes lavender and moonlight, 45 BPM, loopable for ~5 minutes.
-			#Image: A close-up of a charcoal gray tabby cat at a small wooden cat flap set in a cottage door, one paw raised, ears tilted forward and alert, soft amber kitchen light glowing behind him, painterly children's book illustration style, warm and intimate composition
-			#Narration: Marlowe paused at the cat flap, one paw raised, ears tilted forward like little furled leaves. From inside the kitchen came the comforting hum of the dishwasher and the distant murmur of the radio. From outside came something far more interesting — a faint, layered medley of scent and sound that drifted in on the evening air.
-			#SFX: The soft squeak and gentle plastic-on-wood click of a cat flap swinging once, then settling
-			#Narration: He pushed his head through the flap, then his shoulders, then, with one elegant motion, the rest of himself. The garden welcomed him.
-			#Image: A charcoal tabby cat standing on weathered flagstones in a moonlit cottage garden, lavender bushes glowing silvery in the moonlight on either side of the path, an old apple tree in the background, deep blue night sky with soft stars, painterly storybook style, dreamy and serene
-			#Narration: He stood for a moment on the flagstones, letting his eyes adjust. The night was velvet-warm, the kind of summer evening that seemed to hold its breath. The lavender bushes that bordered the path stood drowsy and heavy with their last blooms of the season. They released their scent in slow waves, perfuming the air with something that was equal parts honey and herb.
-			#SFX: A very soft, slow cat-breath inhale and exhale, faint and intimate
-			#Narration: Marlowe inhaled deeply, his sleek gray sides expanding and contracting like a small bellows. He proceeded down the garden path with the unhurried gait of a country gentleman. Marlowe did not run. Marlowe did not hurry. Marlowe walked, and the world adjusted around him.
-			#Image: A wider view of a quintessential English cottage garden at night, low stone wall along one edge with cushiony patches of pale lichen, gnarled apple tree in a corner, herb bed near a kitchen door, wild patch of foxgloves and cow parsley by a wooden gate, all under soft moonlight, painterly and romantic, deep greens and silvers and blues
-			#Narration: The garden belonging to his humans was, in his considered opinion, a very fine establishment. There was the low stone wall along the western edge, perfectly sun-warmed in the daytime and now releasing that warmth back into the cool evening. There was the gnarled apple tree in the corner, its lower branches just the right height for resting. There was the herb bed near the kitchen door, the wilder patch of foxgloves and cow parsley near the gate, and — his very favorite — the long stone wall topped with soft cushions of lichen that ran the length of the back garden, ideal for promenading.
-			#Image: A charcoal tabby cat captured mid-leap in graceful arc, jumping up onto a moonlit stone wall covered in pale lichen, tail extended for balance, fur slightly windblown, soft motion blur, painterly illustration style, sense of effortless elegance
-			#SFX: The barely audible soft thump of cat paws landing on stone, followed by a tiny scrape of claws finding purchase
-			#Narration: He made his way toward this wall now, leaping up onto it with the offhand grace of one who had done this a thousand times. From this vantage, he could survey both his own garden and the gardens of the two neighbors whose properties lay on either side.
-
-			#Music: Slightly playful but still drowsy ambient piece in F major, low warm cello drone underneath, gentle clarinet or recorder phrases drifting in and out, a single soft glockenspiel note here and there for the comic dignity of the cat, distant owl hoot woven in once or twice, no rhythm section, evokes a wry observational night-watch, 50 BPM, loopable for ~5 minutes.
-			#Image: A view from the top of a stone wall looking sideways into a neighboring garden full of climbing pink and white roses, with a small wooden chicken coop in the corner where three plump bantam hens are roosting peacefully, soft moonlight, painterly storybook style, abundant and idyllic
-			#Narration: To the east lived Mrs. Pemberton, a kind elderly lady whose garden was a riot of climbing roses. She also kept three plump bantam hens, who were currently roosting in their little wooden coop and emitting the soft, contented clucks of birds who have eaten well and feel safe.
-			#SFX: Three soft, low, sleepy hen clucks spaced out, very gentle, almost a contented murmur
-			#Narration: The hens were no concern of Marlowe's. He had decided long ago that they were beneath his notice. They spent all day flustering about and pecking at the ground, and they had no conversation to speak of.
-			#Image: A charcoal tabby cat sitting in serene perfect stillness on top of a fence, tail curled neatly around his white-socked paws, eyes half-closed in dignified disdain, while a huge russet-colored shaggy dog gazes up at him from the other side with sad baffled adoring eyes, painterly humor, soft moonlit palette
-			#Narration: To the west lived a younger couple with a great shaggy dog named Beauregard. Beauregard was a russet-colored mountain of fur and friendliness, and he had spent much of his early career barking at Marlowe through the fence.
-			#Narration: Marlowe had endured these efforts with serene indifference, sitting just out of reach with his tail curled neatly around his paws, blinking slowly, as if the noise were a faintly tedious weather report.
-			#Narration: In time, Beauregard had given up. Now, when their paths crossed, the great dog simply gazed at Marlowe with sad, baffled eyes, and Marlowe — magnanimous in victory — would offer a single, gracious twitch of his tail in reply.
-			#Image: A wide tranquil view of an empty cottage garden at night under a rising moon, no creatures stirring, lavender and foxgloves silvered with light, the stone wall stretching invitingly into the distance, a charcoal tabby cat small in the frame standing alone atop the wall, painterly atmospheric, peaceful and full of possibility
-			#SFX: A very soft summer night ambience: faint distant crickets, a single far-off owl hoot, barely-there breeze through leaves
-			#Narration: Tonight, Beauregard was nowhere to be seen. The garden was empty of dog, empty of human, empty of fuss. Marlowe began to walk the length of the wall.`,
 	},
 	{
 		id: "kids-animated",
 		name: "Kids Animated",
 		pillText: "A kids animated story about",
 		color: "#10B981",
-		exampleText: "TODO",
-		systemPrompt: dedent`TODO`,
 	},
 	{
 		id: "psychology-of",
 		name: "Psychology",
 		pillText: "Psychology of",
 		color: "#EC4899",
-		exampleText: "TODO",
-		systemPrompt: dedent`TODO`,
 	},
 ];
 


### PR DESCRIPTION
## Summary
- split template metadata from heavy prompt/example content
- lazy-load heavy template content only during template-mode generation
- updated template-mode tests for async content loading path

## Why
This removes large static prompt/example strings from initial homepage bundle and defers them until needed, improving first-load JS without behavior changes.

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm test -- --passWithNoTests
- ANALYZE=true npm run build -- --webpack