### PR TITLE
perf: collapse script-sync tree scan to a single editor walk

### DIFF
--- a/app/components/canvas/hooks/useScriptSync.ts
+++ b/app/components/canvas/hooks/useScriptSync.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { Editor, Transforms } from "slate";
+import { Editor, type Path, Transforms } from "slate";
 import { useScript } from "@/lib/script/ScriptProvider";
 import {
 	CANVAS_ELEMENT_TYPES,
@@ -8,7 +8,8 @@ import {
 	type ParsedElement,
 } from "../types";
 import { OSMLSerializer } from "../utils/osmlSerializer";
-import { findNodeById, updateNodeText } from "../utils/editorOps";
+import { isContentElement } from "../utils/guards";
+import { updateNodeText } from "../utils/editorOps";
 
 function shouldSkip(node: ParsedElement): boolean {
 	return (
@@ -22,14 +23,21 @@ export function useScriptSync(editor: Editor): void {
 
 	useEffect(() => {
 		Editor.withoutNormalizing(editor, () => {
+			const pathById = new Map<string, Path>();
+			for (const [node, path] of Editor.nodes<CanvasContentElement>(editor, {
+				at: [],
+				match: isContentElement,
+			})) {
+				pathById.set(node.id, path);
+			}
+
 			for (const node of nodes) {
 				if (shouldSkip(node)) continue;
 
 				const canvasNode = node as CanvasContentElement;
-				const entry = findNodeById(editor, canvasNode.id);
+				const path = pathById.get(canvasNode.id);
 
-				if (entry) {
-					const [, path] = entry;
+				if (path) {
 					updateNodeText(
 						editor,
 						path,


### PR DESCRIPTION
## Summary
- in `useScriptSync`, build an `id -> path` map with one `Editor.nodes` pass instead of calling `findNodeById` per streamed node
- streaming the generated script previously scaled O(N*M) (N elements in editor × M nodes received per effect); the linear scan + Map lookups make it O(N + M)

## Why this matters
- script generation is a user-visible streaming hot path; each LLM batch re-fires the effect with the cumulative node list, so the squared cost grows with project size
- larger projects already feel noticeable jank during `/generate` streaming — this removes wasted tree traversals without changing behavior

## Validation
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test:run` (618/618)
- `npm run build`

## Constraints honored
- runtime-only, no behavior change
- `proxy.ts` untouched
- no `<head>` tracking scripts moved
- no `!` non-null assertions, no defensive guards added
- no lodash/bundle micro-opt churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)