### PR TITLE
refactor: nightly maintainability 2026-05-01

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -123,7 +123,8 @@ class:
 - Enqueues `GenerationJob`s and drains them in batches via
   `generateForElement` → `createConnector(...).generate(...)`.
 - Tracks status (`idle | queued | generating`), errors, elapsed seconds, and a
-  per-element history of past results for instant cache hits when inputs match.
+  dedicated `JobHistory` cache keyed by serialized generation inputs for instant
+  per-element cache hits when inputs match.
 - Exposes a Zustand-style subscribe API used by canvas elements to render
   progress.
 

--- a/lib/connectors/plugins.ts
+++ b/lib/connectors/plugins.ts
@@ -1,45 +1,66 @@
+/**
+ * Plugin pipeline runners used by `BaseConnector`.
+ *
+ * Each chain hook (`beforeGenerate`, `afterGenerate`, `transformPrompt`) is a
+ * sequential reducer: every plugin that defines the hook receives the previous
+ * plugin's output and returns the next value. `onError` is fan-out — every
+ * plugin observes the failure but cannot mutate it.
+ */
 import type { ConnectorPlugin, PluginContext } from "./types";
 
-export async function runBeforeGenerate<T>(
+type ChainHook<TIn, TOut, TParams, TResult> = (
+	input: TIn,
+	ctx?: PluginContext<TParams, TResult>,
+) => TOut | Promise<TOut>;
+
+async function chain<T, TParams = unknown, TResult = unknown>(
+	plugins: ConnectorPlugin<TParams, TResult>[],
+	pick: (
+		plugin: ConnectorPlugin<TParams, TResult>,
+	) => ChainHook<T, T, TParams, TResult> | undefined,
+	initial: T,
+	ctx?: PluginContext<TParams, TResult>,
+): Promise<T> {
+	let current = initial;
+	for (const plugin of plugins) {
+		const hook = pick(plugin);
+		if (hook) current = await hook(current, ctx);
+	}
+	return current;
+}
+
+export function runBeforeGenerate<T>(
 	plugins: ConnectorPlugin[],
 	params: T,
 	ctx?: PluginContext,
 ): Promise<T> {
-	let result = params;
-	for (const plugin of plugins) {
-		if (plugin.beforeGenerate) {
-			result = (await plugin.beforeGenerate(result, ctx)) as T;
-		}
-	}
-	return result;
+	return chain(
+		plugins,
+		(p) => p.beforeGenerate as ChainHook<T, T, unknown, unknown> | undefined,
+		params,
+		ctx,
+	);
 }
 
-export async function runAfterGenerate<T>(
+export function runAfterGenerate<T>(
 	plugins: ConnectorPlugin[],
 	result: T,
 	ctx?: PluginContext,
 ): Promise<T> {
-	let current = result;
-	for (const plugin of plugins) {
-		if (plugin.afterGenerate) {
-			current = (await plugin.afterGenerate(current, ctx)) as T;
-		}
-	}
-	return current;
+	return chain(
+		plugins,
+		(p) => p.afterGenerate as ChainHook<T, T, unknown, unknown> | undefined,
+		result,
+		ctx,
+	);
 }
 
-export async function runTransformPrompt(
+export function runTransformPrompt(
 	plugins: ConnectorPlugin[],
 	prompt: string,
 	ctx?: PluginContext,
 ): Promise<string> {
-	let current = prompt;
-	for (const plugin of plugins) {
-		if (plugin.transformPrompt) {
-			current = await plugin.transformPrompt(current, ctx);
-		}
-	}
-	return current;
+	return chain(plugins, (p) => p.transformPrompt, prompt, ctx);
 }
 
 export async function runOnError(
@@ -48,8 +69,6 @@ export async function runOnError(
 	ctx?: PluginContext,
 ): Promise<void> {
 	for (const plugin of plugins) {
-		if (plugin.onError) {
-			await plugin.onError(error, ctx);
-		}
+		if (plugin.onError) await plugin.onError(error, ctx);
 	}
 }

--- a/lib/generation/jobHistory.ts
+++ b/lib/generation/jobHistory.ts
@@ -1,0 +1,26 @@
+/**
+ * Per-element result cache used by `GenerationQueue`.
+ *
+ * Keys results by a serialized snapshot of the inputs that produced them so
+ * that re-running an element with identical inputs is an instant cache hit.
+ * The store is intentionally narrow: callers only `record` after a successful
+ * generation and `lookup` when restoring a cached result.
+ */
+import type { AssetResult } from "../connectors/types";
+import { serializeInputs, type GenerationInputs } from "./generationInputs";
+
+export class JobHistory {
+	private byElement = new Map<string, Map<string, AssetResult>>();
+
+	record(elementId: string, inputs: GenerationInputs, result: AssetResult) {
+		const key = serializeInputs(inputs);
+		const existing =
+			this.byElement.get(elementId) ?? new Map<string, AssetResult>();
+		existing.set(key, result);
+		this.byElement.set(elementId, existing);
+	}
+
+	lookup(elementId: string, inputs: GenerationInputs): AssetResult | undefined {
+		return this.byElement.get(elementId)?.get(serializeInputs(inputs));
+	}
+}

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -1,3 +1,20 @@
+/**
+ * Editor-facing task scheduler for asset generation.
+ *
+ * `GenerationQueue` is a Zustand-style observable store that:
+ *
+ * - Drains queued `GenerationJob`s in batches (`batchSize` concurrent runs).
+ * - Tracks per-element status, elapsed seconds, last result, and last error.
+ * - Caches successful results in `JobHistory` so identical inputs skip the
+ *   network on the next run (`restoreResult`).
+ * - Lets callers register a one-shot `before(fn)` that runs before the next
+ *   batch starts — used for "ensure dependencies" steps like character
+ *   avatar pre-generation.
+ *
+ * The queue is the only direct dependency UI code has on the connector
+ * factory; components dispatch jobs via the `useGenerate` hook and never
+ * reach into `lib/connectors` themselves.
+ */
 import type {
 	AssetResult,
 	ConnectorConfig,
@@ -5,8 +22,8 @@ import type {
 	ProviderKey,
 } from "../connectors/types";
 import { generateForElement } from "./generateForElement";
-import { serializeInputs } from "./generationInputs";
 import type { GenerationInputs } from "./generationInputs";
+import { JobHistory } from "./jobHistory";
 
 export type { GenerationInputs } from "./generationInputs";
 export { isStaleResult } from "./generationInputs";
@@ -40,13 +57,16 @@ const EMPTY_SNAPSHOT: ElementSnapshot = {
 const isActive = (status: ElementSnapshot["status"]) =>
 	status === "queued" || status === "generating";
 
+const errorMessage = (err: unknown) =>
+	err instanceof Error ? err.message : String(err);
+
 export class GenerationQueue {
 	private state = new Map<string, ElementSnapshot>();
 	private pending: GenerationJob[] = [];
 	private controllers = new Map<string, AbortController>();
 	private timers = new Map<string, ReturnType<typeof setInterval>>();
 	private listeners = new Set<() => void>();
-	private history = new Map<string, Map<string, AssetResult>>();
+	private history = new JobHistory();
 	private readonly batchSize: number;
 	private pendingBefore: (() => Promise<void>) | null = null;
 	private processing = false;
@@ -181,8 +201,7 @@ export class GenerationQueue {
 	}
 
 	restoreResult(elementId: string, inputs: GenerationInputs): boolean {
-		const key = serializeInputs(inputs);
-		const cached = this.history.get(elementId)?.get(key);
+		const cached = this.history.lookup(elementId, inputs);
 		if (!cached) return false;
 		this.update(elementId, {
 			result: cached,
@@ -232,64 +251,66 @@ export class GenerationQueue {
 		}
 	}
 
-	private runJob(job: GenerationJob) {
+	private startSecondsTicker(elementId: string) {
+		const start = Date.now();
+		const timer = setInterval(() => {
+			if (this.state.get(elementId)?.status !== "generating") return;
+			this.update(elementId, { seconds: ((Date.now() - start) / 1000) | 0 });
+			this.notify();
+		}, 1000);
+		this.timers.set(elementId, timer);
+	}
+
+	private finalizeSuccess(job: GenerationJob, result: AssetResult) {
+		this.history.record(job.elementId, job.inputs, result);
+		this.update(job.elementId, {
+			status: "idle",
+			seconds: 0,
+			result,
+			error: null,
+			resultInputs: job.inputs,
+		});
+	}
+
+	private finalizeFailure(elementId: string, err: unknown) {
+		console.error(`Generation failed for element ${elementId}:`, err);
+		this.update(elementId, {
+			status: "idle",
+			seconds: 0,
+			result: null,
+			error: errorMessage(err),
+		});
+	}
+
+	private async runJob(job: GenerationJob) {
 		const { elementId } = job;
 		const controller = new AbortController();
 		this.controllers.set(elementId, controller);
 
 		this.update(elementId, { status: "generating", seconds: 0 });
 		this.notify();
+		this.startSecondsTicker(elementId);
 
-		const start = Date.now();
-		const timer = setInterval(() => {
-			if (this.state.get(elementId)?.status === "generating") {
-				this.update(elementId, {
-					seconds: ((Date.now() - start) / 1000) | 0,
-				});
-				this.notify();
-			}
-		}, 1000);
-		this.timers.set(elementId, timer);
-
-		generateForElement(
-			job.connectorType,
-			job.provider,
-			job.config,
-			job.prompt,
-			job.extraParams,
-		)
-			.then((result) => {
-				if (controller.signal.aborted) return;
-				const key = serializeInputs(job.inputs);
-				const elHistory =
-					this.history.get(elementId) ?? new Map<string, AssetResult>();
-				elHistory.set(key, result);
-				this.history.set(elementId, elHistory);
-				this.update(elementId, {
-					status: "idle",
-					seconds: 0,
-					result,
-					error: null,
-					resultInputs: job.inputs,
-				});
-			})
-			.catch((err) => {
-				if (controller.signal.aborted) return;
-				console.error(`Generation failed for element ${elementId}:`, err);
-				this.update(elementId, {
-					status: "idle",
-					seconds: 0,
-					result: null,
-					error: err instanceof Error ? err.message : String(err),
-				});
-			})
-			.finally(() => {
-				if (controller.signal.aborted) return;
-				this.stopTimer(elementId);
-				this.controllers.delete(elementId);
-				this.notify();
-				this.processQueue();
-			});
+		try {
+			const result = await generateForElement(
+				job.connectorType,
+				job.provider,
+				job.config,
+				job.prompt,
+				job.extraParams,
+			);
+			if (controller.signal.aborted) return;
+			this.finalizeSuccess(job, result);
+		} catch (err) {
+			if (controller.signal.aborted) return;
+			this.finalizeFailure(elementId, err);
+		} finally {
+			if (controller.signal.aborted) return;
+			this.stopTimer(elementId);
+			this.controllers.delete(elementId);
+			this.notify();
+			this.processQueue();
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Refactor connector plugin pipeline runners to use one shared chain helper with clearer hook semantics.
- Refactor generation queue internals to extract per-element result caching into a dedicated `JobHistory` module and split job lifecycle steps (`startSecondsTicker`, `finalizeSuccess`, `finalizeFailure`).
- Update architecture docs to describe the new queue cache boundary.

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm test -- --passWithNoTests