### PR TITLE
feat: per-element volume control for audio elements

### DIFF
--- a/app/components/canvas/config/elementConfigs.tsx
+++ b/app/components/canvas/config/elementConfigs.tsx
@@ -29,7 +29,26 @@ export interface ElementConfig {
 }
 
 const LOOPS_OPTIONS = ["1", "2", "3", "4", "5", "6", "7", "8"] as const;
+const VOLUME_OPTIONS = [
+	"0",
+	"1",
+	"2",
+	"3",
+	"4",
+	"5",
+	"6",
+	"7",
+	"8",
+	"9",
+	"10",
+] as const;
 const EMOTION_OPTIONS = Object.values(TTSEmotion);
+
+const volumeSpec = (color: string): AttributeSpec => ({
+	color,
+	label: "Volume",
+	edit: { options: VOLUME_OPTIONS },
+});
 
 export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 	narration: {
@@ -40,12 +59,16 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		icon: <BookOpen size={16} className="text-white" />,
 		bgColor: "bg-slate-600",
 		placeholder: "Write the narration...",
+		defaultAttributes: {
+			volume: "10",
+		},
 		visibleAttributes: {
 			emotion: {
 				color: "bg-pink-500",
 				label: "Emotion",
 				edit: { options: EMOTION_OPTIONS },
 			},
+			volume: volumeSpec("bg-slate-500"),
 		},
 	},
 	character: {
@@ -56,12 +79,16 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		icon: <User size={16} className="text-white" />,
 		bgColor: "bg-amber-600",
 		placeholder: "What does this character say?",
+		defaultAttributes: {
+			volume: "10",
+		},
 		visibleAttributes: {
 			emotion: {
 				color: "bg-pink-500",
 				label: "Emotion",
 				edit: { options: EMOTION_OPTIONS },
 			},
+			volume: volumeSpec("bg-amber-500"),
 		},
 	},
 	image: {
@@ -101,6 +128,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 
 		defaultAttributes: {
 			loops: "1",
+			volume: "10",
 		},
 		visibleAttributes: {
 			loops: {
@@ -108,6 +136,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 				label: "Loops",
 				edit: { options: LOOPS_OPTIONS },
 			},
+			volume: volumeSpec("bg-emerald-500"),
 		},
 	},
 	music: {
@@ -120,6 +149,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		placeholder: "Describe the music...",
 		defaultAttributes: {
 			loops: "1",
+			volume: "10",
 		},
 		visibleAttributes: {
 			loops: {
@@ -127,6 +157,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 				label: "Loops",
 				edit: { options: LOOPS_OPTIONS },
 			},
+			volume: volumeSpec("bg-violet-500"),
 		},
 	},
 };

--- a/app/components/canvas/utils/getGenerationInputs.ts
+++ b/app/components/canvas/utils/getGenerationInputs.ts
@@ -3,7 +3,7 @@ import type { GenerationInputs } from "@/lib/generation/queue";
 import type { CanvasContentElement } from "../types";
 import { getPromptText } from "./getPromptText";
 
-const NON_GENERATION_ATTRIBUTES = ["loops"] as const;
+const NON_GENERATION_ATTRIBUTES = ["loops", "volume"] as const;
 
 export function getGenerationInputs(
 	element: CanvasContentElement,

--- a/lib/video/__tests__/audioVolume.test.ts
+++ b/lib/video/__tests__/audioVolume.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { audioVolume } from "../audioVolume";
+
+describe("audioVolume", () => {
+	it("returns the scalar multiplier when no fade is needed", () => {
+		expect(audioVolume(0.5, 100, 0)).toBe(0.5);
+		expect(audioVolume(1, 1, 10)).toBe(1);
+		expect(audioVolume(0.3, 0, 10)).toBe(0.3);
+	});
+
+	it("returns a function when a fade ramp is produced", () => {
+		const v = audioVolume(1, 100, 10);
+		expect(typeof v).toBe("function");
+	});
+
+	it("applies fade-in and fade-out around the multiplier", () => {
+		const multiplier = 0.8;
+		const v = audioVolume(multiplier, 100, 10);
+		if (typeof v !== "function") throw new Error("Expected function");
+		expect(v(0)).toBeCloseTo(0);
+		expect(v(10)).toBeCloseTo(multiplier);
+		expect(v(50)).toBeCloseTo(multiplier);
+		expect(v(90)).toBeCloseTo(multiplier);
+		expect(v(100)).toBeCloseTo(0);
+		expect(v(5)).toBeCloseTo(multiplier * 0.5);
+		expect(v(95)).toBeCloseTo(multiplier * 0.5);
+	});
+
+	it("clamps outside the ramp range", () => {
+		const v = audioVolume(1, 100, 10);
+		if (typeof v !== "function") throw new Error("Expected function");
+		expect(v(-50)).toBeCloseTo(0);
+		expect(v(1000)).toBeCloseTo(0);
+	});
+
+	it("scales the envelope linearly with the multiplier", () => {
+		const a = audioVolume(1, 100, 10);
+		const b = audioVolume(0.25, 100, 10);
+		if (typeof a !== "function" || typeof b !== "function") {
+			throw new Error("Expected functions");
+		}
+		for (const f of [0, 5, 10, 50, 90, 95, 100]) {
+			expect(b(f)).toBeCloseTo(a(f) * 0.25);
+		}
+	});
+
+	it("handles a zero multiplier by staying silent across the envelope", () => {
+		const v = audioVolume(0, 100, 10);
+		if (typeof v !== "function") throw new Error("Expected function");
+		for (const f of [0, 10, 50, 90, 100]) {
+			expect(v(f)).toBe(0);
+		}
+	});
+
+	it("collapses to a triangle envelope when fade overlaps the duration", () => {
+		const multiplier = 1;
+		const v = audioVolume(multiplier, 2, 100);
+		if (typeof v !== "function") throw new Error("Expected function");
+		expect(v(0)).toBeCloseTo(0);
+		expect(v(1)).toBeCloseTo(multiplier);
+		expect(v(2)).toBeCloseTo(0);
+		expect(v(0.5)).toBeCloseTo(multiplier * 0.5);
+		expect(v(1.5)).toBeCloseTo(multiplier * 0.5);
+	});
+
+	it("returns the multiplier when fadeFrames is negative", () => {
+		expect(audioVolume(0.7, 100, -5)).toBe(0.7);
+	});
+});

--- a/lib/video/__tests__/layoutKey.test.ts
+++ b/lib/video/__tests__/layoutKey.test.ts
@@ -45,6 +45,12 @@ describe("getLayoutKey", () => {
 		expect(getLayoutKey(a, "none")).not.toBe(getLayoutKey(b, "none"));
 	});
 
+	it("changes when volume changes on any element", () => {
+		const a = [el("s1", { volume: "10" })];
+		const b = [el("s1", { volume: "3" })];
+		expect(getLayoutKey(a, "none")).not.toBe(getLayoutKey(b, "none"));
+	});
+
 	it("is stable across unrelated attribute changes", () => {
 		const a = [el("s1", { emotion: "happy" })];
 		const b = [el("s1", { emotion: "sad" })];

--- a/lib/video/__tests__/resolve.test.ts
+++ b/lib/video/__tests__/resolve.test.ts
@@ -66,6 +66,7 @@ describe("resolveElements", () => {
 			url: "https://example.com/img.png",
 			durationSec: 3,
 			loops: 1,
+			volume: 10,
 		});
 		expect(resolved[1]).toEqual({
 			id: "nar1",
@@ -75,6 +76,7 @@ describe("resolveElements", () => {
 			url: "https://example.com/nar.mp3",
 			durationSec: 8,
 			loops: 1,
+			volume: 10,
 		});
 	});
 
@@ -151,6 +153,30 @@ describe("resolveElements", () => {
 		const resolved = resolveElements([wrap(elements)], () => makeSnapshot());
 		expect(resolved[0].loops).toBe(1);
 		expect(resolved[1].loops).toBe(1);
+	});
+
+	it("reads volume from customAttributes (default 10)", () => {
+		const elements = [
+			makeElement("s1", "music", { volume: "3" }),
+			makeElement("s2", "music", { volume: "0" }),
+			makeElement("s3", "music"),
+		];
+		const resolved = resolveElements([wrap(elements)], () => makeSnapshot());
+		expect(resolved[0].volume).toBe(3);
+		expect(resolved[1].volume).toBe(0);
+		expect(resolved[2].volume).toBe(10);
+	});
+
+	it("clamps volume to 0-10 and falls back on invalid values", () => {
+		const elements = [
+			makeElement("s1", "music", { volume: "-2" }),
+			makeElement("s2", "music", { volume: "42" }),
+			makeElement("s3", "music", { volume: "not-a-number" }),
+		];
+		const resolved = resolveElements([wrap(elements)], () => makeSnapshot());
+		expect(resolved[0].volume).toBe(0);
+		expect(resolved[1].volume).toBe(10);
+		expect(resolved[2].volume).toBe(10);
 	});
 
 	it("skips all elements when none have results", () => {

--- a/lib/video/__tests__/scene-builder.test.ts
+++ b/lib/video/__tests__/scene-builder.test.ts
@@ -37,6 +37,7 @@ function el(
 		url: `https://example.com/${overrides.id}`,
 		durationSec: 0,
 		loops: 1,
+		volume: 10,
 		...overrides,
 	};
 }

--- a/lib/video/audioVolume.ts
+++ b/lib/video/audioVolume.ts
@@ -1,0 +1,21 @@
+import { interpolate } from "remotion";
+import { fadeRamp } from "./fadeRamp";
+
+/**
+ * Resolves an audio element's volume to either a constant scalar or a
+ * per-frame function that bakes in a fade envelope. Returning a scalar when
+ * possible lets Remotion skip per-frame evaluation.
+ */
+export function audioVolume(
+	multiplier: number,
+	durationInFrames: number,
+	fadeFrames: number,
+): number | ((frame: number) => number) {
+	const ramp = fadeRamp(durationInFrames, fadeFrames);
+	if (!ramp) return multiplier;
+	return (frame: number) =>
+		interpolate(frame, ramp.input, ramp.output, {
+			extrapolateLeft: "clamp",
+			extrapolateRight: "clamp",
+		}) * multiplier;
+}

--- a/lib/video/layoutKey.ts
+++ b/lib/video/layoutKey.ts
@@ -12,7 +12,10 @@ export function getLayoutKey(
 	transitionType: TransitionType,
 ): string {
 	const elementsKey = elements
-		.map((el) => `${el.id}:${el.type}:${el.customAttributes?.loops ?? ""}`)
+		.map(
+			(el) =>
+				`${el.id}:${el.type}:${el.customAttributes?.loops ?? ""}:${el.customAttributes?.volume ?? ""}`,
+		)
 		.join("|");
 	return `${transitionType}|${elementsKey}`;
 }

--- a/lib/video/resolve.ts
+++ b/lib/video/resolve.ts
@@ -14,6 +14,11 @@ export function resolveElements(
 		const snapshot = getSnapshot(el.id);
 		if (!snapshot.result) continue;
 
+		const rawVolume = Number(el.customAttributes?.volume);
+		const volume = Number.isFinite(rawVolume)
+			? Math.max(0, Math.min(10, rawVolume))
+			: 10;
+
 		resolved.push({
 			id: el.id,
 			type: el.type,
@@ -22,6 +27,7 @@ export function resolveElements(
 			url: snapshot.result.url,
 			durationSec: snapshot.result.durationSec,
 			loops: Math.max(1, Number(el.customAttributes?.loops) || 1),
+			volume,
 		});
 	}
 

--- a/lib/video/types.ts
+++ b/lib/video/types.ts
@@ -31,6 +31,7 @@ export type ResolvedElement = {
 	url: string;
 	durationSec: number;
 	loops: number;
+	volume: number;
 };
 
 export type Sequence = {

--- a/remotion/compositions/VideoComposition.tsx
+++ b/remotion/compositions/VideoComposition.tsx
@@ -3,7 +3,6 @@ import {
 	AbsoluteFill,
 	Html5Audio,
 	Img,
-	interpolate,
 	OffthreadVideo,
 	Sequence,
 	useVideoConfig,
@@ -15,7 +14,7 @@ import type {
 	ResolvedElement,
 } from "@/lib/video/types";
 import { AUDIO_FADE_SEC, getPresentation } from "@/lib/video/transitions";
-import { fadeRamp } from "@/lib/video/fadeRamp";
+import { audioVolume } from "@/lib/video/audioVolume";
 
 const coverStyle: React.CSSProperties = {
 	width: "100%",
@@ -29,26 +28,16 @@ function toFrames(sec: number, fps: number): number {
 	return Math.round(sec * fps);
 }
 
-function fadeVolume(durationInFrames: number, fadeFrames: number) {
-	const ramp = fadeRamp(durationInFrames, fadeFrames);
-	if (!ramp) return () => 1;
-	return (frame: number) =>
-		interpolate(frame, ramp.input, ramp.output, {
-			extrapolateLeft: "clamp",
-			extrapolateRight: "clamp",
-		});
-}
-
 function AudioSequence({ element }: { element: ResolvedElement }) {
 	const { durationInFrames, fps } = useVideoConfig();
-	const fade = element.role === "background";
+	const gain = element.volume / 10;
+	const hasFadeEnvelope = element.role === "background";
+	const fadeFrames = hasFadeEnvelope ? toFrames(AUDIO_FADE_SEC, fps) : 0;
 	return (
 		<Html5Audio
 			src={element.url}
 			pauseWhenBuffering
-			volume={
-				fade ? fadeVolume(durationInFrames, toFrames(AUDIO_FADE_SEC, fps)) : 1
-			}
+			volume={audioVolume(gain, durationInFrames, fadeFrames)}
 		/>
 	);
 }


### PR DESCRIPTION
## Summary
- Adds a 0–10 Volume dropdown to music, sound, narration, and character elements, mirroring the existing `loops` pattern.
- Volume is plumbed through `resolveElements` into the Remotion `Html5Audio` `volume` prop, composed with the existing background fade ramp for music.
- Volume is included in the layout key so the preview player remounts when changed, and excluded from generation inputs so it doesn't retrigger generations.

## Test plan
- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run test:run` all green (608 tests pass)
- [ ] Add a music element, toggle Volume 10 → 3 → 0; preview remounts and loudness changes (fade still audible at low non-zero values)
- [ ] Repeat for sound, narration, character — Volume badge present on each
- [ ] Confirm `loops` on music/sound still works alongside volume
- [ ] Reload page — volume persists via existing autosave/rehydrate path

🤖 Generated with [Claude Code](https://claude.com/claude-code)