### PR TITLE
fix: nightly bug fixes 2026-05-09

### DIFF
--- a/lib/providers/__tests__/cartesia-tts.test.ts
+++ b/lib/providers/__tests__/cartesia-tts.test.ts
@@ -247,6 +247,17 @@ describe("CartesiaTTS", () => {
 			expect(mockEmbedMany).not.toHaveBeenCalled();
 		});
 
+		it("returns early without embedding when semantic query exists but no voices match", async () => {
+			mockVoicesList.mockResolvedValue({ data: [] });
+
+			const provider = new CartesiaTTS("test-key");
+			const voices = await provider.search({ description: "warm narrator" });
+
+			expect(voices).toEqual([]);
+			expect(mockEmbed).not.toHaveBeenCalled();
+			expect(mockEmbedMany).not.toHaveBeenCalled();
+		});
+
 		it("falls back to unranked results when embedding throws", async () => {
 			mockVoicesList.mockResolvedValue({
 				data: [

--- a/lib/providers/tts/voiceSimilarity.ts
+++ b/lib/providers/tts/voiceSimilarity.ts
@@ -23,6 +23,8 @@ export async function rankBySimilarity(
 	voices: VoiceInfo[],
 	queryText: string,
 ): Promise<VoiceInfo[]> {
+	if (voices.length === 0) return [];
+
 	const model = openai.embedding(EMBEDDING_MODEL);
 	const [queryResult, voiceResult] = await Promise.all([
 		embed({ model, value: queryText }),


### PR DESCRIPTION
## Summary
- avoid embedding/ranking calls when no voices are returned for semantic voice search
- add regression test to ensure empty-result semantic queries do not trigger embedding calls

## Validation
- npm test -- --passWithNoTests
- npm run build
- npm run lint
- npm run typecheck
- npm run format:check