### PR TITLE
perf: nightly performance optimizations 2026-05-18

### DIFF
--- a/app/components/ComposerHero.tsx
+++ b/app/components/ComposerHero.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useScript } from "@/lib/script/ScriptProvider";
+import { useScriptControl } from "@/lib/script/ScriptProvider";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import BackToMySlopLink from "./BackToMySlopLink";
 import ComposerCopilot from "./copilot/ComposerCopilot";
@@ -21,7 +21,7 @@ there was a small glowing garden hidden on the moon.
 And in that garden… lived a little rabbit named Lumi…`;
 
 export default function ComposerHero() {
-	const { submitPrompt } = useScript();
+	const { submitPrompt } = useScriptControl();
 	const { mode, applyTemplate } = useConfig();
 	const [value, setValue] = useState("");
 

--- a/app/components/Editor.tsx
+++ b/app/components/Editor.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useScript, useScriptText } from "@/lib/script/ScriptProvider";
+import { useScriptControl, useScriptText } from "@/lib/script/ScriptProvider";
 import PrePromptView from "./PrePromptView";
 import PostPromptView from "./PostPromptView";
 
 export default function Editor() {
-	const { loading } = useScript();
+	const { loading } = useScriptControl();
 	const script = useScriptText();
 	const hasScript = script.length > 0 || loading;
 

--- a/app/components/PostPromptView.tsx
+++ b/app/components/PostPromptView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useRef, useState } from "react";
-import { useScript } from "@/lib/script/ScriptProvider";
+import { useScriptControl } from "@/lib/script/ScriptProvider";
 import {
 	useGenerationQueue,
 	useQueueSelector,
@@ -26,7 +26,7 @@ import editorStyles from "./Editor.module.css";
 import genStyles from "./styles/gen-button.module.css";
 
 function PostPromptViewInner() {
-	const { loading: scriptLoading, stopGeneration } = useScript();
+	const { loading: scriptLoading, stopGeneration } = useScriptControl();
 	const canvasRef = useRef<CanvasHandle>(null);
 	const [layoutKey, setLayoutKey] = useState("");
 	const [refineValue, setRefineValue] = useState("");

--- a/app/components/canvas/ProjectTitle.tsx
+++ b/app/components/canvas/ProjectTitle.tsx
@@ -4,12 +4,12 @@ import { useState } from "react";
 import { Pencil } from "lucide-react";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getProjectStore, useProjectStore } from "@/lib/project/store";
-import { useScript } from "@/lib/script/ScriptProvider";
+import { useScriptControl } from "@/lib/script/ScriptProvider";
 
 export function ProjectTitle() {
 	const { projectId } = useConfig();
 	const title = useProjectStore(projectId, (s) => s.metadata.title);
-	const { loading } = useScript();
+	const { loading } = useScriptControl();
 	const [editing, setEditing] = useState(false);
 	const [draft, setDraft] = useState("");
 

--- a/app/components/canvas/hooks/useMetadataSync.ts
+++ b/app/components/canvas/hooks/useMetadataSync.ts
@@ -2,12 +2,12 @@ import { useEffect } from "react";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getProjectStore } from "@/lib/project/store";
 import type { DeepPartial, Metadata } from "@/lib/project/types";
-import { useScript } from "@/lib/script/ScriptProvider";
+import { useScriptNodes } from "@/lib/script/ScriptProvider";
 import { METADATA_TAG_CONFIGS } from "../config/metadataTags";
 import { OSMLSerializer } from "../utils/osmlSerializer";
 
 export function useMetadataSync(): void {
-	const { nodes } = useScript();
+	const nodes = useScriptNodes();
 	const { projectId } = useConfig();
 
 	useEffect(() => {

--- a/app/components/canvas/hooks/useScriptSync.ts
+++ b/app/components/canvas/hooks/useScriptSync.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { Editor, Transforms } from "slate";
-import { useScript } from "@/lib/script/ScriptProvider";
+import { useScriptNodes } from "@/lib/script/ScriptProvider";
 import {
 	CANVAS_ELEMENT_TYPES,
 	type CanvasContentElement,
@@ -18,7 +18,7 @@ function shouldSkip(node: ParsedElement): boolean {
 }
 
 export function useScriptSync(editor: Editor): void {
-	const { nodes } = useScript();
+	const nodes = useScriptNodes();
 
 	useEffect(() => {
 		// `nodes` is capped at MAX_NODES_TO_SYNC (3) by useOSMLSerializer,

--- a/app/components/video/VideoPanel.tsx
+++ b/app/components/video/VideoPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useScript } from "@/lib/script/ScriptProvider";
+import { useScriptControl } from "@/lib/script/ScriptProvider";
 import { useLayout } from "./VideoLayoutContext";
 import { VideoPreview } from "./VideoPreview";
 import { RenderControls } from "./RenderControls";
@@ -9,7 +9,7 @@ import { PlayerShimmer } from "./PlayerShimmer";
 
 function VideoPanelBody() {
 	const { layout, ready, playerKey } = useLayout();
-	const { loading: scriptLoading } = useScript();
+	const { loading: scriptLoading } = useScriptControl();
 
 	if (scriptLoading) {
 		return (
@@ -31,7 +31,7 @@ function VideoPanelBody() {
 
 export function VideoPanel() {
 	const { layout, ready } = useLayout();
-	const { loading: scriptLoading } = useScript();
+	const { loading: scriptLoading } = useScriptControl();
 	const showControls = !scriptLoading && !!layout?.series.length && ready;
 
 	return (

--- a/lib/script/ScriptProvider.tsx
+++ b/lib/script/ScriptProvider.tsx
@@ -15,19 +15,29 @@ import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import { createConnector } from "@/lib/connectors/factory";
 import { useOSMLSerializer } from "@/app/components/canvas/hooks/useOSMLSerializer";
 
-type ScriptContextValue = {
-	nodes: ParsedElement[];
+type ScriptControl = {
 	loading: boolean;
 	submitPrompt: (prompt: string) => Promise<void>;
 	stopGeneration: () => void;
 };
 
-const ScriptContext = createContext<ScriptContextValue | null>(null);
+// `nodes` is rebuilt on every streamed token, so it lives in its own context
+// to keep low-frequency controls from re-rendering the editor shell per token.
+const ScriptNodesContext = createContext<ParsedElement[] | null>(null);
+const ScriptControlContext = createContext<ScriptControl | null>(null);
 const ScriptTextContext = createContext<string>("");
 
-export function useScript() {
-	const ctx = use(ScriptContext);
-	if (!ctx) throw new Error("useScript must be used within ScriptProvider");
+export function useScriptNodes() {
+	const ctx = use(ScriptNodesContext);
+	if (!ctx)
+		throw new Error("useScriptNodes must be used within ScriptProvider");
+	return ctx;
+}
+
+export function useScriptControl() {
+	const ctx = use(ScriptControlContext);
+	if (!ctx)
+		throw new Error("useScriptControl must be used within ScriptProvider");
 	return ctx;
 }
 
@@ -84,21 +94,18 @@ export function ScriptProvider({
 		[llmProvider, llmConfig, appendChunk],
 	);
 
-	const value = useMemo<ScriptContextValue>(
-		() => ({
-			nodes,
-			loading,
-			submitPrompt,
-			stopGeneration,
-		}),
-		[nodes, loading, submitPrompt, stopGeneration],
+	const control = useMemo<ScriptControl>(
+		() => ({ loading, submitPrompt, stopGeneration }),
+		[loading, submitPrompt, stopGeneration],
 	);
 
 	return (
-		<ScriptContext.Provider value={value}>
-			<ScriptTextContext.Provider value={script}>
-				{children}
-			</ScriptTextContext.Provider>
-		</ScriptContext.Provider>
+		<ScriptControlContext.Provider value={control}>
+			<ScriptNodesContext.Provider value={nodes}>
+				<ScriptTextContext.Provider value={script}>
+					{children}
+				</ScriptTextContext.Provider>
+			</ScriptNodesContext.Provider>
+		</ScriptControlContext.Provider>
 	);
 }


### PR DESCRIPTION
## Summary
- isolate high-frequency streamed `nodes` from low-frequency script controls in `ScriptProvider`
- migrate control-only consumers to `useScriptControl()` and sync hooks to `useScriptNodes()`
- prevent editor shell rerenders on every streamed token while preserving behavior

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build *(fails in this environment at `/login` prerender due to missing Supabase env vars; compile+typecheck succeed)*
- npm run test:run
- npm test -- --passWithNoTests