### PR TITLE
feat: word-by-word captions for narration and character

### DIFF
--- a/app/components/canvas/config/elementConfigs.tsx
+++ b/app/components/canvas/config/elementConfigs.tsx
@@ -49,6 +49,7 @@ const VOLUME_OPTIONS = [
 	"10",
 ] as const;
 const EMOTION_OPTIONS = Object.values(TTSEmotion);
+const CAPTIONS_OPTIONS = ["on", "off"] as const;
 
 const volumeSpec = (color: string): AttributeSpec => ({
 	color,
@@ -66,6 +67,12 @@ const motionSpec = (color: string): AttributeSpec => ({
 	color,
 	label: "Motion",
 	edit: { kind: "enum", options: MOTION_EFFECTS },
+});
+
+const captionsSpec = (color: string): AttributeSpec => ({
+	color,
+	label: "Captions",
+	edit: { kind: "enum", options: CAPTIONS_OPTIONS },
 });
 
 const videoPromptSpec = (color: string): AttributeSpec => ({
@@ -90,6 +97,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		defaultAttributes: {
 			volume: "10",
 			speed: "medium",
+			captions: "on",
 		},
 		visibleAttributes: {
 			emotion: {
@@ -99,6 +107,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 			},
 			speed: speedSpec("bg-slate-500"),
 			volume: volumeSpec("bg-slate-500"),
+			captions: captionsSpec("bg-slate-500"),
 		},
 	},
 	character: {
@@ -112,6 +121,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		defaultAttributes: {
 			volume: "10",
 			speed: "medium",
+			captions: "on",
 		},
 		visibleAttributes: {
 			emotion: {
@@ -121,6 +131,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 			},
 			speed: speedSpec("bg-amber-600"),
 			volume: volumeSpec("bg-amber-600"),
+			captions: captionsSpec("bg-amber-600"),
 		},
 	},
 	image: {

--- a/app/components/video/RenderControls.tsx
+++ b/app/components/video/RenderControls.tsx
@@ -16,7 +16,7 @@ function formatBytes(bytes: number): string {
 }
 
 const pillClass =
-	"flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 backdrop-blur-xl shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12)]";
+	"flex items-center gap-2 rounded-lg border border-white/10 bg-card/90 px-3 py-2 backdrop-blur-xl shadow-md shadow-black/20 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12)]";
 
 export function RenderControls({ layout }: { layout: VideoLayout }) {
 	const { state, render, reset } = useRendering();
@@ -29,7 +29,7 @@ export function RenderControls({ layout }: { layout: VideoLayout }) {
 						type="button"
 						onClick={() => render(layout)}
 						aria-label="Export Video"
-						className="relative grain rounded-lg bg-[#1f1528]/60 p-2 text-violet-300 opacity-0 transition-[opacity,filter] hover:brightness-[1.3] group-hover:opacity-100"
+						className="relative grain rounded-lg bg-[#1f1528]/90 p-2 text-violet-300 opacity-0 shadow-md shadow-black/25 transition-[opacity,filter] hover:brightness-[1.3] group-hover:opacity-100"
 					>
 						<Download size={16} />
 					</button>
@@ -45,7 +45,7 @@ export function RenderControls({ layout }: { layout: VideoLayout }) {
 				<Loader2 size={14} className="animate-spin text-white/60" />
 				<div className="flex flex-col gap-1">
 					<span className="text-xs text-white/80">{state.phase}</span>
-					<div className="h-1 w-32 overflow-hidden rounded-full bg-white/10">
+					<div className="h-1 w-32 overflow-hidden rounded-full bg-white/15">
 						<div
 							className="h-full rounded-full bg-violet-500 transition-all"
 							style={{ width: `${state.progress * 100}%` }}

--- a/lib/connectors/plugins/osml.ts
+++ b/lib/connectors/plugins/osml.ts
@@ -30,7 +30,7 @@ const OSML_SYSTEM_PROMPT = dedent`
   - The narration element is the primary voice of the story.
   - All narrative prose should be wrapped in narration XML tags. Example:
     <narration emotion="neutral">The sun was setting in the west, casting a warm glow on the forest.</narration>
-  - The only supported attribute for narration tags is emotion
+  - Supported attributes for narration tags are emotion and captions
 
   ### Character Dialogue XML Tags
   - Each character's entire dialogue is wrapped in character XML tags with required attributes being name and emotion. Example:
@@ -39,10 +39,11 @@ const OSML_SYSTEM_PROMPT = dedent`
   - Frequently use nonverbalisms to exaggerate the emotion. Example: <character name="Mia" emotion="happy">[laughter] That's the way I want it!</character>.
   - Allowed list of nonverbalisms: [laughter]. Do not use any other nonverbalisms.
   - Occasionally insert ellipsis (...) to indicate a pause or a break in the dialogue, or use exclamations (!) to indicate a strong emotion or action.
-	- The only supported attribute for character tags is emotion
+	- Supported attributes for character tags are name, emotion, and captions
 
 	### Narration and Character XML Tags
 	- For both character and narration tags, the emotion attribute should be appropriately set to one of the following: ${Object.values(TTSEmotion).join(", ")}.
+	- The optional captions attribute is "on" or "off" (default "on") and controls whether on-screen subtitle text is overlaid during the element's audio.
 
   ### Image XML Tags
   - Each scene should include an image XML tag that describes the current scene. Example:

--- a/lib/connectors/plugins/refine.ts
+++ b/lib/connectors/plugins/refine.ts
@@ -33,8 +33,8 @@ const REFINE_SYSTEM_PROMPT = dedent`
   ${ELEMENT_TYPES}
 
   ## Common attributes by type
-  - **narration**: emotion
-  - **character**: name, emotion
+  - **narration**: emotion, captions (on | off)
+  - **character**: name, emotion, captions (on | off)
   - **image**: overlays, motion (${MOTION_EFFECTS.join(" | ")})
   - **animated_image**: videoPrompt (camera/subject motion description), overlays, motion (${MOTION_EFFECTS.join(" | ")})
   - **sound**: loops (number, default 1)

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -60,6 +60,7 @@ export type AssetResult = {
 	url: string;
 	durationSec: number;
 	previewUrl?: string;
+	textTimestamps?: TextTimestamp[];
 };
 
 export interface Connector {

--- a/lib/video/__tests__/elementAttributes.test.ts
+++ b/lib/video/__tests__/elementAttributes.test.ts
@@ -65,18 +65,29 @@ describe("getMotion", () => {
 
 describe("layoutAttributeSignature", () => {
 	it("joins raw layout attribute values in LAYOUT_ATTRIBUTE_KEYS order", () => {
-		expect(LAYOUT_ATTRIBUTE_KEYS).toEqual(["loops", "volume", "motion"]);
+		expect(LAYOUT_ATTRIBUTE_KEYS).toEqual([
+			"loops",
+			"volume",
+			"motion",
+			"captions",
+		]);
 		expect(
 			layoutAttributeSignature(
-				el({ loops: "2", volume: "5", motion: "kenBurnsIn" }),
+				el({
+					loops: "2",
+					volume: "5",
+					motion: "kenBurnsIn",
+					captions: "off",
+				}),
 			),
-		).toBe("2:5:kenBurnsIn");
+		).toBe("2:5:kenBurnsIn:off");
 	});
 
 	it("uses empty segments for absent attributes (raw, uncoerced)", () => {
-		expect(layoutAttributeSignature(el())).toBe("::");
-		expect(layoutAttributeSignature(el({ loops: "0" }))).toBe("0::");
-		expect(layoutAttributeSignature(el({ volume: "10" }))).toBe(":10:");
-		expect(layoutAttributeSignature(el({ motion: "shake" }))).toBe("::shake");
+		expect(layoutAttributeSignature(el())).toBe(":::");
+		expect(layoutAttributeSignature(el({ loops: "0" }))).toBe("0:::");
+		expect(layoutAttributeSignature(el({ volume: "10" }))).toBe(":10::");
+		expect(layoutAttributeSignature(el({ motion: "shake" }))).toBe("::shake:");
+		expect(layoutAttributeSignature(el({ captions: "off" }))).toBe(":::off");
 	});
 });

--- a/lib/video/elementAttributes.ts
+++ b/lib/video/elementAttributes.ts
@@ -6,7 +6,12 @@ import {
 } from "./motionEffects";
 
 /** Raw attribute keys that, when changed, require a layout recompute. */
-export const LAYOUT_ATTRIBUTE_KEYS = ["loops", "volume", "motion"] as const;
+export const LAYOUT_ATTRIBUTE_KEYS = [
+	"loops",
+	"volume",
+	"motion",
+	"captions",
+] as const;
 
 const VOLUME_MIN = 0;
 const VOLUME_MAX = 10;
@@ -29,6 +34,10 @@ export function getLoops(element: CanvasContentElement): number {
 export function getMotion(element: CanvasContentElement): MotionEffect {
 	const raw = element.customAttributes?.motion;
 	return isMotionEffect(raw) ? raw : DEFAULT_MOTION;
+}
+
+export function areCaptionsEnabled(element: CanvasContentElement): boolean {
+	return element.customAttributes?.captions !== "off";
 }
 
 /**

--- a/lib/video/resolve.ts
+++ b/lib/video/resolve.ts
@@ -3,7 +3,12 @@ import { getContentElements } from "@/lib/canvas/scenes";
 import type { ElementSnapshot } from "@/lib/generation/queue";
 import type { ResolvedElement } from "./types";
 import { ELEMENT_ROLES, LAYER_TYPES } from "./types";
-import { getLoops, getMotion, getVolume } from "./elementAttributes";
+import {
+	areCaptionsEnabled,
+	getLoops,
+	getMotion,
+	getVolume,
+} from "./elementAttributes";
 
 export function resolveElements(
 	elements: CanvasElement[],
@@ -15,6 +20,10 @@ export function resolveElements(
 		const snapshot = getSnapshot(el.id);
 		if (!snapshot.result) continue;
 
+		const timestamps = snapshot.result.textTimestamps;
+		const captionTimestamps =
+			areCaptionsEnabled(el) && timestamps?.length ? timestamps : undefined;
+
 		resolved.push({
 			id: el.id,
 			type: el.type,
@@ -25,6 +34,7 @@ export function resolveElements(
 			loops: getLoops(el),
 			volume: getVolume(el),
 			motion: getMotion(el),
+			captionTimestamps,
 		});
 	}
 

--- a/lib/video/types.ts
+++ b/lib/video/types.ts
@@ -1,4 +1,5 @@
 import type { CanvasElementType } from "@/lib/canvas/types";
+import type { TextTimestamp } from "@/lib/connectors/types";
 import type { MotionEffect } from "./motionEffects";
 import type { TransitionType } from "./transitions";
 
@@ -36,6 +37,7 @@ export type ResolvedElement = {
 	loops: number;
 	volume: number;
 	motion: MotionEffect;
+	captionTimestamps?: TextTimestamp[];
 };
 
 export type Sequence = {

--- a/remotion/components/Captions.tsx
+++ b/remotion/components/Captions.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from "react";
+import sortedLastIndex from "lodash/sortedLastIndex";
+import { AbsoluteFill, useCurrentFrame, useVideoConfig } from "remotion";
+import type { TextTimestamp } from "@/lib/connectors/types";
+
+const MAX_LINE_WIDTH_RATIO = 0.8;
+const FONT_SIZE_RATIO = 0.065;
+// Approximate average glyph advance for uppercase bold Geist, in em units.
+// Used to translate the max pixel width into a character cap without measuring.
+const AVG_CHAR_WIDTH_EM = 0.6;
+
+const container: React.CSSProperties = {
+	justifyContent: "flex-end",
+	alignItems: "center",
+	paddingBottom: "5%",
+	pointerEvents: "none",
+	userSelect: "none",
+};
+
+// 8-direction layered shadow outline. Avoids the miter spikes that
+// -webkit-text-stroke produces at acute glyph corners, and adds a soft drop
+// shadow for legibility over busy frames.
+const OUTLINE = "0.06em";
+const textShadow = [
+	`${OUTLINE} 0 0 black`,
+	`-${OUTLINE} 0 0 black`,
+	`0 ${OUTLINE} 0 black`,
+	`0 -${OUTLINE} 0 black`,
+	`${OUTLINE} ${OUTLINE} 0 black`,
+	`-${OUTLINE} ${OUTLINE} 0 black`,
+	`${OUTLINE} -${OUTLINE} 0 black`,
+	`-${OUTLINE} -${OUTLINE} 0 black`,
+	"0 0.08em 0.2em rgba(0, 0, 0, 0.55)",
+].join(", ");
+
+const text: React.CSSProperties = {
+	fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
+	fontWeight: 700,
+	letterSpacing: "-0.01em",
+	color: "white",
+	textShadow,
+	textAlign: "left",
+	textTransform: "uppercase",
+	whiteSpace: "nowrap",
+};
+
+function computeChunkStarts(
+	timestamps: readonly TextTimestamp[],
+	maxChars: number,
+): number[] {
+	const starts: number[] = [];
+	if (timestamps.length === 0) return starts;
+	starts.push(0);
+	let len = timestamps[0].text.length;
+	for (let i = 1; i < timestamps.length; i++) {
+		const wordLen = timestamps[i].text.length;
+		const next = len + 1 + wordLen;
+		if (next > maxChars) {
+			starts.push(i);
+			len = wordLen;
+		} else {
+			len = next;
+		}
+	}
+	return starts;
+}
+
+export function Captions({ timestamps }: { timestamps: TextTimestamp[] }) {
+	const frame = useCurrentFrame();
+	const { fps, width, height } = useVideoConfig();
+	const fontSizePx = height * FONT_SIZE_RATIO;
+	const maxChars = Math.max(
+		1,
+		Math.floor(
+			(width * MAX_LINE_WIDTH_RATIO) / (fontSizePx * AVG_CHAR_WIDTH_EM),
+		),
+	);
+
+	const startTimes = useMemo(
+		() => timestamps.map((ts) => ts.start),
+		[timestamps],
+	);
+	const starts = useMemo(
+		() => computeChunkStarts(timestamps, maxChars),
+		[timestamps, maxChars],
+	);
+
+	if (starts.length === 0) return null;
+
+	const seconds = frame / fps;
+	const wordIndex = sortedLastIndex(startTimes, seconds) - 1;
+	if (wordIndex < 0) return null;
+
+	const chunkStart = starts[sortedLastIndex(starts, wordIndex) - 1];
+	const visible = timestamps
+		.slice(chunkStart, wordIndex + 1)
+		.map((ts) => ts.text)
+		.join(" ");
+
+	return (
+		<AbsoluteFill style={container}>
+			<div
+				style={{
+					width: `${MAX_LINE_WIDTH_RATIO * 100}%`,
+					fontSize: fontSizePx,
+				}}
+			>
+				<span style={text}>{visible}</span>
+			</div>
+		</AbsoluteFill>
+	);
+}

--- a/remotion/compositions/VideoComposition.tsx
+++ b/remotion/compositions/VideoComposition.tsx
@@ -19,6 +19,7 @@ import {
 	getPresentation,
 } from "@/lib/video/transitions";
 import { audioVolume } from "@/lib/video/audioVolume";
+import { Captions } from "../components/Captions";
 import { MotionLayer } from "../components/MotionLayer";
 
 const coverStyle: React.CSSProperties = {
@@ -43,12 +44,17 @@ function AudioSequence({ element }: { element: ResolvedElement }) {
 		[gain, durationInFrames, fadeFrames],
 	);
 	return (
-		<Html5Audio
-			src={element.url}
-			crossOrigin="anonymous"
-			volume={volume}
-			pauseWhenBuffering
-		/>
+		<>
+			<Html5Audio
+				src={element.url}
+				crossOrigin="anonymous"
+				volume={volume}
+				pauseWhenBuffering
+			/>
+			{element.captionTimestamps && (
+				<Captions timestamps={element.captionTimestamps} />
+			)}
+		</>
 	);
 }
 


### PR DESCRIPTION
## Summary

- Adds a per-element `captions` attribute (default on) to narration and character elements, mirroring how `loops`/`volume`/`motion` work: stored in `customAttributes`, surfaced as a Captions dropdown badge, and included in `LAYOUT_ATTRIBUTE_KEYS` so toggling triggers a layout recompute.
- Wires existing Cartesia per-word `TextTimestamp[]` through `AssetResult` → `ResolvedElement.captionTimestamps`, and renders them via a new `remotion/components/Captions.tsx`: words accumulate left-to-right on a single line bounded by ~80% of the video width (derived from `useVideoConfig` width/height + an em-based average glyph width — no DOM measurement). Layered `text-shadow` outline avoids the miter spikes that `-webkit-text-stroke` produces. Binary searches use `lodash/sortedLastIndexBy` and `lodash/sortedLastIndex`.
- Documents the new `captions` attribute in both the OSML and refine LLM prompts.
- Darkens `RenderControls` (`bg-card/90` + outer drop shadow) so the floating pill and idle download button stay legible over any preview background, while keeping the app's translucent/glassy aesthetic.

## Test plan

- [ ] `npm run lint && npm run format:check && npm run typecheck && npm run test:run` all pass locally
- [ ] Generate a narration element and play the preview — verify words appear in sync, accumulate on a single line, and reset when the line fills
- [ ] Toggle the new Captions badge to `off` — overlay disappears, audio unchanged, layout key changes
- [ ] Repeat for a character element
- [ ] Ask the LLM (refine) to "turn captions off for the first narration" — emits a `set` op with `attrs: { captions: "off" }`
- [ ] Render preview over a white frame — `RenderControls` pill and idle download button remain clearly visible in all states (idle / rendering / done / error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)