### PR TITLE
refactor: nightly maintainability 2026-04-30

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,6 +81,11 @@ For audio providers, `lib/providers/elevenlabs.ts` exposes a
 `BaseElevenLabsAudio` class that the `music/` and `sfx/` ElevenLabs subclasses
 share — they only differ in default duration and which SDK method to call.
 
+For video, async-job types (`VideoJob`, `VideoJobStatus`, `VideoJobMetadata`,
+`VideoProviderResponse`) live in `lib/providers/video/base.ts` next to
+`BaseVideoProvider` — they are server-side concerns, not part of the connector
+contract.
+
 ## API routes
 
 Every `app/api/v1/<type>/route.ts` is built from the same factory (shown for
@@ -109,10 +114,11 @@ export const POST = createRouteHandler({
 Add `extraValidation` for type-specific checks (see TTS `voiceId` and Video
 `referenceImages` validation).
 
-Providers are resolved through `lib/api/providers.ts`, which uses a
-`withMockFallback` helper: if the relevant API key isn't set (e.g.
-`RUNWARE_API_KEY`), the route uses the mock provider instead. Provider
-instances are cached per process.
+Providers are resolved through `lib/api/providers.ts`. Each `getXProvider()`
+is built from the same `defineProvider(key, envVar, RealCtor, MockCtor)`
+helper: if the relevant API key isn't set (e.g. `RUNWARE_API_KEY`), the route
+falls back to the mock implementation. Instances are cached per process by
+`key`, so repeated calls return the same provider.
 
 ## Generation queue
 
@@ -134,7 +140,12 @@ components dispatch jobs, never call connectors directly.
 
 - `lib/project/store.ts` holds per-project metadata (characters, defaults) in a
   Zustand store, scoped by project id.
-- `lib/script/` provides a React context for the current script being edited.
+- `lib/project/ensureCharacterAvatars.ts` runs before each generation batch to
+  guarantee every referenced character has an avatar image; the queue invokes it
+  via `generationQueue.before(...)`.
+- `lib/script/ScriptProvider.tsx` provides a React context for the current
+  script being edited; `lib/script/refine/` houses transformation utilities
+  (e.g. `applyOps.ts` for applying LLM-produced refinement ops to the tree).
 - `lib/config/` stores connector configuration globally; per-element
   configuration overlays this.
 

--- a/lib/api/providers.ts
+++ b/lib/api/providers.ts
@@ -11,79 +11,56 @@ import { MockLLM } from "@/lib/providers/llm/mock";
 import { CartesiaTTS } from "@/lib/providers/tts/cartesia";
 import { MockTTS } from "@/lib/providers/tts/mock";
 
-function withMockFallback<TReal, TMock>(
-	envVar: string,
-	real: (apiKey: string) => TReal,
-	mock: () => TMock,
-): TReal | TMock {
-	const apiKey = process.env[envVar];
-	if (!apiKey) return mock();
-	return real(apiKey);
-}
-
 const cache = new Map<string, unknown>();
 
-function cached<T>(key: string, factory: () => T): T {
-	if (!cache.has(key)) cache.set(key, factory());
-	return cache.get(key) as T;
+function defineProvider<R, M>(
+	key: string,
+	envVar: string,
+	RealCtor: new (apiKey: string) => R,
+	MockCtor: new () => M,
+): () => R | M {
+	return () => {
+		if (!cache.has(key)) {
+			const apiKey = process.env[envVar];
+			cache.set(key, apiKey ? new RealCtor(apiKey) : new MockCtor());
+		}
+		return cache.get(key) as R | M;
+	};
 }
 
-export function getImageProvider() {
-	return cached("image", () =>
-		withMockFallback(
-			"RUNWARE_API_KEY",
-			(k) => new RunwareImage(k),
-			() => new MockImage(),
-		),
-	);
-}
-
-export function getVideoProvider() {
-	return cached("video", () =>
-		withMockFallback(
-			"RUNWARE_API_KEY",
-			(k) => new RunwareVideo(k),
-			() => new MockVideo(),
-		),
-	);
-}
-
-export function getMusicProvider() {
-	return cached("music", () =>
-		withMockFallback(
-			"ELEVENLABS_API_KEY",
-			(k) => new ElevenLabsMusic(k),
-			() => new MockMusic(),
-		),
-	);
-}
-
-export function getSFXProvider() {
-	return cached("sfx", () =>
-		withMockFallback(
-			"ELEVENLABS_API_KEY",
-			(k) => new ElevenLabsSFX(k),
-			() => new MockSFX(),
-		),
-	);
-}
-
-export function getLLMProvider() {
-	return cached("llm", () =>
-		withMockFallback(
-			"ANTHROPIC_API_KEY",
-			(k) => new AnthropicLLM(k),
-			() => new MockLLM(),
-		),
-	);
-}
-
-export function getTTSProvider() {
-	return cached("tts", () =>
-		withMockFallback(
-			"CARTESIA_API_KEY",
-			(k) => new CartesiaTTS(k),
-			() => new MockTTS(),
-		),
-	);
-}
+export const getImageProvider = defineProvider(
+	"image",
+	"RUNWARE_API_KEY",
+	RunwareImage,
+	MockImage,
+);
+export const getVideoProvider = defineProvider(
+	"video",
+	"RUNWARE_API_KEY",
+	RunwareVideo,
+	MockVideo,
+);
+export const getMusicProvider = defineProvider(
+	"music",
+	"ELEVENLABS_API_KEY",
+	ElevenLabsMusic,
+	MockMusic,
+);
+export const getSFXProvider = defineProvider(
+	"sfx",
+	"ELEVENLABS_API_KEY",
+	ElevenLabsSFX,
+	MockSFX,
+);
+export const getLLMProvider = defineProvider(
+	"llm",
+	"ANTHROPIC_API_KEY",
+	AnthropicLLM,
+	MockLLM,
+);
+export const getTTSProvider = defineProvider(
+	"tts",
+	"CARTESIA_API_KEY",
+	CartesiaTTS,
+	MockTTS,
+);

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -204,20 +204,6 @@ export type VideoGenerateParams = {
 	height?: number;
 };
 
-export type VideoJobStatus = "queued" | "processing" | "completed" | "failed";
-
-export type VideoJobMetadata = {
-	jobId: string;
-	durationSec?: number;
-	status?: VideoJobStatus;
-	error?: string;
-};
-
-export type VideoJob = {
-	url?: string;
-	progress?: number;
-} & WithMetadata<VideoJobMetadata>;
-
 export interface VideoConnector extends Connector {
 	readonly type: "video";
 	generate(params: VideoGenerateParams): Promise<AssetResult>;

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -239,17 +239,7 @@ export class GenerationQueue {
 
 		this.update(elementId, { status: "generating", seconds: 0 });
 		this.notify();
-
-		const start = Date.now();
-		const timer = setInterval(() => {
-			if (this.state.get(elementId)?.status === "generating") {
-				this.update(elementId, {
-					seconds: ((Date.now() - start) / 1000) | 0,
-				});
-				this.notify();
-			}
-		}, 1000);
-		this.timers.set(elementId, timer);
+		this.startElapsedTimer(elementId);
 
 		generateForElement(
 			job.connectorType,
@@ -258,38 +248,62 @@ export class GenerationQueue {
 			job.prompt,
 			job.extraParams,
 		)
-			.then((result) => {
-				if (controller.signal.aborted) return;
-				const key = serializeInputs(job.inputs);
-				const elHistory =
-					this.history.get(elementId) ?? new Map<string, AssetResult>();
-				elHistory.set(key, result);
-				this.history.set(elementId, elHistory);
-				this.update(elementId, {
-					status: "idle",
-					seconds: 0,
-					result,
-					error: null,
-					resultInputs: job.inputs,
-				});
-			})
-			.catch((err) => {
-				if (controller.signal.aborted) return;
-				console.error(`Generation failed for element ${elementId}:`, err);
-				this.update(elementId, {
-					status: "idle",
-					seconds: 0,
-					result: null,
-					error: err instanceof Error ? err.message : String(err),
-				});
-			})
-			.finally(() => {
-				if (controller.signal.aborted) return;
-				this.stopTimer(elementId);
-				this.controllers.delete(elementId);
-				this.notify();
-				this.processQueue();
-			});
+			.then((result) => this.handleJobSuccess(job, result, controller))
+			.catch((err) => this.handleJobError(elementId, err, controller))
+			.finally(() => this.finalizeJob(elementId, controller));
+	}
+
+	private startElapsedTimer(elementId: string) {
+		const start = Date.now();
+		const timer = setInterval(() => {
+			if (this.state.get(elementId)?.status !== "generating") return;
+			this.update(elementId, { seconds: ((Date.now() - start) / 1000) | 0 });
+			this.notify();
+		}, 1000);
+		this.timers.set(elementId, timer);
+	}
+
+	private handleJobSuccess(
+		job: GenerationJob,
+		result: AssetResult,
+		controller: AbortController,
+	) {
+		if (controller.signal.aborted) return;
+		const key = serializeInputs(job.inputs);
+		const elHistory =
+			this.history.get(job.elementId) ?? new Map<string, AssetResult>();
+		elHistory.set(key, result);
+		this.history.set(job.elementId, elHistory);
+		this.update(job.elementId, {
+			status: "idle",
+			seconds: 0,
+			result,
+			error: null,
+			resultInputs: job.inputs,
+		});
+	}
+
+	private handleJobError(
+		elementId: string,
+		err: unknown,
+		controller: AbortController,
+	) {
+		if (controller.signal.aborted) return;
+		console.error(`Generation failed for element ${elementId}:`, err);
+		this.update(elementId, {
+			status: "idle",
+			seconds: 0,
+			result: null,
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+
+	private finalizeJob(elementId: string, controller: AbortController) {
+		if (controller.signal.aborted) return;
+		this.stopTimer(elementId);
+		this.controllers.delete(elementId);
+		this.notify();
+		this.processQueue();
 	}
 }
 

--- a/lib/providers/video/base.ts
+++ b/lib/providers/video/base.ts
@@ -1,10 +1,21 @@
-import type {
-	VideoGenerateParams,
-	VideoJob,
-	VideoJobMetadata,
-} from "@/lib/connectors/types";
+import type { VideoGenerateParams } from "@/lib/connectors/types";
 import type { BundleFile, BundleResponse } from "@/lib/api/asset-bundle";
+import type { WithMetadata } from "../base";
 import { BaseProvider } from "../base";
+
+export type VideoJobStatus = "queued" | "processing" | "completed" | "failed";
+
+export type VideoJobMetadata = {
+	jobId: string;
+	durationSec?: number;
+	status?: VideoJobStatus;
+	error?: string;
+};
+
+export type VideoJob = {
+	url?: string;
+	progress?: number;
+} & WithMetadata<VideoJobMetadata>;
 
 export type VideoProviderResponse = BundleResponse & {
 	metadata?: VideoJobMetadata;

--- a/lib/providers/video/mock.ts
+++ b/lib/providers/video/mock.ts
@@ -1,5 +1,4 @@
-import type { VideoJob } from "@/lib/connectors/types";
-import type { VideoProviderResponse } from "./base";
+import type { VideoJob, VideoProviderResponse } from "./base";
 import { BaseVideoProvider } from "./base";
 import { pickRandom } from "../mock-utils";
 

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -1,8 +1,5 @@
-import type {
-	VideoGenerateParams,
-	VideoJob,
-	VideoJobStatus,
-} from "@/lib/connectors/types";
+import type { VideoGenerateParams } from "@/lib/connectors/types";
+import type { VideoJob, VideoJobStatus } from "./base";
 import { BaseVideoProvider } from "./base";
 import { withRunware } from "../runware";
 


### PR DESCRIPTION
## Summary
- refactored provider resolution into a single `defineProvider` helper with per-key singleton caching and env-key mock fallback
- moved video async-job domain types from connector contract into `lib/providers/video/base.ts` and updated provider imports
- split `GenerationQueue` job lifecycle into focused helpers (`startElapsedTimer`, `handleJobSuccess`, `handleJobError`, `finalizeJob`) to reduce branching in `startJob`
- updated `ARCHITECTURE.md` to document provider helper pattern, video job-type boundary, and queue/avatar/script responsibilities

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm test -- --passWithNoTests
- npm run test:run

## Constraints respected
- no behavior changes intended (refactor/docs only)
- `proxy.ts` untouched
- no head-tracking script changes