### PR TITLE
refactor: nightly maintainability 2026-05-02

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,8 +111,9 @@ export const POST = createRouteHandler({
 - structured logging on warn/error
 - a `serverError` fallback
 
-Add `extraValidation` for type-specific checks (see TTS `voiceId` and Video
-`referenceImages` validation).
+Add `extraValidation` for type-specific checks. Shared validation helpers live
+in `lib/api/request-validation.ts` (for example, TTS `voiceId` and Video
+`referenceImages` checks), so route files stay orchestration-focused.
 
 Providers are resolved through `lib/api/providers.ts`. Each `getXProvider()`
 is built from the same `defineProvider(key, envVar, RealCtor, MockCtor)`

--- a/app/api/v1/tts/route.ts
+++ b/app/api/v1/tts/route.ts
@@ -1,18 +1,14 @@
 import { NextResponse } from "next/server";
 import { getTTSProvider } from "@/lib/api/providers";
-import { badRequest } from "@/lib/api/response";
 import { createRouteHandler } from "@/lib/api/route-handler";
+import { validateRequiredString } from "@/lib/api/request-validation";
 import { TTS_MODELS } from "@/lib/connectors/tts/openslop/models";
 
 export const POST = createRouteHandler({
 	models: TTS_MODELS,
 	getProvider: getTTSProvider,
 	label: "TTS generation",
-	extraValidation: (body) => {
-		if (!body.voiceId || typeof body.voiceId !== "string")
-			return badRequest("voiceId is required");
-		return null;
-	},
+	extraValidation: (body) => validateRequiredString(body, "voiceId"),
 	handle: async (provider, body) => {
 		const { prompt, voiceId, model, speed, volume, format } = body;
 		const result = await provider.generate({

--- a/app/api/v1/video/route.ts
+++ b/app/api/v1/video/route.ts
@@ -1,31 +1,14 @@
 import { NextResponse } from "next/server";
 import { getVideoProvider } from "@/lib/api/providers";
-import { badRequest } from "@/lib/api/response";
 import { createRouteHandler } from "@/lib/api/route-handler";
+import { validateReferenceImages } from "@/lib/api/request-validation";
 import { VIDEO_MODELS } from "@/lib/connectors/video/openslop/models";
 
 export const POST = createRouteHandler({
 	models: VIDEO_MODELS,
 	getProvider: getVideoProvider,
 	label: "Video submission",
-	extraValidation: (body) => {
-		const { referenceImages } = body;
-		if (referenceImages === undefined) return null;
-		if (!Array.isArray(referenceImages)) {
-			return badRequest("referenceImages must be an array");
-		}
-		for (const img of referenceImages) {
-			if (typeof img !== "string")
-				return badRequest("Each referenceImages entry must be a string");
-			const isDataUri = /^data:[a-z]+\/[a-z+.-]+;base64,/i.test(img);
-			const isUrl = /^https?:\/\//i.test(img);
-			if (!isDataUri && !isUrl)
-				return badRequest(
-					"Each referenceImages entry must be a data URI or an HTTP(S) URL",
-				);
-		}
-		return null;
-	},
+	extraValidation: (body) => validateReferenceImages(body),
 	handle: async (provider, body) => {
 		const { prompt, model, referenceImages, duration, width, height } = body;
 		const result = await provider.generate({

--- a/lib/api/__tests__/request-validation.test.ts
+++ b/lib/api/__tests__/request-validation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+	validateReferenceImages,
+	validateRequiredString,
+} from "../request-validation";
+
+describe("validateRequiredString", () => {
+	it("accepts present non-empty strings", () => {
+		expect(validateRequiredString({ voiceId: "abc" }, "voiceId")).toBeNull();
+	});
+
+	it("rejects missing, non-string, and empty values", async () => {
+		const missing = validateRequiredString({}, "voiceId");
+		const nonString = validateRequiredString({ voiceId: 42 }, "voiceId");
+		const empty = validateRequiredString({ voiceId: "" }, "voiceId");
+
+		expect(missing?.status).toBe(400);
+		expect(nonString?.status).toBe(400);
+		expect(empty?.status).toBe(400);
+		expect((await missing?.json())?.error).toBe("voiceId is required");
+	});
+});
+
+describe("validateReferenceImages", () => {
+	it("accepts missing referenceImages", () => {
+		expect(validateReferenceImages({})).toBeNull();
+	});
+
+	it("rejects invalid container and entry values", async () => {
+		const notArray = validateReferenceImages({ referenceImages: "nope" });
+		const nonString = validateReferenceImages({ referenceImages: [42] });
+		const invalidFormat = validateReferenceImages({
+			referenceImages: ["ftp://example.com/a.png"],
+		});
+
+		expect(notArray?.status).toBe(400);
+		expect(nonString?.status).toBe(400);
+		expect(invalidFormat?.status).toBe(400);
+		expect((await notArray?.json())?.error).toBe(
+			"referenceImages must be an array",
+		);
+	});
+
+	it("accepts data URIs and HTTPS URLs", () => {
+		expect(
+			validateReferenceImages({
+				referenceImages: [
+					"data:image/png;base64,abc123",
+					"https://example.com/image.png",
+				],
+			}),
+		).toBeNull();
+	});
+});

--- a/lib/api/request-validation.ts
+++ b/lib/api/request-validation.ts
@@ -1,0 +1,44 @@
+import { badRequest } from "./response";
+
+const DATA_URI_PATTERN = /^data:[a-z]+\/[a-z+.-]+;base64,/i;
+const HTTP_URL_PATTERN = /^https?:\/\//i;
+
+type UnknownBody = Record<string, unknown>;
+
+export function validateRequiredString(
+	body: UnknownBody,
+	key: string,
+	label = key,
+): Response | null {
+	const value = body[key];
+	if (typeof value === "string" && value.length > 0) {
+		return null;
+	}
+	return badRequest(`${label} is required`);
+}
+
+export function validateReferenceImages(
+	body: UnknownBody,
+	key = "referenceImages",
+): Response | null {
+	const value = body[key];
+	if (value === undefined) {
+		return null;
+	}
+	if (!Array.isArray(value)) {
+		return badRequest(`${key} must be an array`);
+	}
+
+	for (const entry of value) {
+		if (typeof entry !== "string") {
+			return badRequest(`Each ${key} entry must be a string`);
+		}
+		if (!DATA_URI_PATTERN.test(entry) && !HTTP_URL_PATTERN.test(entry)) {
+			return badRequest(
+				`Each ${key} entry must be a data URI or an HTTP(S) URL`,
+			);
+		}
+	}
+
+	return null;
+}


### PR DESCRIPTION
## Summary
- extract shared API request validation helpers into \
- simplify v1 tts/video routes by moving validation branching into reusable helpers
- add focused unit tests for shared validation helpers
- update ARCHITECTURE.md API route section with validation boundary notes

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm test -- --passWithNoTests