### PR TITLE
perf: nightly performance optimizations 2026-05-10

### DIFF
--- a/remotion/compositions/VideoComposition.tsx
+++ b/remotion/compositions/VideoComposition.tsx
@@ -92,6 +92,10 @@ export const VideoComposition: React.FC<VideoLayout> = ({
 }) => {
 	const sequenceEntries = useMemo(() => Object.entries(sequences), [sequences]);
 	const transitionFrames = toFrames(transitionDurationSec, fps);
+	const presentation = useMemo(
+		() => getPresentation(transitionType, { width, height }),
+		[transitionType, width, height],
+	);
 
 	return (
 		<AbsoluteFill style={blackBg}>
@@ -100,10 +104,7 @@ export const VideoComposition: React.FC<VideoLayout> = ({
 					<Fragment key={seq.element?.id ?? `empty-${i}`}>
 						{i > 0 && (
 							<TransitionSeries.Transition
-								presentation={getPresentation(transitionType, {
-									width,
-									height,
-								})}
+								presentation={presentation}
 								timing={linearTiming({ durationInFrames: transitionFrames })}
 							/>
 						)}


### PR DESCRIPTION
## Summary
- prevent Slate selection-only operations from triggering full canvas value updates/rerenders
- memoize Remotion transition presentation objects to avoid repeated recreation during timeline renders

## Why this matters
- reduces unnecessary rerenders during cursor movement/editing in Slate-heavy canvas workflows
- trims avoidable compute/allocation in Remotion transition render path

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm test -- --passWithNoTests