### PR TITLE
perf: nightly performance optimizations 2026-05-19

### DIFF
--- a/app/components/Editor.tsx
+++ b/app/components/Editor.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useScriptControl, useScriptText } from "@/lib/script/ScriptProvider";
+import {
+	useScriptControl,
+	useScriptHasContent,
+} from "@/lib/script/ScriptProvider";
 import PrePromptView from "./PrePromptView";
 import PostPromptView from "./PostPromptView";
 
 export default function Editor() {
 	const { loading } = useScriptControl();
-	const script = useScriptText();
-	const hasScript = script.length > 0 || loading;
+	const hasScript = useScriptHasContent() || loading;
 
 	return (
 		<div

--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -23,7 +23,7 @@ import { useGenerateAll } from "./hooks/useGenerateAll";
 import { useAutosave } from "./hooks/useAutosave";
 import { useProjectRehydrate } from "./hooks/useProjectRehydrate";
 import { useConfig } from "@/lib/config/ConfigProvider";
-import { useScriptText } from "@/lib/script/ScriptProvider";
+import { useScriptInitial } from "@/lib/script/ScriptProvider";
 import { useDragAndDrop } from "./dnd/useDragAndDrop";
 import { DragTransferContext } from "./dnd/DragTransferContext";
 import type { CanvasContentElement } from "./types";
@@ -69,7 +69,7 @@ export default function Canvas({
 	} = useDragAndDrop(editor, value);
 
 	const { projectId } = useConfig();
-	const initialScript = useScriptText();
+	const initialScript = useScriptInitial();
 	useProjectRehydrate(editor, initialScript);
 	useAutosave(projectId, value);
 

--- a/lib/script/ScriptProvider.tsx
+++ b/lib/script/ScriptProvider.tsx
@@ -25,7 +25,12 @@ type ScriptControl = {
 // to keep low-frequency controls from re-rendering the editor shell per token.
 const ScriptNodesContext = createContext<ParsedElement[] | null>(null);
 const ScriptControlContext = createContext<ScriptControl | null>(null);
-const ScriptTextContext = createContext<string>("");
+// The live script string changes per streamed token, but nothing renders it:
+// the shell only needs a stable "has any content" boolean, and the editor only
+// needs the initial script once for rehydration. Exposing those instead of the
+// raw string keeps the whole editor tree off the per-token render path.
+const ScriptHasContentContext = createContext(false);
+const ScriptInitialContext = createContext<string>("");
 
 export function useScriptNodes() {
 	const ctx = use(ScriptNodesContext);
@@ -41,8 +46,12 @@ export function useScriptControl() {
 	return ctx;
 }
 
-export function useScriptText() {
-	return use(ScriptTextContext);
+export function useScriptHasContent() {
+	return use(ScriptHasContentContext);
+}
+
+export function useScriptInitial() {
+	return use(ScriptInitialContext);
 }
 
 export function ScriptProvider({
@@ -53,7 +62,7 @@ export function ScriptProvider({
 	children: ReactNode;
 }) {
 	const { connectorConfig } = useConfig();
-	const [script, setScript] = useState(initialScript);
+	const [hasContent, setHasContent] = useState(initialScript.length > 0);
 	const [loading, setLoading] = useState(false);
 	const abortRef = useRef<AbortController | null>(null);
 	const { nodes, appendChunk } = useOSMLSerializer();
@@ -75,13 +84,14 @@ export function ScriptProvider({
 			const controller = new AbortController();
 			abortRef.current = controller;
 
-			setScript("");
+			setHasContent(false);
 			setLoading(true);
 			try {
 				const connector = createConnector("llm", llmProvider, llmConfig);
 				for await (const chunk of connector.stream({ prompt })) {
 					if (controller.signal.aborted) break;
-					setScript((prev) => prev + chunk.text);
+					if (!chunk.text) continue;
+					setHasContent(true);
 					appendChunk(chunk.text);
 				}
 			} finally {
@@ -102,9 +112,11 @@ export function ScriptProvider({
 	return (
 		<ScriptControlContext.Provider value={control}>
 			<ScriptNodesContext.Provider value={nodes}>
-				<ScriptTextContext.Provider value={script}>
-					{children}
-				</ScriptTextContext.Provider>
+				<ScriptInitialContext.Provider value={initialScript}>
+					<ScriptHasContentContext.Provider value={hasContent}>
+						{children}
+					</ScriptHasContentContext.Provider>
+				</ScriptInitialContext.Provider>
 			</ScriptNodesContext.Provider>
 		</ScriptControlContext.Provider>
 	);


### PR DESCRIPTION
## Summary
- remove per-token Script text state updates from the editor hot path
- split script context into:
  - `useScriptHasContent()` (boolean gate for pre/post prompt UI)
  - `useScriptInitial()` (stable one-time canvas rehydration input)
- prevent `Editor -> Canvas -> Slate` subtree rerenders on every streamed token during script generation

## Why this matters
Script streaming previously triggered global rerenders for each token despite consumers not needing live text. This change keeps behavior identical while reducing unnecessary React/Slate runtime work in the hottest interaction path.

## Validation
- `npm run build`
- `npm test -- --passWithNoTests`