### PR TITLE
fix: nightly security audit 2026-05-09

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10277,9 +10277,9 @@
 			}
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"funding": [
 				{
 					"type": "github",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
 		"vitest": "^4.0.18"
 	},
 	"overrides": {
-		"postcss": "^8.5.10"
+		"postcss": "^8.5.10",
+		"fast-uri": "^3.1.2"
 	}
 }


### PR DESCRIPTION
## Summary
- Ran nightly security audit focused on real exploitable issues only.
- Fixed dependency vulnerability by overriding `fast-uri` to `^3.1.2`.
- Regenerated `package-lock.json`.

## Validation
- npm audit
- npm run build
- npm test -- --passWithNoTests
- npm run lint
- npm run format:check
- npm run typecheck
- npm run test:run

## Notes
- No speculative hardening changes were made.