### PR TITLE
accept string numeric fields for video and update runware video defaults

### DIFF
--- a/app/api/v1/__tests__/routes.test.ts
+++ b/app/api/v1/__tests__/routes.test.ts
@@ -253,6 +253,36 @@ describe("API routes", () => {
 			expect(res.status).toBe(400);
 		});
 
+		it("coerces string duration/width/height into numbers", async () => {
+			const { POST } = await import("@/app/api/v1/video/route");
+			mockVideoGenerate.mockResolvedValue({
+				id: "vid-coerce",
+				provider: "runware",
+				result: {},
+			});
+
+			const res = await POST(
+				makeRequest("/api/v1/video", {
+					prompt: "sunset",
+					duration: "5",
+					width: "1280",
+					height: "720",
+				}),
+			);
+			expect(res.status).toBe(200);
+			expect(mockVideoGenerate).toHaveBeenCalledWith(
+				expect.objectContaining({ duration: 5, width: 1280, height: 720 }),
+			);
+		});
+
+		it("returns 400 for non-numeric duration string", async () => {
+			const { POST } = await import("@/app/api/v1/video/route");
+			const res = await POST(
+				makeRequest("/api/v1/video", { prompt: "x", duration: "abc" }),
+			);
+			expect(res.status).toBe(400);
+		});
+
 		it("returns 500 on provider error", async () => {
 			const { POST } = await import("@/app/api/v1/video/route");
 			mockVideoGenerate.mockRejectedValue(new Error("fail"));

--- a/lib/api/request-schema-fields.ts
+++ b/lib/api/request-schema-fields.ts
@@ -1,8 +1,14 @@
 import { z } from "zod";
 
+const optionalCoercedNumber = z
+	.union([z.number(), z.string()])
+	.transform((v) => (typeof v === "string" ? Number(v) : v))
+	.refine((v) => Number.isFinite(v), { message: "must be a finite number" })
+	.optional();
+
 export const optionalImageDimensions = {
-	width: z.number().optional(),
-	height: z.number().optional(),
+	width: optionalCoercedNumber,
+	height: optionalCoercedNumber,
 } as const;
 
 export const optionalDurationSeconds = {
@@ -10,7 +16,7 @@ export const optionalDurationSeconds = {
 } as const;
 
 export const optionalVideoDuration = {
-	duration: z.number().optional(),
+	duration: optionalCoercedNumber,
 } as const;
 
 export const referenceImageUrlOrDataUri = z

--- a/lib/connectors/video/openslop/models.ts
+++ b/lib/connectors/video/openslop/models.ts
@@ -1,1 +1,3 @@
-export const VIDEO_MODELS = { "Slop Video v1": "bytedance:2@2" } as const;
+export const VIDEO_MODELS = {
+	"Slop Video v1": "bytedance:2@2",
+} as const;

--- a/lib/providers/__tests__/runware-video.test.ts
+++ b/lib/providers/__tests__/runware-video.test.ts
@@ -48,7 +48,10 @@ describe("RunwareVideo", () => {
 				duration: 5,
 				outputType: "URL",
 				deliveryMethod: "async",
-				inputImage: undefined,
+				inputs: {
+					frameImages: undefined,
+				},
+				audio: false,
 			});
 			expect(mockDisconnect).toHaveBeenCalled();
 		});

--- a/lib/providers/__tests__/runware-video.test.ts
+++ b/lib/providers/__tests__/runware-video.test.ts
@@ -43,8 +43,8 @@ describe("RunwareVideo", () => {
 			expect(mockVideoInference).toHaveBeenCalledWith({
 				positivePrompt: "a sunset",
 				model: "bytedance:2@2",
-				width: 512,
-				height: 512,
+				width: 864,
+				height: 480,
 				duration: 5,
 				outputType: "URL",
 				deliveryMethod: "async",
@@ -56,7 +56,7 @@ describe("RunwareVideo", () => {
 			expect(mockDisconnect).toHaveBeenCalled();
 		});
 
-		it("passes referenceImages[0] as inputImage", async () => {
+		it("passes referenceImages[0] via inputs.frameImages", async () => {
 			mockVideoInference.mockResolvedValue({
 				taskUUID: "job-2",
 				status: "processing",
@@ -70,7 +70,7 @@ describe("RunwareVideo", () => {
 
 			expect(mockVideoInference).toHaveBeenCalledWith(
 				expect.objectContaining({
-					inputImage: "data:image/png;base64,abc123",
+					inputs: { frameImages: ["data:image/png;base64,abc123"] },
 				}),
 			);
 		});

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -31,12 +31,16 @@ export class RunwareVideo extends BaseVideoProvider {
 			const result = await runware.videoInference({
 				positivePrompt: params.prompt,
 				model: params.model || "bytedance:2@2",
-				width: params.width || 512,
-				height: params.height || 512,
+				width: params.width || 864,
+				height: params.height || 486,
 				duration: params.duration || 5,
 				outputType: "URL",
 				deliveryMethod: "async",
-				inputImage: params.referenceImages?.[0],
+				inputs: {
+					frameImages: params.referenceImages?.length
+						? [params.referenceImages?.[0]]
+						: undefined,
+				},
 			});
 
 			const video = Array.isArray(result) ? result[0] : result;

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -32,7 +32,7 @@ export class RunwareVideo extends BaseVideoProvider {
 				positivePrompt: params.prompt,
 				model: params.model || "bytedance:2@2",
 				width: params.width || 864,
-				height: params.height || 486,
+				height: params.height || 480,
 				duration: params.duration || 5,
 				outputType: "URL",
 				deliveryMethod: "async",
@@ -41,6 +41,7 @@ export class RunwareVideo extends BaseVideoProvider {
 						? [params.referenceImages?.[0]]
 						: undefined,
 				},
+				audio: false,
 			});
 
 			const video = Array.isArray(result) ? result[0] : result;


### PR DESCRIPTION
## Summary
- Coerce string|number for `duration`, `width`, `height` on `/api/v1/video` so canvas attributes (stored as strings) pass validation
- Update Runware video provider: new default model, 864x486 default resolution, and switch to `inputs.frameImages` shape
- Add route tests for string coercion and non-numeric rejection

## Test plan
- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm test`
- [ ] Manually generate a Clip element on the canvas and confirm the video request succeeds end-to-end