### PR TITLE
perf: nightly performance optimizations 2026-05-08

### DIFF
--- a/app/components/Editor.tsx
+++ b/app/components/Editor.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import { useState } from "react";
-import { useScript } from "@/lib/script/ScriptProvider";
+import { useScript, useScriptText } from "@/lib/script/ScriptProvider";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getProjectStore } from "@/lib/project/store";
 import PrePromptView from "./PrePromptView";
 import PostPromptView from "./PostPromptView";
 
 export default function Editor() {
-	const { script, loading, submitPrompt } = useScript();
+	const { loading, submitPrompt } = useScript();
+	const script = useScriptText();
 	const { projectId } = useConfig();
 	const [prompted, setPrompted] = useState(false);
 

--- a/lib/script/ScriptProvider.tsx
+++ b/lib/script/ScriptProvider.tsx
@@ -16,7 +16,6 @@ import { createConnector } from "@/lib/connectors/factory";
 import { useOSMLSerializer } from "@/app/components/canvas/hooks/useOSMLSerializer";
 
 type ScriptContextValue = {
-	script: string;
 	nodes: ParsedElement[];
 	loading: boolean;
 	submitPrompt: (prompt: string) => Promise<void>;
@@ -24,11 +23,16 @@ type ScriptContextValue = {
 };
 
 const ScriptContext = createContext<ScriptContextValue | null>(null);
+const ScriptTextContext = createContext<string>("");
 
 export function useScript() {
 	const ctx = use(ScriptContext);
 	if (!ctx) throw new Error("useScript must be used within ScriptProvider");
 	return ctx;
+}
+
+export function useScriptText() {
+	return use(ScriptTextContext);
 }
 
 export function ScriptProvider({ children }: { children: ReactNode }) {
@@ -76,16 +80,19 @@ export function ScriptProvider({ children }: { children: ReactNode }) {
 
 	const value = useMemo<ScriptContextValue>(
 		() => ({
-			script,
 			nodes,
 			loading,
 			submitPrompt,
 			stopGeneration,
 		}),
-		[script, nodes, loading, submitPrompt, stopGeneration],
+		[nodes, loading, submitPrompt, stopGeneration],
 	);
 
 	return (
-		<ScriptContext.Provider value={value}>{children}</ScriptContext.Provider>
+		<ScriptContext.Provider value={value}>
+			<ScriptTextContext.Provider value={script}>
+				{children}
+			</ScriptTextContext.Provider>
+		</ScriptContext.Provider>
 	);
 }


### PR DESCRIPTION
## Summary
- Split `ScriptProvider` into two contexts:
  - `ScriptContext` now contains `nodes`, `loading`, `submitPrompt`, `stopGeneration`
  - new `ScriptTextContext` contains only the streaming `script` text
- Updated `Editor` to read streaming text through `useScriptText()` while keeping existing behavior unchanged.

## Why this matters
`script` updates at token-stream frequency during generation. Previously that forced all `useScript()` consumers to rerender on every chunk. By isolating `script` into its own context, only consumers that need the streaming string rerender at chunk frequency, reducing render pressure in heavier UI subtrees during interactive generation.

## Validation
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm test -- --passWithNoTests`
- `npm run build`

All passed.

## Skipped intentionally
- Slate node-indexing micro-optimizations: bounded sync path (`MAX_NODES_TO_SYNC = 3`), expected trivial gain.
- Aggressive dynamic import churn / bundle-only tweaks: secondary for this runtime-first pass and unlikely to materially improve interactivity.
- Library removals/hand-rolled rewrites: avoided per maintainability constraints.