### PR TITLE
refactor: simplify error handling for HTTP, SSE, and stream lifecycles

### DIFF
--- a/lib/api/__tests__/asset-bundle.test.ts
+++ b/lib/api/__tests__/asset-bundle.test.ts
@@ -90,6 +90,9 @@ describe("AssetBundle", () => {
 			vi.stubGlobal(
 				"fetch",
 				vi.fn().mockResolvedValue({
+					ok: true,
+					status: 200,
+					statusText: "OK",
 					json: () => Promise.resolve(payload),
 				}),
 			);
@@ -112,6 +115,33 @@ describe("AssetBundle", () => {
 
 			vi.unstubAllGlobals();
 		});
+
+		it("throws a descriptive error when the response is not ok", async () => {
+			vi.stubGlobal(
+				"fetch",
+				vi.fn().mockResolvedValue({
+					ok: false,
+					status: 404,
+					statusText: "Not Found",
+				}),
+			);
+
+			const bundle = new AssetBundle(
+				"https://blob.example.com/assets/tts/cartesia/abc",
+				{
+					version: 1,
+					type: "tts",
+					createdAt: "",
+					result: { timestamps: "timestamps.json" },
+				},
+			);
+
+			await expect(bundle.fetchJson("timestamps")).rejects.toThrow(
+				/timestamps.*404.*Not Found/,
+			);
+
+			vi.unstubAllGlobals();
+		});
 	});
 
 	describe("fromId", () => {
@@ -129,6 +159,9 @@ describe("AssetBundle", () => {
 			vi.stubGlobal(
 				"fetch",
 				vi.fn().mockResolvedValue({
+					ok: true,
+					status: 200,
+					statusText: "OK",
 					json: () => Promise.resolve(manifest),
 				}),
 			);
@@ -141,6 +174,23 @@ describe("AssetBundle", () => {
 			expect(fetch).toHaveBeenCalledWith(
 				"https://blob.example.com/assets/image/runware/abc/manifest.json",
 			);
+
+			vi.unstubAllGlobals();
+		});
+
+		it("throws when manifest fetch fails", async () => {
+			vi.stubGlobal(
+				"fetch",
+				vi.fn().mockResolvedValue({
+					ok: false,
+					status: 500,
+					statusText: "Server Error",
+				}),
+			);
+
+			await expect(
+				AssetBundle.fromId("image", "runware", "missing"),
+			).rejects.toThrow(/image\/runware\/missing.*500/);
 
 			vi.unstubAllGlobals();
 		});

--- a/lib/api/__tests__/route-handler.test.ts
+++ b/lib/api/__tests__/route-handler.test.ts
@@ -97,7 +97,7 @@ describe("createRouteHandler", () => {
 		expect(res.status).toBe(200);
 	});
 
-	it("returns 500 when handle throws", async () => {
+	it("returns 500 with the error message when handle throws an Error", async () => {
 		const handler = makeHandler({
 			handle: async () => {
 				throw new Error("boom");
@@ -106,6 +106,18 @@ describe("createRouteHandler", () => {
 		const res = await handler(makeRequest({ prompt: "hello" }));
 		expect(res.status).toBe(500);
 		const json = await res.json();
-		expect(json.error).toBe("TestRoute failed: {}");
+		expect(json.error).toBe("TestRoute failed: boom");
+	});
+
+	it("stringifies non-Error throws", async () => {
+		const handler = makeHandler({
+			handle: async () => {
+				throw "raw string failure";
+			},
+		});
+		const res = await handler(makeRequest({ prompt: "hello" }));
+		expect(res.status).toBe(500);
+		const json = await res.json();
+		expect(json.error).toBe("TestRoute failed: raw string failure");
 	});
 });

--- a/lib/api/__tests__/sse.test.ts
+++ b/lib/api/__tests__/sse.test.ts
@@ -62,6 +62,24 @@ describe("createSSEResponse", () => {
 		}
 		expect(chunks.length).toBeGreaterThan(0);
 	});
+
+	it("emits an error event and closes when handler rejects with an Error", async () => {
+		const response = createSSEResponse(async () => {
+			throw new Error("boom");
+		});
+		const text = await response.text();
+		expect(text).toContain('"type":"error"');
+		expect(text).toContain('"message":"boom"');
+	});
+
+	it("emits the stringified message when handler rejects with a non-Error", async () => {
+		const response = createSSEResponse(async () => {
+			throw "string failure";
+		});
+		const text = await response.text();
+		expect(text).toContain('"type":"error"');
+		expect(text).toContain('"message":"string failure"');
+	});
 });
 
 describe("readSSE", () => {
@@ -131,5 +149,15 @@ describe("readSSE", () => {
 			results.push(event);
 		}
 		expect(results).toEqual([{ a: 1 }]);
+	});
+
+	it("releases the underlying reader when the consumer breaks early", async () => {
+		const stream = makeSSEStream(['data: {"a":1}\n\n', 'data: {"b":2}\n\n']);
+		for await (const event of readSSE(stream)) {
+			expect(event).toEqual({ a: 1 });
+			break;
+		}
+		// If the lock had not been released, getReader() would throw.
+		expect(() => stream.getReader()).not.toThrow();
 	});
 });

--- a/lib/api/asset-bundle.ts
+++ b/lib/api/asset-bundle.ts
@@ -1,5 +1,13 @@
 import { nanoid } from "nanoid";
 
+async function fetchJson<T>(url: string, label: string): Promise<T> {
+	const res = await fetch(url);
+	if (!res.ok) {
+		throw new Error(`${label} (${res.status} ${res.statusText})`);
+	}
+	return res.json() as Promise<T>;
+}
+
 export type AssetManifest = {
 	version: number;
 	type: string;
@@ -49,8 +57,7 @@ export class AssetBundle {
 	}
 
 	async fetchJson<T>(key: string): Promise<T> {
-		const res = await fetch(this.resolve(key));
-		return res.json() as Promise<T>;
+		return fetchJson<T>(this.resolve(key), `Failed to fetch "${key}"`);
 	}
 
 	static buildUrl(type: string, provider: string, id: string): string {
@@ -75,8 +82,10 @@ export class AssetBundle {
 		id: string,
 	): Promise<AssetBundle> {
 		const url = AssetBundle.buildUrl(type, provider, id);
-		const res = await fetch(`${url}/manifest.json`);
-		const manifest = (await res.json()) as AssetManifest;
+		const manifest = await fetchJson<AssetManifest>(
+			`${url}/manifest.json`,
+			`Failed to fetch manifest for ${type}/${provider}/${id}`,
+		);
 		return new AssetBundle(url, manifest);
 	}
 

--- a/lib/api/route-handler.ts
+++ b/lib/api/route-handler.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server";
+import { toError } from "@/lib/errors";
 import { badRequest, serverError } from "./response";
 import { logger } from "./logger";
 
@@ -46,7 +47,7 @@ export function createRouteHandler<T>(options: RouteOptions<T>) {
 			return await options.handle(provider, body);
 		} catch (error) {
 			logger.error(error, `${options.label} failed`);
-			return serverError(`${options.label} failed: ${JSON.stringify(error)}`);
+			return serverError(`${options.label} failed: ${toError(error).message}`);
 		}
 	};
 }

--- a/lib/api/sse.ts
+++ b/lib/api/sse.ts
@@ -1,3 +1,5 @@
+import { toError } from "@/lib/errors";
+
 export type SSEMessage =
 	| { type: "phase"; phase: string; progress: number; subtitle?: string }
 	| { type: "done"; url: string; size: number }
@@ -24,7 +26,11 @@ export function createSSEResponse(
 		await writer.write(encoder.encode(formatSSE(message)));
 	};
 
-	handler(send).finally(() => writer.close());
+	handler(send)
+		.catch((err) =>
+			send({ type: "error", message: toError(err).message }).catch(() => {}),
+		)
+		.finally(() => writer.close().catch(() => {}));
 
 	return new Response(stream.readable, { headers: SSE_HEADERS });
 }
@@ -34,21 +40,25 @@ export async function* readSSE<T>(body: ReadableStream): AsyncGenerator<T> {
 	const decoder = new TextDecoder();
 	let buffer = "";
 
-	for (;;) {
-		const { done, value } = await reader.read();
-		if (done) break;
-		buffer += decoder.decode(value, { stream: true });
+	try {
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			buffer += decoder.decode(value, { stream: true });
 
-		const parts = buffer.split("\n\n");
-		buffer = parts.pop() ?? "";
+			const parts = buffer.split("\n\n");
+			buffer = parts.pop() ?? "";
 
-		for (const part of parts) {
-			if (!part.startsWith("data: ")) continue;
-			try {
-				yield JSON.parse(part.slice(6)) as T;
-			} catch {
-				// skip malformed SSE events
+			for (const part of parts) {
+				if (!part.startsWith("data: ")) continue;
+				try {
+					yield JSON.parse(part.slice(6)) as T;
+				} catch {
+					// skip malformed SSE events
+				}
 			}
 		}
+	} finally {
+		reader.releaseLock();
 	}
 }

--- a/lib/generation/__tests__/queue.test.ts
+++ b/lib/generation/__tests__/queue.test.ts
@@ -514,5 +514,22 @@ describe("GenerationQueue", () => {
 				url: "https://example.com/img.png",
 			});
 		});
+
+		it("still drains the queue when before() rejects", async () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const beforeFn = vi.fn().mockRejectedValue(new Error("before failed"));
+			generateMock.mockResolvedValue({ url: "https://example.com/img.png" });
+
+			generationQueue.before(beforeFn).enqueue(makeJob("after-fail"));
+			await vi.runAllTimersAsync();
+
+			expect(beforeFn).toHaveBeenCalledOnce();
+			expect(generateMock).toHaveBeenCalledOnce();
+			const snap = generationQueue.getElementSnapshot("after-fail");
+			expect(snap.status).toBe("idle");
+			expect(snap.result).toEqual({ url: "https://example.com/img.png" });
+			expect(errorSpy).toHaveBeenCalled();
+			errorSpy.mockRestore();
+		});
 	});
 });

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -4,6 +4,7 @@ import type {
 	ConnectorType,
 	ProviderKey,
 } from "../connectors/types";
+import { toError } from "../errors";
 import { generateForElement } from "./generateForElement";
 import { serializeInputs } from "./generationInputs";
 import type { GenerationInputs } from "./generationInputs";
@@ -215,7 +216,11 @@ export class GenerationQueue {
 				if (this.pendingBefore) {
 					const fn = this.pendingBefore;
 					this.pendingBefore = null;
-					await fn();
+					try {
+						await fn();
+					} catch (err) {
+						console.error("GenerationQueue.before failed:", err);
+					}
 				}
 				this.processQueue();
 			} while (this.pendingBefore);
@@ -294,7 +299,7 @@ export class GenerationQueue {
 			status: "idle",
 			seconds: 0,
 			result: null,
-			error: err instanceof Error ? err.message : String(err),
+			error: toError(err).message,
 		});
 	}
 

--- a/lib/providers/__tests__/elevenlabs-music.test.ts
+++ b/lib/providers/__tests__/elevenlabs-music.test.ts
@@ -13,18 +13,12 @@ vi.mock("@elevenlabs/elevenlabs-js", () => ({
 import { ElevenLabsMusic } from "../music/elevenlabs";
 
 function mockReadableStream(data: Uint8Array) {
-	let read = false;
-	return {
-		getReader: () => ({
-			read: async () => {
-				if (!read) {
-					read = true;
-					return { done: false, value: data };
-				}
-				return { done: true, value: undefined };
-			},
-		}),
-	};
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(data);
+			controller.close();
+		},
+	});
 }
 
 describe("ElevenLabsMusic", () => {

--- a/lib/providers/__tests__/elevenlabs-sfx.test.ts
+++ b/lib/providers/__tests__/elevenlabs-sfx.test.ts
@@ -13,18 +13,12 @@ vi.mock("@elevenlabs/elevenlabs-js", () => ({
 import { ElevenLabsSFX } from "../sfx/elevenlabs";
 
 function mockReadableStream(data: Uint8Array) {
-	let read = false;
-	return {
-		getReader: () => ({
-			read: async () => {
-				if (!read) {
-					read = true;
-					return { done: false, value: data };
-				}
-				return { done: true, value: undefined };
-			},
-		}),
-	};
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(data);
+			controller.close();
+		},
+	});
 }
 
 describe("ElevenLabsSFX", () => {

--- a/lib/providers/__tests__/stream.test.ts
+++ b/lib/providers/__tests__/stream.test.ts
@@ -38,4 +38,14 @@ describe("streamToBuffer", () => {
 		expect(new Uint8Array(buffer).every((b) => b === 42)).toBe(true);
 		expect(buffer.byteLength).toBe(10_000);
 	});
+
+	it("propagates stream errors", async () => {
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new Uint8Array([1, 2]));
+				controller.error(new Error("read failed"));
+			},
+		});
+		await expect(streamToBuffer(stream)).rejects.toThrow("read failed");
+	});
 });

--- a/lib/providers/stream.ts
+++ b/lib/providers/stream.ts
@@ -3,10 +3,14 @@ export async function streamToBuffer(
 ): Promise<ArrayBuffer> {
 	const chunks: Uint8Array[] = [];
 	const reader = stream.getReader();
-	while (true) {
-		const { done, value } = await reader.read();
-		if (done) break;
-		chunks.push(value);
+	try {
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			chunks.push(value);
+		}
+	} finally {
+		reader.releaseLock();
 	}
 
 	const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);


### PR DESCRIPTION
## Summary
Consolidates the error-handling fixes from #109 and #111 with simplifications that prefer reuse and idiomatic patterns over deep transform-and-rethrow:

- **`lib/api/asset-bundle.ts`** — extract a `fetchJson(url, label)` helper so the fetch + ok-check + parse pattern lives in one place; both call sites become one-liners.
- **`lib/api/route-handler.ts`** — use the existing `toError` helper from `lib/errors.ts` to unwrap the caught error, instead of an inline ternary. Fixes the existing `JSON.stringify(error)` → `"{}"` bug for `Error` instances.
- **`lib/api/sse.ts`**:
  - replace the IIFE-with-try/catch/finally around `handler(send)` with a chained `.catch().finally()` that emits a typed `{ type: "error" }` event to the client before closing the writer (so consumers see the error, not just an abrupt close).
  - add `try/finally` to `readSSE` so the reader lock is released when the consumer breaks early out of the `for await` loop.
- **`lib/providers/stream.ts`** — wrap the manual reader loop in `try/finally` so the lock is released on read errors as well as normal completion.
- **`lib/generation/queue.ts`** — catch failures from the user-supplied `before()` callback so one bad pre-flight does not wedge the queue, and reuse `toError` in the job-error path for consistency.

Supersedes #109 and #111.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run test:run` (520 tests, all passing)

New/updated tests cover:
- non-ok responses for both `AssetBundle.fetchJson` and `AssetBundle.fromId`
- `Error` and non-`Error` throws through `createRouteHandler`
- SSE handler rejection emitting an error event before close
- `readSSE` releasing its reader on early break
- `streamToBuffer` propagating stream errors (with lock release)
- `GenerationQueue` draining after a rejected `before()` callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)