### PR TITLE
fix: nightly bug fixes 2026-05-13

### DIFF
--- a/app/components/canvas/utils/osmlSerializer.ts
+++ b/app/components/canvas/utils/osmlSerializer.ts
@@ -100,6 +100,7 @@ export class OSMLSerializer {
 			return;
 		}
 		const lastChild = current.children[current.children.length - 1];
+		if (!lastChild) return;
 		lastChild.text += text ?? "";
 	}
 

--- a/lib/config/__tests__/connectorUtils.test.ts
+++ b/lib/config/__tests__/connectorUtils.test.ts
@@ -58,6 +58,13 @@ describe("getDefaultConnector", () => {
 		expect(result.config.defaultModel).toBe("m1");
 	});
 
+	it("throws when no providers are configured for the type", () => {
+		const registry = makeRegistry({});
+		expect(() => getDefaultConnector(registry, "image")).toThrow(
+			/No providers configured/,
+		);
+	});
+
 	it("returns the first default when multiple are marked default", () => {
 		const registry = makeRegistry({
 			first: makeConfig({ isDefault: true, defaultModel: "x" }),

--- a/lib/config/connectorUtils.ts
+++ b/lib/config/connectorUtils.ts
@@ -17,7 +17,10 @@ export function getDefaultConnector(
 			return { provider: provider as ProviderKey, config };
 		}
 	}
-	const [provider, config] = Object.entries(providers)[0];
+	const first = Object.entries(providers)[0];
+	if (!first)
+		throw new Error(`No providers configured for connector type "${type}"`);
+	const [provider, config] = first;
 	return { provider: provider as ProviderKey, config };
 }
 

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -43,6 +43,7 @@ export class RunwareVideo extends BaseVideoProvider {
 			});
 
 			const video = Array.isArray(result) ? result[0] : result;
+			if (!video) throw new Error("Runware video inference returned no result");
 			return toVideoJob(video);
 		});
 	}


### PR DESCRIPTION
## Summary
- fix connector default selection to fail loudly when no providers are configured
- guard runware video inference empty results before mapping to job output
- prevent osml serializer crash when closing tags arrive with no parsed children
- add regression tests for connector default edge-case

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm test -- --passWithNoTests
- npm run build