### PR TITLE
feat: voice similarity search + connector type cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Copy to `.env.local` and fill in. Do not commit secrets.
+
+# --- Supabase (public; safe to expose to the browser) ---
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
+# --- Vercel Blob storage ---
+BLOB_READ_WRITE_TOKEN=
+NEXT_PUBLIC_BLOB_URL=
+
+# --- Embeddings (used by voice similarity ranking) ---
+OPENAI_API_KEY=
+
+# --- Optional providers ---
+# ANTHROPIC_API_KEY=
+# RUNWARE_API_KEY=
+# CARTESIA_API_KEY=
+
+# --- Vercel-managed (auto-populated by `vercel env pull`; do not set by hand) ---
+# VERCEL_OIDC_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -50,6 +50,7 @@ export async function POST(req: Request) {
 			const sandbox = process.env.VERCEL
 				? await restoreSnapshot()
 				: await createSandbox({
+						timeoutInMilliseconds: 15 * 60 * 1000,
 						onProgress: async ({ progress, message }) => {
 							await send({
 								type: "phase",

--- a/app/api/v1/tts/voices/route.ts
+++ b/app/api/v1/tts/voices/route.ts
@@ -1,17 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/api/logger";
 import { getTTSProvider } from "@/lib/api/providers";
 import { serverError } from "@/lib/api/response";
-import { logger } from "@/lib/api/logger";
+import { genderSchema } from "@/lib/project/types";
 
 export async function GET(request: NextRequest) {
 	try {
 		const { searchParams } = request.nextUrl;
 		const query = searchParams.get("query") || undefined;
-		const gender = searchParams.get("gender") || undefined;
+		const gender = genderSchema.parse(searchParams.get("gender"));
 		const age = searchParams.get("age") || undefined;
 		const pitch = searchParams.get("pitch") || undefined;
 		const accent = searchParams.get("accent") || undefined;
-		const texture = searchParams.get("texture") || undefined;
+		const description = searchParams.get("description") || undefined;
 		const language = searchParams.get("language") || undefined;
 
 		const provider = getTTSProvider();
@@ -21,7 +22,7 @@ export async function GET(request: NextRequest) {
 			age,
 			pitch,
 			accent,
-			texture,
+			description,
 			language,
 		});
 

--- a/app/components/PostPromptView.tsx
+++ b/app/components/PostPromptView.tsx
@@ -6,7 +6,7 @@ import { generationQueue } from "@/lib/generation/queue";
 import Copilot from "./Copilot";
 import Canvas, { type CanvasHandle } from "./canvas/Canvas";
 import { useRefineScript } from "./canvas/hooks/useRefineScript";
-import { Clapperboard } from "lucide-react";
+import { Play } from "lucide-react";
 import { TopPlayerPanel, SidePlayerPanel } from "./video/PlayerPanel";
 import {
 	PlayerPositionProvider,
@@ -62,11 +62,11 @@ function PostPromptViewInner() {
 							showPlayer();
 						}}
 						className={`${genStyles.btn} shrink-0 transition-opacity ${busy ? "" : "opacity-80 hover:opacity-100"}`}
-						aria-label="Generate & Preview"
+						aria-label="Play"
 						disabled={busy}
 					>
-						<Clapperboard className={genStyles.svg} />
-						<span className="hidden sm:inline">Generate & Preview</span>
+						<Play className={genStyles.svg} aria-hidden="true" />
+						<span>Play</span>
 					</button>
 				</div>
 			</div>

--- a/app/components/canvas/__tests__/osmlSerializer.test.ts
+++ b/app/components/canvas/__tests__/osmlSerializer.test.ts
@@ -141,18 +141,18 @@ describe("OSMLSerializer streaming", () => {
 	it("parses metadata_narration with voice attributes", () => {
 		const s = new OSMLSerializer();
 		s.appendChunk(
-			'<metadata_narration gender="male" age="adult" pitch="low" accent="british" texture="wise"></metadata_narration>',
+			'<metadata_narration gender="masculine" age="adult" pitch="low" accent="british" description="wise"></metadata_narration>',
 		);
 
 		const nodes = s.getNodes() as ParsedElement[];
 		expect(nodes).toHaveLength(1);
 		expect(nodes[0].type).toBe("metadata_narration");
 		expect(nodes[0].customAttributes).toEqual({
-			gender: "male",
+			gender: "masculine",
 			age: "adult",
 			pitch: "low",
 			accent: "british",
-			texture: "wise",
+			description: "wise",
 		});
 	});
 

--- a/app/components/canvas/__tests__/parseXmlTag.test.ts
+++ b/app/components/canvas/__tests__/parseXmlTag.test.ts
@@ -7,10 +7,10 @@ describe("parseXmlTag", () => {
 	});
 
 	it("parses a tag with attributes", () => {
-		expect(parseXmlTag('character name="Lyra" gender="female"')).toEqual({
+		expect(parseXmlTag('character name="Lyra" gender="feminine"')).toEqual({
 			tag: "character",
 			name: "Lyra",
-			gender: "female",
+			gender: "feminine",
 		});
 	});
 

--- a/app/components/canvas/__tests__/useGenerate.test.ts
+++ b/app/components/canvas/__tests__/useGenerate.test.ts
@@ -53,13 +53,13 @@ describe("generateForElement", () => {
 			"openslop",
 			baseConfig,
 			"hello world",
-			{ gender: "male", accent: "american" },
+			{ gender: "masculine", accent: "american" },
 		);
 
 		expect(generate).toHaveBeenCalledWith(
 			expect.objectContaining({
 				prompt: "hello world",
-				gender: "male",
+				gender: "masculine",
 				accent: "american",
 			}),
 		);

--- a/app/components/canvas/config/metadataTags.ts
+++ b/app/components/canvas/config/metadataTags.ts
@@ -1,4 +1,8 @@
-import type { DeepPartial, Metadata } from "@/lib/project/types";
+import {
+	type DeepPartial,
+	type Metadata,
+	MetadataVoiceSchema,
+} from "@/lib/project/types";
 
 export type MetadataTagConfig = {
 	apply: (
@@ -16,15 +20,17 @@ export const METADATA_TAG_CONFIGS: Record<string, MetadataTagConfig> = {
 	},
 	metadata_narration: {
 		apply: (p, attrs) => {
-			const { id: _id, ...rest } = attrs;
-			Object.assign((p.narration ??= {}), rest);
+			Object.assign((p.narration ??= {}), MetadataVoiceSchema.parse(attrs));
 		},
 	},
 	metadata_character: {
 		apply: (p, attrs, text) => {
-			const { name, id: _id, ...voice } = attrs;
+			const { name } = attrs;
 			if (!name) return;
-			(p.characters ??= {})[name] = { description: text, ...voice };
+			(p.characters ??= {})[name] = {
+				appearance: text,
+				...MetadataVoiceSchema.parse(attrs),
+			};
 		},
 	},
 };

--- a/create-snapshot.ts
+++ b/create-snapshot.ts
@@ -7,6 +7,7 @@ const getSnapshotBlobKey = () =>
 
 const sandbox = await createSandbox({
 	resources: { vcpus: 8 },
+	timeoutInMilliseconds: 15 * 60 * 1000,
 	onProgress: ({ progress, message }) => {
 		console.log(
 			`[create-snapshot] ${message} (${Math.round(progress * 100)}%)`,

--- a/lib/clients/__tests__/openslop.test.ts
+++ b/lib/clients/__tests__/openslop.test.ts
@@ -53,10 +53,10 @@ describe("OpenSlopClient", () => {
 				json: () => Promise.resolve({ voices: [] }),
 			});
 
-			await client.get("/api/v1/tts/voices", { gender: "female" });
+			await client.get("/api/v1/tts/voices", { gender: "feminine" });
 
 			expect(fetchMock).toHaveBeenCalledWith(
-				"https://api.test.com/api/v1/tts/voices?gender=female",
+				"https://api.test.com/api/v1/tts/voices?gender=feminine",
 				expect.objectContaining({ method: "GET" }),
 			);
 		});
@@ -82,12 +82,12 @@ describe("OpenSlopClient", () => {
 			});
 
 			await client.get("/api/v1/tts/voices", {
-				gender: "male",
+				gender: "masculine",
 				age: undefined as unknown as string,
 			});
 
 			const url = fetchMock.mock.calls[0][0] as string;
-			expect(url).toContain("gender=male");
+			expect(url).toContain("gender=masculine");
 			expect(url).not.toContain("age");
 		});
 	});

--- a/lib/connectors/__tests__/character-references.test.ts
+++ b/lib/connectors/__tests__/character-references.test.ts
@@ -9,7 +9,7 @@ import { clearProjectStore, getProjectStore } from "@/lib/project/store";
 const PROJECT_ID = "test-char-refs";
 
 function setupCharacters(
-	characters: Record<string, { description: string; avatarUrl: string }>,
+	characters: Record<string, { appearance: string; avatarUrl: string }>,
 ) {
 	const store = getProjectStore(PROJECT_ID);
 	store.getState().updateMetadata({ characters });
@@ -35,9 +35,9 @@ describe("character-references plugin", () => {
 
 	it("resolves character names to avatar URLs", () => {
 		setupCharacters({
-			Red: { description: "A girl in red", avatarUrl: "https://img/red.png" },
+			Red: { appearance: "A girl in red", avatarUrl: "https://img/red.png" },
 			Granny: {
-				description: "An old woman",
+				appearance: "An old woman",
 				avatarUrl: "https://img/granny.png",
 			},
 		});
@@ -55,7 +55,7 @@ describe("character-references plugin", () => {
 
 	it("strips characters from params when no avatars found", () => {
 		setupCharacters({
-			Wolf: { description: "A big wolf", avatarUrl: "" },
+			Wolf: { appearance: "A big wolf", avatarUrl: "" },
 		});
 
 		const result = runBeforeGenerate(plugin, {
@@ -75,8 +75,8 @@ describe("character-references plugin", () => {
 
 	it("handles whitespace in character CSV", () => {
 		setupCharacters({
-			Alice: { description: "A girl", avatarUrl: "https://img/alice.png" },
-			Bob: { description: "A boy", avatarUrl: "https://img/bob.png" },
+			Alice: { appearance: "A girl", avatarUrl: "https://img/alice.png" },
+			Bob: { appearance: "A boy", avatarUrl: "https://img/bob.png" },
 		});
 
 		const result = runBeforeGenerate(plugin, {
@@ -92,8 +92,8 @@ describe("character-references plugin", () => {
 
 	it("filters out characters without avatars", () => {
 		setupCharacters({
-			Alice: { description: "A girl", avatarUrl: "https://img/alice.png" },
-			Bob: { description: "A boy", avatarUrl: "" },
+			Alice: { appearance: "A girl", avatarUrl: "https://img/alice.png" },
+			Bob: { appearance: "A boy", avatarUrl: "" },
 		});
 
 		const result = runBeforeGenerate(plugin, {
@@ -109,7 +109,7 @@ describe("character-references plugin", () => {
 
 	it("filters out unknown character names", () => {
 		setupCharacters({
-			Alice: { description: "A girl", avatarUrl: "https://img/alice.png" },
+			Alice: { appearance: "A girl", avatarUrl: "https://img/alice.png" },
 		});
 
 		const result = runBeforeGenerate(plugin, {

--- a/lib/connectors/__tests__/metadata-voice.test.ts
+++ b/lib/connectors/__tests__/metadata-voice.test.ts
@@ -23,12 +23,12 @@ describe("createMetadataVoicePlugin", () => {
 		getProjectStore(projectId)
 			.getState()
 			.updateMetadata({
-				narration: { gender: "female", accent: "british", age: "adult" },
+				narration: { gender: "feminine", accent: "british", age: "adult" },
 			});
 		const { beforeGenerate } = createMetadataVoicePlugin(projectId);
 		expect(beforeGenerate?.({ prompt: "hello" })).toEqual({
 			prompt: "hello",
-			gender: "female",
+			gender: "feminine",
 			accent: "british",
 			age: "adult",
 		});
@@ -40,11 +40,11 @@ describe("createMetadataVoicePlugin", () => {
 			.updateMetadata({
 				characters: {
 					Red: {
-						description: "A girl in red",
-						gender: "female",
+						appearance: "A girl in red",
+						gender: "feminine",
 						accent: "southern",
 						pitch: "high",
-						texture: "raspy",
+						description: "raspy",
 					},
 				},
 			});
@@ -52,10 +52,10 @@ describe("createMetadataVoicePlugin", () => {
 		expect(beforeGenerate?.({ prompt: "hi", name: "Red" })).toEqual({
 			prompt: "hi",
 			name: "Red",
-			gender: "female",
+			gender: "feminine",
 			accent: "southern",
 			pitch: "high",
-			texture: "raspy",
+			description: "raspy",
 		});
 	});
 
@@ -63,7 +63,7 @@ describe("createMetadataVoicePlugin", () => {
 		getProjectStore(projectId)
 			.getState()
 			.updateMetadata({
-				narration: { gender: "male" },
+				narration: { gender: "masculine" },
 			});
 		const { beforeGenerate } = createMetadataVoicePlugin(projectId);
 		const params = { prompt: "hi", name: "Ghost" };
@@ -74,14 +74,18 @@ describe("createMetadataVoicePlugin", () => {
 		getProjectStore(projectId)
 			.getState()
 			.updateMetadata({
-				narration: { gender: "female", accent: "british" },
+				narration: { gender: "feminine", accent: "british" },
 			});
 		const { beforeGenerate } = createMetadataVoicePlugin(projectId);
 		expect(
-			beforeGenerate?.({ prompt: "hi", gender: "male", accent: "american" }),
+			beforeGenerate?.({
+				prompt: "hi",
+				gender: "masculine",
+				accent: "american",
+			}),
 		).toEqual({
 			prompt: "hi",
-			gender: "female",
+			gender: "feminine",
 			accent: "british",
 		});
 	});
@@ -90,14 +94,14 @@ describe("createMetadataVoicePlugin", () => {
 		getProjectStore(projectId)
 			.getState()
 			.updateMetadata({
-				narration: { gender: "female" },
+				narration: { gender: "feminine" },
 			});
 		const { beforeGenerate } = createMetadataVoicePlugin(projectId);
 		const result = beforeGenerate?.({ prompt: "hi" });
-		expect(result).toEqual({ prompt: "hi", gender: "female" });
+		expect(result).toEqual({ prompt: "hi", gender: "feminine" });
 		expect(result).not.toHaveProperty("age");
 		expect(result).not.toHaveProperty("pitch");
 		expect(result).not.toHaveProperty("accent");
-		expect(result).not.toHaveProperty("texture");
+		expect(result).not.toHaveProperty("description");
 	});
 });

--- a/lib/connectors/__tests__/tts.test.ts
+++ b/lib/connectors/__tests__/tts.test.ts
@@ -59,23 +59,23 @@ describe("BaseTTSConnector", () => {
 			plugins: [createVoiceSearchPlugin()],
 		});
 		vi.spyOn(connector, "searchVoices").mockResolvedValue([
-			{ id: "voice-42", name: "Test Voice" },
+			{ id: "voice-42", name: "Test Voice", description: "" },
 		]);
 
 		const result = await connector.generate({
 			prompt: "hello",
-			gender: "male",
+			gender: "masculine",
 			accent: "american",
 		});
 
 		expect(connector.searchVoices).toHaveBeenCalledWith({
 			query: undefined,
-			gender: "male",
+			gender: "masculine",
 			age: undefined,
 			pitch: undefined,
 			accent: "american",
-			texture: undefined,
-			language: undefined,
+			description: undefined,
+			language: "en",
 		});
 		expect(result.url).toBe(AUDIO_URL);
 	});
@@ -91,7 +91,7 @@ describe("BaseTTSConnector", () => {
 		vi.spyOn(connector, "searchVoices").mockResolvedValue([]);
 
 		await expect(
-			connector.generate({ prompt: "hello", gender: "alien" }),
+			connector.generate({ prompt: "hello", gender: "masculine" }),
 		).rejects.toThrow("No matching voice found");
 	});
 

--- a/lib/connectors/__tests__/voice-search.test.ts
+++ b/lib/connectors/__tests__/voice-search.test.ts
@@ -16,37 +16,45 @@ describe("createVoiceSearchPlugin", () => {
 	});
 
 	it("returns params unchanged when voiceId already set", async () => {
-		const { ctx, searchVoices } = ctxWith([{ id: "x", name: "X" }]);
+		const { ctx, searchVoices } = ctxWith([
+			{ id: "x", name: "X", description: "" },
+		]);
 		const { beforeGenerate } = createVoiceSearchPlugin();
-		const params = { prompt: "hi", voiceId: "preset", gender: "male" };
+		const params = {
+			prompt: "hi",
+			voiceId: "preset",
+			gender: "masculine" as const,
+		};
 		const result = await beforeGenerate?.(params, ctx);
 		expect(result).toEqual(params);
 		expect(searchVoices).not.toHaveBeenCalled();
 	});
 
 	it("calls searchVoices with all voice descriptors", async () => {
-		const { ctx, searchVoices } = ctxWith([{ id: "v-42", name: "Forty-Two" }]);
+		const { ctx, searchVoices } = ctxWith([
+			{ id: "v-42", name: "Forty-Two", description: "" },
+		]);
 		const { beforeGenerate } = createVoiceSearchPlugin();
 		await beforeGenerate?.(
 			{
 				prompt: "hi",
-				gender: "female",
+				gender: "feminine",
 				accent: "british",
 				query: "narrator",
 				language: "en",
 				age: "adult",
 				pitch: "high",
-				texture: "raspy",
+				description: "raspy",
 				name: "Red",
 			},
 			ctx,
 		);
 		expect(searchVoices).toHaveBeenCalledWith({
-			gender: "female",
+			gender: "feminine",
 			age: "adult",
 			pitch: "high",
 			accent: "british",
-			texture: "raspy",
+			description: "raspy",
 			query: "narrator",
 			language: "en",
 		});
@@ -54,19 +62,19 @@ describe("createVoiceSearchPlugin", () => {
 
 	it("assigns first voice's id and strips descriptor/lookup fields", async () => {
 		const { ctx } = ctxWith([
-			{ id: "v-1", name: "First" },
-			{ id: "v-2", name: "Second" },
+			{ id: "v-1", name: "First", description: "" },
+			{ id: "v-2", name: "Second", description: "" },
 		]);
 		const { beforeGenerate } = createVoiceSearchPlugin();
 		const result = await beforeGenerate?.(
 			{
 				prompt: "hi",
 				model: "test-model",
-				gender: "female",
+				gender: "feminine",
 				age: "adult",
 				pitch: "high",
 				accent: "british",
-				texture: "raspy",
+				description: "raspy",
 				name: "Red",
 				query: "narrator",
 				language: "en",
@@ -80,11 +88,22 @@ describe("createVoiceSearchPlugin", () => {
 		});
 	});
 
+	it("defaults language to 'en' when not provided", async () => {
+		const { ctx, searchVoices } = ctxWith([
+			{ id: "v-1", name: "First", description: "" },
+		]);
+		const { beforeGenerate } = createVoiceSearchPlugin();
+		await beforeGenerate?.({ prompt: "hi", gender: "feminine" }, ctx);
+		expect(searchVoices).toHaveBeenCalledWith(
+			expect.objectContaining({ language: "en" }),
+		);
+	});
+
 	it("throws when searchVoices returns empty", async () => {
 		const { ctx } = ctxWith([]);
 		const { beforeGenerate } = createVoiceSearchPlugin();
 		await expect(
-			beforeGenerate?.({ prompt: "hi", gender: "alien" }, ctx),
+			beforeGenerate?.({ prompt: "hi", gender: "masculine" }, ctx),
 		).rejects.toThrow("No matching voice found");
 	});
 

--- a/lib/connectors/factory.ts
+++ b/lib/connectors/factory.ts
@@ -1,16 +1,30 @@
+import type { BaseImageConnector } from "./image/connector";
 import { OpenSlopImage } from "./image/openslop";
 import { OpenSlopLLM } from "./llm/openslop";
+import type { BaseMusicConnector } from "./music/connector";
 import { OpenSlopMusic } from "./music/openslop";
+import type { BaseSFXConnector } from "./sfx/connector";
 import { OpenSlopSFX } from "./sfx/openslop";
 import { OpenSlopTTS } from "./tts/openslop";
+import type { BaseVideoConnector } from "./video/connector";
 import { OpenSlopVideo } from "./video/openslop";
 import type {
 	ConnectorConfig,
 	ConnectorType,
-	ConnectorTypeMap,
+	LLMConnector,
 	ProviderConstructor,
 	ProviderKey,
+	TTSConnector,
 } from "./types";
+
+type ConnectorTypeMap = {
+	llm: LLMConnector;
+	music: BaseMusicConnector;
+	sfx: BaseSFXConnector;
+	image: BaseImageConnector;
+	tts: TTSConnector;
+	video: BaseVideoConnector;
+};
 
 const PROVIDERS: Record<
 	ConnectorType,

--- a/lib/connectors/image/connector.ts
+++ b/lib/connectors/image/connector.ts
@@ -1,14 +1,10 @@
 import { BaseAssetConnector } from "../asset-base";
-import type {
-	AssetResult,
-	ImageConnector,
-	ImageGenerateParams,
-} from "../types";
+import type { AssetResult, ImageGenerateParams } from "../types";
 
-export abstract class BaseImageConnector
-	extends BaseAssetConnector<ImageGenerateParams, AssetResult>
-	implements ImageConnector
-{
+export abstract class BaseImageConnector extends BaseAssetConnector<
+	ImageGenerateParams,
+	AssetResult
+> {
 	readonly type = "image" as const;
 	readonly assetKey = "image" as const;
 }

--- a/lib/connectors/music/connector.ts
+++ b/lib/connectors/music/connector.ts
@@ -1,14 +1,10 @@
 import { BaseAssetConnector } from "../asset-base";
-import type {
-	AssetResult,
-	MusicConnector,
-	MusicGenerateParams,
-} from "../types";
+import type { AssetResult, MusicGenerateParams } from "../types";
 
-export abstract class BaseMusicConnector
-	extends BaseAssetConnector<MusicGenerateParams, AssetResult>
-	implements MusicConnector
-{
+export abstract class BaseMusicConnector extends BaseAssetConnector<
+	MusicGenerateParams,
+	AssetResult
+> {
 	readonly type = "music" as const;
 	readonly assetKey = "audio" as const;
 }

--- a/lib/connectors/plugins/metadata-voice.ts
+++ b/lib/connectors/plugins/metadata-voice.ts
@@ -1,9 +1,10 @@
-import type { ConnectorPlugin, TTSConnectorParams } from "../types";
 import { getProjectStore } from "@/lib/project/store";
+import { MetadataVoiceSchema } from "@/lib/project/types";
+import type { ConnectorPlugin, TTSGenerateParams } from "../types";
 
 export function createMetadataVoicePlugin(
 	projectId: string,
-): ConnectorPlugin<TTSConnectorParams> {
+): ConnectorPlugin<TTSGenerateParams> {
 	return {
 		name: "metadata-voice",
 		beforeGenerate(params) {
@@ -11,15 +12,7 @@ export function createMetadataVoicePlugin(
 				getProjectStore(projectId).getState().metadata;
 			const voice = params.name ? characters[params.name] : narration;
 			if (!voice) return params;
-			const { gender, age, pitch, accent, texture } = voice;
-			return {
-				...params,
-				...(gender && { gender }),
-				...(age && { age }),
-				...(pitch && { pitch }),
-				...(accent && { accent }),
-				...(texture && { texture }),
-			};
+			return { ...params, ...MetadataVoiceSchema.parse(voice) };
 		},
 	};
 }

--- a/lib/connectors/plugins/osml.ts
+++ b/lib/connectors/plugins/osml.ts
@@ -2,11 +2,11 @@ import dedent from "dedent";
 import { EffectType } from "../image/enums";
 import { MusicLength } from "../music/enums";
 import {
-	TTSAccent,
-	TTSAge,
+	TTS_ACCENTS,
+	TTS_AGES,
+	TTS_GENDERS,
+	TTS_PITCHES,
 	TTSEmotion,
-	TTSGender,
-	TTSPitch,
 } from "../tts/enums";
 import type { LLMPlugin } from "../types";
 
@@ -93,12 +93,12 @@ const OSML_SYSTEM_PROMPT = dedent`
 
 	### Metadata Narration XML tags
 	- Right after the metadata_style tag, emit a single, empty metadata_narration tag that describes the narrator voice. Example:
-		 <metadata_narration gender="male" age="adult" pitch="low" accent="british" texture="wise"></metadata_narration>
+		 <metadata_narration gender="masculine" age="adult" pitch="low" accent="british" description="wise"></metadata_narration>
 	- The attributes should be from the metadata Character/Narration attributes section
 
   ### Metadata Character XML tags
-	- Right after the metadata_narration tag, emit short <metadata_character>...</metadata_character> tags that visually describe each character (excluding the narrator) from the story in detail as if prompting an image model. Example:
-		<metadata_character name="Mia" gender="female" age="child" pitch="high" accent="american" texture="wise">A girl around ten years old with warm brown skin, dark curly hair falling 
+	- Right after the metadata_narration tag, emit short <metadata_character>...</metadata_character> tags that describe each character's visual appearance (excluding the narrator) from the story in detail as if prompting an image model. Example:
+		<metadata_character name="Mia" gender="feminine" age="child" pitch="high" accent="american" description="wise">A girl around ten years old with warm brown skin, dark curly hair falling
 		just past her shoulders, bright hazel eyes, a small gap between her front
 		teeth. Wearing a mustard-yellow cardigan over a white tee, rolled-up denim
 		overalls, scuffed red sneakers, a canvas satchel slung across one shoulder.
@@ -107,11 +107,11 @@ const OSML_SYSTEM_PROMPT = dedent`
 
 	### Metadata Character/Narration attributes
 	- For metadata_character and metadata_narration tags, always include these attributes in addition to any other they may have
-  - gender: ${Object.values(TTSGender).join(", ")}.
-  - age: ${Object.values(TTSAge).join(", ")}.
-  - pitch: ${Object.values(TTSPitch).join(", ")}.
-  - accent: ${Object.values(TTSAccent).join(", ")}.
-  - texture: Free-form short description of the voice texture, tone, and timbre. Example: "Bill Clinton-esque; charming", "Santa, wise, grandfatherly", "Viking, friendly, calm", etc.
+  - gender: ${TTS_GENDERS.join(", ")}.
+  - age: ${TTS_AGES.join(", ")}.
+  - pitch: ${TTS_PITCHES.join(", ")}.
+  - accent: ${TTS_ACCENTS.join(", ")}.
+  - description: A simple descriptor of the voice. Examples: Charming, Confident, Approachable, Friendly, Energetic, Casual, Mature, Warm, Clear, Upbeat, Deep, Soft, etc.
 
   ### General XML Tag Rules
   - NEVER nest XML tags within other XML tags.

--- a/lib/connectors/plugins/voice-search.ts
+++ b/lib/connectors/plugins/voice-search.ts
@@ -1,18 +1,18 @@
 import omit from "lodash/omit";
-import type { ConnectorPlugin, TTSConnectorParams } from "../types";
+import type { ConnectorPlugin, TTSGenerateParams } from "../types";
 
 const VOICE_DESCRIPTOR_KEYS = [
 	"gender",
 	"age",
 	"pitch",
 	"accent",
-	"texture",
+	"description",
 	"name",
 	"query",
 	"language",
 ] as const;
 
-export function createVoiceSearchPlugin(): ConnectorPlugin<TTSConnectorParams> {
+export function createVoiceSearchPlugin(): ConnectorPlugin<TTSGenerateParams> {
 	return {
 		name: "voice-search",
 		async beforeGenerate(params, ctx) {
@@ -28,8 +28,8 @@ export function createVoiceSearchPlugin(): ConnectorPlugin<TTSConnectorParams> {
 				age: params.age,
 				pitch: params.pitch,
 				accent: params.accent,
-				texture: params.texture,
-				language: params.language,
+				description: params.description,
+				language: params.language || "en",
 			});
 			if (!voices.length) throw new Error("No matching voice found");
 			return { ...omit(params, VOICE_DESCRIPTOR_KEYS), voiceId: voices[0].id };

--- a/lib/connectors/sfx/connector.ts
+++ b/lib/connectors/sfx/connector.ts
@@ -1,10 +1,10 @@
 import { BaseAssetConnector } from "../asset-base";
-import type { AssetResult, SFXConnector, SFXGenerateParams } from "../types";
+import type { AssetResult, SFXGenerateParams } from "../types";
 
-export abstract class BaseSFXConnector
-	extends BaseAssetConnector<SFXGenerateParams, AssetResult>
-	implements SFXConnector
-{
+export abstract class BaseSFXConnector extends BaseAssetConnector<
+	SFXGenerateParams,
+	AssetResult
+> {
 	readonly type = "sfx" as const;
 	readonly assetKey = "audio" as const;
 }

--- a/lib/connectors/tts/connector.ts
+++ b/lib/connectors/tts/connector.ts
@@ -2,7 +2,6 @@ import { BaseAssetConnector } from "../asset-base";
 import type {
 	PluginContext,
 	TTSConnector,
-	TTSConnectorParams,
 	TTSGenerateParams,
 	TTSResult,
 	VoiceInfo,
@@ -20,9 +19,5 @@ export abstract class BaseTTSConnector
 
 	protected pluginContext(): PluginContext<TTSGenerateParams, TTSResult> {
 		return { searchVoices: (p) => this.searchVoices(p) };
-	}
-
-	async generate(params: TTSConnectorParams): Promise<TTSResult> {
-		return super.generate(params as unknown as TTSGenerateParams);
 	}
 }

--- a/lib/connectors/tts/enums.ts
+++ b/lib/connectors/tts/enums.ts
@@ -2,34 +2,28 @@
  * TTS attribute enums
  * These enums are used for text-to-speech (TTS) generation
  */
-export enum TTSGender {
-	Male = "male",
-	Female = "female",
-}
+export const TTS_GENDERS = ["masculine", "feminine", "gender_neutral"] as const;
+export type TTSGender = (typeof TTS_GENDERS)[number];
 
-export enum TTSAge {
-	Child = "child",
-	Adult = "adult",
-}
+export const TTS_AGES = ["child", "adult"] as const;
+export type TTSAge = (typeof TTS_AGES)[number];
 
-export enum TTSPitch {
-	High = "high",
-	Medium = "medium",
-	Low = "low",
-}
+export const TTS_PITCHES = ["high", "medium", "low"] as const;
+export type TTSPitch = (typeof TTS_PITCHES)[number];
 
-export enum TTSAccent {
-	American = "american",
-	British = "british",
-	AfricanAmerican = "african-american",
-	Southern = "southern",
-	Australian = "australian",
-	Indian = "indian",
-	French = "french",
-	German = "german",
-	Spanish = "spanish",
-	Japanese = "japanese",
-}
+export const TTS_ACCENTS = [
+	"american",
+	"british",
+	"african-american",
+	"southern",
+	"australian",
+	"indian",
+	"french",
+	"german",
+	"spanish",
+	"japanese",
+] as const;
+export type TTSAccent = (typeof TTS_ACCENTS)[number];
 
 export enum TTSEmotion {
 	Happy = "happy",

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -1,5 +1,6 @@
 import type { GatewayClient } from "@/lib/gateway/base";
 import type { WithMetadata } from "@/lib/providers/base";
+import type { TTSGender } from "./tts/enums";
 
 export type ConnectorType = "llm" | "music" | "sfx" | "image" | "tts" | "video";
 
@@ -52,22 +53,10 @@ export interface ConnectorConfig {
 	options?: Record<string, unknown>;
 }
 
-export interface ConnectorGenerateParams {
+export type ConnectorGenerateParams = {
 	prompt: string;
 	model?: string;
-}
-
-export interface TTSConnectorParams extends ConnectorGenerateParams {
-	voiceId?: string;
-	gender?: string;
-	age?: string;
-	pitch?: string;
-	accent?: string;
-	texture?: string;
-	name?: string;
-	query?: string;
-	language?: string;
-}
+};
 
 export type AssetResult = { url: string; durationSec: number };
 
@@ -82,9 +71,7 @@ export interface Connector {
 
 // LLM types
 
-export type LLMGenerateParams = {
-	prompt: string;
-	model?: string;
+export type LLMGenerateParams = ConnectorGenerateParams & {
 	systemPrompt?: string;
 	thinkingLevel?: string;
 	maxTokens?: number;
@@ -110,45 +97,24 @@ export interface LLMConnector extends Connector {
 
 // Music types
 
-export type MusicGenerateParams = {
-	prompt: string;
-	model?: string;
+export type MusicGenerateParams = ConnectorGenerateParams & {
 	durationSeconds?: number;
 };
-
-export interface MusicConnector extends Connector {
-	readonly type: "music";
-	generate(params: MusicGenerateParams): Promise<AssetResult>;
-}
 
 // SFX types
 
-export type SFXGenerateParams = {
-	prompt: string;
-	model?: string;
+export type SFXGenerateParams = ConnectorGenerateParams & {
 	durationSeconds?: number;
 };
 
-export interface SFXConnector extends Connector {
-	readonly type: "sfx";
-	generate(params: SFXGenerateParams): Promise<AssetResult>;
-}
-
 // Image types
 
-export type ImageGenerateParams = {
-	prompt: string;
-	model?: string;
+export type ImageGenerateParams = ConnectorGenerateParams & {
 	format?: string;
 	width?: number;
 	height?: number;
 	referenceImages?: string[];
 };
-
-export interface ImageConnector extends Connector {
-	readonly type: "image";
-	generate(params: ImageGenerateParams): Promise<AssetResult>;
-}
 
 // TTS types
 
@@ -158,10 +124,16 @@ export type TTSResult = AssetResult & {
 	textTimestamps: TextTimestamp[];
 };
 
-export type TTSGenerateParams = {
-	prompt: string;
-	voiceId: string;
-	model?: string;
+export type TTSGenerateParams = ConnectorGenerateParams & {
+	voiceId?: string;
+	gender?: TTSGender;
+	age?: string;
+	pitch?: string;
+	accent?: string;
+	description?: string;
+	name?: string;
+	query?: string;
+	language?: string;
 	speed?: number | string;
 	volume?: number;
 	format?: string;
@@ -171,56 +143,39 @@ export type VoiceInfo = {
 	id: string;
 	name: string;
 	language?: string;
-	gender?: string;
+	gender?: TTSGender;
 	accent?: string;
-	description?: string;
+	description: string;
 	previewUrl?: string;
 };
 
 export type VoiceSearchParams = {
 	query?: string;
-	gender?: string;
+	gender?: TTSGender;
 	age?: string;
 	pitch?: string;
 	accent?: string;
-	texture?: string;
+	description?: string;
+	name?: string;
 	language?: string;
 };
 
 export interface TTSConnector extends Connector {
 	readonly type: "tts";
-	generate(params: TTSConnectorParams): Promise<TTSResult>;
+	generate(params: TTSGenerateParams): Promise<TTSResult>;
 	searchVoices(params: VoiceSearchParams): Promise<VoiceInfo[]>;
 }
 
 // Video types
 
-export type VideoGenerateParams = {
-	prompt: string;
-	model?: string;
+export type VideoGenerateParams = ConnectorGenerateParams & {
 	referenceImages?: string[];
 	duration?: number;
 	width?: number;
 	height?: number;
 };
 
-export interface VideoConnector extends Connector {
-	readonly type: "video";
-	generate(params: VideoGenerateParams): Promise<AssetResult>;
-}
-
 export type LLMPlugin = ConnectorPlugin<LLMGenerateParams, LLMGenerateResult>;
-
-// Factory types
-
-export type ConnectorTypeMap = {
-	llm: LLMConnector;
-	music: MusicConnector;
-	sfx: SFXConnector;
-	image: ImageConnector;
-	tts: TTSConnector;
-	video: VideoConnector;
-};
 
 export type ProviderConstructor<T extends Connector = Connector> = new (
 	config: ConnectorConfig,

--- a/lib/connectors/video/connector.ts
+++ b/lib/connectors/video/connector.ts
@@ -1,17 +1,13 @@
 import { AssetBundle } from "@/lib/api/asset-bundle";
 import { BaseAssetConnector } from "../asset-base";
-import type {
-	AssetResult,
-	VideoConnector,
-	VideoGenerateParams,
-} from "../types";
+import type { AssetResult, VideoGenerateParams } from "../types";
 import type { VideoProvider } from "@/lib/providers/video/base";
 import { awaitCompletion } from "@/lib/providers/poll";
 
-export abstract class BaseVideoConnector
-	extends BaseAssetConnector<VideoGenerateParams, AssetResult>
-	implements VideoConnector
-{
+export abstract class BaseVideoConnector extends BaseAssetConnector<
+	VideoGenerateParams,
+	AssetResult
+> {
 	readonly type = "video" as const;
 	readonly assetKey = "video" as const;
 

--- a/lib/gateway/__tests__/openslop-gateways.test.ts
+++ b/lib/gateway/__tests__/openslop-gateways.test.ts
@@ -116,18 +116,18 @@ describe("OpenSlop Gateway Clients", () => {
 
 		it("searches voices with query params", async () => {
 			const voices = [
-				{ id: "v1", name: "Alice", gender: "female" },
-				{ id: "v2", name: "Bob", gender: "male" },
+				{ id: "v1", name: "Alice", gender: "feminine" },
+				{ id: "v2", name: "Bob", gender: "masculine" },
 			];
 			fetchMock.mockResolvedValue(jsonResponse({ voices }));
 
 			const gw = new OpenSlopTTSGateway("https://api.test.com");
-			const result = await gw.searchVoices({ gender: "female" });
+			const result = await gw.searchVoices({ gender: "feminine" });
 
 			expect(result).toEqual(voices);
 			const url = fetchMock.mock.calls[0][0] as string;
 			expect(url).toContain("/api/v1/tts/voices");
-			expect(url).toContain("gender=female");
+			expect(url).toContain("gender=feminine");
 		});
 
 		it("searches voices with empty params", async () => {

--- a/lib/generation/__tests__/generationInputs.test.ts
+++ b/lib/generation/__tests__/generationInputs.test.ts
@@ -24,11 +24,11 @@ describe("isStaleResult", () => {
 	});
 
 	it("is false when prompts and attributes match", () => {
-		const i = inputs("hello", { gender: "male" });
+		const i = inputs("hello", { gender: "masculine" });
 		expect(
 			isStaleResult(
 				{ result: { url: "x", durationSec: 0 }, resultInputs: i },
-				inputs("hello", { gender: "male" }),
+				inputs("hello", { gender: "masculine" }),
 			),
 		).toBe(false);
 	});
@@ -50,9 +50,9 @@ describe("isStaleResult", () => {
 			isStaleResult(
 				{
 					result: { url: "x", durationSec: 0 },
-					resultInputs: inputs("hi", { gender: "male" }),
+					resultInputs: inputs("hi", { gender: "masculine" }),
 				},
-				inputs("hi", { gender: "female" }),
+				inputs("hi", { gender: "feminine" }),
 			),
 		).toBe(true);
 	});
@@ -84,8 +84,8 @@ describe("isStaleResult", () => {
 
 describe("serializeInputs", () => {
 	it("produces a stable string for identical inputs", () => {
-		const a = serializeInputs(inputs("hi", { gender: "male" }));
-		const b = serializeInputs(inputs("hi", { gender: "male" }));
+		const a = serializeInputs(inputs("hi", { gender: "masculine" }));
+		const b = serializeInputs(inputs("hi", { gender: "masculine" }));
 		expect(a).toBe(b);
 	});
 
@@ -94,8 +94,8 @@ describe("serializeInputs", () => {
 	});
 
 	it("produces different strings when attributes differ", () => {
-		expect(serializeInputs(inputs("hi", { gender: "male" }))).not.toBe(
-			serializeInputs(inputs("hi", { gender: "female" })),
+		expect(serializeInputs(inputs("hi", { gender: "masculine" }))).not.toBe(
+			serializeInputs(inputs("hi", { gender: "feminine" })),
 		);
 	});
 });

--- a/lib/project/__tests__/ensureCharacterAvatars.test.ts
+++ b/lib/project/__tests__/ensureCharacterAvatars.test.ts
@@ -65,7 +65,7 @@ describe("ensureCharacterAvatars", () => {
 	it("generates avatars for characters missing avatarUrl", async () => {
 		const store = getProjectStore(PROJECT_ID);
 		store.getState().updateMetadata({
-			characters: { Alice: { description: "A young girl with red hair" } },
+			characters: { Alice: { appearance: "A young girl with red hair" } },
 		});
 
 		generateMock.mockResolvedValue({
@@ -80,7 +80,7 @@ describe("ensureCharacterAvatars", () => {
 		expect(generateMock).toHaveBeenCalledOnce();
 		const prompt = generateMock.mock.calls[0][3] as string;
 		expect(prompt).toBe(
-			"Character portrait of Alice. A young girl with red hair",
+			'Character portrait of Alice. A young girl with red hair. A small rectangular nameplate at the bottom of the frame reads "Alice" in clean sans-serif lettering. White background',
 		);
 
 		expect(store.getState().metadata.characters["Alice"].avatarUrl).toBe(
@@ -92,7 +92,7 @@ describe("ensureCharacterAvatars", () => {
 		const store = getProjectStore(PROJECT_ID);
 		store.getState().updateMetadata({
 			style: "Watercolor illustration",
-			characters: { Alice: { description: "A young girl" } },
+			characters: { Alice: { appearance: "A young girl" } },
 		});
 
 		generateMock.mockResolvedValue({
@@ -113,7 +113,7 @@ describe("ensureCharacterAvatars", () => {
 		store.getState().updateMetadata({
 			characters: {
 				Bob: {
-					description: "A tall man",
+					appearance: "A tall man",
 					avatarUrl: "https://existing.com/bob.png",
 				},
 			},
@@ -126,11 +126,11 @@ describe("ensureCharacterAvatars", () => {
 		expect(generateMock).not.toHaveBeenCalled();
 	});
 
-	it("skips characters with empty description", async () => {
+	it("skips characters with empty appearance", async () => {
 		const store = getProjectStore(PROJECT_ID);
 		store
 			.getState()
-			.updateMetadata({ characters: { Empty: { description: "" } } });
+			.updateMetadata({ characters: { Empty: { appearance: "" } } });
 
 		const { ensureCharacterAvatars } =
 			await import("../ensureCharacterAvatars");
@@ -143,8 +143,8 @@ describe("ensureCharacterAvatars", () => {
 		const store = getProjectStore(PROJECT_ID);
 		store.getState().updateMetadata({
 			characters: {
-				Cat: { description: "A fluffy orange cat" },
-				Dog: { description: "A big brown dog" },
+				Cat: { appearance: "A fluffy orange cat" },
+				Dog: { appearance: "A big brown dog" },
 			},
 		});
 

--- a/lib/project/__tests__/store.test.ts
+++ b/lib/project/__tests__/store.test.ts
@@ -19,11 +19,11 @@ describe("project store updateMetadata", () => {
 
 	it("deep-merges narration so prior voice attributes are preserved", () => {
 		const store = getProjectStore(PROJECT_ID);
-		store.getState().updateMetadata({ narration: { gender: "male" } });
+		store.getState().updateMetadata({ narration: { gender: "masculine" } });
 		store.getState().updateMetadata({ narration: { accent: "british" } });
 
 		expect(store.getState().metadata.narration).toEqual({
-			gender: "male",
+			gender: "masculine",
 			accent: "british",
 		});
 	});
@@ -31,14 +31,14 @@ describe("project store updateMetadata", () => {
 	it("preserves sibling character properties across updates", () => {
 		const store = getProjectStore(PROJECT_ID);
 		store.getState().updateMetadata({
-			characters: { Alice: { description: "A girl" } },
+			characters: { Alice: { appearance: "A girl" } },
 		});
 		store.getState().updateMetadata({
 			characters: { Alice: { avatarUrl: "https://img/alice.png" } },
 		});
 
 		expect(store.getState().metadata.characters["Alice"]).toEqual({
-			description: "A girl",
+			appearance: "A girl",
 			avatarUrl: "https://img/alice.png",
 		});
 	});
@@ -46,10 +46,10 @@ describe("project store updateMetadata", () => {
 	it("adds new characters without removing existing ones", () => {
 		const store = getProjectStore(PROJECT_ID);
 		store.getState().updateMetadata({
-			characters: { Alice: { description: "A girl" } },
+			characters: { Alice: { appearance: "A girl" } },
 		});
 		store.getState().updateMetadata({
-			characters: { Bob: { description: "A boy" } },
+			characters: { Bob: { appearance: "A boy" } },
 		});
 
 		expect(Object.keys(store.getState().metadata.characters).sort()).toEqual([

--- a/lib/project/ensureCharacterAvatars.ts
+++ b/lib/project/ensureCharacterAvatars.ts
@@ -14,13 +14,16 @@ export async function ensureCharacterAvatars(
 	// Style is prepended by the art-style plugin on the image connector chain.
 	await Promise.all(
 		Object.entries(characters)
-			.filter(([, ch]) => !ch.avatarUrl && ch.description)
+			.filter(([, ch]) => !ch.avatarUrl && ch.appearance)
 			.map(async ([name, ch]) => {
 				store.getState().setAvatarGenerating(name, true);
 				try {
-					const prompt = [`Character portrait of ${name}`, ch.description].join(
-						". ",
-					);
+					const prompt = [
+						`Character portrait of ${name}`,
+						ch.appearance,
+						`A small rectangular nameplate at the bottom of the frame reads "${name}" in clean sans-serif lettering`,
+						"White background",
+					].join(". ");
 					const result = await generateForElement(
 						"image",
 						provider,

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -1,13 +1,22 @@
-export type MetadataVoice = {
-	gender?: string;
-	age?: string;
-	pitch?: string;
-	accent?: string;
-	texture?: string;
-};
+import { z } from "zod";
+import { TTS_GENDERS } from "@/lib/connectors/tts/enums";
+
+const optionalString = z.string().min(1).optional().catch(undefined);
+
+export const genderSchema = z.enum(TTS_GENDERS).optional().catch(undefined);
+
+export const MetadataVoiceSchema = z.object({
+	gender: genderSchema,
+	age: optionalString,
+	pitch: optionalString,
+	accent: optionalString,
+	description: optionalString,
+});
+
+export type MetadataVoice = z.infer<typeof MetadataVoiceSchema>;
 
 export type MetadataCharacter = MetadataVoice & {
-	description: string;
+	appearance: string;
 	avatarUrl?: string;
 };
 

--- a/lib/providers/__tests__/cartesia-tts.test.ts
+++ b/lib/providers/__tests__/cartesia-tts.test.ts
@@ -6,6 +6,8 @@ const mockClose = vi.fn();
 const mockGenerate = vi.fn();
 const mockConnect = vi.fn();
 const mockVoicesList = vi.fn();
+const mockEmbed = vi.fn();
+const mockEmbedMany = vi.fn();
 
 vi.mock("@cartesia/cartesia-js", () => ({
 	default: class {
@@ -18,6 +20,17 @@ vi.mock("@cartesia/cartesia-js", () => ({
 		};
 		voices = { list: mockVoicesList };
 	},
+}));
+
+vi.mock("ai", () => ({
+	embed: (...args: unknown[]) => mockEmbed(...args),
+	embedMany: (...args: unknown[]) => mockEmbedMany(...args),
+	cosineSimilarity: (a: number[], b: number[]) =>
+		a.reduce((s, x, i) => s + x * b[i], 0),
+}));
+
+vi.mock("@ai-sdk/openai", () => ({
+	openai: { embedding: () => ({}) },
 }));
 
 import { CartesiaTTS } from "../tts/cartesia";
@@ -119,7 +132,7 @@ describe("CartesiaTTS", () => {
 
 			const provider = new CartesiaTTS("test-key");
 			const voices = await provider.search({
-				query: "english",
+				age: "adult",
 				language: "en",
 			});
 
@@ -142,9 +155,9 @@ describe("CartesiaTTS", () => {
 				},
 			]);
 			expect(mockVoicesList).toHaveBeenCalledWith({
-				q: "english",
+				q: "adult",
 				gender: undefined,
-				limit: 20,
+				limit: 100,
 			});
 		});
 
@@ -159,6 +172,114 @@ describe("CartesiaTTS", () => {
 				gender: "masculine",
 				limit: 5,
 			});
+		});
+
+		it("re-ranks voices by description similarity when semantic descriptors provided", async () => {
+			mockVoicesList.mockResolvedValue({
+				data: [
+					{
+						id: "v1",
+						name: "Cold",
+						language: "en",
+						gender: "feminine",
+						description: "cold robotic voice",
+						preview_file_url: null,
+					},
+					{
+						id: "v2",
+						name: "Warm",
+						language: "en",
+						gender: "feminine",
+						description: "warm british narrator",
+						preview_file_url: null,
+					},
+				],
+			});
+			mockEmbed.mockResolvedValue({ embedding: [1, 0] });
+			mockEmbedMany.mockResolvedValue({
+				embeddings: [
+					[0, 1],
+					[1, 0],
+				],
+			});
+
+			const provider = new CartesiaTTS("test-key");
+			const voices = await provider.search({ description: "warm british" });
+
+			expect(voices.map((v) => v.id)).toEqual(["v2", "v1"]);
+			expect(mockEmbed).toHaveBeenCalledWith(
+				expect.objectContaining({ value: "warm british" }),
+			);
+			expect(mockEmbedMany).toHaveBeenCalledWith(
+				expect.objectContaining({
+					values: ["cold robotic voice", "warm british narrator"],
+				}),
+			);
+		});
+
+		it("skips embedding when no semantic descriptors provided", async () => {
+			mockVoicesList.mockResolvedValue({
+				data: [
+					{
+						id: "v1",
+						name: "A",
+						language: "en",
+						gender: "masculine",
+						description: "first",
+						preview_file_url: null,
+					},
+					{
+						id: "v2",
+						name: "B",
+						language: "en",
+						gender: "masculine",
+						description: "second",
+						preview_file_url: null,
+					},
+				],
+			});
+
+			const provider = new CartesiaTTS("test-key");
+			const voices = await provider.search({ gender: "masculine" });
+
+			expect(voices.map((v) => v.id)).toEqual(["v1", "v2"]);
+			expect(mockEmbed).not.toHaveBeenCalled();
+			expect(mockEmbedMany).not.toHaveBeenCalled();
+		});
+
+		it("falls back to unranked results when embedding throws", async () => {
+			mockVoicesList.mockResolvedValue({
+				data: [
+					{
+						id: "v1",
+						name: "A",
+						language: "en",
+						gender: "feminine",
+						description: "first",
+						preview_file_url: null,
+					},
+					{
+						id: "v2",
+						name: "B",
+						language: "en",
+						gender: "feminine",
+						description: "second",
+						preview_file_url: null,
+					},
+				],
+			});
+			mockEmbed.mockRejectedValue(new Error("missing api key"));
+			mockEmbedMany.mockResolvedValue({
+				embeddings: [
+					[1, 0],
+					[0, 1],
+				],
+			});
+
+			const provider = new CartesiaTTS("test-key");
+			const voices = await provider.search({ description: "anything" });
+
+			expect(voices.map((v) => v.id)).toEqual(["v1", "v2"]);
 		});
 
 		it("filters voices by language", async () => {

--- a/lib/providers/llm/mock.ts
+++ b/lib/providers/llm/mock.ts
@@ -7,19 +7,13 @@ import { pickRandom } from "../mock-utils";
 
 const MOCK_SCRIPT = `<metadata_style>Warm, earth tones. Whimsical storybook illustration with soft watercolors, gentle brush strokes, warm lighting.</metadata_style>
 
-<metadata_narration gender="female" age="adult" pitch="medium" accent="american" texture="warm, grandmotherly, kind"></metadata_narration>
+<metadata_narration gender="feminine" age="adult" pitch="medium" accent="american" description="warm, grandmotherly, kind"></metadata_narration>
 
-<metadata_character name="Red" gender="female" age="child" pitch="high" accent="american" texture="bright, cheerful, youthful">A cheerful girl around eight years old with warm brown skin, dark curly hair in two puffs, bright brown eyes, wearing a bright red hooded cloak over a white dress, small brown leather boots.</metadata_character>
+<metadata_character name="Red" gender="feminine" age="child" pitch="high" accent="american" description="bright, cheerful, youthful">A cheerful girl around eight years old with warm brown skin, dark curly hair in two puffs, bright brown eyes, wearing a bright red hooded cloak over a white dress, small brown leather boots.</metadata_character>
 
-<metadata_character name="Wolf" gender="male" age="adult" pitch="low" accent="american" texture="gentle, soft-spoken, kind">A large gray wolf with kind amber eyes, soft thick fur, wearing a worn brown vest with wooden buttons, slightly hunched posture, gentle expression despite sharp teeth.</metadata_character>
+<metadata_character name="Wolf" gender="masculine" age="adult" pitch="low" accent="american" description="gentle, soft-spoken, kind">A large gray wolf with kind amber eyes, soft thick fur, wearing a worn brown vest with wooden buttons, slightly hunched posture, gentle expression despite sharp teeth.</metadata_character>
 
-<metadata_character name="Mother" gender="female" age="adult" pitch="medium" accent="american" texture="caring, gentle, melodic">Red's mother, a tall woman with warm brown skin, long black braided hair tied back with a green ribbon, kind dark eyes, wearing a long blue dress and a flour-dusted apron.</metadata_character>
-
-<metadata_character name="Granny" gender="female" age="elderly" pitch="medium" accent="american" texture="raspy, warm, wise">A small elderly woman with deep brown skin, silver hair tied in a bun, twinkling hazel eyes behind round spectacles, wearing a soft purple shawl over a long gray nightgown, knitted slippers.</metadata_character>
-
-<metadata_character name="Owl" gender="female" age="adult" pitch="medium" accent="british" texture="ethereal, slow, knowing">A large tawny owl with copper and brown speckled feathers, enormous golden eyes, wearing a tiny silver pendant on a chain around her neck.</metadata_character>
-
-<metadata_character name="Hunter" gender="male" age="adult" pitch="low" accent="american" texture="hearty, friendly, booming">A broad-shouldered woodsman with weathered tan skin, a thick brown beard, crinkled blue eyes, wearing a green cloak, a leather belt with a hatchet, sturdy brown boots.</metadata_character>
+<metadata_character name="Mother" gender="feminine" age="adult" pitch="medium" accent="american" description="caring, gentle, melodic">Red's mother, a tall woman with warm brown skin, long black braided hair tied back with a green ribbon, kind dark eyes, wearing a long blue dress and a flour-dusted apron.</metadata_character>
 
 <image animate="true" animation="slow pan across the village to the forest path">A peaceful village at the edge of a lush green forest on a sunny morning. A cozy cottage with a red door sits near the forest path. Birds fly overhead. Flowers bloom along the dirt path leading into the woods.</image>
 

--- a/lib/providers/tts/cartesia.ts
+++ b/lib/providers/tts/cartesia.ts
@@ -5,8 +5,12 @@ import type {
 	VoiceInfo,
 	VoiceSearchParams,
 } from "@/lib/connectors/types";
+import type { TTSGender } from "@/lib/connectors/tts/enums";
 import type { BundleFile } from "@/lib/api/asset-bundle";
+import { logger } from "@/lib/api/logger";
 import { BaseProvider, type WithMetadata } from "../base";
+import { buildQueryText, rankBySimilarity } from "./voiceSimilarity";
+import { GenerationRequest } from "@cartesia/cartesia-js/resources/tts.mjs";
 
 type RawTTSResult = {
 	data: string;
@@ -79,16 +83,35 @@ export class CartesiaTTS extends BaseProvider<TTSGenerateParams, RawTTSResult> {
 	async search(
 		params: VoiceSearchParams & { limit?: number },
 	): Promise<VoiceInfo[]> {
-		const page = await this.client.voices.list({
-			q: params.query || undefined,
-			gender: params.gender as
-				| "masculine"
-				| "feminine"
-				| "gender_neutral"
-				| undefined,
-			limit: params.limit || 20,
-		});
+		const { age, gender, limit, language } = params;
+		let results = await this.searchOnce(age, gender, limit, language);
+		if (results.length === 0 && age) {
+			results = await this.searchOnce(undefined, gender, limit, language);
+		}
+		const queryText = buildQueryText(params);
+		if (!queryText) return results;
+		try {
+			return await rankBySimilarity(results, queryText);
+		} catch (err) {
+			logger.warn(
+				{ err },
+				"Voice similarity ranking failed; returning unranked results",
+			);
+			return results;
+		}
+	}
 
+	private async searchOnce(
+		query?: string,
+		gender?: TTSGender,
+		limit?: number,
+		language?: string,
+	): Promise<VoiceInfo[]> {
+		const page = await this.client.voices.list({
+			q: query,
+			gender,
+			limit: limit || 100,
+		});
 		return page.data
 			.map((voice) => ({
 				id: voice.id,
@@ -98,20 +121,18 @@ export class CartesiaTTS extends BaseProvider<TTSGenerateParams, RawTTSResult> {
 				description: voice.description,
 				previewUrl: voice.preview_file_url ?? undefined,
 			}))
-			.filter(
-				(voice) => !params.language || voice.language === params.language,
-			);
+			.filter((voice) => !language || voice.language === language);
 	}
 
 	protected async _generate(params: TTSGenerateParams) {
+		if (!params.voiceId) throw new Error("voiceId is required");
 		const ws = await this.client.tts.websocket();
 		await ws.connect();
 
 		try {
 			const audioChunks: Buffer[] = [];
 			const textTimestamps: TextTimestamp[] = [];
-
-			for await (const response of ws.generate({
+			const req: GenerationRequest = {
 				model_id: params.model || "sonic-3",
 				transcript: params.prompt,
 				voice: { mode: "id", id: params.voiceId },
@@ -124,7 +145,8 @@ export class CartesiaTTS extends BaseProvider<TTSGenerateParams, RawTTSResult> {
 				...(params.speed !== undefined && {
 					speed: params.speed as "slow" | "normal" | "fast",
 				}),
-			})) {
+			};
+			for await (const response of ws.generate(req)) {
 				if (response.type === "chunk" && response.audio) {
 					audioChunks.push(
 						Buffer.isBuffer(response.audio)
@@ -150,7 +172,7 @@ export class CartesiaTTS extends BaseProvider<TTSGenerateParams, RawTTSResult> {
 			return {
 				data: wrapPcmInWav(combined).toString("base64"),
 				textTimestamps,
-				metadata: lastTs ? { durationSec: lastTs.end } : undefined,
+				metadata: lastTs ? { durationSec: lastTs.end + 1 } : undefined,
 			};
 		} finally {
 			ws.close();

--- a/lib/providers/tts/mock.ts
+++ b/lib/providers/tts/mock.ts
@@ -67,6 +67,7 @@ export class MockTTS extends MockProvider<TTSGenerateParams> {
 				name: "Mock Voice",
 				language: "en",
 				gender: "feminine",
+				description: "Mock voice",
 			},
 		];
 	}

--- a/lib/providers/tts/voiceSimilarity.ts
+++ b/lib/providers/tts/voiceSimilarity.ts
@@ -1,0 +1,41 @@
+import { embed, embedMany, cosineSimilarity } from "ai";
+import { openai } from "@ai-sdk/openai";
+import type { VoiceInfo, VoiceSearchParams } from "@/lib/connectors/types";
+
+const SEMANTIC_FIELDS = [
+	"query",
+	"description",
+	"accent",
+	"pitch",
+	"age",
+] as const satisfies ReadonlyArray<keyof VoiceSearchParams>;
+
+const EMBEDDING_MODEL = "text-embedding-3-small";
+
+export function buildQueryText(params: VoiceSearchParams): string {
+	return SEMANTIC_FIELDS.map((k) => params[k])
+		.filter((v): v is string => Boolean(v))
+		.join(" ")
+		.trim();
+}
+
+export async function rankBySimilarity(
+	voices: VoiceInfo[],
+	queryText: string,
+): Promise<VoiceInfo[]> {
+	const model = openai.embedding(EMBEDDING_MODEL);
+	const [queryResult, voiceResult] = await Promise.all([
+		embed({ model, value: queryText }),
+		embedMany({ model, values: voices.map((v) => v.description) }),
+	]);
+
+	const scores = new Map(
+		voices.map((v, i) => [
+			v.id,
+			cosineSimilarity(queryResult.embedding, voiceResult.embeddings[i]),
+		]),
+	);
+	return [...voices].sort(
+		(a, b) => (scores.get(b.id) ?? -Infinity) - (scores.get(a.id) ?? -Infinity),
+	);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "openslop",
 			"version": "0.1.0",
 			"dependencies": {
+				"@ai-sdk/openai": "^3.0.54",
 				"@anthropic-ai/sdk": "^0.78.0",
 				"@cartesia/cartesia-js": "^3.0.0",
 				"@dnd-kit/core": "^6.3.1",
@@ -18,13 +19,14 @@
 				"@remotion/player": "^4.0.443",
 				"@remotion/preload": "^4.0.448",
 				"@remotion/tailwind-v4": "^4.0.443",
-				"@remotion/vercel": "^4.0.443",
+				"@remotion/vercel": "^4.0.456",
 				"@runware/sdk-js": "^1.2.5",
 				"@supabase/ssr": "^0.9.0",
 				"@supabase/supabase-js": "^2.98.0",
 				"@vercel/blob": "^2.3.2",
 				"@vercel/functions": "^3.4.3",
 				"@vercel/sandbox": "^1.9.0",
+				"ai": "^6.0.170",
 				"clsx": "^2.1.1",
 				"dedent": "^1.7.2",
 				"immer": "^11.1.4",
@@ -65,6 +67,77 @@
 				"tw-animate-css": "^1.4.0",
 				"typescript": "^5",
 				"vitest": "^4.0.18"
+			}
+		},
+		"node_modules/@ai-sdk/gateway": {
+			"version": "3.0.105",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.105.tgz",
+			"integrity": "sha512-XpERadvLMHkYGJO4hz1Sw7Y9J705Iex48TmdZLdZdaPiFFtVgiA9qhXugLUWGAxdlXU/2N6ipoPSOwfnULZbXw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "3.0.9",
+				"@ai-sdk/provider-utils": "4.0.24",
+				"@vercel/oidc": "3.2.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/gateway/node_modules/@vercel/oidc": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+			"integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@ai-sdk/openai": {
+			"version": "3.0.54",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.54.tgz",
+			"integrity": "sha512-j1qrNe/ebUKuE+fETzS+CVnczs11jQBR9y9M6aoKtJZAosg6SZnPC1Bb92e2u6yaSK+88TZoFhiY67uYphPitw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "3.0.9",
+				"@ai-sdk/provider-utils": "4.0.24"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/provider": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.9.tgz",
+			"integrity": "sha512-/ngMKqKdL9dSlY/eQ3NFDzzFyw0Hix+cbFFlyuKEKcOgpHdBt/spKUvX/i0wGrDLFPYJeVvv3N0j92LxWRL7yQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"json-schema": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@ai-sdk/provider-utils": {
+			"version": "4.0.24",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.24.tgz",
+			"integrity": "sha512-oXIw1oLmuBILuvHgSj6w5LOV8oSnFRouPSv0MGkG9sRMeukZ9JnMF17kldaRQaRq8lSJIxo6aS3NzWlVmSb+4Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "3.0.9",
+				"@standard-schema/spec": "^1.1.0",
+				"eventsource-parser": "^3.0.8"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
 			}
 		},
 		"node_modules/@alloc/quick-lru": {
@@ -2771,6 +2844,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
 		"node_modules/@oxc-project/types": {
 			"version": "0.127.0",
 			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
@@ -4659,16 +4741,210 @@
 			"license": "MIT"
 		},
 		"node_modules/@remotion/vercel": {
-			"version": "4.0.451",
-			"resolved": "https://registry.npmjs.org/@remotion/vercel/-/vercel-4.0.451.tgz",
-			"integrity": "sha512-gMpxIt3GC1FfyWVJ/Qazzw9TlVj4oKZnHFrqz81t8d2J4mS0qcQ2MEE/NBM0dQbqakwZLzRxs/zAsze3R4skqQ==",
+			"version": "4.0.456",
+			"resolved": "https://registry.npmjs.org/@remotion/vercel/-/vercel-4.0.456.tgz",
+			"integrity": "sha512-1CY84RqUwArw1fy1iGhOl6GO4BZrSzPTji3gFfir5uuBOq+raM1wxTSo2MM0g0/Npi6W7oWIGSENsbOYXU8gOg==",
 			"license": "Remotion License",
 			"dependencies": {
-				"@remotion/renderer": "4.0.451",
-				"remotion": "4.0.451"
+				"@remotion/renderer": "4.0.456",
+				"remotion": "4.0.456"
 			},
 			"peerDependencies": {
 				"@vercel/sandbox": ">=1.0.0"
+			}
+		},
+		"node_modules/@remotion/vercel/node_modules/@remotion/compositor-darwin-arm64": {
+			"version": "4.0.456",
+			"resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-arm64/-/compositor-darwin-arm64-4.0.456.tgz",
+			"integrity": "sha512-aF5ZnO2Vt6KDeb4h5quxk5x1g+B7emcUh9wsHdWlPIr5OvB43IglfMw5hKGabwHiI28q8KYWd1PBeStUkskpFg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@remotion/vercel/node_modules/@remotion/compositor-darwin-x64": {
+			"version": "4.0.456",
+			"resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-x64/-/compositor-darwin-x64-4.0.456.tgz",
+			"integrity": "sha512-Q1rsmu3xw38oxYFLmAFBJ5JLOwp6B8KCbeU1N9LRcs0TO9ONETA88suPBqqKf5G1SvGuo8265CG/KAr5yHhDdQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@remotion/vercel/node_modules/@remotion/compositor-linux-arm64-gnu": {
+			"version": "4.0.456",
+			"resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-gnu/-/compositor-linux-arm64-gnu-4.0.456.tgz",
+			"integrity": "sha512-vAOyvXizFDZ4031nnkYmeSuUKP+0g4pF1miKgGsGFJrLT9uWmUl2i8VQEmCCliMyVtYGd/hI7nMiHYsDE3MWGw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@remotion/vercel/node_modules/@remotion/compositor-linux-arm64-musl": {
+			"version": "4.0.456",
+			"resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-musl/-/compositor-linux-arm64-musl-4.0.456.tgz",
+			"integrity": "sha512-Bsq//++CpTG1ht3PI1Y5A9n0CQYCOrOAS2UyJmgCmezE1G609b6NvD2ZPAsXH9WXNZU7C+0b7Hf11Mzmxpasvw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@remotion/vercel/node_modules/@remotion/compositor-linux-x64-gnu": {
+			"version": "4.0.456",
+			"resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-gnu/-/compositor-linux-x64-gnu-4.0.456.tgz",
+			"integrity": "sha512-L1s1fJdp3PsfrsEoTSFY7Q6MirZZ8frdErQ63uEwV0L4sh8aUaS27PhG1a7tFdtuGZbxp3Cf+jR2uZC5jqvBXQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@remotion/vercel/node_modules/@remotion/compositor-linux-x64-musl": {
+			"version": "4.0.456",
+			"resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-musl/-/compositor-linux-x64-musl-4.0.456.tgz",
+			"integrity": "sha512-8tYxgSfJ9yLgrsB/z6H1PNnLHqECqbV7aW5ox/djolqgd6aSVEYwsKGlapikfk9jeEK+Ucr9GciNjvyiQbohkA==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@remotion/vercel/node_modules/@remotion/compositor-win32-x64-msvc": {
+			"version": "4.0.456",
+			"resolved": "https://registry.npmjs.org/@remotion/compositor-win32-x64-msvc/-/compositor-win32-x64-msvc-4.0.456.tgz",
+			"integrity": "sha512-be+0bYKlIaKIOhlfL7rZUDSXT1Anu/ImqjGjBLI5fbUJgYi+l7J8XqWxGhuhlr5ff3EwPuK38igFknt/ppi2HA==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@remotion/vercel/node_modules/@remotion/licensing": {
+			"version": "4.0.456",
+			"resolved": "https://registry.npmjs.org/@remotion/licensing/-/licensing-4.0.456.tgz",
+			"integrity": "sha512-/sMMInqx0rmGsQi1idmwCCTKmv5S4ed/ASlNf+01Dz0UxZv+/6NLfsDKDrQKZ2LV3+/BsreUSAUxN33FmvP7sw==",
+			"license": "MIT"
+		},
+		"node_modules/@remotion/vercel/node_modules/@remotion/renderer": {
+			"version": "4.0.456",
+			"resolved": "https://registry.npmjs.org/@remotion/renderer/-/renderer-4.0.456.tgz",
+			"integrity": "sha512-GWQSBmao+Njl5ZnfP0xohK9Nk9LziYRPJ8kM+A8yTy33cTSPRL0yeMCse6iBsxpj2XrA6Ci58OWrSwYDLbhKTA==",
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@remotion/licensing": "4.0.456",
+				"@remotion/streaming": "4.0.456",
+				"execa": "5.1.1",
+				"extract-zip": "2.0.1",
+				"remotion": "4.0.456",
+				"source-map": "^0.8.0-beta.0",
+				"ws": "8.17.1"
+			},
+			"optionalDependencies": {
+				"@remotion/compositor-darwin-arm64": "4.0.456",
+				"@remotion/compositor-darwin-x64": "4.0.456",
+				"@remotion/compositor-linux-arm64-gnu": "4.0.456",
+				"@remotion/compositor-linux-arm64-musl": "4.0.456",
+				"@remotion/compositor-linux-x64-gnu": "4.0.456",
+				"@remotion/compositor-linux-x64-musl": "4.0.456",
+				"@remotion/compositor-win32-x64-msvc": "4.0.456"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@remotion/vercel/node_modules/@remotion/streaming": {
+			"version": "4.0.456",
+			"resolved": "https://registry.npmjs.org/@remotion/streaming/-/streaming-4.0.456.tgz",
+			"integrity": "sha512-E0xp8rsmxtzx6pijXrbxkBASkQ1uf5iKgfk4yZOvlBCymzTiDH6F4iqi/k62MRsTju+3Q3HTbDL+jJZ94HRCUA==",
+			"license": "MIT"
+		},
+		"node_modules/@remotion/vercel/node_modules/remotion": {
+			"version": "4.0.456",
+			"resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.456.tgz",
+			"integrity": "sha512-yi0joZ0u4hIdhcSKV+Ou3myP5qQbzSyb592AjYUli1O9oOOt+CGFFn3LNNii4vI6pqM2Wjh+X1x9iSuITo7Vhw==",
+			"license": "SEE LICENSE IN LICENSE.md",
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@remotion/vercel/node_modules/source-map": {
+			"version": "0.8.0-beta.0",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+			"integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+			"deprecated": "The work that was done in this beta branch won't be included in future versions",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"whatwg-url": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@remotion/vercel/node_modules/tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/@remotion/vercel/node_modules/webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/@remotion/vercel/node_modules/whatwg-url": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+			"license": "MIT",
+			"dependencies": {
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
+			}
+		},
+		"node_modules/@remotion/vercel/node_modules/ws": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@remotion/web-renderer": {
@@ -5223,7 +5499,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
 			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@supabase/auth-js": {
@@ -7439,6 +7714,24 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/ai": {
+			"version": "6.0.170",
+			"resolved": "https://registry.npmjs.org/ai/-/ai-6.0.170.tgz",
+			"integrity": "sha512-FWTKeGGDRcYJtPWIrdZDSuvOW5LCjI2NZUJmaml8OTOaPEsXnFdFvmawCXbT+wTGxyWKJTgZ9sZtCjbJsmjM2Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/gateway": "3.0.105",
+				"@ai-sdk/provider": "3.0.9",
+				"@ai-sdk/provider-utils": "4.0.24",
+				"@opentelemetry/api": "1.9.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
 			}
 		},
 		"node_modules/ajv": {
@@ -9762,7 +10055,6 @@
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
 			"integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.0.0"
@@ -11646,6 +11938,12 @@
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"license": "MIT"
+		},
+		"node_modules/json-schema": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+			"license": "(AFL-2.1 OR BSD-3-Clause)"
 		},
 		"node_modules/json-schema-to-ts": {
 			"version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		]
 	},
 	"dependencies": {
+		"@ai-sdk/openai": "^3.0.54",
 		"@anthropic-ai/sdk": "^0.78.0",
 		"@cartesia/cartesia-js": "^3.0.0",
 		"@dnd-kit/core": "^6.3.1",
@@ -39,13 +40,14 @@
 		"@remotion/player": "^4.0.443",
 		"@remotion/preload": "^4.0.448",
 		"@remotion/tailwind-v4": "^4.0.443",
-		"@remotion/vercel": "^4.0.443",
+		"@remotion/vercel": "^4.0.456",
 		"@runware/sdk-js": "^1.2.5",
 		"@supabase/ssr": "^0.9.0",
 		"@supabase/supabase-js": "^2.98.0",
 		"@vercel/blob": "^2.3.2",
 		"@vercel/functions": "^3.4.3",
 		"@vercel/sandbox": "^1.9.0",
+		"ai": "^6.0.170",
 		"clsx": "^2.1.1",
 		"dedent": "^1.7.2",
 		"immer": "^11.1.4",


### PR DESCRIPTION
## Summary

- **Cartesia voice search now re-ranks by description similarity.** When the user passes any free-text descriptor (`query`, `description`, `accent`, `pitch`, `age`, `name`), `CartesiaTTS.search` embeds it via `text-embedding-3-small` (Vercel AI SDK + `@ai-sdk/openai`), embeds each returned voice's description, and sorts by `cosineSimilarity`. Hard filters (`gender`, `language`) still apply before ranking. Falls back to the unranked list with a `logger.warn` if the embeddings call throws (e.g. missing `OPENAI_API_KEY`), so existing flows don't break.
- **New helper** at `lib/providers/tts/voiceSimilarity.ts` so the same logic can later be reused for ElevenLabs.
- **`VoiceSearchParams` gains `name?: string`** so the plugin contract matches what's already passed through.
- **`.env.example` + `.gitignore` allow-list** for the example file (project is going OSS).
- **Connector layer cleanup carry-over from this branch**: collapses per-type `MusicConnector` / `SFXConnector` / `ImageConnector` / `VideoConnector` interfaces into the base `Connector`, moves `ConnectorTypeMap` into `factory.ts`, and replaces TS `enum`s in `lib/connectors/tts/enums.ts` with `as const` arrays + literal types. Gender values renamed to `masculine` / `feminine` / `gender_neutral`; `parseGender` helper added.
- **Two stale test fixtures fixed** so the suite is green: Cartesia `searchOnce` default `limit` (20 → 100) and the character-avatar prompt template (now includes nameplate + white background).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test:run` — 515 / 515 pass
- [ ] Manual: with `OPENAI_API_KEY` and `CARTESIA_API_KEY` set, `curl 'http://localhost:3000/api/v1/tts/voices?description=warm%20british%20narrator&language=en&gender=feminine&limit=20'` and confirm the top voice description matches the descriptors; repeat with `description=energetic%20young%20american` and confirm a different voice rises.
- [ ] Manual: trigger a TTS generation through the UI with semantic descriptors and confirm the picked voice matches intent.
- [ ] Manual: unset `OPENAI_API_KEY` and confirm the endpoint still returns voices (unranked) instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)