### PR TITLE
refactor: nightly maintainability 2026-05-03

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,6 +51,10 @@ caller gets back an `AssetResult` (or `LLMGenerateResult`, etc.).
   `"openslop"`-only — every connector ultimately calls our own REST API.
 - Plugins live in `lib/connectors/plugins/` and can be composed onto any
   connector via `ConnectorConfig.plugins`.
+- Models are declared statically per connector in `lib/connectors/<type>/openslop/models.ts`
+  and surfaced to the UI through `ConfigProvider`'s initial registry. Connectors
+  do not expose runtime model discovery — slugs are validated server-side by
+  `createRouteHandler` against the `<TYPE>_MODELS` map.
 
 ### 2. `lib/gateway/` — HTTP transport
 
@@ -131,9 +135,16 @@ class:
   per-element history of past results for instant cache hits when inputs match.
 - Exposes a Zustand-style subscribe API used by canvas elements to render
   progress.
+- Accepts a one-shot `before(fn)` setup callback that runs once before the next
+  batch is drained (used to backfill character avatars). Calls are guarded so a
+  callback only fires once even if multiple dispatchers register before the
+  queue starts processing.
 
 The queue is the single point that wires connectors into the React app — UI
-components dispatch jobs, never call connectors directly.
+components dispatch jobs, never call connectors directly. The canonical entry
+point is `lib/generation/scheduleGeneration.ts`, which wires the avatar-setup
+phase onto the queue so editor hooks (`useGenerate`, `useGenerateAll`) stay
+focused on element-level state.
 
 ## Project & script state
 

--- a/app/components/canvas/hooks/useGenerate.ts
+++ b/app/components/canvas/hooks/useGenerate.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useSyncExternalStore } from "react";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { generationQueue, isStaleResult } from "@/lib/generation/queue";
-import { ensureCharacterAvatars } from "@/lib/project/ensureCharacterAvatars";
+import { scheduleGeneration } from "@/lib/generation/scheduleGeneration";
 import type { CanvasContentElement } from "../types";
 import { buildGenerationJob } from "../utils/buildGenerationJob";
 import { getGenerationInputs } from "../utils/getGenerationInputs";
@@ -27,9 +27,7 @@ export function useGenerate(element: CanvasContentElement) {
 			generationQueue.setError(element.id, "Enter a prompt first");
 			return;
 		}
-		generationQueue
-			.before(() => ensureCharacterAvatars(projectId, connectorConfig))
-			.enqueue(job);
+		scheduleGeneration(job, { projectId, registry: connectorConfig });
 	}, [element, connectorConfig, projectId]);
 
 	const discard = useCallback(() => {

--- a/app/components/canvas/hooks/useGenerateAll.ts
+++ b/app/components/canvas/hooks/useGenerateAll.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { Editor } from "slate";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { generationQueue, isStaleResult } from "@/lib/generation/queue";
-import { ensureCharacterAvatars } from "@/lib/project/ensureCharacterAvatars";
+import { scheduleGeneration } from "@/lib/generation/scheduleGeneration";
 import { buildGenerationJob } from "../utils/buildGenerationJob";
 import { getGenerationInputs } from "../utils/getGenerationInputs";
 import { getContentElements } from "../utils/nodeUtils";
@@ -18,9 +18,7 @@ export function useGenerateAll(editor: Editor) {
 			})
 			.map((el) => buildGenerationJob(el, connectorConfig))
 			.filter((job): job is NonNullable<typeof job> => job !== null);
-		generationQueue
-			.before(() => ensureCharacterAvatars(projectId, connectorConfig))
-			.enqueueAll(jobs);
+		scheduleGeneration(jobs, { projectId, registry: connectorConfig });
 	}, [editor, connectorConfig, projectId]);
 
 	return { generateAll };

--- a/lib/connectors/__tests__/asset-base.test.ts
+++ b/lib/connectors/__tests__/asset-base.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { BaseAssetConnector } from "../asset-base";
 import { AssetBundle } from "@/lib/api/asset-bundle";
 import type { BundleResponse } from "@/lib/api/asset-bundle";
-import type { ConnectorConfig, ConnectorType, ModelInfo } from "../types";
+import type { ConnectorConfig, ConnectorType } from "../types";
 
 type TestParams = { prompt: string };
 type TestResult = { url: string; durationSec: number };
@@ -21,10 +21,6 @@ class TestAssetConnector extends BaseAssetConnector<TestParams, TestResult> {
 	) {
 		super(config);
 		this.gateway = { generate: generateFn ?? vi.fn() };
-	}
-
-	async listModels(): Promise<ModelInfo[]> {
-		return [{ id: "test", name: "Test" }];
 	}
 }
 

--- a/lib/connectors/__tests__/base.test.ts
+++ b/lib/connectors/__tests__/base.test.ts
@@ -1,17 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { BaseConnector } from "../base";
-import type {
-	ConnectorConfig,
-	ConnectorPlugin,
-	ConnectorType,
-	ModelInfo,
-} from "../types";
+import type { ConnectorConfig, ConnectorPlugin, ConnectorType } from "../types";
 
 class TestConnector extends BaseConnector {
 	readonly type: ConnectorType = "llm";
-	async listModels(): Promise<ModelInfo[]> {
-		return [{ id: "test", name: "Test" }];
-	}
 	protected async _generate(): Promise<unknown> {
 		return {};
 	}

--- a/lib/connectors/base.ts
+++ b/lib/connectors/base.ts
@@ -10,7 +10,6 @@ import type {
 	ConnectorConfig,
 	ConnectorPlugin,
 	ConnectorType,
-	ModelInfo,
 	PluginContext,
 } from "./types";
 
@@ -30,8 +29,6 @@ export abstract class BaseConnector<
 		return true;
 	}
 	async destroy(): Promise<void> {}
-
-	abstract listModels(): Promise<ModelInfo[]>;
 
 	protected pluginContext(): PluginContext<TParams, TResult> {
 		return {};

--- a/lib/connectors/image/openslop/index.ts
+++ b/lib/connectors/image/openslop/index.ts
@@ -1,8 +1,6 @@
 import { BaseImageConnector } from "../connector";
 import { OpenSlopImageGateway } from "@/lib/gateway/openslop/image";
-import type { ConnectorConfig, ModelInfo } from "@/lib/connectors/types";
-import { modelsFromMap } from "@/lib/connectors/types";
-import { IMAGE_MODELS } from "./models";
+import type { ConnectorConfig } from "@/lib/connectors/types";
 
 export class OpenSlopImage extends BaseImageConnector {
 	protected gateway: OpenSlopImageGateway;
@@ -10,9 +8,5 @@ export class OpenSlopImage extends BaseImageConnector {
 	constructor(config: ConnectorConfig) {
 		super(config);
 		this.gateway = new OpenSlopImageGateway(config.baseUrl);
-	}
-
-	async listModels(): Promise<ModelInfo[]> {
-		return modelsFromMap(IMAGE_MODELS);
 	}
 }

--- a/lib/connectors/llm/openslop/index.ts
+++ b/lib/connectors/llm/openslop/index.ts
@@ -4,18 +4,11 @@ import type {
 	ConnectorConfig,
 	LLMGenerateParams,
 	LLMStreamChunk,
-	ModelInfo,
 } from "@/lib/connectors/types";
-import { modelsFromMap } from "@/lib/connectors/types";
-import { LLM_MODELS } from "./models";
 
 export class OpenSlopLLM extends BaseLLMConnector<OpenSlopLLMGateway> {
 	constructor(config: ConnectorConfig) {
 		super(new OpenSlopLLMGateway(config.baseUrl), config);
-	}
-
-	async listModels(): Promise<ModelInfo[]> {
-		return modelsFromMap(LLM_MODELS);
 	}
 
 	protected async *_stream(

--- a/lib/connectors/music/openslop/index.ts
+++ b/lib/connectors/music/openslop/index.ts
@@ -1,8 +1,6 @@
 import { BaseMusicConnector } from "../connector";
 import { OpenSlopMusicGateway } from "@/lib/gateway/openslop/music";
-import type { ConnectorConfig, ModelInfo } from "@/lib/connectors/types";
-import { modelsFromMap } from "@/lib/connectors/types";
-import { MUSIC_MODELS } from "./models";
+import type { ConnectorConfig } from "@/lib/connectors/types";
 
 export class OpenSlopMusic extends BaseMusicConnector {
 	protected gateway: OpenSlopMusicGateway;
@@ -10,9 +8,5 @@ export class OpenSlopMusic extends BaseMusicConnector {
 	constructor(config: ConnectorConfig) {
 		super(config);
 		this.gateway = new OpenSlopMusicGateway(config.baseUrl);
-	}
-
-	async listModels(): Promise<ModelInfo[]> {
-		return modelsFromMap(MUSIC_MODELS);
 	}
 }

--- a/lib/connectors/sfx/openslop/index.ts
+++ b/lib/connectors/sfx/openslop/index.ts
@@ -1,8 +1,6 @@
 import { BaseSFXConnector } from "../connector";
 import { OpenSlopSFXGateway } from "@/lib/gateway/openslop/sfx";
-import type { ConnectorConfig, ModelInfo } from "@/lib/connectors/types";
-import { modelsFromMap } from "@/lib/connectors/types";
-import { SFX_MODELS } from "./models";
+import type { ConnectorConfig } from "@/lib/connectors/types";
 
 export class OpenSlopSFX extends BaseSFXConnector {
 	protected gateway: OpenSlopSFXGateway;
@@ -10,9 +8,5 @@ export class OpenSlopSFX extends BaseSFXConnector {
 	constructor(config: ConnectorConfig) {
 		super(config);
 		this.gateway = new OpenSlopSFXGateway(config.baseUrl);
-	}
-
-	async listModels(): Promise<ModelInfo[]> {
-		return modelsFromMap(SFX_MODELS);
 	}
 }

--- a/lib/connectors/tts/openslop/index.ts
+++ b/lib/connectors/tts/openslop/index.ts
@@ -3,14 +3,11 @@ import { BaseTTSConnector } from "../connector";
 import { OpenSlopTTSGateway } from "@/lib/gateway/openslop/tts";
 import type {
 	ConnectorConfig,
-	ModelInfo,
 	TextTimestamp,
 	TTSResult,
 	VoiceInfo,
 	VoiceSearchParams,
 } from "@/lib/connectors/types";
-import { modelsFromMap } from "@/lib/connectors/types";
-import { TTS_MODELS } from "./models";
 
 export class OpenSlopTTS extends BaseTTSConnector {
 	protected gateway: OpenSlopTTSGateway;
@@ -18,10 +15,6 @@ export class OpenSlopTTS extends BaseTTSConnector {
 	constructor(config: ConnectorConfig) {
 		super(config);
 		this.gateway = new OpenSlopTTSGateway(config.baseUrl);
-	}
-
-	async listModels(): Promise<ModelInfo[]> {
-		return modelsFromMap(TTS_MODELS);
 	}
 
 	async searchVoices(params: VoiceSearchParams): Promise<VoiceInfo[]> {

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -6,16 +6,6 @@ export type ConnectorType = "llm" | "music" | "sfx" | "image" | "tts" | "video";
 
 export type ProviderKey = "openslop";
 
-export type ModelInfo = {
-	id: string;
-	name: string;
-	description?: string;
-};
-
-export function modelsFromMap(map: Record<string, string>): ModelInfo[] {
-	return Object.entries(map).map(([name, id]) => ({ id, name }));
-}
-
 export type VoiceSearchFn = (params: VoiceSearchParams) => Promise<VoiceInfo[]>;
 
 export interface PluginContext<TParams = unknown, TResult = unknown> {
@@ -66,7 +56,6 @@ export interface Connector {
 	init(): Promise<void>;
 	validate(): Promise<boolean>;
 	destroy(): Promise<void>;
-	listModels(): Promise<ModelInfo[]>;
 }
 
 // LLM types

--- a/lib/connectors/video/openslop/index.ts
+++ b/lib/connectors/video/openslop/index.ts
@@ -1,8 +1,6 @@
 import { BaseVideoConnector } from "../connector";
 import { OpenSlopVideoGateway } from "@/lib/gateway/openslop/video";
-import type { ConnectorConfig, ModelInfo } from "@/lib/connectors/types";
-import { modelsFromMap } from "@/lib/connectors/types";
-import { VIDEO_MODELS } from "./models";
+import type { ConnectorConfig } from "@/lib/connectors/types";
 
 export class OpenSlopVideo extends BaseVideoConnector {
 	protected gateway: OpenSlopVideoGateway;
@@ -10,9 +8,5 @@ export class OpenSlopVideo extends BaseVideoConnector {
 	constructor(config: ConnectorConfig) {
 		super(config);
 		this.gateway = new OpenSlopVideoGateway(config.baseUrl);
-	}
-
-	async listModels(): Promise<ModelInfo[]> {
-		return modelsFromMap(VIDEO_MODELS);
 	}
 }

--- a/lib/generation/scheduleGeneration.ts
+++ b/lib/generation/scheduleGeneration.ts
@@ -1,0 +1,21 @@
+import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
+import { ensureCharacterAvatars } from "@/lib/project/ensureCharacterAvatars";
+import { generationQueue, type GenerationJob } from "./queue";
+
+/**
+ * Single entry point for dispatching generation jobs from the editor.
+ *
+ * Wires the avatar-setup phase onto the queue so callers don't have to
+ * remember to do it themselves; the queue's `before()` guard ensures the
+ * setup callback runs at most once per processing cycle even if multiple
+ * dispatchers fire back-to-back.
+ */
+export function scheduleGeneration(
+	jobs: GenerationJob | GenerationJob[],
+	{ projectId, registry }: { projectId: string; registry: ConnectorRegistry },
+): void {
+	const list = Array.isArray(jobs) ? jobs : [jobs];
+	generationQueue
+		.before(() => ensureCharacterAvatars(projectId, registry))
+		.enqueueAll(list);
+}


### PR DESCRIPTION
## Summary
- remove dead connector model-discovery interface (`listModels` / `ModelInfo`) and related implementations/tests
- centralize generation queue orchestration into `lib/generation/scheduleGeneration.ts`
- simplify `useGenerate` and `useGenerateAll` to depend on a narrow scheduling interface
- document architecture boundary updates in `ARCHITECTURE.md`

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm test -- --passWithNoTests
- npm run build