### PR TITLE
fix: nightly bug fixes 2026-05-06

### DIFF
--- a/app/components/video/useAssetPrefetch.ts
+++ b/app/components/video/useAssetPrefetch.ts
@@ -57,7 +57,11 @@ export function useAssetPrefetch(layout: VideoLayout | null): boolean {
 				}
 
 				if (added) setReady(false);
-				await Promise.all([...active.values()].map((h) => h.waitUntilDone()));
+				try {
+					await Promise.all([...active.values()].map((h) => h.waitUntilDone()));
+				} catch (err) {
+					console.error("Asset prefetch failed", err);
+				}
 				if (!cancelled) setReady(true);
 			},
 			(err) => {


### PR DESCRIPTION
## Summary
- fix unhandled asset prefetch rejection that could keep video UI stuck in loading state
- log and swallow individual prefetch failures so readiness still transitions

## Validation
- npm test -- --passWithNoTests
- npm run build
