### PR TITLE
refactor: nightly maintainability 2026-05-09

### DIFF
--- a/app/components/canvas/types.ts
+++ b/app/components/canvas/types.ts
@@ -1,61 +1,22 @@
-import { BaseEditor } from "slate";
-import { ReactEditor } from "slate-react";
+import type {
+	CanvasEditor,
+	CanvasElement,
+	CanvasText,
+} from "@/lib/canvas/types";
 
-export type ResultKind = "image" | "video" | "audio";
-
-export type CanvasElementType =
-	| "narration"
-	| "character"
-	| "image"
-	| "clip"
-	| "sound"
-	| "music";
-
-export const CANVAS_ELEMENT_TYPES = new Set<CanvasElementType>([
-	"narration",
-	"character",
-	"image",
-	"clip",
-	"sound",
-	"music",
-]);
-
-export const SCENE_TYPE = "scene" as const;
-
-export const FOREGROUND_TYPES: ReadonlySet<CanvasElementType> = new Set([
-	"image",
-	"clip",
-]);
-
-export type CanvasEditor = BaseEditor & ReactEditor & { id?: string };
-
-export type CanvasContentElement = {
-	id: string;
-	type: CanvasElementType;
-	customAttributes?: Record<string, string>;
-	children: CanvasText[];
-};
-
-export type SceneElement = {
-	id: string;
-	type: typeof SCENE_TYPE;
-	children: CanvasContentElement[];
-};
-
-export type CanvasElement = SceneElement | CanvasContentElement;
-
-export type CanvasText = {
-	id: string;
-	type: CanvasElementType;
-	text: string;
-};
-
-export type ParsedElement = {
-	id: string;
-	type: string;
-	customAttributes?: Record<string, string>;
-	children: { id: string; type: string; text: string }[];
-};
+export {
+	CANVAS_ELEMENT_TYPES,
+	FOREGROUND_TYPES,
+	SCENE_TYPE,
+	type CanvasContentElement,
+	type CanvasEditor,
+	type CanvasElement,
+	type CanvasElementType,
+	type CanvasText,
+	type ParsedElement,
+	type ResultKind,
+	type SceneElement,
+} from "@/lib/canvas/types";
 
 export {
 	METADATA_TAG_TYPES,

--- a/app/components/canvas/utils/guards.ts
+++ b/app/components/canvas/utils/guards.ts
@@ -2,14 +2,11 @@ import { Element } from "slate";
 import {
 	CANVAS_ELEMENT_TYPES,
 	FOREGROUND_TYPES,
-	SCENE_TYPE,
 	type CanvasContentElement,
 	type CanvasElementType,
-	type SceneElement,
 } from "../types";
 
-export const isSceneElement = (n: unknown): n is SceneElement =>
-	Element.isElement(n) && n.type === SCENE_TYPE;
+export { isSceneElement } from "@/lib/canvas/scenes";
 
 export const isContentElement = (n: unknown): n is CanvasContentElement =>
 	Element.isElement(n) && CANVAS_ELEMENT_TYPES.has(n.type as CanvasElementType);

--- a/app/components/canvas/utils/nodeUtils.ts
+++ b/app/components/canvas/utils/nodeUtils.ts
@@ -1,14 +1,9 @@
-import { Descendant, Element, Node } from "slate";
+import { Element, Node } from "slate";
 import { nanoid } from "nanoid";
-import type { CanvasContentElement } from "../types";
-import { isSceneElement } from "./guards";
+
+export { getContentElements } from "@/lib/canvas/scenes";
 
 export const makeNodeId = () => nanoid(16);
-
-export const getContentElements = (
-	nodes: Descendant[],
-): CanvasContentElement[] =>
-	nodes.flatMap((node) => (isSceneElement(node) ? node.children : []));
 
 export const stripIds = (node: Node): Node => {
 	if (Element.isElement(node)) {

--- a/lib/canvas/scenes.ts
+++ b/lib/canvas/scenes.ts
@@ -1,0 +1,14 @@
+import { Element, type Descendant } from "slate";
+import {
+	type CanvasContentElement,
+	type SceneElement,
+	SCENE_TYPE,
+} from "./types";
+
+export const isSceneElement = (n: unknown): n is SceneElement =>
+	Element.isElement(n) && n.type === SCENE_TYPE;
+
+export const getContentElements = (
+	nodes: Descendant[],
+): CanvasContentElement[] =>
+	nodes.flatMap((node) => (isSceneElement(node) ? node.children : []));

--- a/lib/canvas/types.ts
+++ b/lib/canvas/types.ts
@@ -1,0 +1,58 @@
+import type { BaseEditor } from "slate";
+import type { ReactEditor } from "slate-react";
+
+export type ResultKind = "image" | "video" | "audio";
+
+export type CanvasElementType =
+	| "narration"
+	| "character"
+	| "image"
+	| "clip"
+	| "sound"
+	| "music";
+
+export const CANVAS_ELEMENT_TYPES = new Set<CanvasElementType>([
+	"narration",
+	"character",
+	"image",
+	"clip",
+	"sound",
+	"music",
+]);
+
+export const SCENE_TYPE = "scene" as const;
+
+export const FOREGROUND_TYPES: ReadonlySet<CanvasElementType> = new Set([
+	"image",
+	"clip",
+]);
+
+export type CanvasEditor = BaseEditor & ReactEditor & { id?: string };
+
+export type CanvasContentElement = {
+	id: string;
+	type: CanvasElementType;
+	customAttributes?: Record<string, string>;
+	children: CanvasText[];
+};
+
+export type SceneElement = {
+	id: string;
+	type: typeof SCENE_TYPE;
+	children: CanvasContentElement[];
+};
+
+export type CanvasElement = SceneElement | CanvasContentElement;
+
+export type CanvasText = {
+	id: string;
+	type: CanvasElementType;
+	text: string;
+};
+
+export type ParsedElement = {
+	id: string;
+	type: string;
+	customAttributes?: Record<string, string>;
+	children: { id: string; type: string; text: string }[];
+};

--- a/lib/connectors/plugins/refine.ts
+++ b/lib/connectors/plugins/refine.ts
@@ -1,5 +1,5 @@
 import dedent from "dedent";
-import { CANVAS_ELEMENT_TYPES } from "@/app/components/canvas/types";
+import { CANVAS_ELEMENT_TYPES } from "@/lib/canvas/types";
 import { MusicLength } from "../music/enums";
 import type { LLMPlugin } from "../types";
 

--- a/lib/script/ScriptProvider.tsx
+++ b/lib/script/ScriptProvider.tsx
@@ -9,7 +9,7 @@ import {
 	useState,
 	type ReactNode,
 } from "react";
-import type { ParsedElement } from "@/app/components/canvas/types";
+import type { ParsedElement } from "@/lib/canvas/types";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import { createConnector } from "@/lib/connectors/factory";

--- a/lib/video/layoutKey.ts
+++ b/lib/video/layoutKey.ts
@@ -1,4 +1,4 @@
-import type { CanvasContentElement } from "@/app/components/canvas/types";
+import type { CanvasContentElement } from "@/lib/canvas/types";
 
 /**
  * Stable key over every element field that resolveElements/buildVideoLayout

--- a/lib/video/resolve.ts
+++ b/lib/video/resolve.ts
@@ -1,5 +1,5 @@
-import type { CanvasElement } from "@/app/components/canvas/types";
-import { getContentElements } from "@/app/components/canvas/utils/nodeUtils";
+import type { CanvasElement } from "@/lib/canvas/types";
+import { getContentElements } from "@/lib/canvas/scenes";
 import type { ElementSnapshot } from "@/lib/generation/queue";
 import type { ResolvedElement } from "./types";
 import { ELEMENT_ROLES, LAYER_TYPES } from "./types";

--- a/lib/video/types.ts
+++ b/lib/video/types.ts
@@ -1,4 +1,4 @@
-import type { CanvasElementType } from "@/app/components/canvas/types";
+import type { CanvasElementType } from "@/lib/canvas/types";
 
 export type ElementRole = "foreground" | "background" | "overlay" | "effect";
 


### PR DESCRIPTION
## Summary
- refactor canvas domain types into lib-owned modules to remove lib->app layering inversion
- centralize scene traversal helpers in lib/canvas/scenes.ts with stable interfaces
- keep app canvas types as a thin compatibility facade via re-exports
- update dependent lib modules to consume lib canvas interfaces directly

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm test -- --passWithNoTests