### PR TITLE
perf: nightly performance optimizations 2026-05-02

### DIFF
--- a/app/components/LazyEditor.tsx
+++ b/app/components/LazyEditor.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const LazyEditor = dynamic(() => import("./Editor"));
+
+export default LazyEditor;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import { ConfigProvider } from "@/lib/config/ConfigProvider";
 import { ScriptProvider } from "@/lib/script/ScriptProvider";
 import { UserProvider } from "@/lib/user/UserProvider";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import Editor from "./components/Editor";
+import LazyEditor from "./components/LazyEditor";
 import OnboardingCard from "./components/OnboardingCard";
 import AccessCodeInput from "./components/AccessCodeInput";
 import GradientButton from "./components/GradientButton";
@@ -29,7 +29,7 @@ export default async function Home() {
 				<ConfigProvider>
 					<ScriptProvider>
 						<UserProvider user={user}>
-							<Editor />
+							<LazyEditor />
 						</UserProvider>
 					</ScriptProvider>
 				</ConfigProvider>


### PR DESCRIPTION
## Summary
- lazy-load authenticated editor surface with `next/dynamic` via a thin client wrapper (`LazyEditor`)
- keep existing behavior and provider tree intact; only loading strategy changed
- keep `@next/bundle-analyzer` guarded config intact

## Why this matters
- reduces initial `/` route page chunk by moving heavy editor subtree into deferred chunks
- keeps onboarding/non-authenticated experience lighter on first load

## Validation
- `npm run build`
- `npm test -- --passWithNoTests`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`