### PR TITLE
fix: nightly security audit 2026-05-20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
 				"shadcn": "^3.8.5",
 				"supabase": "^2.76.16",
 				"tailwindcss": "^4",
-				"turbo": "^2.9.4",
+				"turbo": "^2.9.14",
 				"tw-animate-css": "^1.4.0",
 				"typescript": "^5",
 				"vitest": "^4.0.18"
@@ -6451,9 +6451,9 @@
 			}
 		},
 		"node_modules/@turbo/darwin-64": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.6.tgz",
-			"integrity": "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.14.tgz",
+			"integrity": "sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==",
 			"cpu": [
 				"x64"
 			],
@@ -6465,9 +6465,9 @@
 			]
 		},
 		"node_modules/@turbo/darwin-arm64": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.6.tgz",
-			"integrity": "sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.14.tgz",
+			"integrity": "sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw==",
 			"cpu": [
 				"arm64"
 			],
@@ -6479,9 +6479,9 @@
 			]
 		},
 		"node_modules/@turbo/linux-64": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.6.tgz",
-			"integrity": "sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.14.tgz",
+			"integrity": "sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA==",
 			"cpu": [
 				"x64"
 			],
@@ -6493,9 +6493,9 @@
 			]
 		},
 		"node_modules/@turbo/linux-arm64": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.6.tgz",
-			"integrity": "sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.14.tgz",
+			"integrity": "sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g==",
 			"cpu": [
 				"arm64"
 			],
@@ -6507,9 +6507,9 @@
 			]
 		},
 		"node_modules/@turbo/windows-64": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.6.tgz",
-			"integrity": "sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.14.tgz",
+			"integrity": "sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A==",
 			"cpu": [
 				"x64"
 			],
@@ -6521,9 +6521,9 @@
 			]
 		},
 		"node_modules/@turbo/windows-arm64": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.6.tgz",
-			"integrity": "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.14.tgz",
+			"integrity": "sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g==",
 			"cpu": [
 				"arm64"
 			],
@@ -16266,21 +16266,21 @@
 			"license": "0BSD"
 		},
 		"node_modules/turbo": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.6.tgz",
-			"integrity": "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.14.tgz",
+			"integrity": "sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"turbo": "bin/turbo"
 			},
 			"optionalDependencies": {
-				"@turbo/darwin-64": "2.9.6",
-				"@turbo/darwin-arm64": "2.9.6",
-				"@turbo/linux-64": "2.9.6",
-				"@turbo/linux-arm64": "2.9.6",
-				"@turbo/windows-64": "2.9.6",
-				"@turbo/windows-arm64": "2.9.6"
+				"@turbo/darwin-64": "2.9.14",
+				"@turbo/darwin-arm64": "2.9.14",
+				"@turbo/linux-64": "2.9.14",
+				"@turbo/linux-arm64": "2.9.14",
+				"@turbo/windows-64": "2.9.14",
+				"@turbo/windows-arm64": "2.9.14"
 			}
 		},
 		"node_modules/tw-animate-css": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 		"shadcn": "^3.8.5",
 		"supabase": "^2.76.16",
 		"tailwindcss": "^4",
-		"turbo": "^2.9.4",
+		"turbo": "^2.9.14",
 		"tw-animate-css": "^1.4.0",
 		"typescript": "^5",
 		"vitest": "^4.0.18"


### PR DESCRIPTION
## Summary
- Bumped `turbo` from `^2.9.4` to `^2.9.14` to remediate known vulnerabilities.
- Regenerated `package-lock.json`.
- Audited code for exploitable issues (secrets, injection patterns, redirect/path traversal, env leakage, auth/CORS/rate-limit gaps, Supabase key exposure); no additional real exploitable issues found.

## Validation
- npm audit (remaining 8 moderate advisories are `ws` via `@remotion/*`, no non-breaking fix available)
- npm run lint
- npm run format:check
- npm run typecheck
- npm test -- --passWithNoTests
- npm run build (fails locally without Supabase env vars)
