### PR TITLE
feat: TTS speed controls, character pill UX, and assorted tuning

### DIFF
--- a/app/api/v1/tts/route.ts
+++ b/app/api/v1/tts/route.ts
@@ -3,10 +3,11 @@ import { getTTSProvider } from "@/lib/api/providers";
 import { requiredVoiceId } from "@/lib/api/request-schema-fields";
 import { bodySchema, createRouteHandler } from "@/lib/api/route-handler";
 import { TTS_MODELS } from "@/lib/connectors/tts/openslop/models";
+import { TTS_SPEEDS } from "@/lib/connectors/tts/enums";
 
 const schema = bodySchema(TTS_MODELS, {
 	voiceId: requiredVoiceId,
-	speed: z.union([z.number(), z.string()]).optional(),
+	speed: z.enum(TTS_SPEEDS).optional(),
 	volume: z.number().optional(),
 	format: z.string().optional(),
 });

--- a/app/components/canvas/config/elementConfigs.tsx
+++ b/app/components/canvas/config/elementConfigs.tsx
@@ -8,7 +8,7 @@ import {
 } from "lucide-react";
 import type { CanvasElementType, ResultKind } from "../types";
 import type { ConnectorType } from "@/lib/connectors/types";
-import { TTSEmotion } from "@/lib/connectors/tts/enums";
+import { TTSEmotion, TTS_SPEEDS } from "@/lib/connectors/tts/enums";
 
 export interface AttributeSpec {
 	color: string;
@@ -50,6 +50,12 @@ const volumeSpec = (color: string): AttributeSpec => ({
 	edit: { options: VOLUME_OPTIONS },
 });
 
+const speedSpec = (color: string): AttributeSpec => ({
+	color,
+	label: "Speed",
+	edit: { options: TTS_SPEEDS },
+});
+
 export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 	narration: {
 		type: "narration",
@@ -61,6 +67,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		placeholder: "Write the narration...",
 		defaultAttributes: {
 			volume: "10",
+			speed: "medium",
 		},
 		visibleAttributes: {
 			emotion: {
@@ -68,6 +75,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 				label: "Emotion",
 				edit: { options: EMOTION_OPTIONS },
 			},
+			speed: speedSpec("bg-slate-500"),
 			volume: volumeSpec("bg-slate-500"),
 		},
 	},
@@ -81,6 +89,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		placeholder: "What does this character say?",
 		defaultAttributes: {
 			volume: "10",
+			speed: "medium",
 		},
 		visibleAttributes: {
 			emotion: {
@@ -88,7 +97,8 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 				label: "Emotion",
 				edit: { options: EMOTION_OPTIONS },
 			},
-			volume: volumeSpec("bg-amber-500"),
+			speed: speedSpec("bg-amber-600"),
+			volume: volumeSpec("bg-amber-600"),
 		},
 	},
 	image: {
@@ -112,7 +122,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 
 		defaultAttributes: {
 			duration: "5",
-			volume: "10",
+			volume: "5",
 		},
 		visibleAttributes: {
 			duration: { color: "bg-indigo-500", label: "Duration" },
@@ -130,7 +140,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 
 		defaultAttributes: {
 			loops: "1",
-			volume: "10",
+			volume: "5",
 		},
 		visibleAttributes: {
 			loops: {
@@ -151,7 +161,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		placeholder: "Describe the music...",
 		defaultAttributes: {
 			loops: "1",
-			volume: "10",
+			volume: "5",
 		},
 		visibleAttributes: {
 			loops: {

--- a/app/components/canvas/elements/CharacterBadge.tsx
+++ b/app/components/canvas/elements/CharacterBadge.tsx
@@ -62,8 +62,8 @@ export function CharacterPill({
 	const avatarUrl = useCharacterAvatarUrl(name);
 	return (
 		<div
-			className={`group/pill relative inline-flex items-center shrink-0 max-w-[140px] rounded-full bg-white/10 ${
-				name ? "gap-1.5 pr-2" : ""
+			className={`group/pill relative inline-flex items-center shrink-0 max-w-[140px] rounded-full bg-white/10 ring-1 ring-inset ring-white/20 ${
+				name ? "gap-1.5 pr-2 py-px" : ""
 			}`}
 		>
 			<CharacterAvatar name={name} avatarUrl={avatarUrl} />

--- a/app/components/canvas/elements/CharacterBadge.tsx
+++ b/app/components/canvas/elements/CharacterBadge.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { User } from "lucide-react";
+import { User, X } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useProjectStore } from "@/lib/project/store";
@@ -52,16 +52,33 @@ export function CharacterBadge({ name }: { name?: string }) {
 	);
 }
 
-export function CharacterPill({ name }: { name?: string }) {
+export function CharacterPill({
+	name,
+	onRemove,
+}: {
+	name?: string;
+	onRemove?: () => void;
+}) {
 	const avatarUrl = useCharacterAvatarUrl(name);
 	return (
 		<div
-			className={`inline-flex items-center shrink-0 max-w-[140px] rounded-full bg-white/10 ${
+			className={`group/pill relative inline-flex items-center shrink-0 max-w-[140px] rounded-full bg-white/10 ${
 				name ? "gap-1.5 pr-2" : ""
 			}`}
 		>
 			<CharacterAvatar name={name} avatarUrl={avatarUrl} />
 			{name && <CharacterName name={name} />}
+			{onRemove && (
+				<button
+					type="button"
+					aria-label={`Remove ${name}`}
+					onMouseDown={(e) => e.preventDefault()}
+					onClick={onRemove}
+					className="absolute -top-1 -right-1 rounded-full bg-black/60 ring-1 ring-white/20 p-0.5 opacity-0 group-hover/pill:opacity-100 transition-opacity cursor-pointer hover:bg-black/80"
+				>
+					<X className="w-2.5 h-2.5 text-white" />
+				</button>
+			)}
 		</div>
 	);
 }

--- a/app/components/canvas/elements/CharactersPicker.tsx
+++ b/app/components/canvas/elements/CharactersPicker.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Check, UserPlus } from "lucide-react";
+import { Editor } from "slate";
+import { ReactEditor, useSlateStatic } from "slate-react";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useConfig } from "@/lib/config/ConfigProvider";
+import { useProjectStore } from "@/lib/project/store";
+import type { CanvasContentElement } from "../types";
+import { getElementCharacterNames } from "../utils/characters";
+import { setNodeAttrs } from "../utils/editorOps";
+
+function writeCharacters(
+	editor: Editor,
+	element: CanvasContentElement,
+	names: string[],
+): void {
+	const path = ReactEditor.findPath(editor, element);
+	const joined = names.join(", ");
+	setNodeAttrs(editor, path, element, { characters: joined || null });
+}
+
+export function toggleCharacter(
+	editor: Editor,
+	element: CanvasContentElement,
+	name: string,
+): void {
+	const current = getElementCharacterNames(element);
+	const next = current.includes(name)
+		? current.filter((n) => n !== name)
+		: [...current, name];
+	writeCharacters(editor, element, next);
+}
+
+export function removeCharacter(
+	editor: Editor,
+	element: CanvasContentElement,
+	name: string,
+): void {
+	writeCharacters(
+		editor,
+		element,
+		getElementCharacterNames(element).filter((n) => n !== name),
+	);
+}
+
+export function CharactersPicker({
+	element,
+}: {
+	element: CanvasContentElement;
+}) {
+	const editor = useSlateStatic();
+	const { projectId } = useConfig();
+	const characters = useProjectStore(projectId, (s) => s.metadata.characters);
+	const names = Object.keys(characters);
+	const selected = new Set(getElementCharacterNames(element));
+	const disabled = names.length === 0;
+
+	return (
+		<DropdownMenu modal={false}>
+			<DropdownMenuTrigger asChild disabled={disabled}>
+				<button
+					aria-label={disabled ? "No characters in project" : "Add character"}
+					title={disabled ? "No characters in project" : "Add character"}
+					onMouseDown={(e) => e.preventDefault()}
+					disabled={disabled}
+					className="bg-cyan-500 text-white text-[12px] px-2 py-1 rounded-full inline-flex items-center gap-1 cursor-pointer ring-1 ring-inset ring-white/20 hover:ring-white/50 hover:brightness-110 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+				>
+					<UserPlus className="w-3 h-3" />
+					<span>Character</span>
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent
+				align="start"
+				className="min-w-32 max-h-64 overflow-y-auto rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+			>
+				{names.map((name) => (
+					<DropdownMenuItem
+						key={name}
+						onClick={() => toggleCharacter(editor, element, name)}
+						onSelect={(e) => e.preventDefault()}
+						className="cursor-pointer rounded-full px-2 py-1 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10"
+					>
+						<span className="w-3.5 shrink-0 flex items-center justify-center">
+							{selected.has(name) && (
+								<Check className="w-3 h-3 text-white" aria-hidden="true" />
+							)}
+						</span>
+						{name}
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/app/components/canvas/elements/CharactersPicker.tsx
+++ b/app/components/canvas/elements/CharactersPicker.tsx
@@ -14,6 +14,13 @@ import { useProjectStore } from "@/lib/project/store";
 import type { CanvasContentElement } from "../types";
 import { getElementCharacterNames } from "../utils/characters";
 import { setNodeAttrs } from "../utils/editorOps";
+import { CharacterPill } from "./CharacterBadge";
+
+function useProjectCharacterNames(): string[] {
+	const { projectId } = useConfig();
+	const characters = useProjectStore(projectId, (s) => s.metadata.characters);
+	return Object.keys(characters);
+}
 
 function writeCharacters(
 	editor: Editor,
@@ -49,17 +56,58 @@ export function removeCharacter(
 	);
 }
 
+function setCharacterName(
+	editor: Editor,
+	element: CanvasContentElement,
+	name: string,
+): void {
+	const path = ReactEditor.findPath(editor, element);
+	setNodeAttrs(editor, path, element, { name });
+}
+
+/** Dropdown listing the project's characters with checkmarks for selected ones. */
+function ProjectCharactersMenu({
+	selected,
+	onSelect,
+}: {
+	selected: Set<string>;
+	onSelect: (name: string) => void;
+}) {
+	const names = useProjectCharacterNames();
+	return (
+		<DropdownMenuContent
+			align="start"
+			className="min-w-32 max-h-64 overflow-y-auto rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+		>
+			{names.map((name) => (
+				<DropdownMenuItem
+					key={name}
+					onClick={() => onSelect(name)}
+					onSelect={(e) => e.preventDefault()}
+					className="cursor-pointer rounded-full px-2 py-1 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10"
+				>
+					<span className="w-3.5 shrink-0 flex items-center justify-center">
+						{selected.has(name) && (
+							<Check className="w-3 h-3 text-white" aria-hidden="true" />
+						)}
+					</span>
+					{name}
+				</DropdownMenuItem>
+			))}
+		</DropdownMenuContent>
+	);
+}
+
+/** Multi-select add picker (image elements: many characters per element). */
 export function CharactersPicker({
 	element,
 }: {
 	element: CanvasContentElement;
 }) {
 	const editor = useSlateStatic();
-	const { projectId } = useConfig();
-	const characters = useProjectStore(projectId, (s) => s.metadata.characters);
-	const names = Object.keys(characters);
-	const selected = new Set(getElementCharacterNames(element));
+	const names = useProjectCharacterNames();
 	const disabled = names.length === 0;
+	const selected = new Set(getElementCharacterNames(element));
 
 	return (
 		<DropdownMenu modal={false}>
@@ -75,26 +123,43 @@ export function CharactersPicker({
 					<span>Character</span>
 				</button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent
-				align="start"
-				className="min-w-32 max-h-64 overflow-y-auto rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
-			>
-				{names.map((name) => (
-					<DropdownMenuItem
-						key={name}
-						onClick={() => toggleCharacter(editor, element, name)}
-						onSelect={(e) => e.preventDefault()}
-						className="cursor-pointer rounded-full px-2 py-1 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10"
-					>
-						<span className="w-3.5 shrink-0 flex items-center justify-center">
-							{selected.has(name) && (
-								<Check className="w-3 h-3 text-white" aria-hidden="true" />
-							)}
-						</span>
-						{name}
-					</DropdownMenuItem>
-				))}
-			</DropdownMenuContent>
+			<ProjectCharactersMenu
+				selected={selected}
+				onSelect={(name) => toggleCharacter(editor, element, name)}
+			/>
+		</DropdownMenu>
+	);
+}
+
+/** Single-select switcher (character elements: exactly one character per element). */
+export function CharacterSwitcher({
+	element,
+}: {
+	element: CanvasContentElement;
+}) {
+	const editor = useSlateStatic();
+	const names = useProjectCharacterNames();
+	const currentName = element.customAttributes?.name;
+
+	if (names.length === 0) return <CharacterPill name={currentName} />;
+
+	return (
+		<DropdownMenu modal={false}>
+			<DropdownMenuTrigger asChild>
+				<button
+					type="button"
+					aria-label="Change character"
+					title="Change character"
+					onMouseDown={(e) => e.preventDefault()}
+					className="inline-flex items-center cursor-pointer rounded-full hover:ring-1 hover:ring-white/30 transition-shadow"
+				>
+					<CharacterPill name={currentName} />
+				</button>
+			</DropdownMenuTrigger>
+			<ProjectCharactersMenu
+				selected={new Set(currentName ? [currentName] : [])}
+				onSelect={(name) => setCharacterName(editor, element, name)}
+			/>
 		</DropdownMenu>
 	);
 }

--- a/app/components/canvas/elements/ElementCharacters.tsx
+++ b/app/components/canvas/elements/ElementCharacters.tsx
@@ -4,7 +4,11 @@ import { useSlateStatic } from "slate-react";
 import type { CanvasContentElement } from "../types";
 import { getElementCharacterNames } from "../utils/characters";
 import { CharacterPill } from "./CharacterBadge";
-import { CharactersPicker, removeCharacter } from "./CharactersPicker";
+import {
+	CharacterSwitcher,
+	CharactersPicker,
+	removeCharacter,
+} from "./CharactersPicker";
 
 export function ElementCharacters({
 	element,
@@ -12,6 +16,9 @@ export function ElementCharacters({
 	element: CanvasContentElement;
 }) {
 	const editor = useSlateStatic();
+	if (element.type === "character")
+		return <CharacterSwitcher element={element} />;
+	if (element.type !== "image") return null;
 	const characters = getElementCharacterNames(element);
 	return (
 		<>
@@ -22,7 +29,7 @@ export function ElementCharacters({
 					onRemove={() => removeCharacter(editor, element, name)}
 				/>
 			))}
-			{characters.length > 0 && <CharactersPicker element={element} />}
+			<CharactersPicker element={element} />
 		</>
 	);
 }

--- a/app/components/canvas/elements/ElementCharacters.tsx
+++ b/app/components/canvas/elements/ElementCharacters.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useSlateStatic } from "slate-react";
+import type { CanvasContentElement } from "../types";
+import { getElementCharacterNames } from "../utils/characters";
+import { CharacterPill } from "./CharacterBadge";
+import { CharactersPicker, removeCharacter } from "./CharactersPicker";
+
+export function ElementCharacters({
+	element,
+}: {
+	element: CanvasContentElement;
+}) {
+	const editor = useSlateStatic();
+	const characters = getElementCharacterNames(element);
+	return (
+		<>
+			{characters.map((name) => (
+				<CharacterPill
+					key={`char:${name}`}
+					name={name}
+					onRemove={() => removeCharacter(editor, element, name)}
+				/>
+			))}
+			{characters.length > 0 && <CharactersPicker element={element} />}
+		</>
+	);
+}

--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -3,7 +3,6 @@ import { RenderElementProps, ReactEditor, useSlateStatic } from "slate-react";
 import { Node } from "slate";
 import type { CanvasContentElement, SceneElement } from "../types";
 import { isSceneElement } from "../utils/guards";
-import { getElementCharacterNames } from "../utils/characters";
 import { ZERO_WIDTH_SPACE } from "../config/constants";
 import { ELEMENT_CONFIGS } from "../config/elementConfigs";
 import { useViewMode } from "../ViewModeContext";
@@ -11,7 +10,7 @@ import { OutputPreview } from "./OutputPreview";
 import { DeleteButton } from "./DeleteButton";
 import { CompactElement } from "./CompactElement";
 import { SceneContainer } from "./SceneContainer";
-import { CharacterPill } from "./CharacterBadge";
+import { ElementCharacters } from "./ElementCharacters";
 import { AttributeBadge } from "./AttributeBadge";
 import { ModelBadge } from "./ModelBadge";
 
@@ -50,9 +49,7 @@ export function ElementContainer({
 							{config.icon}
 							<span className="text-xs">{config.label}</span>
 						</div>
-						{getElementCharacterNames(element).map((name) => (
-							<CharacterPill key={`char:${name}`} name={name} />
-						))}
+						<ElementCharacters element={element} />
 						{Object.entries(config.visibleAttributes).map(([key, spec]) => (
 							<AttributeBadge
 								key={key}

--- a/app/components/canvas/hooks/useAutosave.ts
+++ b/app/components/canvas/hooks/useAutosave.ts
@@ -40,13 +40,14 @@ export function useAutosave(projectId: string, value: Descendant[]): void {
 		}
 		const snapshot = extractStoreSnapshot(store);
 		const script = OSMLSerializer.serializeWithScenes(valueRef.current);
+		const generation = queue.snapshot();
 		try {
 			await saveProject(projectId, {
 				name: deriveProjectName(snapshot.metadata),
 				script,
 				store: snapshot,
-				generation: queue.snapshot(),
-				thumbnail_url: pickThumbnailUrl(queue.values()),
+				generation,
+				thumbnail_url: pickThumbnailUrl(Object.entries(generation)),
 			});
 			toast("Saved", TOAST_OPTIONS);
 		} catch (err) {

--- a/app/components/video/VideoPreview.tsx
+++ b/app/components/video/VideoPreview.tsx
@@ -26,6 +26,7 @@ const RemotionPlayer = dynamic(
 					style={fullWidthStyle}
 					controls
 					acknowledgeRemotionLicense
+					numberOfSharedAudioTags={10}
 				/>
 			);
 		}

--- a/lib/components/Waveform.tsx
+++ b/lib/components/Waveform.tsx
@@ -183,7 +183,7 @@ export function Waveform({
 
 		let cancelled = false;
 		const ac = new AudioContext();
-		fetch(src)
+		fetch(src, { mode: "cors" })
 			.then((r) => r.arrayBuffer())
 			.then((buf) => ac.decodeAudioData(buf))
 			.then((ab) => {
@@ -271,6 +271,7 @@ export function Waveform({
 			<audio
 				ref={audioRef}
 				src={src}
+				crossOrigin="anonymous"
 				preload="metadata"
 				hidden
 				onTimeUpdate={() => {

--- a/lib/connectors/llm/openslop/models.ts
+++ b/lib/connectors/llm/openslop/models.ts
@@ -1,3 +1,3 @@
 export const LLM_MODELS = {
-	"Slop LLM v1": "claude-sonnet-4-5-20250929",
+	"Slop LLM v1": "claude-opus-4-7",
 } as const;

--- a/lib/connectors/plugins/osml.ts
+++ b/lib/connectors/plugins/osml.ts
@@ -34,8 +34,8 @@ const OSML_SYSTEM_PROMPT = dedent`
   ### Character Dialogue XML Tags
   - Each character's entire dialogue is wrapped in character XML tags with required attributes being name and emotion. Example:
     <narration emotion="neutral">Lyra steps forward. </narration>
-    <character name="Lyra" emotion="excited">"Truce?"</character>
-  - Frequently use nonverbalisms to exaggerate the emotion. Example: <character name="Mia" emotion="happy">"[laughter] That's the way I want it!"</character>.
+    <character name="Lyra" emotion="excited">Truce?</character>
+  - Frequently use nonverbalisms to exaggerate the emotion. Example: <character name="Mia" emotion="happy">[laughter] That's the way I want it!</character>.
   - Allowed list of nonverbalisms: [laughter]. Do not use any other nonverbalisms.
   - Occasionally insert ellipsis (...) to indicate a pause or a break in the dialogue, or use exclamations (!) to indicate a strong emotion or action.
 	- The only supported attribute for character tags is emotion

--- a/lib/connectors/tts/enums.ts
+++ b/lib/connectors/tts/enums.ts
@@ -11,6 +11,9 @@ export type TTSAge = (typeof TTS_AGES)[number];
 export const TTS_PITCHES = ["high", "medium", "low"] as const;
 export type TTSPitch = (typeof TTS_PITCHES)[number];
 
+export const TTS_SPEEDS = ["slow", "medium", "fast"] as const;
+export type TTSSpeed = (typeof TTS_SPEEDS)[number];
+
 export const TTS_ACCENTS = [
 	"american",
 	"british",

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -1,6 +1,6 @@
 import type { GatewayClient } from "@/lib/gateway/base";
 import type { WithMetadata } from "@/lib/providers/base";
-import type { TTSGender } from "./tts/enums";
+import type { TTSGender, TTSSpeed } from "./tts/enums";
 
 export type ConnectorType = "llm" | "music" | "sfx" | "image" | "tts" | "video";
 
@@ -123,7 +123,7 @@ export type TTSGenerateParams = ConnectorGenerateParams & {
 	name?: string;
 	query?: string;
 	language?: string;
-	speed?: number | string;
+	speed?: TTSSpeed;
 	volume?: number;
 	format?: string;
 };

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -329,4 +329,4 @@ export class GenerationQueue {
 	}
 }
 
-export const DEFAULT_BATCH_SIZE = 3;
+export const DEFAULT_BATCH_SIZE = 2;

--- a/lib/project/__tests__/thumbnail.test.ts
+++ b/lib/project/__tests__/thumbnail.test.ts
@@ -1,31 +1,36 @@
 import { describe, expect, it } from "vitest";
 import type { ConnectorType } from "@/lib/connectors/types";
 import type { ElementSnapshot } from "@/lib/generation/queue";
+import { characterAvatarElementId } from "../ensureCharacterAvatars";
 import { pickThumbnailUrl } from "../thumbnail";
 
 const entry = (
+	id: string,
 	connectorType: ConnectorType | null,
 	url: string | null,
-): ElementSnapshot => ({
-	status: "idle",
-	seconds: 0,
-	result: url ? { url, durationSec: 0 } : null,
-	error: null,
-	resultInputs: null,
-	connectorType,
-});
+): [string, ElementSnapshot] => [
+	id,
+	{
+		status: "idle",
+		seconds: 0,
+		result: url ? { url, durationSec: 0 } : null,
+		error: null,
+		resultInputs: null,
+		connectorType,
+	},
+];
 
 describe("pickThumbnailUrl", () => {
 	it("returns null for no entries", () => {
 		expect(pickThumbnailUrl([])).toBeNull();
 	});
 
-	it("returns the first image url", () => {
+	it("returns the first image url in iteration order", () => {
 		expect(
 			pickThumbnailUrl([
-				entry("tts", "n.mp3"),
-				entry("image", "a.png"),
-				entry("image", "b.png"),
+				entry("1", "tts", "n.mp3"),
+				entry("2", "image", "a.png"),
+				entry("3", "image", "b.png"),
 			]),
 		).toBe("a.png");
 	});
@@ -33,15 +38,24 @@ describe("pickThumbnailUrl", () => {
 	it("ignores non-image connector types", () => {
 		expect(
 			pickThumbnailUrl([
-				entry("tts", "n.mp3"),
-				entry("video", "v.mp4"),
-				entry("sfx", "s.mp3"),
-				entry("music", "m.mp3"),
+				entry("1", "tts", "n.mp3"),
+				entry("2", "video", "v.mp4"),
+				entry("3", "sfx", "s.mp3"),
+				entry("4", "music", "m.mp3"),
 			]),
 		).toBeNull();
 	});
 
 	it("ignores entries with no result", () => {
-		expect(pickThumbnailUrl([entry("image", null)])).toBeNull();
+		expect(pickThumbnailUrl([entry("1", "image", null)])).toBeNull();
+	});
+
+	it("skips character avatar entries", () => {
+		expect(
+			pickThumbnailUrl([
+				entry(characterAvatarElementId("Alice"), "image", "avatar.png"),
+				entry("scene-1", "image", "scene.png"),
+			]),
+		).toBe("scene.png");
 	});
 });

--- a/lib/project/ensureCharacterAvatars.ts
+++ b/lib/project/ensureCharacterAvatars.ts
@@ -4,8 +4,10 @@ import { buildCharacterAvatarPlugins } from "@/lib/connectors/plugins/imageChain
 import type { GenerationJob, GenerationQueue } from "@/lib/generation/queue";
 import { getProjectStore } from "./store";
 
+export const CHARACTER_AVATAR_ID_PREFIX = "character-avatar:";
+
 export const characterAvatarElementId = (name: string) =>
-	`character-avatar:${name}`;
+	`${CHARACTER_AVATAR_ID_PREFIX}${name}`;
 
 export function ensureCharacterAvatars(
 	queue: GenerationQueue,

--- a/lib/project/thumbnail.ts
+++ b/lib/project/thumbnail.ts
@@ -1,12 +1,14 @@
 import type { ElementSnapshot } from "@/lib/generation/queue";
+import { CHARACTER_AVATAR_ID_PREFIX } from "./ensureCharacterAvatars";
 
 export function pickThumbnailUrl(
-	entries: Iterable<ElementSnapshot>,
+	entries: Iterable<[string, ElementSnapshot]>,
 ): string | null {
-	for (const snap of entries) {
-		if (snap.result && snap.connectorType === "image") {
-			return snap.result.url;
-		}
+	for (const [id, snap] of entries) {
+		if (id.startsWith(CHARACTER_AVATAR_ID_PREFIX)) continue;
+		if (snap.connectorType !== "image") continue;
+		const url = snap.result?.url;
+		if (url) return url;
 	}
 	return null;
 }

--- a/lib/providers/__tests__/anthropic-llm.test.ts
+++ b/lib/providers/__tests__/anthropic-llm.test.ts
@@ -34,7 +34,7 @@ describe("AnthropicLLM", () => {
 			});
 			expect(mockCreate).toHaveBeenCalledWith({
 				model: "claude-sonnet-4-5-20250929",
-				max_tokens: 4096,
+				max_tokens: 8192,
 				temperature: undefined,
 				system: undefined,
 				messages: [{ role: "user", content: "hi" }],

--- a/lib/providers/__tests__/elevenlabs-music.test.ts
+++ b/lib/providers/__tests__/elevenlabs-music.test.ts
@@ -41,6 +41,7 @@ describe("ElevenLabsMusic", () => {
 			musicLengthMs: undefined,
 			modelId: "music_v1",
 			outputFormat: "mp3_44100_128",
+			forceInstrumental: true,
 		});
 	});
 

--- a/lib/providers/llm/anthropic.ts
+++ b/lib/providers/llm/anthropic.ts
@@ -29,7 +29,7 @@ export class AnthropicLLM extends BaseProvider<
 	private buildRequest(params: LLMGenerateParams) {
 		return {
 			model: params.model || "claude-sonnet-4-5-20250929",
-			max_tokens: params.maxTokens || 4096,
+			max_tokens: params.maxTokens || 8192,
 			temperature: params.temperature,
 			system: params.systemPrompt || undefined,
 			messages: [{ role: "user" as const, content: params.prompt }],

--- a/lib/providers/music/elevenlabs.ts
+++ b/lib/providers/music/elevenlabs.ts
@@ -25,6 +25,7 @@ export class ElevenLabsMusic extends BaseElevenLabsAudio<MusicGenerateParams> {
 					: undefined,
 			modelId: (params.model as "music_v1") || "music_v1",
 			outputFormat: toElevenLabsOutputFormat(this.outputFormat),
+			forceInstrumental: true,
 		});
 	}
 }

--- a/lib/providers/tts/cartesia.ts
+++ b/lib/providers/tts/cartesia.ts
@@ -5,7 +5,7 @@ import type {
 	VoiceInfo,
 	VoiceSearchParams,
 } from "@/lib/connectors/types";
-import type { TTSGender } from "@/lib/connectors/tts/enums";
+import type { TTSGender, TTSSpeed } from "@/lib/connectors/tts/enums";
 import type { BundleFile } from "@/lib/api/asset-bundle";
 import { logger } from "@/lib/api/logger";
 import { BaseProvider, type WithMetadata } from "../base";
@@ -20,6 +20,12 @@ type RawTTSResult = {
 const SAMPLE_RATE = 44100;
 const NUM_CHANNELS = 1;
 const ENCODING = "pcm_f32le";
+
+const CARTESIA_SPEED: Record<TTSSpeed, number> = {
+	slow: 0.6,
+	medium: 1.0,
+	fast: 1.5,
+};
 
 const PCM_WAV_PARAMS: Record<
 	string,
@@ -142,9 +148,9 @@ export class CartesiaTTS extends BaseProvider<TTSGenerateParams, RawTTSResult> {
 					sample_rate: SAMPLE_RATE,
 				},
 				add_timestamps: true,
-				...(params.speed !== undefined && {
-					speed: params.speed as "slow" | "normal" | "fast",
-				}),
+				generation_config: {
+					speed: CARTESIA_SPEED[params.speed ?? "medium"],
+				},
 			};
 			for await (const response of ws.generate(req)) {
 				if (response.type === "chunk" && response.audio) {

--- a/lib/templates/templates.ts
+++ b/lib/templates/templates.ts
@@ -57,17 +57,18 @@ export const TEMPLATES: Template[] = [
 		},
 		systemPrompt: dedent`
 		# Important
-		- The main character (you) is always called Protagonist, and the Protagonist must always be present in the character list
+		- The main character (you) is always called Protagonist, and the Protagonist must always be present in the character list of images where appropriate
 		- The art style is: 2D cartoon illustration, thick black outlines, muted desaturated colors, cinematic night lighting, flat shading, western animation style, no gradients
 		- Do not generate character metadata for the Protagonist, but do use him like a regular character in the story
-		- Never mention any specific character ages in the image descriptions, just generic ones like young man instead of 11 year old boy`,
+		- The Protagonist is always male, average build, slightly hunched posture, bald, wearing a worn olive green jacket, grey t-shirt underneath, faded blue jeans, brown work boots
+		- Never mention any specific ages in the image descriptions, just generic ones like young man`,
 		exampleText: dedent`
 				#Image: A title card with a black background and white Arial text that says "Level 1: The Kid with the Idea"
 				#Narration: Level 1: The Kid with the Idea
 
 				#Music: Soft, dreamy, optimistic lo-fi piano with twinkling synths, hopeful and childlike
 
-				#Image: The Protagonist, a young man, lying on his bedroom floor watching YouTube videos on a phone about young app founders who got rich, posters on the wall behind him
+				#Image: The young Protagonist watching YouTube videos on a phone about young app founders who got rich, posters on the wall behind him
 				#Narration: You're 11. You watch YouTube videos about people who made apps and got rich.
 
 				#Image: The Protagonist, a young man, daydreaming with a smile, imagining stacks of money and a sports car floating above his head in cartoon thought bubbles

--- a/remotion/compositions/VideoComposition.tsx
+++ b/remotion/compositions/VideoComposition.tsx
@@ -37,14 +37,21 @@ function AudioSequence({ element }: { element: ResolvedElement }) {
 		() => audioVolume(gain, durationInFrames, fadeFrames),
 		[gain, durationInFrames, fadeFrames],
 	);
-	return <Html5Audio src={element.url} pauseWhenBuffering volume={volume} />;
+	return (
+		<Html5Audio
+			src={element.url}
+			crossOrigin="anonymous"
+			pauseWhenBuffering
+			volume={volume}
+		/>
+	);
 }
 
 function SequenceContent({ element }: { element: ResolvedElement }) {
 	switch (element.layer) {
 		case "visual":
 			return element.type === "image" ? (
-				<Img src={element.url} style={coverStyle} />
+				<Img src={element.url} crossOrigin="anonymous" style={coverStyle} />
 			) : (
 				<OffthreadVideo
 					src={element.url}


### PR DESCRIPTION
## Summary

Mixed bag of UX, content, and tuning changes.

### TTS speed control
- New `TTS_SPEEDS` enum (`slow` | `medium` | `fast`) in `lib/connectors/tts/enums.ts`, threaded through `TTSGenerateParams`, the `/api/v1/tts` schema, and the canvas attribute config so narration/character elements expose a Speed badge.
- Cartesia provider maps the enum to numeric speeds (0.6 / 1.0 / 1.5) under `generation_config` (the previous string passthrough no longer matched the SDK).

### Character pill management
- `CharacterPill` gains an optional `onRemove` — hover-revealed X button.
- New `ElementCharacters` component wraps the per-element character row (pills + add picker), with its own Slate editor + character lookup. `ElementContainer` now just renders `<ElementCharacters element={element} />`.
- New `CharactersPicker` (dropdown to add characters from the project) and `removeCharacter` / `toggleCharacter` helpers in `CharactersPicker.tsx`.

### Thumbnail no longer picks character avatars
- `CHARACTER_AVATAR_ID_PREFIX` exported from `ensureCharacterAvatars`.
- `pickThumbnailUrl` now iterates over `[id, snapshot]` pairs and skips ids with that prefix so an avatar can't be picked as the project thumbnail.
- `useAutosave` updated to pass entries instead of values.

### Tuning / defaults
- `Slop LLM v1` -> `claude-opus-4-7`.
- `AnthropicLLM` default `max_tokens` 4096 -> 8192.
- `DEFAULT_BATCH_SIZE` 3 -> 2.
- Default volumes lowered to `5` for image/sfx/music; character voice color recolored to amber.
- ElevenLabs music: `forceInstrumental: true` (avoids accidental vocals on prompts that read like songs).
- OSML system prompt: drop literal quote marks from character dialogue examples.
- Templates: `pov-life-stages` Protagonist appearance pinned; age numbers banned.
- Remotion `<Player>` gets `numberOfSharedAudioTags={10}` to reduce audio element churn.
- `Waveform` / Remotion `<Img>` / `<Html5Audio>` get `crossOrigin="anonymous"` so Web Audio decoding and canvas reads aren't tainted on cross-origin blobs.

## Test plan

- [ ] `npm run typecheck`, `npm run lint`, `npm test` all pass locally
- [ ] Generate a TTS clip at each speed (slow/medium/fast) — verify audible difference and that no errors fire
- [ ] Add multiple characters to a canvas element, hover a pill, click X — character is removed; reopen picker, re-add
- [ ] Generate a project with both character avatars and a scene image; confirm saved thumbnail is the scene image, not an avatar
- [ ] Generate music with a vocal-sounding prompt — output should be instrumental only
- [ ] Render a video — Remotion playback works, audio sequences play with no CORS errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)