### PR TITLE
fix: nightly bug fixes 2026-05-14

### DIFF
--- a/app/components/canvas/elements/OutputPreview.tsx
+++ b/app/components/canvas/elements/OutputPreview.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { X as XIcon, AlertCircle, Check, Copy } from "lucide-react";
 import {
 	Tooltip,
@@ -231,10 +231,22 @@ function PlaceholderOverlay({
 
 function ErrorMessage({ message }: { message: string }) {
 	const [copied, setCopied] = useState(false);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	useEffect(() => {
+		return () => {
+			if (timerRef.current) clearTimeout(timerRef.current);
+		};
+	}, []);
 	const handleCopy = async () => {
-		await navigator.clipboard.writeText(message);
+		try {
+			await navigator.clipboard.writeText(message);
+		} catch (err) {
+			console.error("Failed to copy error to clipboard:", err);
+			return;
+		}
 		setCopied(true);
-		setTimeout(() => setCopied(false), 1500);
+		if (timerRef.current) clearTimeout(timerRef.current);
+		timerRef.current = setTimeout(() => setCopied(false), 1500);
 	};
 	return (
 		<div className="absolute inset-x-2 top-12 bottom-2 z-20 flex items-start justify-center pointer-events-none">

--- a/lib/providers/__tests__/runware-video.test.ts
+++ b/lib/providers/__tests__/runware-video.test.ts
@@ -95,6 +95,24 @@ describe("RunwareVideo", () => {
 			expect(result.url).toBe("https://v.mp4");
 		});
 
+		it("throws when videoInference returns no result", async () => {
+			mockVideoInference.mockResolvedValue(undefined);
+			const provider = new RunwareVideo("test-key");
+			await expect(provider.submit({ prompt: "x" })).rejects.toThrow(
+				"Runware returned no video result",
+			);
+			expect(mockDisconnect).toHaveBeenCalled();
+		});
+
+		it("throws when videoInference returns an empty array", async () => {
+			mockVideoInference.mockResolvedValue([]);
+			const provider = new RunwareVideo("test-key");
+			await expect(provider.submit({ prompt: "x" })).rejects.toThrow(
+				"Runware returned no video result",
+			);
+			expect(mockDisconnect).toHaveBeenCalled();
+		});
+
 		it("disconnects on error", async () => {
 			mockVideoInference.mockRejectedValue(new Error("fail"));
 

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -43,6 +43,7 @@ export class RunwareVideo extends BaseVideoProvider {
 			});
 
 			const video = Array.isArray(result) ? result[0] : result;
+			if (!video) throw new Error("Runware returned no video result");
 			return toVideoJob(video);
 		});
 	}


### PR DESCRIPTION
## Summary
- fix runware video submission to fail loudly when provider returns no video payload
- add regression tests for undefined/empty runware videoInference result
- harden error copy UI to avoid unhandled clipboard rejections and clear timers on unmount

## Validation
- npm test -- --passWithNoTests
- npm run build