### PR TITLE
refactor: nightly maintainability 2026-05-17

### DIFF
--- a/lib/video/__tests__/elementAttributes.test.ts
+++ b/lib/video/__tests__/elementAttributes.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { CanvasContentElement } from "@/lib/canvas/types";
+import {
+	LAYOUT_ATTRIBUTE_KEYS,
+	getLoops,
+	getVolume,
+	layoutAttributeSignature,
+} from "../elementAttributes";
+
+function el(customAttributes?: Record<string, string>): CanvasContentElement {
+	return {
+		id: "e1",
+		type: "music",
+		...(customAttributes && { customAttributes }),
+		children: [{ id: "e1-t", type: "music", text: "" }],
+	};
+}
+
+describe("getVolume", () => {
+	it("defaults to 10 when missing or non-numeric", () => {
+		expect(getVolume(el())).toBe(10);
+		expect(getVolume(el({ volume: "not-a-number" }))).toBe(10);
+	});
+
+	it("passes through valid values including 0", () => {
+		expect(getVolume(el({ volume: "0" }))).toBe(0);
+		expect(getVolume(el({ volume: "3" }))).toBe(3);
+	});
+
+	it("clamps out-of-range values to [0, 10]", () => {
+		expect(getVolume(el({ volume: "-2" }))).toBe(0);
+		expect(getVolume(el({ volume: "42" }))).toBe(10);
+	});
+});
+
+describe("getLoops", () => {
+	it("defaults to 1 when missing, invalid, or below 1", () => {
+		expect(getLoops(el())).toBe(1);
+		expect(getLoops(el({ loops: "not-a-number" }))).toBe(1);
+		expect(getLoops(el({ loops: "0" }))).toBe(1);
+	});
+
+	it("reads valid loop counts", () => {
+		expect(getLoops(el({ loops: "4" }))).toBe(4);
+	});
+});
+
+describe("layoutAttributeSignature", () => {
+	it("joins raw layout attribute values in LAYOUT_ATTRIBUTE_KEYS order", () => {
+		expect(LAYOUT_ATTRIBUTE_KEYS).toEqual(["loops", "volume"]);
+		expect(layoutAttributeSignature(el({ loops: "2", volume: "5" }))).toBe(
+			"2:5",
+		);
+	});
+
+	it("uses empty segments for absent attributes (raw, uncoerced)", () => {
+		expect(layoutAttributeSignature(el())).toBe(":");
+		expect(layoutAttributeSignature(el({ loops: "0" }))).toBe("0:");
+		expect(layoutAttributeSignature(el({ volume: "10" }))).toBe(":10");
+	});
+});

--- a/lib/video/elementAttributes.ts
+++ b/lib/video/elementAttributes.ts
@@ -1,0 +1,44 @@
+import type { CanvasContentElement } from "@/lib/canvas/types";
+
+/**
+ * Single boundary for reading layout-affecting element `customAttributes`.
+ *
+ * These values are stored as raw strings on the element but consumed as typed,
+ * clamped numbers by `resolveElements`, while `getLayoutKey` must include the
+ * same fields so memoized layouts invalidate when they change. Keeping both the
+ * coercion rules and the field list here is the only place to change when a new
+ * layout-affecting attribute is added — the resolver and the memo key can no
+ * longer drift apart.
+ */
+
+/** Raw attribute keys that, when changed, require a layout recompute. */
+export const LAYOUT_ATTRIBUTE_KEYS = ["loops", "volume"] as const;
+
+const VOLUME_MIN = 0;
+const VOLUME_MAX = 10;
+const DEFAULT_VOLUME = VOLUME_MAX;
+
+/** Volume coerced to a finite number clamped to [0, 10], defaulting to 10. */
+export function getVolume(element: CanvasContentElement): number {
+	const raw = Number(element.customAttributes?.volume);
+	return Number.isFinite(raw)
+		? Math.max(VOLUME_MIN, Math.min(VOLUME_MAX, raw))
+		: DEFAULT_VOLUME;
+}
+
+/** Loop count coerced to an integer of at least 1, defaulting to 1. */
+export function getLoops(element: CanvasContentElement): number {
+	return Math.max(1, Number(element.customAttributes?.loops) || 1);
+}
+
+/**
+ * Stable signature over the raw layout-affecting attribute values, in
+ * `LAYOUT_ATTRIBUTE_KEYS` order. Used to build the layout memo key.
+ */
+export function layoutAttributeSignature(
+	element: CanvasContentElement,
+): string {
+	return LAYOUT_ATTRIBUTE_KEYS.map(
+		(key) => element.customAttributes?.[key] ?? "",
+	).join(":");
+}

--- a/lib/video/layoutKey.ts
+++ b/lib/video/layoutKey.ts
@@ -1,21 +1,19 @@
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import type { TransitionType } from "./transitions";
+import { layoutAttributeSignature } from "./elementAttributes";
 
 /**
  * Stable key over every element field that resolveElements/buildVideoLayout
- * actually read, plus project-wide layout-affecting settings. Extend this when
- * adding a new layout-affecting attribute so useVideoLayout's memo invalidates
- * correctly.
+ * actually read, plus project-wide layout-affecting settings. The set of
+ * layout-affecting attributes lives in `LAYOUT_ATTRIBUTE_KEYS` so this key and
+ * the resolver stay in lockstep — add new attributes there, not here.
  */
 export function getLayoutKey(
 	elements: CanvasContentElement[],
 	transitionType: TransitionType,
 ): string {
 	const elementsKey = elements
-		.map(
-			(el) =>
-				`${el.id}:${el.type}:${el.customAttributes?.loops ?? ""}:${el.customAttributes?.volume ?? ""}`,
-		)
+		.map((el) => `${el.id}:${el.type}:${layoutAttributeSignature(el)}`)
 		.join("|");
 	return `${transitionType}|${elementsKey}`;
 }

--- a/lib/video/resolve.ts
+++ b/lib/video/resolve.ts
@@ -3,6 +3,7 @@ import { getContentElements } from "@/lib/canvas/scenes";
 import type { ElementSnapshot } from "@/lib/generation/queue";
 import type { ResolvedElement } from "./types";
 import { ELEMENT_ROLES, LAYER_TYPES } from "./types";
+import { getLoops, getVolume } from "./elementAttributes";
 
 export function resolveElements(
 	elements: CanvasElement[],
@@ -14,11 +15,6 @@ export function resolveElements(
 		const snapshot = getSnapshot(el.id);
 		if (!snapshot.result) continue;
 
-		const rawVolume = Number(el.customAttributes?.volume);
-		const volume = Number.isFinite(rawVolume)
-			? Math.max(0, Math.min(10, rawVolume))
-			: 10;
-
 		resolved.push({
 			id: el.id,
 			type: el.type,
@@ -26,8 +22,8 @@ export function resolveElements(
 			layer: LAYER_TYPES[el.type],
 			url: snapshot.result.url,
 			durationSec: snapshot.result.durationSec,
-			loops: Math.max(1, Number(el.customAttributes?.loops) || 1),
-			volume,
+			loops: getLoops(el),
+			volume: getVolume(el),
 		});
 	}
 


### PR DESCRIPTION
## Summary
- extract a single `lib/video/elementAttributes.ts` boundary for layout-affecting element attributes (`loops`, `volume`) so resolution and layout-key generation share one contract
- remove duplicated ad-hoc attribute parsing from `resolve.ts` and `layoutKey.ts` to prevent drift between behavior and memo invalidation
- add focused tests for the new boundary while preserving existing behavior and constraints

## Validation
- npm run build
- npm test -- --passWithNoTests