### PR TITLE
refactor: nightly maintainability 2026-05-18

### DIFF
--- a/app/components/canvas/utils/__tests__/getGenerationInputs.test.ts
+++ b/app/components/canvas/utils/__tests__/getGenerationInputs.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { LAYOUT_ATTRIBUTE_KEYS } from "@/lib/video/elementAttributes";
+import type { CanvasContentElement } from "../../types";
+import { getGenerationInputs } from "../getGenerationInputs";
+
+const element = (
+	customAttributes: Record<string, string>,
+): CanvasContentElement => ({
+	id: "el-1",
+	type: "clip",
+	customAttributes,
+	children: [{ id: "t-1", type: "clip", text: "a dragon flying" }],
+});
+
+describe("getGenerationInputs", () => {
+	it("keeps generation-affecting attributes", () => {
+		const { prompt, attributes } = getGenerationInputs(
+			element({ model: "Slop Video v1", duration: "5", provider: "openslop" }),
+		);
+		expect(prompt).toBe("a dragon flying");
+		expect(attributes).toEqual({
+			model: "Slop Video v1",
+			duration: "5",
+			provider: "openslop",
+		});
+	});
+
+	it("strips exactly the centralized LAYOUT_ATTRIBUTE_KEYS contract", () => {
+		const layoutOnly = Object.fromEntries(
+			LAYOUT_ATTRIBUTE_KEYS.map((k) => [k, "1"]),
+		);
+		const { attributes } = getGenerationInputs(
+			element({ ...layoutOnly, model: "Slop Video v1" }),
+		);
+		for (const key of LAYOUT_ATTRIBUTE_KEYS) {
+			expect(attributes).not.toHaveProperty(key);
+		}
+		expect(attributes).toEqual({ model: "Slop Video v1" });
+	});
+});

--- a/app/components/canvas/utils/getGenerationInputs.ts
+++ b/app/components/canvas/utils/getGenerationInputs.ts
@@ -1,15 +1,14 @@
 import omit from "lodash/omit";
 import type { GenerationInputs } from "@/lib/generation/queue";
+import { LAYOUT_ATTRIBUTE_KEYS } from "@/lib/video/elementAttributes";
 import type { CanvasContentElement } from "../types";
 import { getPromptText } from "./getPromptText";
-
-const NON_GENERATION_ATTRIBUTES = ["loops", "volume", "motion"] as const;
 
 export function getGenerationInputs(
 	element: CanvasContentElement,
 ): GenerationInputs {
 	return {
 		prompt: getPromptText(element),
-		attributes: omit(element.customAttributes ?? {}, NON_GENERATION_ATTRIBUTES),
+		attributes: omit(element.customAttributes ?? {}, LAYOUT_ATTRIBUTE_KEYS),
 	};
 }

--- a/lib/video/elementAttributes.ts
+++ b/lib/video/elementAttributes.ts
@@ -5,17 +5,6 @@ import {
 	type MotionEffect,
 } from "./motionEffects";
 
-/**
- * Single boundary for reading layout-affecting element `customAttributes`.
- *
- * These values are stored as raw strings on the element but consumed as typed,
- * clamped numbers by `resolveElements`, while `getLayoutKey` must include the
- * same fields so memoized layouts invalidate when they change. Keeping both the
- * coercion rules and the field list here is the only place to change when a new
- * layout-affecting attribute is added — the resolver and the memo key can no
- * longer drift apart.
- */
-
 /** Raw attribute keys that, when changed, require a layout recompute. */
 export const LAYOUT_ATTRIBUTE_KEYS = ["loops", "volume", "motion"] as const;
 


### PR DESCRIPTION
## Summary
- centralize generation-input filtering to the shared layout attribute contract
- add regression test to enforce contract alignment and prevent silent drift
- tighten maintainability docs/comments around the contract boundary

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm test -- --passWithNoTests