### PR TITLE
fix: nightly bug fixes 2026-05-10

### DIFF
--- a/app/components/video/__tests__/useResize.test.ts
+++ b/app/components/video/__tests__/useResize.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+import { attachResizeListeners, clampResize } from "../useResize";
+
+describe("clampResize", () => {
+	it("expands vertically when cursor moves down", () => {
+		expect(clampResize("vertical", 100, 150, 200, 50, 500)).toBe(250);
+	});
+
+	it("expands horizontally when cursor moves left (delta = start - current)", () => {
+		expect(clampResize("horizontal", 200, 150, 200, 50, 500)).toBe(250);
+	});
+
+	it("clamps to minSize", () => {
+		expect(clampResize("vertical", 100, 0, 50, 50, 500)).toBe(50);
+	});
+
+	it("clamps to maxSize", () => {
+		expect(clampResize("vertical", 0, 10_000, 100, 50, 500)).toBe(500);
+	});
+});
+
+function createHost() {
+	const listeners = new Map<string, Set<(ev: MouseEvent) => void>>();
+	return {
+		listeners,
+		addEventListener(type: string, listener: (ev: MouseEvent) => void) {
+			if (!listeners.has(type)) listeners.set(type, new Set());
+			listeners.get(type)!.add(listener);
+		},
+		removeEventListener(type: string, listener: (ev: MouseEvent) => void) {
+			listeners.get(type)?.delete(listener);
+		},
+		fire(type: string, ev: Partial<MouseEvent>) {
+			for (const l of listeners.get(type) ?? []) l(ev as MouseEvent);
+		},
+		count(type: string) {
+			return listeners.get(type)?.size ?? 0;
+		},
+	};
+}
+
+describe("attachResizeListeners", () => {
+	it("registers move and up listeners", () => {
+		const host = createHost();
+		attachResizeListeners(host, {
+			axis: "vertical",
+			startPos: 0,
+			startSize: 100,
+			minSize: 50,
+			maxSize: 500,
+			onResize: () => {},
+			onEnd: () => {},
+		});
+		expect(host.count("mousemove")).toBe(1);
+		expect(host.count("mouseup")).toBe(1);
+	});
+
+	it("forwards mousemove deltas through clampResize to onResize", () => {
+		const host = createHost();
+		const onResize = vi.fn();
+		attachResizeListeners(host, {
+			axis: "vertical",
+			startPos: 100,
+			startSize: 200,
+			minSize: 0,
+			maxSize: 1000,
+			onResize,
+			onEnd: () => {},
+		});
+		host.fire("mousemove", { clientY: 150 });
+		expect(onResize).toHaveBeenCalledWith(250);
+	});
+
+	it("removes both listeners on mouseup and calls onEnd", () => {
+		const host = createHost();
+		const onEnd = vi.fn();
+		attachResizeListeners(host, {
+			axis: "vertical",
+			startPos: 0,
+			startSize: 100,
+			minSize: 0,
+			maxSize: 500,
+			onResize: () => {},
+			onEnd,
+		});
+		host.fire("mouseup", {});
+		expect(onEnd).toHaveBeenCalledTimes(1);
+		expect(host.count("mousemove")).toBe(0);
+		expect(host.count("mouseup")).toBe(0);
+	});
+
+	it("returned cleanup removes listeners (covers unmount-during-drag leak)", () => {
+		const host = createHost();
+		const onResize = vi.fn();
+		const onEnd = vi.fn();
+		const cleanup = attachResizeListeners(host, {
+			axis: "horizontal",
+			startPos: 0,
+			startSize: 100,
+			minSize: 0,
+			maxSize: 500,
+			onResize,
+			onEnd,
+		});
+
+		cleanup();
+
+		expect(host.count("mousemove")).toBe(0);
+		expect(host.count("mouseup")).toBe(0);
+		host.fire("mousemove", { clientX: 200 });
+		host.fire("mouseup", {});
+		expect(onResize).not.toHaveBeenCalled();
+		expect(onEnd).not.toHaveBeenCalled();
+	});
+
+	it("cleanup is idempotent — double-cleanup does not double-detach unrelated listeners", () => {
+		const host = createHost();
+		const cleanup = attachResizeListeners(host, {
+			axis: "vertical",
+			startPos: 0,
+			startSize: 100,
+			minSize: 0,
+			maxSize: 500,
+			onResize: () => {},
+			onEnd: () => {},
+		});
+
+		// Re-add a fresh mousemove to verify second cleanup() doesn't touch it.
+		const sentinel = vi.fn();
+		cleanup();
+		host.addEventListener("mousemove", sentinel);
+		cleanup();
+		expect(host.count("mousemove")).toBe(1);
+	});
+});

--- a/app/components/video/useResize.ts
+++ b/app/components/video/useResize.ts
@@ -2,13 +2,80 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+export type ResizeAxis = "vertical" | "horizontal";
+
+export function clampResize(
+	axis: ResizeAxis,
+	startPos: number,
+	currentPos: number,
+	startSize: number,
+	minSize: number,
+	maxSize: number,
+): number {
+	const delta =
+		axis === "vertical" ? currentPos - startPos : startPos - currentPos;
+	return Math.max(minSize, Math.min(startSize + delta, maxSize));
+}
+
+type ResizeListenerHost = {
+	addEventListener: (type: string, listener: (ev: MouseEvent) => void) => void;
+	removeEventListener: (
+		type: string,
+		listener: (ev: MouseEvent) => void,
+	) => void;
+};
+
+export function attachResizeListeners(
+	host: ResizeListenerHost,
+	options: {
+		axis: ResizeAxis;
+		startPos: number;
+		startSize: number;
+		minSize: number;
+		maxSize: number;
+		onResize: (size: number) => void;
+		onEnd: () => void;
+	},
+): () => void {
+	const onMove = (ev: MouseEvent) => {
+		const pos = options.axis === "vertical" ? ev.clientY : ev.clientX;
+		options.onResize(
+			clampResize(
+				options.axis,
+				options.startPos,
+				pos,
+				options.startSize,
+				options.minSize,
+				options.maxSize,
+			),
+		);
+	};
+
+	let cleaned = false;
+	const cleanup = () => {
+		if (cleaned) return;
+		cleaned = true;
+		host.removeEventListener("mousemove", onMove);
+		host.removeEventListener("mouseup", onUp);
+	};
+
+	const onUp = () => {
+		options.onEnd();
+		cleanup();
+	};
+
+	host.addEventListener("mousemove", onMove);
+	host.addEventListener("mouseup", onUp);
+	return cleanup;
+}
+
 export function useResize({
 	axis,
 	defaultSize,
 	minSize,
 	maxSize,
 }: {
-	axis: "vertical" | "horizontal";
+	axis: ResizeAxis;
 	defaultSize: number;
 	minSize: number;
 	maxSize: number;
@@ -20,27 +87,30 @@ export function useResize({
 		sizeRef.current = size;
 	}, [size]);
 
+	const cleanupRef = useRef<(() => void) | null>(null);
+
+	useEffect(
+		() => () => {
+			cleanupRef.current?.();
+			cleanupRef.current = null;
+		},
+		[],
+	);
+
 	const handleMouseDown = useCallback(
 		(e: React.MouseEvent) => {
 			e.preventDefault();
-			const start = axis === "vertical" ? e.clientY : e.clientX;
-			const startSize = sizeRef.current;
+			cleanupRef.current?.();
 			setResizing(true);
-
-			const onMove = (ev: MouseEvent) => {
-				const pos = axis === "vertical" ? ev.clientY : ev.clientX;
-				const delta = axis === "vertical" ? pos - start : start - pos;
-				setSize(Math.max(minSize, Math.min(startSize + delta, maxSize)));
-			};
-
-			const onUp = () => {
-				setResizing(false);
-				document.removeEventListener("mousemove", onMove);
-				document.removeEventListener("mouseup", onUp);
-			};
-
-			document.addEventListener("mousemove", onMove);
-			document.addEventListener("mouseup", onUp);
+			cleanupRef.current = attachResizeListeners(document, {
+				axis,
+				startPos: axis === "vertical" ? e.clientY : e.clientX,
+				startSize: sizeRef.current,
+				minSize,
+				maxSize,
+				onResize: setSize,
+				onEnd: () => setResizing(false),
+			});
 		},
 		[axis, minSize, maxSize],
 	);


### PR DESCRIPTION
## Summary
- Fix listener cleanup correctness bug in `useResize` where document-level drag listeners could leak if the component unmounted during an active drag.
- Refactor resize math and listener wiring into testable helpers (`clampResize`, `attachResizeListeners`) while preserving runtime behavior.
- Add high-value unit tests for resize clamping and listener lifecycle/cleanup edge cases.

## Validation
- npm test -- --passWithNoTests
- npm run build