### PR TITLE
feat: animated_image element type with image→video chaining

### DIFF
--- a/app/components/canvas/__tests__/buildGenerationJob.test.ts
+++ b/app/components/canvas/__tests__/buildGenerationJob.test.ts
@@ -28,6 +28,13 @@ const registry: ConnectorRegistry = {
 			isDefault: true,
 		},
 	},
+	animated_image: {
+		openslop: {
+			defaultModel: "Slop Image v1",
+			models: ["Slop Image v1"],
+			isDefault: true,
+		},
+	},
 	video: {
 		openslop: {
 			defaultModel: "Slop Video v1",

--- a/app/components/canvas/__tests__/hydrateConnectorConfig.test.ts
+++ b/app/components/canvas/__tests__/hydrateConnectorConfig.test.ts
@@ -28,6 +28,14 @@ const connectors: ConnectorRegistry = {
 			apiKey: "",
 		},
 	},
+	animated_image: {
+		openslop: {
+			defaultModel: "img-v1",
+			models: ["img-v1"],
+			isDefault: true,
+			apiKey: "",
+		},
+	},
 	video: {
 		openslop: {
 			defaultModel: "vid-v1",

--- a/app/components/canvas/__tests__/insertElement.test.ts
+++ b/app/components/canvas/__tests__/insertElement.test.ts
@@ -46,6 +46,9 @@ const connectors: ConnectorRegistry = {
 	image: {
 		openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },
 	},
+	animated_image: {
+		openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },
+	},
 	video: {
 		openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },
 	},

--- a/app/components/canvas/__tests__/osmlSerializer.test.ts
+++ b/app/components/canvas/__tests__/osmlSerializer.test.ts
@@ -18,6 +18,9 @@ const connectors: ConnectorRegistry = {
 	image: {
 		openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },
 	},
+	animated_image: {
+		openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },
+	},
 	video: {
 		openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },
 	},
@@ -234,6 +237,20 @@ describe("OSMLSerializer streaming", () => {
 		const nodes = s.getNodes() as ParsedElement[];
 		expect(nodes[0].id).toBe("abc");
 		expect(nodes[0].customAttributes?.id).toBeUndefined();
+	});
+
+	it("parses <animated_image> with a videoPrompt attribute", () => {
+		const s = new OSMLSerializer();
+		s.appendChunk(
+			'<animated_image videoPrompt="slow zoom in">a dark forest</animated_image>',
+			connectors,
+		);
+
+		const nodes = s.getNodes() as ParsedElement[];
+		expect(nodes).toHaveLength(1);
+		expect(nodes[0].type).toBe("animated_image");
+		expect(nodes[0].customAttributes?.videoPrompt).toBe("slow zoom in");
+		expect(OSMLSerializer.getTextContent(nodes[0])).toContain("a dark forest");
 	});
 
 	it("hydrates connector model and provider on streamed canvas elements", () => {

--- a/app/components/canvas/__tests__/useGenerateAll.test.ts
+++ b/app/components/canvas/__tests__/useGenerateAll.test.ts
@@ -26,6 +26,13 @@ const registry: ConnectorRegistry = {
 			isDefault: true,
 		},
 	},
+	animated_image: {
+		openslop: {
+			defaultModel: "m",
+			models: ["m"],
+			isDefault: true,
+		},
+	},
 	video: {
 		openslop: {
 			defaultModel: "m",

--- a/app/components/canvas/config/elementConfigs.tsx
+++ b/app/components/canvas/config/elementConfigs.tsx
@@ -3,6 +3,7 @@ import {
 	User,
 	Image as ImageIcon,
 	Film,
+	Sparkles,
 	Volume2,
 	Music,
 } from "lucide-react";
@@ -11,10 +12,14 @@ import type { ConnectorType } from "@/lib/connectors/types";
 import { TTSEmotion, TTS_SPEEDS } from "@/lib/connectors/tts/enums";
 import { MOTION_EFFECTS } from "@/lib/video/motionEffects";
 
+export type AttributeEdit =
+	| { kind: "enum"; options: readonly string[] }
+	| { kind: "text"; placeholder?: string; rows?: number };
+
 export interface AttributeSpec {
 	color: string;
 	label: string;
-	edit?: { options: readonly string[] };
+	edit?: AttributeEdit;
 }
 
 export interface ElementConfig {
@@ -48,19 +53,29 @@ const EMOTION_OPTIONS = Object.values(TTSEmotion);
 const volumeSpec = (color: string): AttributeSpec => ({
 	color,
 	label: "Volume",
-	edit: { options: VOLUME_OPTIONS },
+	edit: { kind: "enum", options: VOLUME_OPTIONS },
 });
 
 const speedSpec = (color: string): AttributeSpec => ({
 	color,
 	label: "Speed",
-	edit: { options: TTS_SPEEDS },
+	edit: { kind: "enum", options: TTS_SPEEDS },
 });
 
 const motionSpec = (color: string): AttributeSpec => ({
 	color,
 	label: "Motion",
-	edit: { options: MOTION_EFFECTS },
+	edit: { kind: "enum", options: MOTION_EFFECTS },
+});
+
+const videoPromptSpec = (color: string): AttributeSpec => ({
+	color,
+	label: "Video prompt",
+	edit: {
+		kind: "text",
+		placeholder: "Describe the camera or subject motion…",
+		rows: 3,
+	},
 });
 
 export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
@@ -80,7 +95,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 			emotion: {
 				color: "bg-pink-500",
 				label: "Emotion",
-				edit: { options: EMOTION_OPTIONS },
+				edit: { kind: "enum", options: EMOTION_OPTIONS },
 			},
 			speed: speedSpec("bg-slate-500"),
 			volume: volumeSpec("bg-slate-500"),
@@ -102,7 +117,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 			emotion: {
 				color: "bg-pink-500",
 				label: "Emotion",
-				edit: { options: EMOTION_OPTIONS },
+				edit: { kind: "enum", options: EMOTION_OPTIONS },
 			},
 			speed: speedSpec("bg-amber-600"),
 			volume: volumeSpec("bg-amber-600"),
@@ -121,6 +136,23 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		},
 		visibleAttributes: {
 			motion: motionSpec("bg-cyan-500"),
+		},
+	},
+	animated_image: {
+		type: "animated_image",
+		connector: "animated_image",
+		outputKind: "video",
+		label: "Animated image",
+		icon: <Sparkles size={16} className="text-white" />,
+		bgColor: "bg-fuchsia-600",
+		placeholder: "Describe the still image...",
+		defaultAttributes: {
+			motion: "none",
+			videoPrompt: "slow cinematic pan",
+		},
+		visibleAttributes: {
+			videoPrompt: videoPromptSpec("bg-fuchsia-500"),
+			motion: motionSpec("bg-fuchsia-500"),
 		},
 	},
 	clip: {
@@ -160,7 +192,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 			loops: {
 				color: "bg-teal-500",
 				label: "Loops",
-				edit: { options: LOOPS_OPTIONS },
+				edit: { kind: "enum", options: LOOPS_OPTIONS },
 			},
 			volume: volumeSpec("bg-emerald-500"),
 		},
@@ -181,7 +213,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 			loops: {
 				color: "bg-violet-500",
 				label: "Loops",
-				edit: { options: LOOPS_OPTIONS },
+				edit: { kind: "enum", options: LOOPS_OPTIONS },
 			},
 			volume: volumeSpec("bg-violet-500"),
 		},

--- a/app/components/canvas/elements/AttributeBadge.tsx
+++ b/app/components/canvas/elements/AttributeBadge.tsx
@@ -43,7 +43,7 @@ export function AttributeBadge({
 			{formatValue(attrKey, value)}
 		</>
 	);
-	const tooltip = value ? `${spec.label}: ${value}` : spec.label;
+	const tooltip = `${spec.label}: ${value || ""}`;
 
 	if (!spec.edit) {
 		return (

--- a/app/components/canvas/elements/AttributeBadge.tsx
+++ b/app/components/canvas/elements/AttributeBadge.tsx
@@ -9,6 +9,7 @@ import {
 import type { CanvasContentElement } from "../types";
 import type { AttributeSpec } from "../config/elementConfigs";
 import { setNodeAttrs } from "../utils/editorOps";
+import { TextAttributePopover } from "./attributes/TextAttributePopover";
 
 const ATTRIBUTE_UNITS: Record<string, string> = { duration: "s" };
 
@@ -48,6 +49,21 @@ export function AttributeBadge({
 			<span className={`${spec.color} ${PILL}`} title={tooltip}>
 				{labeled}
 			</span>
+		);
+	}
+
+	if (spec.edit.kind === "text") {
+		return (
+			<TextAttributePopover
+				element={element}
+				attrKey={attrKey}
+				value={value}
+				label={spec.label}
+				color={spec.color}
+				tooltip={tooltip}
+				placeholder={spec.edit.placeholder}
+				rows={spec.edit.rows}
+			/>
 		);
 	}
 

--- a/app/components/canvas/elements/AttributeBadge.tsx
+++ b/app/components/canvas/elements/AttributeBadge.tsx
@@ -33,8 +33,9 @@ export function AttributeBadge({
 	spec,
 }: AttributeBadgeProps) {
 	const editor = useSlateStatic();
-	const value = element.customAttributes?.[attrKey];
-	if (!value) return null;
+	const value = element.customAttributes?.[attrKey] ?? "";
+	const isTextEdit = spec.edit?.kind === "text";
+	if (!value && !isTextEdit) return null;
 
 	const labeled = (
 		<>
@@ -42,7 +43,7 @@ export function AttributeBadge({
 			{formatValue(attrKey, value)}
 		</>
 	);
-	const tooltip = `${spec.label}: ${value}`;
+	const tooltip = value ? `${spec.label}: ${value}` : spec.label;
 
 	if (!spec.edit) {
 		return (

--- a/app/components/canvas/elements/ElementCharacters.tsx
+++ b/app/components/canvas/elements/ElementCharacters.tsx
@@ -18,7 +18,8 @@ export function ElementCharacters({
 	const editor = useSlateStatic();
 	if (element.type === "character")
 		return <CharacterSwitcher element={element} />;
-	if (element.type !== "image") return null;
+	if (element.type !== "image" && element.type !== "animated_image")
+		return null;
 	const characters = getElementCharacterNames(element);
 	return (
 		<>

--- a/app/components/canvas/elements/GenerationIndicator.tsx
+++ b/app/components/canvas/elements/GenerationIndicator.tsx
@@ -24,9 +24,10 @@ const ICON_ANIMATION: Record<Status, string> = {
 };
 
 const SIZE_CLASSES: Record<Size, { wrapper: string; icon: string }> = {
-	sm: { wrapper: "h-4 w-4 bg-black/40", icon: "h-2.5 w-2.5" },
+	sm: { wrapper: "h-4 w-4 bg-black/55", icon: "h-2.5 w-2.5" },
 	md: {
-		wrapper: "h-7 w-7 bg-white/10 hover:bg-white/20 grain grain-light",
+		wrapper:
+			"h-7 w-7 bg-black/55 hover:bg-black/70 backdrop-blur-xl grain grain-light ring-1 ring-inset ring-white/10",
 		icon: "h-3 w-3",
 	},
 };

--- a/app/components/canvas/elements/ModelBadge.tsx
+++ b/app/components/canvas/elements/ModelBadge.tsx
@@ -17,7 +17,7 @@ export function ModelBadge({ element }: { element: CanvasContentElement }) {
 		return {
 			color: "bg-white/15",
 			label: "Model",
-			edit: { options },
+			edit: { kind: "enum", options },
 		};
 	}, [connector, connectorConfig, model, provider]);
 

--- a/app/components/canvas/elements/OutputPreview.tsx
+++ b/app/components/canvas/elements/OutputPreview.tsx
@@ -9,6 +9,7 @@ import {
 	MediaPreview,
 	MediaPlaceholder,
 } from "./preview/results";
+import { AnimatedImagePreview } from "./preview/AnimatedImagePreview";
 
 function OutputPreviewComponent({
 	element,
@@ -55,12 +56,27 @@ function OutputPreviewComponent({
 	}
 
 	if (result) {
+		const borderColor = BORDER_COLORS[type] ?? "border-white/20";
+		if (type === "animated_image" && result.previewUrl) {
+			return (
+				<AnimatedImagePreview
+					key={result.url}
+					url={result.url}
+					previewUrl={result.previewUrl}
+					borderColor={borderColor}
+					status={status}
+					seconds={seconds}
+					stale={stale}
+					onRegenerate={generate}
+				/>
+			);
+		}
 		return (
 			<MediaPreview
 				key={result.url}
 				url={result.url}
 				outputKind={outputKind}
-				borderColor={BORDER_COLORS[type] ?? "border-white/20"}
+				borderColor={borderColor}
 				status={status}
 				seconds={seconds}
 				stale={stale}

--- a/app/components/canvas/elements/attributes/TextAttributePopover.tsx
+++ b/app/components/canvas/elements/attributes/TextAttributePopover.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ReactEditor, useSlateStatic } from "slate-react";
+import type { CanvasContentElement } from "../../types";
+import { setNodeAttrs } from "../../utils/editorOps";
+
+interface TextAttributePopoverProps {
+	element: CanvasContentElement;
+	attrKey: string;
+	value: string;
+	label: string;
+	color: string;
+	tooltip: string;
+	placeholder?: string;
+	rows?: number;
+}
+
+export function TextAttributePopover({
+	element,
+	attrKey,
+	value,
+	label,
+	color,
+	tooltip,
+	placeholder,
+	rows = 3,
+}: TextAttributePopoverProps) {
+	const editor = useSlateStatic();
+	const [open, setOpen] = useState(false);
+	const [draft, setDraft] = useState(value);
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	const openPopover = () => {
+		setDraft(value);
+		setOpen(true);
+	};
+
+	const commit = useCallback(
+		(next: string) => {
+			if (next === value) return;
+			const path = ReactEditor.findPath(editor, element);
+			setNodeAttrs(editor, path, element, { [attrKey]: next });
+		},
+		[editor, element, attrKey, value],
+	);
+
+	useEffect(() => {
+		if (!open) return;
+		const handlePointer = (e: MouseEvent) => {
+			if (!containerRef.current?.contains(e.target as Node)) {
+				commit(draft);
+				setOpen(false);
+			}
+		};
+		document.addEventListener("mousedown", handlePointer);
+		return () => document.removeEventListener("mousedown", handlePointer);
+	}, [open, draft, commit]);
+
+	return (
+		<div ref={containerRef} className="relative inline-block">
+			<button
+				type="button"
+				aria-label={tooltip}
+				title={tooltip}
+				onClick={() => (open ? setOpen(false) : openPopover())}
+				className={`${color} text-white text-[12px] px-2 py-1 rounded-full max-w-[140px] inline-flex items-center gap-1.5 cursor-pointer ring-1 ring-inset ring-white/20 hover:ring-white/50 hover:brightness-110 transition-all`}
+			>
+				<span className="truncate min-w-0">
+					<span className="opacity-70 mr-1">{label}</span>
+					{value}
+				</span>
+				<ChevronDown className="w-3 h-3 shrink-0 text-white/80" />
+			</button>
+			{open && (
+				<div className="absolute left-0 top-full z-50 mt-1 w-72 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-1.5">
+					<textarea
+						autoFocus
+						rows={rows}
+						value={draft}
+						placeholder={placeholder}
+						onChange={(e) => setDraft(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Escape") {
+								setDraft(value);
+								setOpen(false);
+							} else if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+								commit(draft);
+								setOpen(false);
+							}
+						}}
+						className="w-full resize-none rounded-lg border border-white/10 bg-white/5 px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
+					/>
+					<div className="mt-1 px-1 text-[10px] text-white/40">
+						⌘↵ to save · esc to cancel
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/app/components/canvas/elements/attributes/TextAttributePopover.tsx
+++ b/app/components/canvas/elements/attributes/TextAttributePopover.tsx
@@ -68,8 +68,10 @@ export function TextAttributePopover({
 				className={`${color} text-white text-[12px] px-2 py-1 rounded-full max-w-[140px] inline-flex items-center gap-1.5 cursor-pointer ring-1 ring-inset ring-white/20 hover:ring-white/50 hover:brightness-110 transition-all`}
 			>
 				<span className="truncate min-w-0">
-					<span className="opacity-70 mr-1">{label}</span>
-					{value}
+					<span className={value ? "opacity-70 mr-1" : "opacity-90"}>
+						{label}
+					</span>
+					{value ? value : <span className="opacity-50 ml-1">— add</span>}
 				</span>
 				<ChevronDown className="w-3 h-3 shrink-0 text-white/80" />
 			</button>

--- a/app/components/canvas/elements/attributes/TextAttributePopover.tsx
+++ b/app/components/canvas/elements/attributes/TextAttributePopover.tsx
@@ -64,7 +64,14 @@ export function TextAttributePopover({
 				type="button"
 				aria-label={tooltip}
 				title={tooltip}
-				onClick={() => (open ? setOpen(false) : openPopover())}
+				onClick={() => {
+					if (open) {
+						commit(draft);
+						setOpen(false);
+					} else {
+						openPopover();
+					}
+				}}
 				className={`${color} text-white text-[12px] px-2 py-1 rounded-full max-w-[140px] inline-flex items-center gap-1.5 cursor-pointer ring-1 ring-inset ring-white/20 hover:ring-white/50 hover:brightness-110 transition-all`}
 			>
 				<span className="truncate min-w-0">

--- a/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
+++ b/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import { MediaPreview } from "./results";
+import type { GenerationState } from "./status";
+
+type AnimatedImagePreviewProps = GenerationState & {
+	url: string;
+	previewUrl: string;
+	borderColor: string;
+	stale: boolean;
+	onRegenerate: () => void;
+};
+
+export function AnimatedImagePreview({
+	url,
+	previewUrl,
+	borderColor,
+	status,
+	seconds,
+	stale,
+	onRegenerate,
+}: AnimatedImagePreviewProps) {
+	const [mode, setMode] = useState<"animated" | "still">("animated");
+	const isAnimated = mode === "animated";
+
+	return (
+		<div className="relative w-full">
+			<MediaPreview
+				key={mode}
+				url={isAnimated ? url : previewUrl}
+				outputKind={isAnimated ? "video" : "image"}
+				borderColor={borderColor}
+				status={status}
+				seconds={seconds}
+				stale={stale}
+				onRegenerate={onRegenerate}
+			/>
+			<div className="absolute top-2 right-2 z-10 flex items-center rounded-full border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/20 p-0.5">
+				<ToggleButton
+					active={isAnimated}
+					label="Video"
+					onClick={() => setMode("animated")}
+				/>
+				<ToggleButton
+					active={!isAnimated}
+					label="Still"
+					onClick={() => setMode("still")}
+				/>
+			</div>
+		</div>
+	);
+}
+
+function ToggleButton({
+	active,
+	label,
+	onClick,
+}: {
+	active: boolean;
+	label: string;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={`rounded-full px-2 py-0.5 text-[11px] transition-colors ${
+				active ? "bg-white/15 text-white" : "text-white/60 hover:text-white"
+			}`}
+		>
+			{label}
+		</button>
+	);
+}

--- a/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
+++ b/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
@@ -21,7 +21,7 @@ export function AnimatedImagePreview({
 	stale,
 	onRegenerate,
 }: AnimatedImagePreviewProps) {
-	const [mode, setMode] = useState<"animated" | "still">("animated");
+	const [mode, setMode] = useState<"animated" | "still">("still");
 	const isAnimated = mode === "animated";
 
 	return (
@@ -36,7 +36,7 @@ export function AnimatedImagePreview({
 				stale={stale}
 				onRegenerate={onRegenerate}
 			/>
-			<div className="absolute top-2 right-2 z-10 flex items-center rounded-full border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/20 p-0.5">
+			<div className="absolute top-2 right-2 z-10 flex items-center rounded-full border border-white/10 bg-black/55 backdrop-blur-xl shadow-md shadow-black/40 p-0.5">
 				<ToggleButton
 					active={isAnimated}
 					label="Video"

--- a/app/components/canvas/elements/preview/status.ts
+++ b/app/components/canvas/elements/preview/status.ts
@@ -24,6 +24,7 @@ export function deriveStatus(
 export const BORDER_COLORS: Record<CanvasElementType, string> = {
 	character: "border-amber-500/30",
 	image: "border-cyan-500/30",
+	animated_image: "border-fuchsia-500/30",
 	clip: "border-indigo-500/30",
 	narration: "border-white/20",
 	music: "border-violet-500/30",
@@ -36,5 +37,6 @@ export const WAVE_COLORS: Record<CanvasElementType, string> = {
 	music: "rgb(167, 139, 250)",
 	sound: "rgb(52, 211, 153)",
 	image: "rgb(34, 211, 238)",
+	animated_image: "rgb(232, 121, 249)",
 	clip: "rgb(129, 140, 248)",
 };

--- a/lib/canvas/types.ts
+++ b/lib/canvas/types.ts
@@ -7,6 +7,7 @@ export type CanvasElementType =
 	| "narration"
 	| "character"
 	| "image"
+	| "animated_image"
 	| "clip"
 	| "sound"
 	| "music";
@@ -15,6 +16,7 @@ export const CANVAS_ELEMENT_TYPES = new Set<CanvasElementType>([
 	"narration",
 	"character",
 	"image",
+	"animated_image",
 	"clip",
 	"sound",
 	"music",
@@ -24,6 +26,7 @@ export const SCENE_TYPE = "scene" as const;
 
 export const FOREGROUND_TYPES: ReadonlySet<CanvasElementType> = new Set([
 	"image",
+	"animated_image",
 	"clip",
 ]);
 

--- a/lib/config/ConfigProvider.tsx
+++ b/lib/config/ConfigProvider.tsx
@@ -22,6 +22,7 @@ import { VIDEO_MODELS } from "@/lib/connectors/video/openslop/models";
 import { SFX_MODELS } from "@/lib/connectors/sfx/openslop/models";
 import { MUSIC_MODELS } from "@/lib/connectors/music/openslop/models";
 import { buildImagePlugins } from "../connectors/plugins/imageChain";
+import { buildAnimatedImagePlugins } from "../connectors/plugins/animated-image-chain";
 import { createMetadataVoicePlugin } from "../connectors/plugins/metadata-voice";
 import { createReferenceImagesPlugin } from "../connectors/plugins/reference-images";
 import { createVoiceSearchPlugin } from "../connectors/plugins/voice-search";
@@ -71,6 +72,7 @@ const initialConnectorConfig: ConnectorRegistry = {
 	llm: openslopConfig("Slop LLM v1", LLM_MODELS, [osmlPlugin]),
 	tts: openslopConfig("Slop TTS v1", TTS_MODELS),
 	image: openslopConfig("Slop Image v1", IMAGE_MODELS),
+	animated_image: openslopConfig("Slop Image v1", IMAGE_MODELS),
 	video: openslopConfig("Slop Video v1", VIDEO_MODELS),
 	sfx: openslopConfig("Slop SFX v1", SFX_MODELS),
 	music: openslopConfig("Slop Music v1", MUSIC_MODELS),
@@ -131,12 +133,18 @@ export function ConfigProvider({
 		const modePlugin = MODE_PLUGIN_FACTORIES[mode]({
 			templateId: selectedTemplateId,
 		});
-		return withRegistry(connectorConfig)
+		const base = withRegistry(connectorConfig)
 			.appendPlugins("llm", modePlugin)
 			.appendPlugins("image", ...buildImagePlugins(projectId))
 			.appendPlugins("video", createReferenceImagesPlugin(projectId))
 			.appendPlugins("tts", createMetadataVoicePlugin(projectId))
 			.appendPlugins("tts", createVoiceSearchPlugin())
+			.build();
+		return withRegistry(base)
+			.appendPlugins(
+				"animated_image",
+				...buildAnimatedImagePlugins(projectId, base),
+			)
 			.build();
 	}, [connectorConfig, mode, selectedTemplateId, projectId]);
 

--- a/lib/connectors/animated_image/connector.ts
+++ b/lib/connectors/animated_image/connector.ts
@@ -1,0 +1,10 @@
+import { BaseAssetConnector } from "../asset-base";
+import type { AnimatedImageGenerateParams, AssetResult } from "../types";
+
+export abstract class BaseAnimatedImageConnector extends BaseAssetConnector<
+	AnimatedImageGenerateParams,
+	AssetResult
+> {
+	readonly type = "image" as const;
+	readonly assetKey = "image" as const;
+}

--- a/lib/connectors/animated_image/openslop/index.ts
+++ b/lib/connectors/animated_image/openslop/index.ts
@@ -1,0 +1,12 @@
+import { OpenSlopImageGateway } from "@/lib/gateway/openslop/image";
+import type { ConnectorConfig } from "@/lib/connectors/types";
+import { BaseAnimatedImageConnector } from "../connector";
+
+export class OpenSlopAnimatedImage extends BaseAnimatedImageConnector {
+	protected gateway: OpenSlopImageGateway;
+
+	constructor(config: ConnectorConfig) {
+		super(config);
+		this.gateway = new OpenSlopImageGateway(config.baseUrl);
+	}
+}

--- a/lib/connectors/factory.ts
+++ b/lib/connectors/factory.ts
@@ -1,5 +1,7 @@
 import type { BaseImageConnector } from "./image/connector";
 import { OpenSlopImage } from "./image/openslop";
+import type { BaseAnimatedImageConnector } from "./animated_image/connector";
+import { OpenSlopAnimatedImage } from "./animated_image/openslop";
 import { OpenSlopLLM } from "./llm/openslop";
 import type { BaseMusicConnector } from "./music/connector";
 import { OpenSlopMusic } from "./music/openslop";
@@ -22,6 +24,7 @@ type ConnectorTypeMap = {
 	music: BaseMusicConnector;
 	sfx: BaseSFXConnector;
 	image: BaseImageConnector;
+	animated_image: BaseAnimatedImageConnector;
 	tts: TTSConnector;
 	video: BaseVideoConnector;
 };
@@ -34,6 +37,7 @@ const PROVIDERS: Record<
 	music: { openslop: OpenSlopMusic },
 	sfx: { openslop: OpenSlopSFX },
 	image: { openslop: OpenSlopImage },
+	animated_image: { openslop: OpenSlopAnimatedImage },
 	tts: { openslop: OpenSlopTTS },
 	video: { openslop: OpenSlopVideo },
 };

--- a/lib/connectors/plugins/__tests__/animated-image-chain.test.ts
+++ b/lib/connectors/plugins/__tests__/animated-image-chain.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+
+const generateMock = vi.fn();
+
+vi.mock("../../factory", () => ({
+	createConnector: () => ({ generate: generateMock }),
+}));
+
+import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
+import type {
+	AnimatedImageGenerateParams,
+	AssetResult,
+	PluginContext,
+} from "../../types";
+import { createVideoChainPlugin } from "../animated-image-chain";
+
+const registry: ConnectorRegistry = {
+	llm: { openslop: { defaultModel: "m", models: ["m"], isDefault: true } },
+	tts: { openslop: { defaultModel: "m", models: ["m"], isDefault: true } },
+	image: { openslop: { defaultModel: "m", models: ["m"], isDefault: true } },
+	animated_image: {
+		openslop: { defaultModel: "m", models: ["m"], isDefault: true },
+	},
+	video: { openslop: { defaultModel: "m", models: ["m"], isDefault: true } },
+	sfx: { openslop: { defaultModel: "m", models: ["m"], isDefault: true } },
+	music: { openslop: { defaultModel: "m", models: ["m"], isDefault: true } },
+};
+
+describe("createVideoChainPlugin", () => {
+	it("stashes videoPrompt and animates the still via the video connector", async () => {
+		generateMock.mockReset();
+		generateMock.mockResolvedValue({
+			url: "https://example.com/video.mp4",
+			durationSec: 5,
+		});
+
+		const plugin = createVideoChainPlugin(registry);
+		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
+
+		const cleaned = (await plugin.beforeGenerate?.(
+			{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
+			ctx,
+		)) as AnimatedImageGenerateParams;
+
+		expect(cleaned).not.toHaveProperty("videoPrompt");
+		expect(ctx.data?.videoPrompt).toBe("slow zoom in");
+
+		const still = {
+			url: "https://example.com/still.png",
+			durationSec: 0,
+		} satisfies AssetResult;
+		const result = (await plugin.afterGenerate?.(still, ctx)) as AssetResult;
+
+		expect(generateMock).toHaveBeenCalledWith({
+			prompt: "slow zoom in",
+			frameImages: ["https://example.com/still.png"],
+		});
+		expect(result).toEqual({
+			url: "https://example.com/video.mp4",
+			durationSec: 5,
+			previewUrl: "https://example.com/still.png",
+		});
+	});
+
+	it("passes the still result through untouched when no videoPrompt is set", async () => {
+		generateMock.mockReset();
+		const plugin = createVideoChainPlugin(registry);
+		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
+
+		await plugin.beforeGenerate?.({ prompt: "a dark forest" }, ctx);
+
+		const still = {
+			url: "https://example.com/still.png",
+			durationSec: 0,
+		} satisfies AssetResult;
+		const result = (await plugin.afterGenerate?.(still, ctx)) as AssetResult;
+
+		expect(generateMock).not.toHaveBeenCalled();
+		expect(result).toBe(still);
+	});
+});

--- a/lib/connectors/plugins/__tests__/animated-image-chain.test.ts
+++ b/lib/connectors/plugins/__tests__/animated-image-chain.test.ts
@@ -62,7 +62,7 @@ describe("createVideoChainPlugin", () => {
 		});
 	});
 
-	it("passes the still result through untouched when no videoPrompt is set", async () => {
+	it("throws when videoPrompt is missing so the still URL never leaks into video rendering", async () => {
 		generateMock.mockReset();
 		const plugin = createVideoChainPlugin(registry);
 		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
@@ -73,9 +73,10 @@ describe("createVideoChainPlugin", () => {
 			url: "https://example.com/still.png",
 			durationSec: 0,
 		} satisfies AssetResult;
-		const result = (await plugin.afterGenerate?.(still, ctx)) as AssetResult;
 
+		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
+			/videoPrompt/,
+		);
 		expect(generateMock).not.toHaveBeenCalled();
-		expect(result).toBe(still);
 	});
 });

--- a/lib/connectors/plugins/animated-image-chain.ts
+++ b/lib/connectors/plugins/animated-image-chain.ts
@@ -1,0 +1,54 @@
+import set from "lodash/fp/set";
+import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
+import { getDefaultConnector } from "@/lib/config/connectorUtils";
+import { createConnector } from "../factory";
+import type {
+	AnimatedImageGenerateParams,
+	AssetResult,
+	ConnectorPlugin,
+} from "../types";
+import { buildImagePlugins } from "./imageChain";
+
+const STASH_KEY = "videoPrompt";
+
+export function createVideoChainPlugin(
+	registry: ConnectorRegistry,
+): ConnectorPlugin<AnimatedImageGenerateParams, AssetResult> {
+	return {
+		name: "video-chain",
+		beforeGenerate(params, ctx) {
+			const { videoPrompt, ...rest } = params;
+			if (videoPrompt && ctx) {
+				ctx.data ??= {};
+				ctx.data[STASH_KEY] = videoPrompt;
+			}
+			return rest as AnimatedImageGenerateParams;
+		},
+		async afterGenerate(result, ctx) {
+			const videoPrompt = ctx?.data?.[STASH_KEY] as string | undefined;
+			if (!videoPrompt) return result;
+			const { provider, config } = getDefaultConnector(registry, "video");
+			const video = createConnector(
+				"video",
+				provider,
+				set("plugins", [], config),
+			);
+			const videoResult = await video.generate({
+				prompt: videoPrompt,
+				frameImages: [result.url],
+			});
+			return {
+				url: videoResult.url,
+				durationSec: videoResult.durationSec,
+				previewUrl: result.url,
+			};
+		},
+	};
+}
+
+export function buildAnimatedImagePlugins(
+	projectId: string,
+	registry: ConnectorRegistry,
+): ConnectorPlugin[] {
+	return [...buildImagePlugins(projectId), createVideoChainPlugin(registry)];
+}

--- a/lib/connectors/plugins/animated-image-chain.ts
+++ b/lib/connectors/plugins/animated-image-chain.ts
@@ -26,7 +26,11 @@ export function createVideoChainPlugin(
 		},
 		async afterGenerate(result, ctx) {
 			const videoPrompt = ctx?.data?.[STASH_KEY] as string | undefined;
-			if (!videoPrompt) return result;
+			if (!videoPrompt) {
+				throw new Error(
+					"animated_image element is missing required videoPrompt attribute",
+				);
+			}
 			const { provider, config } = getDefaultConnector(registry, "video");
 			const video = createConnector(
 				"video",

--- a/lib/connectors/plugins/osml.ts
+++ b/lib/connectors/plugins/osml.ts
@@ -45,10 +45,8 @@ const OSML_SYSTEM_PROMPT = dedent`
 	- For both character and narration tags, the emotion attribute should be appropriately set to one of the following: ${Object.values(TTSEmotion).join(", ")}.
 
   ### Image XML Tags
-  - Each scene should include an image XML tag that describes the current scene with required attributes: animate, animation. Example:
-		<image animate="true" animation="slow zoom out revealing the full landscape">A dark forest with a clearing in the center. A full moon shines through the trees, casting eerie shadows.</image>
-  - animate: Include a required animate attribute that is either "true" or "false". This controls whether the image is animated or static.
-  - animation: If animate is "true", include an animation attribute that describes the motion/camera movement for the video. The animation description should be simple, focused, and relaxing.
+  - Each scene should include an image XML tag that describes the current scene. Example:
+		<image>A dark forest with a clearing in the center. A full moon shines through the trees, casting eerie shadows.</image>
   - motion: Optional camera-motion effect applied for the element's full duration. Use sparingly — at most one per scene, and prefer omitting when the image already carries the energy. Example: <image motion="kenBurnsIn">...</image>
   - Allowed motion values: ${MOTION_EFFECTS.join(", ")}
 	- characters: Include a comma-separated list of character names that occur in the image. These should be characters from the story with their exact names. Example:
@@ -60,10 +58,19 @@ const OSML_SYSTEM_PROMPT = dedent`
   - Overlays should be a comma-separated list containing any of the following: ${Object.values(
 		EffectType,
 	).join(", ")}
-  - Image descriptions should describe the characters (along with their gender, age, ethnicity, species, hair color, eye color, skin tone, clothing, and physical appearances), the time of day, the background, the weather (if outdoors), and objects in detail.
-  - Each <image> description must be written as a fully standalone prompt, as if the generative image model has absolutely no knowledge of the story, characters, prior images, or previous prompts.
-  - The first time a character is mentioned in each image tag description, describe the character next to their name. Example: "Kirito, a black haired Japanese boy with brown eyes and a white shirt..."
-  - Each image description should include all relevant details about the scene (except for art style), even if this requires repeating details from previous descriptions or the story.
+  - Image descriptions should describe the time of day, the background, the weather (if outdoors), and objects in detail.
+  - Each <image> description must be written as a standalone prompt, as if the generative image model has absolutely no knowledge of the story, prior images, or previous prompts.
+	- Reference characters by their names in the image description, no need to redescribe their appearance
+  - Each image description should include all relevant details about the scene (except for art style and character descriptions), even if this requires repeating details from previous descriptions or the story.
+
+  ### Animated Image XML Tags
+  - An <animated_image> tag is an <image> tag whose still frame is then animated by an image-to-video model. Use it for hero moments, establishing shots, or emotional beats that benefit from subtle motion. The tag body describes the still frame in the same way as an <image>; the videoPrompt attribute describes the camera/subject motion. Example:
+		<animated_image videoPrompt="slow zoom out revealing the full landscape" motion="kenBurnsIn" characters="Red,Wolf" overlays="rain">A dark forest with a clearing in the center. A full moon shines through the trees, casting eerie shadows. Red (a cheerful girl with warm brown skin, dark curly hair in two puffs, brown eyes, wearing a bright red hooded cloak) walks beside Wolf (a large gray wolf with kind amber eyes, soft thick fur).</animated_image>
+  - videoPrompt: required. A short, focused, relaxing description of the motion or camera movement (e.g. "slow cinematic pan", "gentle dolly in", "warm zoom on the character's face"). Keep it simple — one camera move per shot.
+  - motion: optional. Same enum as for <image>. Allowed motion values: ${MOTION_EFFECTS.join(", ")}.
+  - characters: optional. Same as for <image> — a comma-separated list of exact story character names appearing in the frame. Example: <animated_image videoPrompt="..." characters="Red,Granny">Red hands the basket to Granny at the cottage door.</animated_image>
+  - All <image> description rules apply unchanged: write a prompt that describes the time of day, background, weather, and objects in detail. Repeat any details necessary even if they appeared in earlier prompts.
+  - Use <animated_image> sparingly — mostly at intro shots and hero moments. Default to <image> for typical scenes; image-to-video generation is significantly slower and more expensive.
 
   ### Sound XML Tags
   - Frequently break up character (including narration) dialogue to insert <sound> tags (as if prompting a sound model) that should accompany a scene.

--- a/lib/connectors/plugins/refine.ts
+++ b/lib/connectors/plugins/refine.ts
@@ -35,7 +35,8 @@ const REFINE_SYSTEM_PROMPT = dedent`
   ## Common attributes by type
   - **narration**: emotion
   - **character**: name, emotion
-  - **image**: animate, animation, overlays, motion (${MOTION_EFFECTS.join(" | ")})
+  - **image**: overlays, motion (${MOTION_EFFECTS.join(" | ")})
+  - **animated_image**: videoPrompt (camera/subject motion description), overlays, motion (${MOTION_EFFECTS.join(" | ")})
   - **sound**: loops (number, default 1)
   - **music**: length (${vals(MusicLength)}), loops (number, default 1)
   - **clip**: duration (in seconds), volume (0-10), motion (${MOTION_EFFECTS.join(" | ")})

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -2,7 +2,14 @@ import type { GatewayClient } from "@/lib/gateway/base";
 import type { WithMetadata } from "@/lib/providers/base";
 import type { TTSGender, TTSSpeed } from "./tts/enums";
 
-export type ConnectorType = "llm" | "music" | "sfx" | "image" | "tts" | "video";
+export type ConnectorType =
+	| "llm"
+	| "music"
+	| "sfx"
+	| "image"
+	| "animated_image"
+	| "tts"
+	| "video";
 
 export type ProviderKey = "openslop";
 
@@ -11,6 +18,7 @@ export type VoiceSearchFn = (params: VoiceSearchParams) => Promise<VoiceInfo[]>;
 export interface PluginContext<TParams = unknown, TResult = unknown> {
 	gateway?: GatewayClient<TParams, TResult>;
 	searchVoices?: VoiceSearchFn;
+	data?: Record<string, unknown>;
 }
 
 export interface ConnectorPlugin<TParams = unknown, TResult = unknown> {
@@ -48,7 +56,11 @@ export type ConnectorGenerateParams = {
 	model?: string;
 };
 
-export type AssetResult = { url: string; durationSec: number };
+export type AssetResult = {
+	url: string;
+	durationSec: number;
+	previewUrl?: string;
+};
 
 export interface Connector {
 	readonly type: ConnectorType;
@@ -103,6 +115,10 @@ export type ImageGenerateParams = ConnectorGenerateParams & {
 	width?: number;
 	height?: number;
 	referenceImages?: string[];
+};
+
+export type AnimatedImageGenerateParams = ImageGenerateParams & {
+	videoPrompt?: string;
 };
 
 // TTS types

--- a/lib/project/__tests__/ensureCharacterAvatars.test.ts
+++ b/lib/project/__tests__/ensureCharacterAvatars.test.ts
@@ -16,6 +16,13 @@ const registry = {
 			isDefault: true,
 		},
 	},
+	animated_image: {
+		openslop: {
+			defaultModel: "test-model",
+			models: ["test-model"],
+			isDefault: true,
+		},
+	},
 	llm: {
 		openslop: { defaultModel: "m", models: ["m"], isDefault: true },
 	},

--- a/lib/project/__tests__/serialize.test.ts
+++ b/lib/project/__tests__/serialize.test.ts
@@ -15,6 +15,7 @@ const connectors: ConnectorRegistry = {
 	llm: connector,
 	tts: connector,
 	image: connector,
+	animated_image: connector,
 	video: connector,
 	sfx: connector,
 	music: connector,

--- a/lib/project/__tests__/thumbnail.test.ts
+++ b/lib/project/__tests__/thumbnail.test.ts
@@ -8,12 +8,15 @@ const entry = (
 	id: string,
 	connectorType: ConnectorType | null,
 	url: string | null,
+	previewUrl?: string,
 ): [string, ElementSnapshot] => [
 	id,
 	{
 		status: "idle",
 		seconds: 0,
-		result: url ? { url, durationSec: 0 } : null,
+		result: url
+			? { url, durationSec: 0, ...(previewUrl && { previewUrl }) }
+			: null,
 		error: null,
 		resultInputs: null,
 		connectorType,
@@ -57,5 +60,20 @@ describe("pickThumbnailUrl", () => {
 				entry("scene-1", "image", "scene.png"),
 			]),
 		).toBe("scene.png");
+	});
+
+	it("accepts animated_image and prefers previewUrl over the video url", () => {
+		expect(
+			pickThumbnailUrl([
+				entry("1", "tts", "n.mp3"),
+				entry("2", "animated_image", "video.mp4", "still.png"),
+			]),
+		).toBe("still.png");
+	});
+
+	it("falls back to animated_image url when no previewUrl is present", () => {
+		expect(pickThumbnailUrl([entry("1", "animated_image", "video.mp4")])).toBe(
+			"video.mp4",
+		);
 	});
 });

--- a/lib/project/thumbnail.ts
+++ b/lib/project/thumbnail.ts
@@ -6,8 +6,12 @@ export function pickThumbnailUrl(
 ): string | null {
 	for (const [id, snap] of entries) {
 		if (id.startsWith(CHARACTER_AVATAR_ID_PREFIX)) continue;
-		if (snap.connectorType !== "image") continue;
-		const url = snap.result?.url;
+		if (
+			snap.connectorType !== "image" &&
+			snap.connectorType !== "animated_image"
+		)
+			continue;
+		const url = snap.result?.previewUrl ?? snap.result?.url;
 		if (url) return url;
 	}
 	return null;

--- a/lib/providers/__tests__/runware-video.test.ts
+++ b/lib/providers/__tests__/runware-video.test.ts
@@ -52,6 +52,9 @@ describe("RunwareVideo", () => {
 					frameImages: undefined,
 					referenceImages: undefined,
 				},
+				settings: {
+					audio: false,
+				},
 			});
 			expect(mockDisconnect).toHaveBeenCalled();
 		});

--- a/lib/providers/llm/mock.ts
+++ b/lib/providers/llm/mock.ts
@@ -19,13 +19,13 @@ const MOCK_SCRIPT = `<metadata_title>Little Red</metadata_title>
 
 <metadata_character name="Granny" gender="feminine" age="adult" pitch="medium" accent="american" description="caring, gentle, melodic">Red's grandmother, a small elderly woman with deep brown skin, silver hair in a bun, twinkling hazel eyes behind round spectacles, wearing a soft purple shawl.</metadata_character>
 
-<image animate="true" animation="slow pan across the village to the forest path" motion="kenBurnsOut">A peaceful village at the edge of a lush green forest on a sunny morning. A cozy cottage with a red door sits near the forest path. Birds fly overhead. Flowers bloom along the dirt path leading into the woods.</image>
+<animated_image videoPrompt="slow pan across the village to the forest path" motion="kenBurnsOut">A peaceful village at the edge of a lush green forest on a sunny morning. A cozy cottage with a red door sits near the forest path. Birds fly overhead. Flowers bloom along the dirt path leading into the woods.</animated_image>
 
 <music length="medium">Gentle, playful orchestral music with flutes and strings, lighthearted and cheerful</music>
 
 <narration emotion="cheerful">Once upon a time, in a village at the edge of a great forest, there lived a kind girl named Red.</narration>
 
-<image animate="true" animation="warm dolly in toward the kitchen window" motion="pushIn" characters="Red,Mother">Inside a sunlit kitchen with copper pots hanging on the wall, Red (a cheerful girl with brown skin, dark curly hair in two puffs, brown eyes, wearing a bright red hooded cloak and a white dress) stands beside her Mother (a tall woman with warm brown skin, long black braided hair tied back with a green ribbon, kind dark eyes, wearing a long blue dress and a flour-dusted apron). Mother gently places a wicker basket of fresh vegetables in Red's hands.</image>
+<image motion="pushIn" characters="Red,Mother">Inside a sunlit kitchen with copper pots hanging on the wall, Red (a cheerful girl with brown skin, dark curly hair in two puffs, brown eyes, wearing a bright red hooded cloak and a white dress) stands beside her Mother (a tall woman with warm brown skin, long black braided hair tied back with a green ribbon, kind dark eyes, wearing a long blue dress and a flour-dusted apron). Mother gently places a wicker basket of fresh vegetables in Red's hands.</image>
 
 <character name="Mother" emotion="gentle">"Take these straight to Granny, sweetheart. And please don't dawdle along the way."</character>
 
@@ -41,7 +41,7 @@ const MOCK_SCRIPT = `<metadata_title>Little Red</metadata_title>
 
 <sound>footsteps on dirt path</sound>
 
-<image animate="true" animation="gentle pan upward through the forest canopy" motion="tiltUp" characters="Owl">High in the branches of an ancient oak, Owl (a tawny owl with copper and brown speckled feathers, enormous golden eyes, wearing a tiny silver pendant) watches with wisdom in her gaze. Sunlight filters through the leaves around her.</image>
+<animated_image videoPrompt="gentle pan upward through the forest canopy" motion="tiltUp" characters="Owl">High in the branches of an ancient oak, Owl (a tawny owl with copper and brown speckled feathers, enormous golden eyes, wearing a tiny silver pendant) watches with wisdom in her gaze. Sunlight filters through the leaves around her.</animated_image>
 
 <narration emotion="wonder">High above, Owl watched silently from the trees. She had been the keeper of these woods for longer than anyone could remember.</narration>
 
@@ -59,7 +59,7 @@ const MOCK_SCRIPT = `<metadata_title>Little Red</metadata_title>
 
 <narration emotion="calm">Wolf's mother had a terrible cold, and he wanted to bring her something special.</narration>
 
-<image animate="true" animation="warm camera dolly as the two meet on the path" characters="Red,Wolf">Red and Wolf meet face to face on a sunlit forest path. Red holds her vegetable basket; Wolf holds his berry basket. Both look surprised but unafraid. A shaft of golden light falls between them. Wildflowers grow along the path.</image>
+<image characters="Red,Wolf">Red and Wolf meet face to face on a sunlit forest path. Red holds her vegetable basket; Wolf holds his berry basket. Both look surprised but unafraid. A shaft of golden light falls between them. Wildflowers grow along the path.</image>
 
 <character name="Red" emotion="curious">"Oh! Hello, Mr. Wolf. Are those berries for someone special?"</character>
 
@@ -79,7 +79,7 @@ const MOCK_SCRIPT = `<metadata_title>Little Red</metadata_title>
 
 <character name="Red" emotion="proud">"She tells the best stories! And she knits the warmest mittens. And she always has cookies."</character>
 
-<image animate="true" animation="wide reveal as they round a bend" motion="panLeft" characters="Red,Wolf,Hunter">A clearing where the forest path meets a sturdy bridge over a stream. Hunter (a broad-shouldered woodsman with a thick brown beard, blue eyes, wearing a green cloak with a hatchet at his belt) stands by the bridge waving warmly at Red and Wolf as they approach. His sturdy brown boots crunch on the gravel.</image>
+<image motion="panLeft" characters="Red,Wolf,Hunter">A clearing where the forest path meets a sturdy bridge over a stream. Hunter (a broad-shouldered woodsman with a thick brown beard, blue eyes, wearing a green cloak with a hatchet at his belt) stands by the bridge waving warmly at Red and Wolf as they approach. His sturdy brown boots crunch on the gravel.</image>
 
 <character name="Hunter" emotion="hearty">"Well now! Little Red and her woodland friend! You two heading to the old oak cottage?"</character>
 
@@ -91,7 +91,7 @@ const MOCK_SCRIPT = `<metadata_title>Little Red</metadata_title>
 
 <narration emotion="warm">They thanked Hunter and crossed the little bridge, the stream singing beneath their feet.</narration>
 
-<image animate="true" animation="slow push-in toward the cottage door" motion="kenBurnsIn" characters="Granny">A small thatched cottage nestled among ancient oaks, with smoke curling from the chimney and a window box of bright marigolds. Granny (a small elderly woman with deep brown skin, silver hair in a bun, twinkling hazel eyes behind round spectacles, wearing a soft purple shawl) stands at the open door, leaning on a wooden cane, smiling warmly.</image>
+<animated_image videoPrompt="slow push-in toward the cottage door" motion="kenBurnsIn" characters="Granny">A small thatched cottage nestled among ancient oaks, with smoke curling from the chimney and a window box of bright marigolds. Granny (a small elderly woman with deep brown skin, silver hair in a bun, twinkling hazel eyes behind round spectacles, wearing a soft purple shawl) stands at the open door, leaning on a wooden cane, smiling warmly.</animated_image>
 
 <character name="Granny" emotion="delighted">"Red, my darling! And who is this handsome fellow you've brought along?"</character>
 `;
@@ -126,7 +126,7 @@ const MOCK_REFINEMENTS: RefinementFactory[] = [
 	() =>
 		[
 			`{"op":"insert","position":"before","type":"narration","text":"Long ago, in a land of endless forests..."}`,
-			`{"op":"insert","position":"before","type":"image","attrs":{"animate":"true"},"text":"A sweeping aerial view of an ancient forest stretching to the horizon"}`,
+			`{"op":"insert","position":"before","type":"animated_image","attrs":{"videoPrompt":"slow aerial drift over the canopy"},"text":"A sweeping aerial view of an ancient forest stretching to the horizon"}`,
 		].join("\n"),
 
 	// Multiple set ops on different elements (tests independent edits)

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -40,6 +40,9 @@ export class RunwareVideo extends BaseVideoProvider {
 					frameImages: params.frameImages,
 					referenceImages: params.referenceImages,
 				},
+				settings: {
+					audio: false,
+				},
 			});
 
 			const video = Array.isArray(result) ? result[0] : result;

--- a/lib/script/refine/__tests__/applyOps.test.ts
+++ b/lib/script/refine/__tests__/applyOps.test.ts
@@ -75,6 +75,9 @@ const connectors: ConnectorRegistry = {
 	image: {
 		openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },
 	},
+	animated_image: {
+		openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },
+	},
 	video: {
 		openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },
 	},

--- a/lib/script/refine/types.ts
+++ b/lib/script/refine/types.ts
@@ -1,12 +1,12 @@
 import { z } from "zod";
+import {
+	CANVAS_ELEMENT_TYPES,
+	type CanvasElementType,
+} from "@/lib/canvas/types";
 
-const canvasElementType = z.enum([
-	"narration",
-	"character",
-	"image",
-	"clip",
-	"sound",
-	"music",
+const canvasElementType = z.enum([...CANVAS_ELEMENT_TYPES] as [
+	CanvasElementType,
+	...CanvasElementType[],
 ]);
 
 const insertOp = z.object({

--- a/lib/video/__tests__/resolve.test.ts
+++ b/lib/video/__tests__/resolve.test.ts
@@ -107,6 +107,7 @@ describe("resolveElements", () => {
 	it("assigns correct roles and layers for all element types", () => {
 		const types: CanvasContentElement["type"][] = [
 			"image",
+			"animated_image",
 			"clip",
 			"narration",
 			"character",
@@ -119,6 +120,7 @@ describe("resolveElements", () => {
 		const roleMap = Object.fromEntries(resolved.map((r) => [r.type, r.role]));
 		expect(roleMap).toEqual({
 			image: "foreground",
+			animated_image: "foreground",
 			clip: "foreground",
 			narration: "overlay",
 			character: "overlay",
@@ -129,6 +131,7 @@ describe("resolveElements", () => {
 		const layerMap = Object.fromEntries(resolved.map((r) => [r.type, r.layer]));
 		expect(layerMap).toEqual({
 			image: "visual",
+			animated_image: "visual",
 			clip: "visual",
 			narration: "audio",
 			character: "audio",

--- a/lib/video/transitions.ts
+++ b/lib/video/transitions.ts
@@ -24,6 +24,9 @@ export type TransitionType = (typeof TRANSITION_TYPES)[number];
 export const DEFAULT_TRANSITION: TransitionType = "none";
 export const TRANSITION_DURATION_SEC = 0.4;
 export const AUDIO_FADE_SEC = 2;
+// Lead time to mount foreground video before it's visible so it decodes ahead
+// of the transition and doesn't stall the Player (which would stutter audio).
+export const VIDEO_PREMOUNT_SEC = 2;
 
 type Dimensions = { width: number; height: number };
 

--- a/lib/video/types.ts
+++ b/lib/video/types.ts
@@ -6,6 +6,7 @@ export type ElementRole = "foreground" | "background" | "overlay" | "effect";
 
 export const ELEMENT_ROLES: Record<CanvasElementType, ElementRole> = {
 	image: "foreground",
+	animated_image: "foreground",
 	clip: "foreground",
 	narration: "overlay",
 	character: "overlay",
@@ -17,6 +18,7 @@ export type LayerType = "audio" | "visual";
 
 export const LAYER_TYPES: Record<CanvasElementType, LayerType> = {
 	image: "visual",
+	animated_image: "visual",
 	clip: "visual",
 	narration: "audio",
 	character: "audio",

--- a/remotion/compositions/VideoComposition.tsx
+++ b/remotion/compositions/VideoComposition.tsx
@@ -59,7 +59,6 @@ function SequenceContent({ element }: { element: ResolvedElement }) {
 						<OffthreadVideo
 							src={element.url}
 							style={coverStyle}
-							pauseWhenBuffering
 							volume={element.volume / 10}
 						/>
 					)}

--- a/remotion/compositions/VideoComposition.tsx
+++ b/remotion/compositions/VideoComposition.tsx
@@ -13,7 +13,11 @@ import type {
 	Sequence as SeqType,
 	ResolvedElement,
 } from "@/lib/video/types";
-import { AUDIO_FADE_SEC, getPresentation } from "@/lib/video/transitions";
+import {
+	AUDIO_FADE_SEC,
+	VIDEO_PREMOUNT_SEC,
+	getPresentation,
+} from "@/lib/video/transitions";
 import { audioVolume } from "@/lib/video/audioVolume";
 import { MotionLayer } from "../components/MotionLayer";
 
@@ -42,8 +46,8 @@ function AudioSequence({ element }: { element: ResolvedElement }) {
 		<Html5Audio
 			src={element.url}
 			crossOrigin="anonymous"
-			pauseWhenBuffering
 			volume={volume}
+			pauseWhenBuffering
 		/>
 	);
 }
@@ -60,6 +64,7 @@ function SequenceContent({ element }: { element: ResolvedElement }) {
 							src={element.url}
 							style={coverStyle}
 							volume={element.volume / 10}
+							pauseWhenBuffering
 						/>
 					)}
 				</MotionLayer>
@@ -108,6 +113,7 @@ export const VideoComposition: React.FC<VideoLayout> = ({
 					)}
 					<TransitionSeries.Sequence
 						durationInFrames={toFrames(seq.duration, fps)}
+						premountFor={toFrames(VIDEO_PREMOUNT_SEC, fps)}
 					>
 						<SeriesEntry seq={seq} />
 					</TransitionSeries.Sequence>


### PR DESCRIPTION
## Summary
- New `<animated_image>` OSML tag + canvas element that generates a still image and then animates it through the video connector. Final asset is a video; the still is preserved as `previewUrl` so the canvas preview can toggle between still and animated views (Remotion / scene-builder / resolve only ever see the video URL).
- New `animated_image` connector reuses the image gateway and pipes results through the standard image plugin chain (art-style, character references, reference images) plus a new `video-chain` plugin that re-runs the video connector with the still URL as `frameImages`.
- New modular `TextAttributePopover` for freeform-text attribute editing (used for `videoPrompt`); `AttributeSpec.edit` is now a `{kind:"enum"|"text"}` discriminated union — all existing enum specs migrated.
- OSML prompt rewritten: `<image>` drops `animate`/`animation`; new `<animated_image videoPrompt="...">` tag documented with the full image-tag attribute set (motion, characters, overlays) restated inline.
- Animated images get character add/remove just like regular image elements; element card uses a distinct fuchsia color.
- Unrelated test fix: assert new `settings.audio: false` field in `runware-video` test (matches existing local change in `lib/providers/video/runware.ts`).

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run test:run` (763 passing, includes new osmlSerializer + animated-image-chain unit tests + extended resolve fixture)
- [ ] Manual: generate a story containing `<animated_image videoPrompt="...">`; confirm the queue runs the chained image→video generation, the canvas preview shows the still by default with a working toggle to the video, the Remotion timeline plays the animated clip in place, and editing `videoPrompt` via the new textarea popover invalidates the cached result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)