### PR TITLE
fix: nightly security audit 2026-05-10

### DIFF
--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,6 +1,7 @@
 import { createBrowserClient } from "@supabase/ssr";
-import { SUPABASE_ANON_KEY, SUPABASE_URL } from "./env";
+import { getSupabaseEnv } from "./env";
 
 export function createClient() {
-	return createBrowserClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+	const { url, anonKey } = getSupabaseEnv();
+	return createBrowserClient(url, anonKey);
 }

--- a/lib/supabase/env.ts
+++ b/lib/supabase/env.ts
@@ -1,3 +1,18 @@
-export const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
-export const SUPABASE_ANON_KEY =
-	process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+type PublicSupabaseEnvKey =
+	| "NEXT_PUBLIC_SUPABASE_URL"
+	| "NEXT_PUBLIC_SUPABASE_ANON_KEY";
+
+function getRequiredEnv(name: PublicSupabaseEnvKey): string {
+	const value = process.env[name]?.trim();
+	if (!value) {
+		throw new Error(`Missing required environment variable: ${name}`);
+	}
+	return value;
+}
+
+export function getSupabaseEnv() {
+	return {
+		url: getRequiredEnv("NEXT_PUBLIC_SUPABASE_URL"),
+		anonKey: getRequiredEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY"),
+	};
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,13 +1,14 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
-import { SUPABASE_ANON_KEY, SUPABASE_URL } from "./env";
+import { getSupabaseEnv } from "./env";
 
 const AUTH_ROUTES = ["/login", "/signup"];
 
 export async function updateSession(request: NextRequest) {
 	let supabaseResponse = NextResponse.next({ request });
+	const { url, anonKey } = getSupabaseEnv();
 
-	const supabase = createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+	const supabase = createServerClient(url, anonKey, {
 		cookies: {
 			getAll() {
 				return request.cookies.getAll();

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,11 +1,12 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
-import { SUPABASE_ANON_KEY, SUPABASE_URL } from "./env";
+import { getSupabaseEnv } from "./env";
 
 export async function createClient() {
 	const cookieStore = await cookies();
+	const { url, anonKey } = getSupabaseEnv();
 
-	return createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+	return createServerClient(url, anonKey, {
 		cookies: {
 			getAll() {
 				return cookieStore.getAll();


### PR DESCRIPTION
## Summary
- enforce required Supabase public env vars (URL and anon key) via explicit runtime validation
- remove silent empty-string fallback for auth/session client configuration
- wire server/client/middleware Supabase client constructors to validated env accessor

## Security rationale
Silent fallback to empty Supabase credentials can lead to degraded or undefined auth/session behavior. This change fails loudly when required auth configuration is missing, preventing insecure degraded operation.

## Validation
- npm audit
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm test -- --passWithNoTests