### PR TITLE
refactor: nightly maintainability 2026-04-29

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,176 @@
+# Architecture
+
+This document explains how OpenSlop is wired together end-to-end. Read it before
+adding a new asset type, swapping a third-party API, or hooking a new generation
+step into the editor.
+
+## High-level layout
+
+```
+Browser (React 19, Slate, Remotion Player)
+    │
+    │ fetch /api/v1/<type>           (uses lib/clients/openslop)
+    ▼
+Next.js App Router (app/api/v1/*)    (uses lib/api/route-handler factory)
+    │
+    │ getXProvider() → BaseProvider  (lib/api/providers.ts)
+    ▼
+Provider implementation              (lib/providers/<type>/<vendor>.ts)
+    │
+    │ writes manifest.json + asset   (lib/api/asset-bundle.ts → Vercel Blob)
+    ▼
+BundleResponse { id, result, … }     (returned to the browser)
+```
+
+The browser then drives Remotion (`lib/video/`, `remotion/`) for composition and
+preview, and persists project state via Supabase (`lib/supabase/`).
+
+## Three layers of abstraction
+
+The generation pipeline is intentionally split into three layers. Each layer has
+a different concern and a different test surface, which is what makes it easy
+to swap providers or add new asset types without touching the others.
+
+### 1. `lib/connectors/` — client-facing API
+
+A **connector** is what the editor talks to. Connectors are model-agnostic and
+plugin-pipelined: they don't care how an asset gets produced, only that the
+caller gets back an `AssetResult` (or `LLMGenerateResult`, etc.).
+
+- `BaseConnector` (`base.ts`) runs the plugin pipeline:
+  `transformPrompt → beforeGenerate → _generate → afterGenerate`, with `onError`
+  on failure.
+- `BaseAssetConnector` (`asset-base.ts`) extends it for asset types and resolves
+  a `BundleResponse` to a public URL via `AssetBundle`.
+- Per-type bases (`image/connector.ts`, `music/connector.ts`, …) pin
+  `type` and `assetKey`.
+- `BaseVideoConnector` adds polling for async jobs (`awaitCompletion` in
+  `lib/providers/poll.ts`).
+- The factory (`factory.ts`) instantiates the right concrete connector from a
+  `(ConnectorType, ProviderKey)` pair. `ProviderKey` is currently
+  `"openslop"`-only — every connector ultimately calls our own REST API.
+- Plugins live in `lib/connectors/plugins/` and can be composed onto any
+  connector via `ConnectorConfig.plugins`.
+
+### 2. `lib/gateway/` — HTTP transport
+
+Connectors don't know about HTTP. They delegate to a `GatewayClient` that
+wraps `fetch` against `app/api/v1/<type>`. Gateways are thin: they post the
+params, surface errors, and return a `BundleResponse`.
+
+This is the seam that lets the same connector code run against the local API
+during development, against a hosted API in production, or against a mock in
+tests.
+
+### 3. `lib/providers/` — server-side model wrappers
+
+A **provider** is the server-side adapter for a specific vendor (Runware,
+ElevenLabs, Cartesia, Anthropic, …). Each provider extends `BaseProvider` and
+implements three things:
+
+1. `_generate(params)` — call the vendor SDK, return raw bytes/JSON plus
+   `metadata`.
+2. `toFiles(result)` — describe the asset files to upload.
+3. `blobConfig` — pick the bundle path (`assets/<type>/<provider>/<id>/`).
+
+`BaseProvider.generate()` then handles the upload via `AssetBundle.upload()`
+and returns the `BundleResponse` that gateways round-trip back to the
+connector.
+
+For audio providers, `lib/providers/elevenlabs.ts` exposes a
+`BaseElevenLabsAudio` class that the `music/` and `sfx/` ElevenLabs subclasses
+share — they only differ in default duration and which SDK method to call.
+
+## API routes
+
+Every `app/api/v1/<type>/route.ts` is built from the same factory (shown for
+the `image` route):
+
+```ts
+export const POST = createRouteHandler({
+	models: IMAGE_MODELS,
+	getProvider: getImageProvider,
+	label: "Image generation",
+	handle: async (provider, body) => {
+		const result = await provider.generate(body);
+		return NextResponse.json(result);
+	},
+});
+```
+
+`createRouteHandler` (`lib/api/route-handler.ts`) takes care of:
+
+- JSON parsing
+- `prompt` validation
+- model slug resolution against the `<type>_MODELS` map
+- structured logging on warn/error
+- a `serverError` fallback
+
+Add `extraValidation` for type-specific checks (see TTS `voiceId` and Video
+`referenceImages` validation).
+
+Providers are resolved through `lib/api/providers.ts`, which uses a
+`withMockFallback` helper: if the relevant API key isn't set (e.g.
+`RUNWARE_API_KEY`), the route uses the mock provider instead. Provider
+instances are cached per process.
+
+## Generation queue
+
+`lib/generation/queue.ts` is the editor's task scheduler. The `GenerationQueue`
+class:
+
+- Snapshots inputs (`generationInputs.ts`) so stale results can be detected.
+- Enqueues `GenerationJob`s and drains them in batches via
+  `generateForElement` → `createConnector(...).generate(...)`.
+- Tracks status (`idle | queued | generating`), errors, elapsed seconds, and a
+  per-element history of past results for instant cache hits when inputs match.
+- Exposes a Zustand-style subscribe API used by canvas elements to render
+  progress.
+
+The queue is the single point that wires connectors into the React app — UI
+components dispatch jobs, never call connectors directly.
+
+## Project & script state
+
+- `lib/project/store.ts` holds per-project metadata (characters, defaults) in a
+  Zustand store, scoped by project id.
+- `lib/script/` provides a React context for the current script being edited.
+- `lib/config/` stores connector configuration globally; per-element
+  configuration overlays this.
+
+## Auth & request lifecycle
+
+- `proxy.ts` is the Next.js 16 proxy entry (renamed upstream from
+  `middleware.ts` — **do not rename it back**).
+- It calls `updateSession()` from `lib/supabase/middleware.ts`, which refreshes
+  the Supabase session cookie on every non-static request.
+- Browser-side Supabase access goes through `lib/supabase/client.ts`;
+  server-side via `lib/supabase/server.ts`.
+
+## Video rendering
+
+- Compositions live in `remotion/` and `lib/video/`.
+- `app/api/render/route.ts` invokes Remotion's render pipeline; the bundle is
+  produced via `npm run remotion:bundle` or on-demand.
+- `app/components/video/VideoPreview.tsx` is a Client Component that
+  `next/dynamic`-imports the Remotion Player with `ssr: false` (this is the
+  only sanctioned use of `ssr: false` — see CLAUDE.md).
+
+## Adding a new asset type
+
+If you need to introduce, say, "captions" as a first-class asset:
+
+1. Add `CaptionsGenerateParams` and `CaptionsConnector` to
+   `lib/connectors/types.ts`, plus an entry in `ConnectorTypeMap`.
+2. Create `lib/connectors/captions/connector.ts` (a `BaseCaptionsConnector`
+   extending `BaseAssetConnector`) and a `captions/openslop/index.ts`
+   implementation that wires up a gateway.
+3. Add a `lib/gateway/openslop/captions.ts` gateway client.
+4. Implement one or more providers in `lib/providers/captions/<vendor>.ts`
+   extending `BaseProvider`.
+5. Register the provider in `lib/api/providers.ts` (`getCaptionsProvider`).
+6. Add `CAPTIONS_MODELS` and `app/api/v1/captions/route.ts` using
+   `createRouteHandler`.
+7. Wire the connector into `lib/connectors/factory.ts`.
+
+Tests for each layer live in `__tests__` folders next to the code they cover.

--- a/README.md
+++ b/README.md
@@ -168,7 +168,10 @@ openslop/
 
 Contributions welcome. Fork the repo, make your changes, open a PR.
 
-Please read `CLAUDE.md` for the project's coding conventions before submitting.
+- Read [`CLAUDE.md`](CLAUDE.md) for the project's coding conventions.
+- Read [`ARCHITECTURE.md`](ARCHITECTURE.md) for an end-to-end tour of how
+  connectors, gateways, providers, and the generation queue fit together —
+  helpful before adding a new asset type or swapping a provider.
 
 ## Community
 

--- a/lib/connectors/__tests__/character-references.test.ts
+++ b/lib/connectors/__tests__/character-references.test.ts
@@ -15,6 +15,16 @@ function setupCharacters(
 	store.getState().updateMetadata({ characters });
 }
 
+function runBeforeGenerate(
+	plugin: ConnectorPlugin<ParamsWithCharacters>,
+	params: ParamsWithCharacters,
+) {
+	if (!plugin.beforeGenerate) {
+		throw new Error(`Plugin "${plugin.name}" has no beforeGenerate hook`);
+	}
+	return plugin.beforeGenerate(params);
+}
+
 describe("character-references plugin", () => {
 	let plugin: ConnectorPlugin<ParamsWithCharacters>;
 
@@ -32,7 +42,7 @@ describe("character-references plugin", () => {
 			},
 		});
 
-		const result = plugin.beforeGenerate!({
+		const result = runBeforeGenerate(plugin, {
 			prompt: "Red meets Granny",
 			characters: "Red,Granny",
 		});
@@ -48,7 +58,7 @@ describe("character-references plugin", () => {
 			Wolf: { description: "A big wolf", avatarUrl: "" },
 		});
 
-		const result = plugin.beforeGenerate!({
+		const result = runBeforeGenerate(plugin, {
 			prompt: "The wolf howls",
 			characters: "Wolf",
 		});
@@ -58,8 +68,8 @@ describe("character-references plugin", () => {
 	});
 
 	it("returns params unchanged when no characters attribute", () => {
-		const params = { prompt: "A sunset" };
-		const result = plugin.beforeGenerate!(params as never);
+		const params: ParamsWithCharacters = { prompt: "A sunset" };
+		const result = runBeforeGenerate(plugin, params);
 		expect(result).toEqual(params);
 	});
 
@@ -69,7 +79,7 @@ describe("character-references plugin", () => {
 			Bob: { description: "A boy", avatarUrl: "https://img/bob.png" },
 		});
 
-		const result = plugin.beforeGenerate!({
+		const result = runBeforeGenerate(plugin, {
 			prompt: "Hello",
 			characters: " Alice , Bob ",
 		});
@@ -86,7 +96,7 @@ describe("character-references plugin", () => {
 			Bob: { description: "A boy", avatarUrl: "" },
 		});
 
-		const result = plugin.beforeGenerate!({
+		const result = runBeforeGenerate(plugin, {
 			prompt: "Hello",
 			characters: "Alice,Bob",
 		});
@@ -102,7 +112,7 @@ describe("character-references plugin", () => {
 			Alice: { description: "A girl", avatarUrl: "https://img/alice.png" },
 		});
 
-		const result = plugin.beforeGenerate!({
+		const result = runBeforeGenerate(plugin, {
 			prompt: "Hello",
 			characters: "Alice,Unknown",
 		});

--- a/lib/providers/elevenlabs.ts
+++ b/lib/providers/elevenlabs.ts
@@ -1,0 +1,48 @@
+import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+import type { BundleFile } from "@/lib/api/asset-bundle";
+import { BaseProvider, type WithMetadata } from "./base";
+import { streamToBuffer } from "./stream";
+
+type AudioResult = {
+	data: ArrayBuffer;
+} & WithMetadata;
+
+/** Shared base for ElevenLabs providers that emit a single MP3 audio asset. */
+export abstract class BaseElevenLabsAudio<
+	TParams extends { durationSeconds?: number },
+> extends BaseProvider<TParams, AudioResult> {
+	protected readonly client: ElevenLabsClient;
+
+	constructor(apiKey: string) {
+		super();
+		this.client = new ElevenLabsClient({ apiKey });
+	}
+
+	protected abstract readonly defaultDurationSeconds: number;
+
+	protected abstract requestStream(
+		params: TParams,
+		durationSeconds: number,
+	): Promise<ReadableStream<Uint8Array>>;
+
+	protected toFiles(r: AudioResult): BundleFile[] {
+		return [
+			{
+				key: "audio",
+				filename: "output.mp3",
+				data: r.data,
+				contentType: "audio/mpeg",
+			},
+		];
+	}
+
+	protected async _generate(params: TParams) {
+		const durationSeconds =
+			params.durationSeconds ?? this.defaultDurationSeconds;
+		const stream = await this.requestStream(params, durationSeconds);
+		return {
+			data: await streamToBuffer(stream),
+			metadata: { durationSec: durationSeconds },
+		};
+	}
+}

--- a/lib/providers/music/elevenlabs.ts
+++ b/lib/providers/music/elevenlabs.ts
@@ -1,48 +1,19 @@
-import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
 import type { MusicGenerateParams } from "@/lib/connectors/types";
-import type { BundleFile } from "@/lib/api/asset-bundle";
-import { BaseProvider, type WithMetadata } from "../base";
-import { streamToBuffer } from "../stream";
+import { BaseElevenLabsAudio } from "../elevenlabs";
 
-type MusicResult = {
-	data: ArrayBuffer;
-} & WithMetadata;
-
-export class ElevenLabsMusic extends BaseProvider<
-	MusicGenerateParams,
-	MusicResult
-> {
+export class ElevenLabsMusic extends BaseElevenLabsAudio<MusicGenerateParams> {
 	protected readonly blobConfig = { type: "music", provider: "elevenlabs" };
-	private client: ElevenLabsClient;
+	protected readonly defaultDurationSeconds = 30;
 
-	constructor(apiKey: string) {
-		super();
-		this.client = new ElevenLabsClient({ apiKey });
-	}
-
-	protected toFiles(r: MusicResult): BundleFile[] {
-		return [
-			{
-				key: "audio",
-				filename: "output.mp3",
-				data: r.data,
-				contentType: "audio/mpeg",
-			},
-		];
-	}
-
-	protected async _generate(params: MusicGenerateParams) {
-		const durationSeconds = params.durationSeconds ?? 30;
-		const stream = await this.client.music.compose({
+	protected requestStream(
+		params: MusicGenerateParams,
+		durationSeconds: number,
+	) {
+		return this.client.music.compose({
 			prompt: params.prompt,
 			musicLengthMs: durationSeconds * 1000,
 			modelId: (params.model as "music_v1") || "music_v1",
 			outputFormat: "mp3_22050_32",
 		});
-
-		return {
-			data: await streamToBuffer(stream),
-			metadata: { durationSec: durationSeconds },
-		};
 	}
 }

--- a/lib/providers/sfx/elevenlabs.ts
+++ b/lib/providers/sfx/elevenlabs.ts
@@ -1,44 +1,15 @@
-import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
 import type { SFXGenerateParams } from "@/lib/connectors/types";
-import type { BundleFile } from "@/lib/api/asset-bundle";
-import { BaseProvider, type WithMetadata } from "../base";
-import { streamToBuffer } from "../stream";
+import { BaseElevenLabsAudio } from "../elevenlabs";
 
-type SFXResult = {
-	data: ArrayBuffer;
-} & WithMetadata;
-
-export class ElevenLabsSFX extends BaseProvider<SFXGenerateParams, SFXResult> {
+export class ElevenLabsSFX extends BaseElevenLabsAudio<SFXGenerateParams> {
 	protected readonly blobConfig = { type: "sfx", provider: "elevenlabs" };
-	private client: ElevenLabsClient;
+	protected readonly defaultDurationSeconds = 5;
 
-	constructor(apiKey: string) {
-		super();
-		this.client = new ElevenLabsClient({ apiKey });
-	}
-
-	protected toFiles(r: SFXResult): BundleFile[] {
-		return [
-			{
-				key: "audio",
-				filename: "output.mp3",
-				data: r.data,
-				contentType: "audio/mpeg",
-			},
-		];
-	}
-
-	protected async _generate(params: SFXGenerateParams) {
-		const durationSeconds = params.durationSeconds ?? 5;
-		const stream = await this.client.textToSoundEffects.convert({
+	protected requestStream(params: SFXGenerateParams, durationSeconds: number) {
+		return this.client.textToSoundEffects.convert({
 			text: params.prompt,
 			durationSeconds,
 			outputFormat: "mp3_22050_32",
 		});
-
-		return {
-			data: await streamToBuffer(stream),
-			metadata: { durationSec: durationSeconds },
-		};
 	}
 }


### PR DESCRIPTION
## Summary
- improve maintainability with high-confidence refactors and simplifications
- remove non-null assertions in connector tests via explicit hook helper
- add architecture documentation and link from README

## Test plan
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm test -- --passWithNoTests