### PR TITLE
refactor: nightly maintainability 2026-05-07

### DIFF
--- a/app/api/v1/llm/route.ts
+++ b/app/api/v1/llm/route.ts
@@ -1,9 +1,8 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { logger } from "@/lib/api/logger";
 import { getLLMProvider } from "@/lib/api/providers";
 import { bodySchema, createRouteHandler } from "@/lib/api/route-handler";
-import { formatSSE } from "@/lib/api/sse";
+import { createSSEStreamResponse } from "@/lib/api/sse";
 import { LLM_MODELS } from "@/lib/connectors/llm/openslop/models";
 
 const schema = bodySchema(LLM_MODELS, {
@@ -20,32 +19,9 @@ export const POST = createRouteHandler({
 	label: "LLM generation",
 	handle: async (provider, body) => {
 		const { stream, ...genParams } = body;
-
 		if (stream) {
-			const encoder = new TextEncoder();
-			const readable = new ReadableStream({
-				async start(controller) {
-					try {
-						for await (const chunk of provider.stream(genParams)) {
-							controller.enqueue(encoder.encode(formatSSE(chunk)));
-						}
-						controller.close();
-					} catch (error) {
-						logger.error(error, "LLM stream error");
-						controller.error(error);
-					}
-				},
-			});
-
-			return new Response(readable, {
-				headers: {
-					"content-type": "text/event-stream",
-					"cache-control": "no-cache",
-					connection: "keep-alive",
-				},
-			});
+			return createSSEStreamResponse(provider.stream(genParams), "LLM");
 		}
-
 		return NextResponse.json(await provider.generate(genParams));
 	},
 });

--- a/lib/api/sse.ts
+++ b/lib/api/sse.ts
@@ -1,4 +1,5 @@
 import { stringifyError } from "../errors";
+import { logger } from "./logger";
 
 export type SSEMessage =
 	| { type: "phase"; phase: string; progress: number; subtitle?: string }
@@ -36,6 +37,27 @@ export function createSSEResponse(
 		.finally(() => writer.close().catch(() => {}));
 
 	return new Response(stream.readable, { headers: SSE_HEADERS });
+}
+
+export function createSSEStreamResponse<T>(
+	iter: AsyncIterable<T>,
+	label: string,
+): Response {
+	const encoder = new TextEncoder();
+	const stream = new ReadableStream({
+		async start(controller) {
+			try {
+				for await (const chunk of iter) {
+					controller.enqueue(encoder.encode(formatSSE(chunk)));
+				}
+				controller.close();
+			} catch (error) {
+				logger.error(error, `${label} stream error`);
+				controller.error(error);
+			}
+		},
+	});
+	return new Response(stream, { headers: SSE_HEADERS });
 }
 
 export async function* readSSE<T>(body: ReadableStream): AsyncGenerator<T> {

--- a/lib/config/ConfigProvider.tsx
+++ b/lib/config/ConfigProvider.tsx
@@ -68,7 +68,6 @@ type ConfigContextValue = {
 	connectorConfig: ConnectorRegistry;
 	composerMode: ComposerMode;
 	selectedTemplateId: string | null;
-	setConnectorConfig: React.Dispatch<React.SetStateAction<ConnectorRegistry>>;
 	setComposerMode: React.Dispatch<React.SetStateAction<ComposerMode>>;
 	setSelectedTemplateId: React.Dispatch<React.SetStateAction<string | null>>;
 };
@@ -83,9 +82,7 @@ export function useConfig() {
 
 export function ConfigProvider({ children }: { children: ReactNode }) {
 	const projectId = MOCK_PROJECT_ID;
-	const [connectorConfig, setConnectorConfig] = useState<ConnectorRegistry>(
-		initialConnectorConfig,
-	);
+	const [connectorConfig] = useState<ConnectorRegistry>(initialConnectorConfig);
 	const [composerMode, setComposerMode] = useState<ComposerMode>("story");
 	const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(
 		TEMPLATES[0]?.id ?? null,
@@ -111,7 +108,6 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
 			connectorConfig: configWithPlugins,
 			composerMode,
 			selectedTemplateId,
-			setConnectorConfig,
 			setComposerMode,
 			setSelectedTemplateId,
 		}),


### PR DESCRIPTION
## Summary
- remove unused writable config setter from Config context public API
- centralize async-iterable SSE response construction in lib/api/sse
- simplify LLM route streaming path to use shared helper

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm test -- --passWithNoTests
