### PR TITLE
perf: nightly performance optimizations 2026-05-11

### DIFF
--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -68,7 +68,10 @@ export default function Canvas({
 	useMetadataSync();
 	const { generateAll } = useGenerateAll(editor);
 
-	const layoutKey = getLayoutKey(contentElements, transitionType);
+	const layoutKey = useMemo(
+		() => getLayoutKey(contentElements, transitionType),
+		[contentElements, transitionType],
+	);
 	const prevKeyRef = useRef(layoutKey);
 	useEffect(() => {
 		if (layoutKey !== prevKeyRef.current) {

--- a/remotion/compositions/VideoComposition.tsx
+++ b/remotion/compositions/VideoComposition.tsx
@@ -96,6 +96,10 @@ export const VideoComposition: React.FC<VideoLayout> = ({
 		() => getPresentation(transitionType, { width, height }),
 		[transitionType, width, height],
 	);
+	const timing = useMemo(
+		() => linearTiming({ durationInFrames: transitionFrames }),
+		[transitionFrames],
+	);
 
 	return (
 		<AbsoluteFill style={blackBg}>
@@ -105,7 +109,7 @@ export const VideoComposition: React.FC<VideoLayout> = ({
 						{i > 0 && (
 							<TransitionSeries.Transition
 								presentation={presentation}
-								timing={linearTiming({ durationInFrames: transitionFrames })}
+								timing={timing}
 							/>
 						)}
 						<TransitionSeries.Sequence


### PR DESCRIPTION
## Summary
- memoize Canvas `layoutKey` derivation so editor re-renders don't rebuild the full scene signature on every keystroke
- memoize Remotion `linearTiming` transition config so transition objects are stable across composition re-renders

## Why this matters
These are hot interaction/render paths (canvas editing and timeline/video composition rendering). Stabilizing derived values reduces avoidable allocations and recomputation, improving responsiveness without changing behavior.

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm test -- --passWithNoTests
- npm run test:run