### PR TITLE
fix: nightly bug fixes 2026-05-20

### DIFF
--- a/app/components/canvas/elements/preview/overlays.tsx
+++ b/app/components/canvas/elements/preview/overlays.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { X as XIcon, AlertCircle, Check, Copy } from "lucide-react";
 import {
 	Tooltip,
@@ -92,10 +92,23 @@ export function ResultOverlay({
 
 function ErrorMessage({ message }: { message: string }) {
 	const [copied, setCopied] = useState(false);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	useEffect(
+		() => () => {
+			if (timerRef.current) clearTimeout(timerRef.current);
+		},
+		[],
+	);
 	const handleCopy = async () => {
-		await navigator.clipboard.writeText(message);
+		try {
+			await navigator.clipboard.writeText(message);
+		} catch (e) {
+			console.error("Failed to copy error message:", e);
+			return;
+		}
 		setCopied(true);
-		setTimeout(() => setCopied(false), 1500);
+		if (timerRef.current) clearTimeout(timerRef.current);
+		timerRef.current = setTimeout(() => setCopied(false), 1500);
 	};
 	return (
 		<div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center px-12 py-2">

--- a/lib/components/Waveform.tsx
+++ b/lib/components/Waveform.tsx
@@ -210,10 +210,6 @@ export function Waveform({
 	}, [loading, draw]);
 
 	useEffect(() => {
-		draw();
-	}, [draw]);
-
-	useEffect(() => {
 		const c = canvasRef.current;
 		if (!c) return;
 		const ro = new ResizeObserver(() => drawRef.current());

--- a/lib/video/__tests__/elementAttributes.test.ts
+++ b/lib/video/__tests__/elementAttributes.test.ts
@@ -44,6 +44,25 @@ describe("getLoops", () => {
 	it("reads valid loop counts", () => {
 		expect(getLoops(el({ loops: "4" }))).toBe(4);
 	});
+
+	it("floors fractional loop counts to an integer", () => {
+		expect(getLoops(el({ loops: "4.7" }))).toBe(4);
+		expect(getLoops(el({ loops: "1.999" }))).toBe(1);
+	});
+
+	it("rejects Infinity and NaN, defaulting to 1", () => {
+		expect(getLoops(el({ loops: "Infinity" }))).toBe(1);
+		expect(getLoops(el({ loops: "-Infinity" }))).toBe(1);
+		expect(getLoops(el({ loops: "NaN" }))).toBe(1);
+	});
+
+	it("clamps absurdly large loop counts to a sane maximum", () => {
+		expect(getLoops(el({ loops: "999999999" }))).toBe(1000);
+	});
+
+	it("clamps negative loop counts to 1", () => {
+		expect(getLoops(el({ loops: "-5" }))).toBe(1);
+	});
 });
 
 describe("getMotion", () => {

--- a/lib/video/elementAttributes.ts
+++ b/lib/video/elementAttributes.ts
@@ -25,9 +25,13 @@ export function getVolume(element: CanvasContentElement): number {
 		: DEFAULT_VOLUME;
 }
 
-/** Loop count coerced to an integer of at least 1, defaulting to 1. */
+const LOOPS_MAX = 1000;
+
+/** Loop count coerced to an integer in [1, 1000], defaulting to 1. */
 export function getLoops(element: CanvasContentElement): number {
-	return Math.max(1, Number(element.customAttributes?.loops) || 1);
+	const raw = Number(element.customAttributes?.loops);
+	if (!Number.isFinite(raw)) return 1;
+	return Math.max(1, Math.min(LOOPS_MAX, Math.floor(raw)));
 }
 
 /** Motion effect validated against the known set, defaulting to "none". */


### PR DESCRIPTION
## Summary
- Fix loop count coercion to prevent non-finite/fractional values from causing incorrect or unbounded loop iteration.
- Remove redundant waveform redraw effect that bypassed loading guard.
- Harden preview error-message copy behavior by handling clipboard write failures and cleaning up timeout on unmount.
- Add focused tests for loop-count edge cases (fractional, Infinity/NaN, negative, very large).

## Validation
- npm test -- --passWithNoTests
- npm run build
- npm run lint
- npm run format:check
- npm run typecheck