### PR TITLE
fix: nightly bug fixes 2026-05-08

### DIFF
--- a/lib/upload/__tests__/uploadImage.test.ts
+++ b/lib/upload/__tests__/uploadImage.test.ts
@@ -35,6 +35,28 @@ describe("uploadImage", () => {
 		);
 	});
 
+	it("throws if success payload is missing url", async () => {
+		fetchMock.mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		});
+		await expect(uploadImage(file)).rejects.toThrow(
+			"Upload endpoint returned invalid payload",
+		);
+	});
+
+	it("throws if success payload url is empty", async () => {
+		fetchMock.mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({ url: "" }),
+		});
+		await expect(uploadImage(file)).rejects.toThrow(
+			"Upload endpoint returned invalid payload",
+		);
+	});
+
 	it("propagates network failures", async () => {
 		fetchMock.mockRejectedValue(new TypeError("network down"));
 		await expect(uploadImage(file)).rejects.toThrow("network down");

--- a/lib/upload/uploadImage.ts
+++ b/lib/upload/uploadImage.ts
@@ -1,3 +1,10 @@
+class UploadImageResponseError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "UploadImageResponseError";
+	}
+}
+
 export async function uploadImage(file: File): Promise<string> {
 	const formData = new FormData();
 	formData.append("file", file);
@@ -9,6 +16,18 @@ export async function uploadImage(file: File): Promise<string> {
 
 	if (!res.ok) throw new Error(`${res.status} ${await res.text()}`);
 
-	const { url } = (await res.json()) as { url: string };
-	return url;
+	const body: unknown = await res.json();
+	if (
+		typeof body !== "object" ||
+		body === null ||
+		!("url" in body) ||
+		typeof body.url !== "string" ||
+		body.url.length === 0
+	) {
+		throw new UploadImageResponseError(
+			"Upload endpoint returned invalid payload",
+		);
+	}
+
+	return body.url;
 }


### PR DESCRIPTION
## Summary
- validate `/api/upload/image` success payload before returning a URL
- fail loudly when backend returns malformed success payloads
- add regression tests for malformed payload edge cases

## Validation
- npm test -- --passWithNoTests
- npm run build