### PR TITLE
chore: increase render sandbox timeout to 120m

### DIFF
--- a/app/api/render/restore-snapshot.ts
+++ b/app/api/render/restore-snapshot.ts
@@ -1,7 +1,7 @@
 import { get } from "@vercel/blob";
 import { Sandbox } from "@vercel/sandbox";
 
-const SANDBOX_TIMEOUT_MS = 2700 * 1000;
+const SANDBOX_TIMEOUT_MS = 120 * 60 * 1000;
 
 const getSnapshotBlobKey = () =>
 	`snapshot-cache/${process.env.VERCEL_DEPLOYMENT_ID ?? "local"}.json`;

--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -56,7 +56,7 @@ export async function POST(req: Request) {
 			const sandbox = process.env.VERCEL
 				? await restoreSnapshot()
 				: await createSandbox({
-						timeoutInMilliseconds: 15 * 60 * 1000,
+						timeoutInMilliseconds: 120 * 60 * 1000,
 						onProgress: async ({ progress, message }) => {
 							await send({
 								type: "phase",


### PR DESCRIPTION
## Summary
- Bump sandbox timeout in `app/api/render/route.ts` and `app/api/render/restore-snapshot.ts` to 120 minutes so long renders don't get cut off mid-run.

## Test plan
- [ ] Kick off a long render and confirm the sandbox stays alive past the previous 15m/45m limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)