### PR TITLE
feat: editable project title from metadata_title

### DIFF
--- a/app/components/PostPromptView.tsx
+++ b/app/components/PostPromptView.tsx
@@ -5,6 +5,7 @@ import { useScript } from "@/lib/script/ScriptProvider";
 import { generationQueue } from "@/lib/generation/queue";
 import Copilot from "./Copilot";
 import Canvas, { type CanvasHandle } from "./canvas/Canvas";
+import { ProjectTitle } from "./canvas/ProjectTitle";
 import { useRefineScript } from "./canvas/hooks/useRefineScript";
 import { Sparkles } from "lucide-react";
 import { TopPlayerPanel, SidePlayerPanel } from "./video/PlayerPanel";
@@ -78,6 +79,7 @@ function PostPromptViewInner() {
 					>
 						<div className="pointer-events-none sticky top-0 z-10 -mb-8 h-8 backdrop-blur-sm [mask-image:linear-gradient(to_bottom,black,transparent)]" />
 						<div className="mx-auto max-w-6xl px-4 py-4">
+							<ProjectTitle />
 							<Canvas ref={canvasRef} onStructureChange={setStructureKey} />
 						</div>
 					</div>

--- a/app/components/canvas/ProjectTitle.tsx
+++ b/app/components/canvas/ProjectTitle.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import { Pencil } from "lucide-react";
+import { useConfig } from "@/lib/config/ConfigProvider";
+import { getProjectStore, useProjectStore } from "@/lib/project/store";
+import { useScript } from "@/lib/script/ScriptProvider";
+
+export function ProjectTitle() {
+	const { projectId } = useConfig();
+	const title = useProjectStore(projectId, (s) => s.metadata.title);
+	const { loading } = useScript();
+	const [editing, setEditing] = useState(false);
+	const [draft, setDraft] = useState("");
+
+	if (!title && !editing) {
+		if (!loading) return null;
+		return (
+			<div className="mb-3 flex h-8 items-center">
+				<div className="shimmer-surface h-7 w-48 rounded-md" />
+			</div>
+		);
+	}
+
+	const commit = () => {
+		const next = draft.trim();
+		if (next && next !== title) {
+			getProjectStore(projectId).getState().updateMetadata({ title: next });
+		}
+		setEditing(false);
+	};
+
+	const startEditing = () => {
+		setDraft(title);
+		setEditing(true);
+	};
+
+	if (editing) {
+		return (
+			<input
+				autoFocus
+				value={draft}
+				onChange={(e) => setDraft(e.target.value)}
+				onBlur={commit}
+				onFocus={(e) => e.currentTarget.select()}
+				onKeyDown={(e) => {
+					if (e.key === "Enter") commit();
+					else if (e.key === "Escape") setEditing(false);
+				}}
+				className="mb-3 w-full bg-transparent text-2xl font-semibold text-white/90 outline-none"
+				aria-label="Project title"
+			/>
+		);
+	}
+
+	return (
+		<div className="group mb-3 flex items-center gap-2">
+			<h1 className="text-2xl font-semibold text-white/90">{title}</h1>
+			<button
+				type="button"
+				onClick={startEditing}
+				className="rounded p-1 text-white/40 opacity-0 transition-opacity hover:bg-white/10 hover:text-white/80 group-hover:opacity-100"
+				aria-label="Edit title"
+			>
+				<Pencil className="h-3.5 w-3.5" />
+			</button>
+		</div>
+	);
+}

--- a/app/components/canvas/config/metadataTags.ts
+++ b/app/components/canvas/config/metadataTags.ts
@@ -13,6 +13,11 @@ export type MetadataTagConfig = {
 };
 
 export const METADATA_TAG_CONFIGS: Record<string, MetadataTagConfig> = {
+	metadata_title: {
+		apply: (p, _attrs, text) => {
+			if (text) p.title = text;
+		},
+	},
 	metadata_style: {
 		apply: (p, _attrs, text) => {
 			if (text) p.style = text;

--- a/app/components/video/VideoPanel.tsx
+++ b/app/components/video/VideoPanel.tsx
@@ -32,7 +32,7 @@ function VideoPanelBody() {
 export function VideoPanel() {
 	const { layout, ready } = useLayout();
 	const { loading: scriptLoading } = useScript();
-	const showControls = !scriptLoading && layout?.series.length && ready;
+	const showControls = !scriptLoading && !!layout?.series.length && ready;
 
 	return (
 		<div className="group relative overflow-hidden rounded-lg border border-white/10 bg-white/5 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12)]">

--- a/lib/connectors/plugins/osml.ts
+++ b/lib/connectors/plugins/osml.ts
@@ -87,8 +87,12 @@ const OSML_SYSTEM_PROMPT = dedent`
   - Music should change frequently (at least once every few scenes) to keep the reader engaged.
   - length: ${Object.values(MusicLength).join(", ")}
 
+	### Metadata Title XML tag
+	- The script must begin with a single, short <metadata_title>...</metadata_title> tag containing a succinct title (1-4 words) for the story. Example:
+	<metadata_title>Little Red</metadata_title>
+
 	### Metadata Style XML tag
-	- The script must begin with a single, concise <metadata_style>...</metadata_style> tag that describes the visual style of the story as if prompting an image model. Example:
+	- Right after the metadata_title tag, emit a single, concise <metadata_style>...</metadata_style> tag that describes the visual style of the story as if prompting an image model. Example:
 	<metadata_style>Warm, earth tones. Whimsical storybook illustration with soft watercolors, gentle brush strokes, warm lighting.</metadata_style>
 
 	### Metadata Narration XML tags

--- a/lib/project/__tests__/store.test.ts
+++ b/lib/project/__tests__/store.test.ts
@@ -11,6 +11,7 @@ describe("project store updateMetadata", () => {
 		store.getState().updateMetadata({ style: "cinematic" });
 
 		expect(store.getState().metadata).toEqual({
+			title: "",
 			style: "cinematic",
 			narration: {},
 			characters: {},

--- a/lib/project/store.ts
+++ b/lib/project/store.ts
@@ -25,7 +25,7 @@ export function getProjectStore(projectId: string): ProjectStore {
 	if (!store) {
 		store = createStore<ProjectContext>()(
 			immer((set) => ({
-				metadata: { style: "", narration: {}, characters: {} },
+				metadata: { title: "", style: "", narration: {}, characters: {} },
 				referenceImages: [],
 				generatingAvatars: new Set(),
 				updateMetadata: (partial) =>

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -21,6 +21,7 @@ export type MetadataCharacter = MetadataVoice & {
 };
 
 export type Metadata = {
+	title: string;
 	style: string;
 	narration: MetadataVoice;
 	characters: Record<string, MetadataCharacter>;

--- a/lib/providers/llm/mock.ts
+++ b/lib/providers/llm/mock.ts
@@ -5,7 +5,9 @@ import type {
 import { BaseProvider } from "../base";
 import { pickRandom } from "../mock-utils";
 
-const MOCK_SCRIPT = `<metadata_style>Warm, earth tones. Whimsical storybook illustration with soft watercolors, gentle brush strokes, warm lighting.</metadata_style>
+const MOCK_SCRIPT = `<metadata_title>Little Red</metadata_title>
+
+<metadata_style>Warm, earth tones. Whimsical storybook illustration with soft watercolors, gentle brush strokes, warm lighting.</metadata_style>
 
 <metadata_narration gender="feminine" age="adult" pitch="medium" accent="american" description="warm, grandmotherly, kind"></metadata_narration>
 


### PR DESCRIPTION
## Summary
- LLM now emits `<metadata_title>` as the first tag in OSML; synced to the project store via the existing `METADATA_TAG_CONFIGS` registry (no parser changes).
- Renders above the canvas as an `<h1>` with a hover-revealed pencil to edit inline (commit on Enter/blur, cancel on Escape). Shows a `shimmer-surface` placeholder during script generation to prevent layout shift.
- Mock LLM provider updated to include `<metadata_title>Little Red</metadata_title>`.
- Drive-by fix: `VideoPanel` was rendering a stray `0` when `layout.series.length === 0` because `&&` returned the falsy number — coerced with `!!`.

## Test plan
- [ ] Generate a new script — title appears above the canvas as it streams; no layout shift (shimmer placeholder while loading).
- [ ] Hover the title — pencil icon fades in. Click → input focused with current value selected. Enter commits, Escape cancels, blur commits.
- [ ] Confirm the empty/no-script state of the video panel no longer shows a stray `0`.
- [ ] CI: lint, format, typecheck, 532 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)