### PR TITLE
perf: nightly performance optimizations 2026-05-06

### DIFF
--- a/app/components/canvas/hooks/useScriptSync.ts
+++ b/app/components/canvas/hooks/useScriptSync.ts
@@ -9,7 +9,7 @@ import {
 } from "../types";
 import { OSMLSerializer } from "../utils/osmlSerializer";
 import { hydrateConnectorConfig } from "../utils/hydrateConnectorConfig";
-import { findNodeById, updateNodeText } from "../utils/editorOps";
+import { buildContentNodeIndex, updateNodeText } from "../utils/editorOps";
 import flow from "lodash/fp/flow";
 
 export function useScriptSync(editor: Editor): void {
@@ -23,6 +23,11 @@ export function useScriptSync(editor: Editor): void {
 
 	useEffect(() => {
 		Editor.withoutNormalizing(editor, () => {
+			// Build an id index up front so the per-node lookup below is O(1).
+			// Inserts go to the end and don't shift existing paths, so the
+			// index stays valid for the duration of this pass.
+			const index = buildContentNodeIndex(editor);
+
 			for (const node of nodes) {
 				if (!CANVAS_ELEMENT_TYPES.has(node.type as CanvasElementType)) continue;
 
@@ -30,7 +35,7 @@ export function useScriptSync(editor: Editor): void {
 				const normalized = normalize(canvasNode);
 				if (shouldSkipNode(normalized)) continue;
 
-				const entry = findNodeById(editor, node.id);
+				const entry = index.get(node.id);
 
 				if (entry) {
 					const [, path] = entry;

--- a/app/components/canvas/utils/editorOps.ts
+++ b/app/components/canvas/utils/editorOps.ts
@@ -1,17 +1,52 @@
 import { Editor, type NodeEntry, type Path, Transforms } from "slate";
 import type { CanvasContentElement } from "../types";
-import { isContentElement } from "./guards";
+import { isContentElement, isSceneElement } from "./guards";
 
-/** Find a content element by ID. Returns [node, path] or null. */
+/**
+ * Find a content element by ID. Returns [node, path] or null.
+ *
+ * The canvas tree is a fixed two-level shape (root → scenes → content), so
+ * we scan it directly instead of paying for `Editor.nodes`' generator
+ * traversal — meaningfully cheaper when called in a tight loop (script
+ * streaming, refine ops).
+ */
 export function findNodeById(
 	editor: Editor,
 	id: string,
 ): NodeEntry<CanvasContentElement> | null {
-	const [entry] = Editor.nodes<CanvasContentElement>(editor, {
-		at: [],
-		match: (n) => isContentElement(n) && n.id === id,
-	});
-	return entry ?? null;
+	const root = editor.children;
+	for (let i = 0; i < root.length; i++) {
+		const scene = root[i];
+		if (!isSceneElement(scene)) continue;
+		const kids = scene.children;
+		for (let j = 0; j < kids.length; j++) {
+			const child = kids[j];
+			if (isContentElement(child) && child.id === id) {
+				return [child, [i, j]];
+			}
+		}
+	}
+	return null;
+}
+
+/** Build an O(1) id → entry index over all content elements in the editor. */
+export function buildContentNodeIndex(
+	editor: Editor,
+): Map<string, NodeEntry<CanvasContentElement>> {
+	const index = new Map<string, NodeEntry<CanvasContentElement>>();
+	const root = editor.children;
+	for (let i = 0; i < root.length; i++) {
+		const scene = root[i];
+		if (!isSceneElement(scene)) continue;
+		const kids = scene.children;
+		for (let j = 0; j < kids.length; j++) {
+			const child = kids[j];
+			if (isContentElement(child)) {
+				index.set(child.id, [child, [i, j]]);
+			}
+		}
+	}
+	return index;
 }
 
 /**


### PR DESCRIPTION
## Summary
- optimize Slate script sync node resolution by pre-indexing content nodes once per sync pass
- replace generator-based tree traversal in `findNodeById` with direct path-aware scan for canvas structure

## Why
- removes repeated full-tree traversals during script streaming updates
- reduces editor hot-path from repeated O(N) lookups per node to single-pass indexing + O(1) retrieval, improving runtime responsiveness

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm test -- --passWithNoTests