### PR TITLE
fix: nightly bug fixes 2026-05-11

### DIFF
--- a/app/components/canvas/hooks/useRefineScript.ts
+++ b/app/components/canvas/hooks/useRefineScript.ts
@@ -44,8 +44,10 @@ export function useRefineScript(getEditor: () => Editor | null) {
 						applyRefineOp(editor, op, anchorMap, connectorConfig);
 					}
 				}
-				for (const op of parser.flush()) {
-					applyRefineOp(editor, op, anchorMap, connectorConfig);
+				if (!controller.signal.aborted) {
+					for (const op of parser.flush()) {
+						applyRefineOp(editor, op, anchorMap, connectorConfig);
+					}
 				}
 			} finally {
 				if (abortRef.current === controller) {

--- a/lib/video/__tests__/fadeRamp.test.ts
+++ b/lib/video/__tests__/fadeRamp.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { fadeRamp } from "../fadeRamp";
+
+function isStrictlyIncreasing(arr: readonly number[]): boolean {
+	for (let i = 1; i < arr.length; i++) {
+		if (arr[i] <= arr[i - 1]) return false;
+	}
+	return true;
+}
+
+describe("fadeRamp", () => {
+	it("returns a trapezoid when duration comfortably exceeds fade", () => {
+		const r = fadeRamp(100, 10);
+		expect(r).toEqual({ input: [0, 10, 90, 100], output: [0, 1, 1, 0] });
+		if (!r) throw new Error("Expected ramp for long duration");
+		expect(isStrictlyIncreasing(r.input)).toBe(true);
+	});
+
+	it("avoids equal adjacent values when fade*2 would equal duration", () => {
+		const r = fadeRamp(10, 5);
+		expect(r).not.toBeNull();
+		if (!r) throw new Error("Expected ramp for equal fade-duration case");
+		expect(isStrictlyIncreasing(r.input)).toBe(true);
+	});
+
+	it("clamps fade when fadeFrames exceeds half the duration", () => {
+		const r = fadeRamp(6, 100);
+		expect(r).not.toBeNull();
+		if (!r) throw new Error("Expected ramp for clamped fade case");
+		expect(isStrictlyIncreasing(r.input)).toBe(true);
+	});
+
+	it("collapses to a triangle when duration only fits a single-frame fade", () => {
+		const r = fadeRamp(2, 10);
+		expect(r).toEqual({ input: [0, 1, 2], output: [0, 1, 0] });
+		if (!r) throw new Error("Expected ramp for tiny duration case");
+		expect(isStrictlyIncreasing(r.input)).toBe(true);
+	});
+
+	it("returns null when duration is 1 frame or less", () => {
+		expect(fadeRamp(1, 5)).toBeNull();
+		expect(fadeRamp(0, 5)).toBeNull();
+	});
+
+	it("returns null when fadeFrames is zero or negative", () => {
+		expect(fadeRamp(100, 0)).toBeNull();
+		expect(fadeRamp(100, -5)).toBeNull();
+	});
+
+	it("produces strictly increasing input for short even durations", () => {
+		for (let d = 2; d <= 20; d++) {
+			const r = fadeRamp(d, 100);
+			if (r) expect(isStrictlyIncreasing(r.input)).toBe(true);
+		}
+	});
+
+	it("produces strictly increasing input for short odd durations", () => {
+		for (let d = 3; d <= 21; d += 2) {
+			const r = fadeRamp(d, 100);
+			if (r) expect(isStrictlyIncreasing(r.input)).toBe(true);
+		}
+	});
+});

--- a/lib/video/fadeRamp.ts
+++ b/lib/video/fadeRamp.ts
@@ -1,0 +1,31 @@
+export type FadeRamp = {
+	input: readonly number[];
+	output: readonly number[];
+};
+
+/**
+ * Builds an input/output range for an audio fade-in/out envelope. Returns null
+ * when the duration is too short to need any envelope (caller should hold at
+ * full volume).
+ *
+ * Remotion's interpolate() requires strictly increasing input values, so when
+ * the fade windows would touch or overlap we collapse to a triangle peaking at
+ * the midpoint instead of a trapezoid with equal adjacent values.
+ */
+export function fadeRamp(
+	durationInFrames: number,
+	fadeFrames: number,
+): FadeRamp | null {
+	if (durationInFrames <= 1 || fadeFrames <= 0) return null;
+	const f = Math.min(fadeFrames, Math.floor((durationInFrames - 1) / 2));
+	if (f <= 0 || 2 * f >= durationInFrames) {
+		return {
+			input: [0, durationInFrames / 2, durationInFrames],
+			output: [0, 1, 0],
+		};
+	}
+	return {
+		input: [0, f, durationInFrames - f, durationInFrames],
+		output: [0, 1, 1, 0],
+	};
+}

--- a/remotion/compositions/VideoComposition.tsx
+++ b/remotion/compositions/VideoComposition.tsx
@@ -15,6 +15,7 @@ import type {
 	ResolvedElement,
 } from "@/lib/video/types";
 import { AUDIO_FADE_SEC, getPresentation } from "@/lib/video/transitions";
+import { fadeRamp } from "@/lib/video/fadeRamp";
 
 const coverStyle: React.CSSProperties = {
 	width: "100%",
@@ -29,16 +30,13 @@ function toFrames(sec: number, fps: number): number {
 }
 
 function fadeVolume(durationInFrames: number, fadeFrames: number) {
-	// Cap so the fade-in and fade-out windows don't overlap — interpolate()
-	// requires a monotonically increasing input range and throws otherwise.
-	const f = Math.min(fadeFrames, Math.floor(durationInFrames / 2));
+	const ramp = fadeRamp(durationInFrames, fadeFrames);
+	if (!ramp) return () => 1;
 	return (frame: number) =>
-		interpolate(
-			frame,
-			[0, f, durationInFrames - f, durationInFrames],
-			[0, 1, 1, 0],
-			{ extrapolateLeft: "clamp", extrapolateRight: "clamp" },
-		);
+		interpolate(frame, ramp.input, ramp.output, {
+			extrapolateLeft: "clamp",
+			extrapolateRight: "clamp",
+		});
 }
 
 function AudioSequence({ element }: { element: ResolvedElement }) {


### PR DESCRIPTION
## Summary
- fix script refine abort edge case that could still apply flushed ops after cancellation
- fix remotion audio fade envelope for short durations to avoid non-monotonic interpolate ranges
- add focused tests for fade ramp edge cases and monotonicity

## Validation
- npm test -- --passWithNoTests
- npm run build