### PR TITLE
feat: finance tips template + popover/runware tweaks

### DIFF
--- a/app/components/canvas/elements/attributes/TextAttributePopover.tsx
+++ b/app/components/canvas/elements/attributes/TextAttributePopover.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import { ChevronDown } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { ReactEditor, useSlateStatic } from "slate-react";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
 import type { CanvasContentElement } from "../../types";
 import { setNodeAttrs } from "../../utils/editorOps";
 
@@ -30,12 +35,7 @@ export function TextAttributePopover({
 	const editor = useSlateStatic();
 	const [open, setOpen] = useState(false);
 	const [draft, setDraft] = useState(value);
-	const containerRef = useRef<HTMLDivElement>(null);
-
-	const openPopover = () => {
-		setDraft(value);
-		setOpen(true);
-	};
+	const cancelRef = useRef(false);
 
 	const commit = useCallback(
 		(next: string) => {
@@ -46,66 +46,62 @@ export function TextAttributePopover({
 		[editor, element, attrKey, value],
 	);
 
-	useEffect(() => {
-		if (!open) return;
-		const handlePointer = (e: MouseEvent) => {
-			if (!containerRef.current?.contains(e.target as Node)) {
-				commit(draft);
-				setOpen(false);
-			}
-		};
-		document.addEventListener("mousedown", handlePointer);
-		return () => document.removeEventListener("mousedown", handlePointer);
-	}, [open, draft, commit]);
+	const handleOpenChange = (next: boolean) => {
+		if (next) {
+			setDraft(value);
+		} else if (cancelRef.current) {
+			setDraft(value);
+		} else {
+			commit(draft);
+		}
+		cancelRef.current = false;
+		setOpen(next);
+	};
 
 	return (
-		<div ref={containerRef} className="relative inline-block">
-			<button
-				type="button"
-				aria-label={tooltip}
-				title={tooltip}
-				onClick={() => {
-					if (open) {
-						commit(draft);
-						setOpen(false);
-					} else {
-						openPopover();
-					}
-				}}
-				className={`${color} text-white text-[12px] px-2 py-1 rounded-full max-w-[140px] inline-flex items-center gap-1.5 cursor-pointer ring-1 ring-inset ring-white/20 hover:ring-white/50 hover:brightness-110 transition-all`}
-			>
-				<span className="truncate min-w-0">
-					<span className={value ? "opacity-70 mr-1" : "opacity-90"}>
-						{label}
+		<Popover open={open} onOpenChange={handleOpenChange}>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					aria-label={tooltip}
+					title={tooltip}
+					className={`${color} text-white text-[12px] px-2 py-1 rounded-full max-w-[140px] inline-flex items-center gap-1.5 cursor-pointer ring-1 ring-inset ring-white/20 hover:ring-white/50 hover:brightness-110 transition-all`}
+				>
+					<span className="truncate min-w-0">
+						<span className={value ? "opacity-70 mr-1" : "opacity-90"}>
+							{label}
+						</span>
+						{value ? value : <span className="opacity-50 ml-1">— add</span>}
 					</span>
-					{value ? value : <span className="opacity-50 ml-1">— add</span>}
-				</span>
-				<ChevronDown className="w-3 h-3 shrink-0 text-white/80" />
-			</button>
-			{open && (
-				<div className="absolute left-0 top-full z-50 mt-1 w-72 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-1.5">
-					<textarea
-						autoFocus
-						rows={rows}
-						value={draft}
-						placeholder={placeholder}
-						onChange={(e) => setDraft(e.target.value)}
-						onKeyDown={(e) => {
-							if (e.key === "Escape") {
-								setDraft(value);
-								setOpen(false);
-							} else if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-								commit(draft);
-								setOpen(false);
-							}
-						}}
-						className="w-full resize-none rounded-lg border border-white/10 bg-white/5 px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
-					/>
-					<div className="mt-1 px-1 text-[10px] text-white/40">
-						⌘↵ to save · esc to cancel
-					</div>
+					<ChevronDown className="w-3 h-3 shrink-0 text-white/80" />
+				</button>
+			</PopoverTrigger>
+			<PopoverContent
+				align="start"
+				sideOffset={4}
+				onEscapeKeyDown={() => {
+					cancelRef.current = true;
+				}}
+				className="w-72 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-1.5"
+			>
+				<textarea
+					autoFocus
+					rows={rows}
+					value={draft}
+					placeholder={placeholder}
+					onChange={(e) => setDraft(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+							commit(draft);
+							setOpen(false);
+						}
+					}}
+					className="w-full resize-none rounded-lg border border-white/10 bg-white/5 px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
+				/>
+				<div className="mt-1 px-1 text-[10px] text-white/40">
+					⌘↵ to save · esc to cancel
 				</div>
-			)}
-		</div>
+			</PopoverContent>
+		</Popover>
 	);
 }

--- a/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
+++ b/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
@@ -21,7 +21,7 @@ export function AnimatedImagePreview({
 	stale,
 	onRegenerate,
 }: AnimatedImagePreviewProps) {
-	const [mode, setMode] = useState<"animated" | "still">("still");
+	const [mode, setMode] = useState<"animated" | "still">("animated");
 	const isAnimated = mode === "animated";
 
 	return (

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import * as React from "react";
+import { Popover as PopoverPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Popover({
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+	return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+	return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverAnchor({
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+	return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+function PopoverContent({
+	className,
+	align = "center",
+	sideOffset = 4,
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+	return (
+		<PopoverPrimitive.Portal>
+			<PopoverPrimitive.Content
+				data-slot="popover-content"
+				align={align}
+				sideOffset={sideOffset}
+				className={cn(
+					"z-50 origin-(--radix-popover-content-transform-origin) outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+					className,
+				)}
+				{...props}
+			/>
+		</PopoverPrimitive.Portal>
+	);
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/lib/connectors/plugins/osml.ts
+++ b/lib/connectors/plugins/osml.ts
@@ -36,7 +36,7 @@ const OSML_SYSTEM_PROMPT = dedent`
   - Each character's entire dialogue is wrapped in character XML tags with required attributes being name and emotion. Example:
     <narration emotion="neutral">Lyra steps forward. </narration>
     <character name="Lyra" emotion="excited">Truce?</character>
-  - Frequently use nonverbalisms to exaggerate the emotion. Example: <character name="Mia" emotion="happy">[laughter] That's the way I want it!</character>.
+  - Frequently use nonverbalisms. Example: <character name="Mia" emotion="happy">[laughter] That's the way I want it!</character>.
   - Allowed list of nonverbalisms: [laughter]. Do not use any other nonverbalisms.
   - Occasionally insert ellipsis (...) to indicate a pause or a break in the dialogue, or use exclamations (!) to indicate a strong emotion or action.
 	- Supported attributes for character tags are name, emotion, and captions

--- a/lib/providers/__tests__/anthropic-llm.test.ts
+++ b/lib/providers/__tests__/anthropic-llm.test.ts
@@ -20,7 +20,7 @@ describe("AnthropicLLM", () => {
 		it("returns text and usage with defaults", async () => {
 			mockCreate.mockResolvedValue({
 				content: [{ type: "text", text: "Hello world" }],
-				model: "claude-sonnet-4-5-20250929",
+				model: "claude-opus-4-7",
 				usage: { input_tokens: 10, output_tokens: 5 },
 			});
 
@@ -29,11 +29,11 @@ describe("AnthropicLLM", () => {
 
 			expect(result).toEqual({
 				text: "Hello world",
-				model: "claude-sonnet-4-5-20250929",
+				model: "claude-opus-4-7",
 				usage: { inputTokens: 10, outputTokens: 5 },
 			});
 			expect(mockCreate).toHaveBeenCalledWith({
-				model: "claude-sonnet-4-5-20250929",
+				model: "claude-opus-4-7",
 				max_tokens: 8192,
 				temperature: undefined,
 				system: undefined,

--- a/lib/providers/llm/anthropic.ts
+++ b/lib/providers/llm/anthropic.ts
@@ -28,7 +28,7 @@ export class AnthropicLLM extends BaseProvider<
 
 	private buildRequest(params: LLMGenerateParams) {
 		return {
-			model: params.model || "claude-sonnet-4-5-20250929",
+			model: params.model || "claude-opus-4-7",
 			max_tokens: params.maxTokens || 8192,
 			temperature: params.temperature,
 			system: params.systemPrompt || undefined,

--- a/lib/providers/runware.ts
+++ b/lib/providers/runware.ts
@@ -12,10 +12,6 @@ export async function withRunware<T>(
 	});
 	try {
 		return await fn(runware);
-	} catch (e) {
-		throw e instanceof Error
-			? e
-			: new Error(typeof e === "string" ? e : JSON.stringify(e));
 	} finally {
 		runware.disconnect?.();
 	}

--- a/lib/providers/runware.ts
+++ b/lib/providers/runware.ts
@@ -4,9 +4,18 @@ export async function withRunware<T>(
 	apiKey: string,
 	fn: (runware: InstanceType<typeof Runware>) => Promise<T>,
 ): Promise<T> {
-	const runware = new Runware({ apiKey });
+	const runware = new Runware({
+		apiKey,
+		timeoutDuration: 180_000,
+		shouldReconnect: true,
+		globalMaxRetries: 3,
+	});
 	try {
 		return await fn(runware);
+	} catch (e) {
+		throw e instanceof Error
+			? e
+			: new Error(typeof e === "string" ? e : JSON.stringify(e));
 	} finally {
 		runware.disconnect?.();
 	}

--- a/lib/templates/templates.ts
+++ b/lib/templates/templates.ts
@@ -322,6 +322,213 @@ export const TEMPLATES: Template[] = [
 			#Narration: Tonight, Beauregard was nowhere to be seen. The garden was empty of dog, empty of human, empty of fuss. Marlowe began to walk the length of the wall.`,
 	},
 	{
+		id: "finance-tips",
+		name: "Finance Tips",
+		pillText: "Finance tips for...",
+		color: "#3B82F6",
+		referenceImages: [
+			"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/finance-tips-2",
+			"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/finance-tips-3",
+			"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/finance-tips-4",
+		],
+		characters: {
+			Ethan: {
+				description: "American male, neutral accent",
+				appearance:
+					"man with short light brown hair parted to the side, oversized rounded head with prominent chin and double-chin, small oval eyes with tiny black pupils, thin arched eyebrows, long pointed nose, small mouth. Bean-shaped body with stubby limbs. Wearing a blue hoodie and blue pants with white sneakers",
+				avatarUrl:
+					"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/finance-tips-1",
+			},
+		},
+		narration: {
+			gender: "masculine",
+			age: "adult",
+			pitch: "neutral",
+			accent: "american",
+			description: "wise",
+		},
+		showcase: {
+			image:
+				"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/finance-tips-4",
+			title: "Finance tips",
+			description: "Long-form, stories to teach personal finance lessons",
+			examplePrompt:
+				"Subscriptions, bank fees, impulse buys, unused gym memberships - the money leaks most people ignore",
+		},
+		systemPrompt: dedent`
+			# Important
+			- The main character is always called Ethan, and the Ethan must always be present in the character list of images where relevant
+			- The art style is: Flat 2D cartoon, Family Guy-style: bold black outlines, cel-shaded flat colors, oversized rounded heads with prominent chins, small oval eyes, bean-shaped bodies, stubby limbs. Vector-style props with thick outlines. Saturated colors. YouTube explainer-cartoon aesthetic. Plain white background.
+			- Do not generate character metadata for Ethan, but do use him like a regular character in the story
+			- Ethan is a man with short light brown hair parted to the side, oversized rounded head with prominent chin and double-chin, small oval eyes with tiny black pupils, thin arched eyebrows, long pointed nose, small mouth. Bean-shaped body with stubby limbs. Wearing a blue hoodie and blue pants with white sneakers`,
+		exampleText: dedent`
+			#Image: Black screen. White Arial text: "You're leaking money every month."
+			#Sound: [single water drip echoing in a quiet room]
+			#Narration: You're leaking money every month.
+
+			#Animated Image: Ethan stares at a bathtub as dollar bills swirl down the drain. He reaches in too late — the last bill slips away.
+			#Narration: Right now. Today. And you probably don't even know it's happening.
+
+			#Animated Image: Ethan holds up a sign that says "$86/month." It flips to reveal "$219/month." His eyes go wide.
+			#Narration: A big study asked Americans how much they spend on subscriptions every month. They guessed about 86 dollars. The real number? 219 dollars.
+
+			#Animated Image: Giant red text slams onto the screen behind Ethan — "$133 EXTRA / MONTH." His jaw drops to the floor.
+			#Narration: That's 133 dollars more than people think. Every. Single. Month.
+
+			#Animated Image: A pie chart spins next to Ethan. A 42% red slice pops out as he points at it.
+			#Narration: And 42 percent of people are paying for stuff they already stopped using.
+
+			#Animated Image: Ethan sits at a dark kitchen table, face lit by his phone. The screen shows "$43.17" with a red arrow pointing down. A question mark floats above his head.
+			#Narration: Meet Ethan. He's 28. He makes 55 thousand dollars a year. Last week, he checked his bank account and it was almost empty. He had no idea why.
+
+			#Animated Image: Ethan slumps on a couch. Dollar bills float up around him and disappear into the ceiling, one by one.
+			#Narration: By the end of this video, Ethan is going to find 200 dollars hiding in his own bank statement. And so are you. My name is Nick. Today we're hunting down the five money leaks almost everyone has.
+
+			#Image: Title card — "Leak 1: The Gym You Don't Go To"
+			#Sound: [squeaky treadmill belt, then silence]
+			#Narration: Leak number one. The gym you don't go to.
+
+			#Animated Image: Ethan stands in workout clothes in an empty gym. A single treadmill hums on its own behind him. Tumbleweed rolls past.
+			#Narration: There are 77 million gym members in America. Half of them quit going in the first six months. But they keep paying.
+
+			#Animated Image: Ethan holds up a shiny gym card. The price "$69 / MONTH" stamps onto the screen behind him.
+			#Narration: The average gym costs 69 dollars a month.
+
+			#Animated Image: Ethan peeks through a Planet Fitness window. Text floats above him — "60% never visit in 30 days." Crickets chirp inside.
+			#Narration: At Planet Fitness, 60 percent of members don't even step inside once in a whole month. The gym only works because most people stay home.
+
+			#Animated Image: Ethan at a chalkboard writes "$69 × 12 = $828." He circles the answer, then sighs.
+			#Narration: If you pay and don't go, that's 828 dollars a year. Gone.
+
+			#Animated Image: Ethan holds up an envelope stamped "CANCELLATION LETTER." It grows arms and runs away from him.
+			#Narration: And here's the dirty trick. You can sign up online in two minutes. But to cancel? You have to go in person. Or mail them a letter. They make it hard on purpose.
+
+			#Image: Title card — "Leak 2: Streaming You Don't Watch"
+			#Sound: [TV static, then a quick channel-flip click]
+			#Narration: Leak number two. Streaming.
+
+			#Animated Image: Ethan on the couch points a remote. Netflix, Hulu, Disney+, and Paramount+ logos circle around his head like planets.
+			#Narration: The average American house pays for four streaming services. That adds up to 69 dollars a month. Over 800 dollars a year.
+
+			#Animated Image: Stats pop into the air next to Ethan one by one — "ESPN+: 26%" — "Hulu: 26%" — "Paramount+: 25%" — "Disney+: 23%." Each one lands with a thud.
+			#Narration: But here's the kicker. One in four people pay for these services and didn't watch them once last month. Not a single show.
+
+			#Animated Image: Ethan scrolls Netflix endlessly. His thumb gets tired. Popcorn sits cold next to him.
+			#Narration: Even Netflix — the most popular one — 17 percent of people haven't opened it in a month.
+
+			#Animated Image: A price tag in front of Ethan flips from "$15" to "$20." He winces but doesn't move.
+			#Narration: When prices go up by just 5 dollars, most people say they'll cancel. But they don't. They just keep paying.
+
+			#Image: Title card — "Leak 3: The Free Trial Trap"
+			#Sound: [mouse trap snapping shut]
+			#Narration: Leak number three. The free trial trap.
+
+			#Animated Image: Ethan reaches for a glowing mousetrap labeled "FREE 7-DAY TRIAL." The trap snaps shut on his credit card. He yelps.
+			#Narration: You sign up for a free trial. You type in your credit card. You forget. Seven days later — you're paying.
+
+			#Animated Image: Ethan opens his bank app. A red alert bubble pops up — "65% of Americans got charged." He clutches his chest.
+			#Narration: 65 percent of Americans have been charged because they forgot to cancel a free trial. That's two out of every three people.
+
+			#Animated Image: Ethan taps "Download" on his phone. A "DAY 1" stamp slams onto the screen. A speech bubble next to him reads "89%."
+			#Narration: 89 percent of people sign up for the free trial the same day they download the app. Then they never think about it again.
+
+			#Animated Image: Ethan signs up, then immediately taps "Cancel" with a sly grin. A pop-up emails him — "Wait! 50% off to come back!"
+			#Narration: Here's a trick almost nobody knows. The moment you sign up for any trial — go cancel it right away. The company will keep letting you use it until the trial ends. And when it does, they will often email you a better deal to come back.
+
+			#Image: Title card — "Halfway check-in"
+			#Sound: [soft synth chime, like a level-up sound]
+			#Narration: Halfway check-in. The next two leaks are the sneakiest of all.
+
+			#Animated Image: Ethan at his desk crosses items off a notepad. A list reads "Leak 1 ✓ Leak 2 ✓ Leak 3 ✓." He looks up with growing excitement.
+			#Narration: Ethan's been taking notes. He's already found three leaks in his own life. Let's keep going.
+
+			#Image: Title card — "Leak 4: The Protection Plan"
+			#Sound: [cash register cha-ching]
+			#Narration: Leak number four. The protection plan.
+
+			#Animated Image: Ethan holds a new TV box at a checkout. The cashier leans forward with a wide smile — "Want the protection plan?" Ethan freezes.
+			#Narration: You buy a TV. The cashier asks, "Want to add the protection plan?" The answer is almost always: no.
+
+			#Animated Image: Two giant glowing numbers float in the sky above Ethan — "$1.27 BILLION collected" and "$210 MILLION paid back." He stares up, mouth open.
+			#Narration: Last year, Lowe's made over a billion dollars selling warranties. They only paid back 210 million.
+
+			#Animated Image: A dollar bill rips in two in front of Ethan. He's left holding a tiny 17-cent scrap. The giant 83-cent piece flies into a store window.
+			#Narration: That means for every dollar you spend on a warranty, the store keeps 83 cents. You get back 17.
+
+			#Animated Image: Three appliance icons line up next to Ethan — a TV, microwave, and dishwasher. Tiny break percentages pop above each one. He points down the line.
+			#Narration: TVs only break 5 to 8 percent of the time. Microwaves, 12 percent. Dishwashers, 13 percent. The odds are on your side.
+
+			#Animated Image: Ethan flashes a thumbs up. Green text booms next to him — "SKIP THE WARRANTY."
+			#Narration: Skip it. Keep your cash. The only thing worth a warranty? A laptop. About one in three of those break.
+
+			#Image: Title card — "Leak 5: Zombie Spending"
+			#Sound: [low spooky moan with a heartbeat thump]
+			#Narration: Leak number five. Zombie spending.
+
+			#Animated Image: Ethan backs away as old subscription logos crawl out of a graveyard, zombie style. They claw their way onto his credit card.
+			#Narration: These are the worst. The subscription is dead to you. But it's still alive on your credit card.
+
+			#Animated Image: Ethan stares at a card floating in front of him — "60% forgot a recurring payment." He scratches his head.
+			#Narration: 60 percent of people have forgotten about a payment coming out every month. 71 percent say they waste at least 50 dollars a month on stuff they don't want anymore.
+
+			#Animated Image: Ethan punches numbers into a calculator. The screen flashes "$50 × 12 = $600." His shoulders drop.
+			#Narration: That's 600 dollars a year. For nothing.
+
+			#Animated Image: Ethan flips a calendar. Three months in a row are stamped red with a giant X. He winces with each flip.
+			#Narration: And here's the saddest part. When people finally notice, it takes them three to six months to actually cancel. That's half a year of paying for nothing.
+
+			#Animated Image: A factory machine labeled "BIG COMPANIES" runs in front of Ethan. A mechanical arm reaches into his pocket and pulls out dollar bills onto a conveyor belt.
+			#Narration: Here's the big secret. Every company you pay has set up a robot to take your money automatically. Your gym. Netflix. Your phone bill. They all know — if they didn't make it automatic, you'd stop paying.
+
+			#Animated Image: Ethan grabs a big red lever. He yanks it down. The conveyor belt reverses. Money pours back into his piggy bank. He grins.
+			#Narration: So here's the move. Turn that robot around. Make it pay you instead.
+
+			#Image: Title card — "The Fix"
+			#Sound: [wrench tightening a bolt with a satisfying clink]
+			#Narration: Okay. Here's how. It takes 15 minutes. Tonight.
+
+			#Animated Image: Close up of Ethan's iPhone. His thumb taps "Settings" → his name → "Subscriptions." A long list scrolls into view.
+			#Narration: Step one. The big one. If you have an iPhone, open Settings. Tap your name at the top. Tap Subscriptions. Every single thing you've signed up for will show up in one list.
+
+			#Animated Image: Ethan's thumb taps "Cancel" over and over. A counter ticks up — "1, 2, 3, 4, 5…" — and his smile grows bigger with each tap.
+			#Narration: Tap. Cancel. Tap. Cancel. Most people find 5 to 10 things they totally forgot about. On Android, open the Play Store, then Payments and Subscriptions. Same magic list.
+
+			#Animated Image: Ethan at his kitchen table holds a red marker. He circles repeating charges on his bank statement — one, two, three — as the numbers glow.
+			#Narration: Step two. Open your bank app. Look at the last three months. Circle every charge that shows up every month. Even the tiny ones. Especially the 4 dollar and 99 cent ones. Those are the hiding spots.
+
+			#Animated Image: Ethan types into his email search bar — "subscription, renewal, free trial." Old emails fly out of the screen and pile up around him.
+			#Narration: Step three. Search your email for "subscription", "renewal", and "free trial". You'll find stuff you forgot existed.
+
+			#Image: Title card — "The Subscription Freeze"
+			#Sound: [ice crystals forming, soft frosty crackle]
+			#Narration: Now here's the lazy trick. It's called the Subscription Freeze. Cancel everything at once. All of it.
+
+			#Animated Image: Ethan on the couch eats popcorn calmly. A clock ticks loud beside him. He shrugs — nothing to miss.
+			#Narration: Then wait. See what you actually miss. You can always sign back up with one click. Most people find they don't miss much at all.
+
+			#Animated Image: Ethan taps his bank app and sets up an auto-transfer. A glowing arrow labeled "$100 / month" flows out of his account and into a piggy bank.
+			#Narration: Now here's the part nobody talks about. Don't just save that money. Send it somewhere automatic. Set up your bank to move 100 dollars a month into a savings or investing account. Same way Netflix takes from you. But now it's working for you.
+
+			#Animated Image: Older Ethan with grey hair stands under a giant money tree. Leaves of cash drift down around him. A glowing "$632,000" hangs at the top.
+			#Narration: 100 dollars a month. Invested for 40 years. Grows into 632 thousand dollars. From the same money you were already losing.
+
+			#Animated Image: Ethan points at bold text that bounces onto the screen — "Can't do 12%? Start with 1%." A tiny coin drops into a piggy bank beside him.
+			#Narration: Can't save a hundred bucks? Start with one percent of your paycheck. You won't even feel it. In a year, you'll be saving more than most Americans.
+
+			#Animated Image: A dark screen. Ethan's silhouette stands small and hunched. White text appears next to him — "You pay. You forget. They win."
+			#Sound: [low, slow heartbeat]
+			#Narration: You pay. You forget. They win.
+
+			#Animated Image: The silhouette of Ethan slowly straightens up tall and strong. The text rewrites itself — "Or you can stop forgetting."
+			#Sound: [heartbeat speeds up, then a sharp inhale]
+			#Narration: Or you can stop forgetting.
+
+			#Image: Final title card — Ethan holds his phone up triumphantly. Text glows beside him: "Audit your bank statement. TONIGHT. 15 minutes."
+			#Sound: [phone alarm chime, then a satisfying click]
+			#Narration: 15 minutes. Open your phone. Tap Settings. Tap Subscriptions. The money is already yours. Go get it back.
+		`,
+	},
+	{
 		id: "kids-animated",
 		name: "Kids Animated",
 		pillText: "A kids animated story about",


### PR DESCRIPTION
## Summary
- Adds "Finance Tips" template with Ethan character, showcase, system prompt, and example script
- Refactors `TextAttributePopover` to use the shared shadcn `Popover` primitive (adds `components/ui/popover.tsx`)
- `AnimatedImagePreview` now defaults to the animated mode
- `withRunware` sets timeout/retry/reconnect options and normalizes thrown non-Error values
- Bumps default Anthropic model to `claude-opus-4-7`
- Minor OSML prompt tweak (drop "to exaggerate the emotion" qualifier)

## Test plan
- [ ] Open a project and verify the Finance Tips template appears in the showcase and generates a script
- [ ] Click a text attribute pill — popover opens, commits draft on outside click, cancels on Escape, saves on ⌘↵
- [ ] Animated image preview starts in animated mode
- [ ] Runware image generation succeeds with the new client options
- [ ] Anthropic LLM calls still succeed against the new default model

🤖 Generated with [Claude Code](https://claude.com/claude-code)