### PR TITLE
Split AssetResult url into type-scoped fields

### DIFF
--- a/app/components/canvas/elements/ForegroundPreview.tsx
+++ b/app/components/canvas/elements/ForegroundPreview.tsx
@@ -4,6 +4,7 @@ import { useGenerate } from "../hooks/useGenerate";
 import { PlaceholderBallsLoader } from "./preview/placeholderBalls";
 import { StaleIndicator } from "./preview/overlays";
 import { MediaWithSkeleton } from "./MediaWithSkeleton";
+import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 
 export function ForegroundPreview({
 	element,
@@ -12,8 +13,9 @@ export function ForegroundPreview({
 }) {
 	const { result, generating, stale, generate } = useGenerate(element);
 	const { outputKind } = ELEMENT_CONFIGS[element.type];
+	const url = getPrimaryUrl(result, outputKind);
 
-	if (!result) {
+	if (!url) {
 		return (
 			<div className="relative w-full h-full rounded-lg overflow-hidden border bg-white/[0.03]">
 				<PlaceholderBallsLoader generating={generating} />
@@ -25,7 +27,7 @@ export function ForegroundPreview({
 		<div className="relative w-full h-full rounded-lg overflow-hidden border">
 			<MediaWithSkeleton
 				outputKind={outputKind}
-				src={result.url}
+				src={url}
 				alt="Scene preview"
 			/>
 			{stale && <StaleIndicator onClick={generate} />}

--- a/app/components/canvas/elements/OutputPreview.tsx
+++ b/app/components/canvas/elements/OutputPreview.tsx
@@ -3,6 +3,7 @@ import type { CanvasContentElement } from "../types";
 import { ELEMENT_CONFIGS } from "../config/elementConfigs";
 import { useGenerate } from "../hooks/useGenerate";
 import { deriveStatus, BORDER_COLORS } from "./preview/status";
+import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 import {
 	AudioResult,
 	AudioPlaceholder,
@@ -31,11 +32,11 @@ function OutputPreviewComponent({
 	const status = deriveStatus(generating, queued);
 
 	if (outputKind === "audio") {
-		if (result) {
+		if (result?.audioUrl) {
 			return (
 				<AudioResult
 					type={type}
-					src={result.url}
+					src={result.audioUrl}
 					characterName={element.customAttributes?.name}
 					status={status}
 					seconds={seconds}
@@ -55,26 +56,31 @@ function OutputPreviewComponent({
 		);
 	}
 
-	if (result) {
-		const borderColor = BORDER_COLORS[type] ?? "border-white/20";
-		if (type === "animated_image" && result.previewUrl) {
-			return (
-				<AnimatedImagePreview
-					key={result.url}
-					url={result.url}
-					previewUrl={result.previewUrl}
-					borderColor={borderColor}
-					status={status}
-					seconds={seconds}
-					stale={stale}
-					onRegenerate={generate}
-				/>
-			);
-		}
+	const borderColor = BORDER_COLORS[type] ?? "border-white/20";
+
+	if (type === "animated_image") {
+		return (
+			<AnimatedImagePreview
+				imageUrl={result?.imageUrl}
+				videoUrl={result?.videoUrl}
+				borderColor={borderColor}
+				status={status}
+				seconds={seconds}
+				stale={stale}
+				error={error}
+				onRegenerate={generate}
+				onGenerate={generate}
+				onDiscard={discard}
+			/>
+		);
+	}
+
+	const url = getPrimaryUrl(result, outputKind);
+	if (url) {
 		return (
 			<MediaPreview
-				key={result.url}
-				url={result.url}
+				key={url}
+				url={url}
 				outputKind={outputKind}
 				borderColor={borderColor}
 				status={status}

--- a/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
+++ b/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
@@ -1,49 +1,62 @@
 "use client";
 
 import { useState } from "react";
-import { MediaPreview } from "./results";
-import type { GenerationState } from "./status";
+import { MediaPreview, MediaPlaceholder } from "./results";
+import type { PlaceholderProps } from "./status";
 
-type AnimatedImagePreviewProps = GenerationState & {
-	url: string;
-	previewUrl: string;
+type AnimatedImagePreviewProps = PlaceholderProps & {
+	imageUrl?: string;
+	videoUrl?: string;
 	borderColor: string;
 	stale: boolean;
 	onRegenerate: () => void;
 };
 
 export function AnimatedImagePreview({
-	url,
-	previewUrl,
+	imageUrl,
+	videoUrl,
 	borderColor,
 	status,
 	seconds,
 	stale,
+	error,
 	onRegenerate,
+	onGenerate,
+	onDiscard,
 }: AnimatedImagePreviewProps) {
 	const [mode, setMode] = useState<"animated" | "still">("animated");
-	const isAnimated = mode === "animated";
+	const url = mode === "animated" ? videoUrl : imageUrl;
 
 	return (
 		<div className="relative w-full">
-			<MediaPreview
-				key={mode}
-				url={isAnimated ? url : previewUrl}
-				outputKind={isAnimated ? "video" : "image"}
-				borderColor={borderColor}
-				status={status}
-				seconds={seconds}
-				stale={stale}
-				onRegenerate={onRegenerate}
-			/>
+			{url ? (
+				<MediaPreview
+					key={url}
+					url={url}
+					outputKind={mode === "animated" ? "video" : "image"}
+					borderColor={borderColor}
+					status={status}
+					seconds={seconds}
+					stale={stale}
+					onRegenerate={onRegenerate}
+				/>
+			) : (
+				<MediaPlaceholder
+					status={status}
+					seconds={seconds}
+					error={error}
+					onGenerate={onGenerate}
+					onDiscard={onDiscard}
+				/>
+			)}
 			<div className="absolute top-2 right-2 z-10 flex items-center rounded-full border border-white/10 bg-black/55 backdrop-blur-xl shadow-md shadow-black/40 p-0.5">
 				<ToggleButton
-					active={isAnimated}
+					active={mode === "animated"}
 					label="Video"
 					onClick={() => setMode("animated")}
 				/>
 				<ToggleButton
-					active={!isAnimated}
+					active={mode === "still"}
 					label="Still"
 					onClick={() => setMode("still")}
 				/>

--- a/lib/connectors/__tests__/asset-base.test.ts
+++ b/lib/connectors/__tests__/asset-base.test.ts
@@ -6,7 +6,7 @@ import type { AssetGateway, JobPoll } from "@/lib/gateway/base";
 import type { ConnectorConfig, ConnectorType } from "../types";
 
 type TestParams = { prompt: string };
-type TestResult = { url: string; durationSec: number };
+type TestResult = { imageUrl?: string; durationSec: number };
 
 function makeGateway(
 	generateImpl: (params: TestParams) => Promise<BundleResponse>,
@@ -81,7 +81,8 @@ describe("BaseAssetConnector", () => {
 
 			const result = await connector.resolveBundle(bundle);
 			expect(result).toEqual({
-				url: "https://blob.example.com/assets/image/runware/abc/output.png",
+				imageUrl:
+					"https://blob.example.com/assets/image/runware/abc/output.png",
 				durationSec: 10,
 			});
 		});
@@ -134,7 +135,7 @@ describe("BaseAssetConnector", () => {
 			const result = await connector.generate({ prompt: "test" });
 
 			expect(generateFn).toHaveBeenCalledWith({ prompt: "test" });
-			expect(result.url).toBe(
+			expect(result.imageUrl).toBe(
 				"https://blob.example.com/assets/image/mock/abc/output.png",
 			);
 			expect(result.durationSec).toBe(5);
@@ -159,7 +160,7 @@ describe("BaseAssetConnector", () => {
 			const connector = new TestAssetConnector(config, generateFn);
 
 			const result = await connector.generate({ prompt: "test" });
-			expect(result.url).toBe("https://cdn.example.com/image.webp");
+			expect(result.imageUrl).toBe("https://cdn.example.com/image.webp");
 			expect(result.durationSec).toBe(0);
 		});
 	});

--- a/lib/connectors/__tests__/character-avatar.test.ts
+++ b/lib/connectors/__tests__/character-avatar.test.ts
@@ -27,7 +27,10 @@ describe("character-avatar plugin", () => {
 			.updateMetadata({ characters: { Alice: { appearance: "A girl" } } });
 
 		const plugin = createCharacterAvatarPlugin(PROJECT_ID, "Alice");
-		plugin.afterGenerate?.({ url: "https://img/alice.png", durationSec: 0 });
+		plugin.afterGenerate?.({
+			imageUrl: "https://img/alice.png",
+			durationSec: 0,
+		});
 
 		expect(store.getState().metadata.characters["Alice"].avatarUrl).toBe(
 			"https://img/alice.png",

--- a/lib/connectors/__tests__/image.test.ts
+++ b/lib/connectors/__tests__/image.test.ts
@@ -32,13 +32,13 @@ describe("BaseImageConnector", () => {
 		const result = await new OpenSlopImage(config).generate({
 			prompt: "a cat",
 		});
-		expect(result.url).toBe(IMAGE_URL);
+		expect(result.imageUrl).toBe(IMAGE_URL);
 	});
 
 	it("runs afterGenerate plugin", async () => {
 		mockSuccess();
 		const replacement: AssetResult = {
-			url: "https://example.com/replaced.png",
+			imageUrl: "https://example.com/replaced.png",
 			durationSec: 0,
 		};
 		const plugin: ConnectorPlugin = {
@@ -49,6 +49,6 @@ describe("BaseImageConnector", () => {
 			...config,
 			plugins: [plugin],
 		}).generate({ prompt: "test" });
-		expect(result.url).toBe("https://example.com/replaced.png");
+		expect(result.imageUrl).toBe("https://example.com/replaced.png");
 	});
 });

--- a/lib/connectors/__tests__/music.test.ts
+++ b/lib/connectors/__tests__/music.test.ts
@@ -36,13 +36,13 @@ describe("BaseMusicConnector", () => {
 			...config,
 			plugins: [plugin],
 		}).generate({ prompt: "rock song" });
-		expect(result).toEqual({ url: AUDIO_URL, durationSec: 0 });
+		expect(result).toEqual({ audioUrl: AUDIO_URL, durationSec: 0 });
 	});
 
 	it("runs afterGenerate plugin", async () => {
 		mockSuccess();
 		const replacement: AssetResult = {
-			url: "https://example.com/replaced.mp3",
+			audioUrl: "https://example.com/replaced.mp3",
 			durationSec: 0,
 		};
 		const plugin: ConnectorPlugin = {
@@ -53,7 +53,7 @@ describe("BaseMusicConnector", () => {
 			...config,
 			plugins: [plugin],
 		}).generate({ prompt: "test" });
-		expect(result.url).toBe("https://example.com/replaced.mp3");
+		expect(result.audioUrl).toBe("https://example.com/replaced.mp3");
 	});
 
 	it("runs onError plugin on failure", async () => {

--- a/lib/connectors/__tests__/openslop-connectors.test.ts
+++ b/lib/connectors/__tests__/openslop-connectors.test.ts
@@ -79,13 +79,13 @@ describe("OpenSlop connectors (via gateways)", () => {
 	it("Music: generate returns AssetResult with url", async () => {
 		const bundleUrl = mockAsset("music", { audio: "output.mp3" });
 		const result = await new OpenSlopMusic(config).generate({ prompt: "jazz" });
-		expect(result.url).toBe(`${bundleUrl}/output.mp3`);
+		expect(result.audioUrl).toBe(`${bundleUrl}/output.mp3`);
 	});
 
 	it("SFX: generate returns AssetResult with url", async () => {
 		const bundleUrl = mockAsset("sfx", { audio: "output.mp3" });
 		const result = await new OpenSlopSFX(config).generate({ prompt: "boom" });
-		expect(result.url).toBe(`${bundleUrl}/output.mp3`);
+		expect(result.audioUrl).toBe(`${bundleUrl}/output.mp3`);
 	});
 
 	it("Image: generate returns AssetResult with url", async () => {
@@ -93,7 +93,7 @@ describe("OpenSlop connectors (via gateways)", () => {
 		const result = await new OpenSlopImage(config).generate({
 			prompt: "mountain",
 		});
-		expect(result.url).toBe(`${bundleUrl}/output.png`);
+		expect(result.imageUrl).toBe(`${bundleUrl}/output.png`);
 	});
 
 	it("TTS: generate returns TTSResult with url", async () => {
@@ -116,7 +116,7 @@ describe("OpenSlop connectors (via gateways)", () => {
 			voiceId: "v1",
 		});
 
-		expect(result.url).toBe(`${bundleUrl}/output.wav`);
+		expect(result.audioUrl).toBe(`${bundleUrl}/output.wav`);
 		expect(result.textTimestamps).toHaveLength(1);
 		expect(result.textTimestamps[0].text).toBe("hello");
 	});
@@ -140,6 +140,6 @@ describe("OpenSlop connectors (via gateways)", () => {
 		const result = await new OpenSlopVideo(config).generate({
 			prompt: "sunset",
 		});
-		expect(result.url).toBe("https://cdn.example.com/v.mp4");
+		expect(result.videoUrl).toBe("https://cdn.example.com/v.mp4");
 	});
 });

--- a/lib/connectors/__tests__/sfx.test.ts
+++ b/lib/connectors/__tests__/sfx.test.ts
@@ -32,7 +32,7 @@ describe("BaseSFXConnector", () => {
 		const result = await new OpenSlopSFX(config).generate({
 			prompt: "explosion",
 		});
-		expect(result.url).toBe(AUDIO_URL);
+		expect(result.audioUrl).toBe(AUDIO_URL);
 	});
 
 	it("runs plugins in order", async () => {

--- a/lib/connectors/__tests__/tts.test.ts
+++ b/lib/connectors/__tests__/tts.test.ts
@@ -40,7 +40,7 @@ describe("BaseTTSConnector", () => {
 			prompt: "hello",
 			voiceId: "default",
 		});
-		expect(result.url).toBe(AUDIO_URL);
+		expect(result.audioUrl).toBe(AUDIO_URL);
 		expect(result.textTimestamps).toHaveLength(1);
 	});
 
@@ -69,7 +69,7 @@ describe("BaseTTSConnector", () => {
 			description: undefined,
 			language: "en",
 		});
-		expect(result.url).toBe(AUDIO_URL);
+		expect(result.audioUrl).toBe(AUDIO_URL);
 	});
 
 	it("throws when no matching voice found via voice-search plugin", async () => {
@@ -94,7 +94,7 @@ describe("BaseTTSConnector", () => {
 			...config,
 			plugins: [plugin],
 		}).generate({ prompt: "hello", voiceId: "default" });
-		expect(result.url).toBe(AUDIO_URL);
+		expect(result.audioUrl).toBe(AUDIO_URL);
 	});
 
 	it("runs onError plugin on failure", async () => {

--- a/lib/connectors/__tests__/video.test.ts
+++ b/lib/connectors/__tests__/video.test.ts
@@ -32,7 +32,7 @@ describe("BaseVideoConnector", () => {
 		const result = await new OpenSlopVideo(config).generate({
 			prompt: "a sunset",
 		});
-		expect(result.url).toBe(VIDEO_URL);
+		expect(result.videoUrl).toBe(VIDEO_URL);
 		expect(result.durationSec).toBe(5);
 	});
 
@@ -54,7 +54,7 @@ describe("BaseVideoConnector", () => {
 		const result = await new OpenSlopVideo(config).generate({
 			prompt: "a sunset",
 		});
-		expect(result.url).toBe(VIDEO_URL);
+		expect(result.videoUrl).toBe(VIDEO_URL);
 		expect(result.durationSec).toBe(5);
 		expect(fetch).toHaveBeenCalledTimes(3);
 	});

--- a/lib/connectors/asset-base.ts
+++ b/lib/connectors/asset-base.ts
@@ -3,17 +3,28 @@ import type { AssetGateway } from "@/lib/gateway/base";
 import { awaitCompletion } from "@/lib/providers/poll";
 import { BaseConnector } from "./base";
 
+export type AssetKey = "image" | "audio" | "video";
+
+const ASSET_KEY_TO_URL_FIELD: Record<
+	AssetKey,
+	"imageUrl" | "audioUrl" | "videoUrl"
+> = {
+	image: "imageUrl",
+	audio: "audioUrl",
+	video: "videoUrl",
+};
+
 export abstract class BaseAssetConnector<
 	TParams extends { prompt: string },
 	TResult,
 > extends BaseConnector<TParams, TResult> {
-	abstract readonly assetKey: string;
+	abstract readonly assetKey: AssetKey;
 
 	protected abstract gateway: AssetGateway<TParams>;
 
 	async resolveBundle(bundle: AssetBundle): Promise<TResult> {
 		return {
-			url: bundle.resolve(this.assetKey),
+			[ASSET_KEY_TO_URL_FIELD[this.assetKey]]: bundle.resolve(this.assetKey),
 			durationSec: Number(bundle.manifest.metadata?.durationSec ?? 0),
 		} as TResult;
 	}

--- a/lib/connectors/assetUrl.ts
+++ b/lib/connectors/assetUrl.ts
@@ -1,0 +1,12 @@
+import type { ResultKind } from "@/lib/canvas/types";
+import type { AssetResult } from "./types";
+
+export function getPrimaryUrl(
+	result: AssetResult | null | undefined,
+	outputKind: ResultKind,
+): string | undefined {
+	if (!result) return undefined;
+	if (outputKind === "image") return result.imageUrl;
+	if (outputKind === "audio") return result.audioUrl;
+	return result.videoUrl;
+}

--- a/lib/connectors/plugins/__tests__/animated-image-chain.test.ts
+++ b/lib/connectors/plugins/__tests__/animated-image-chain.test.ts
@@ -30,7 +30,7 @@ describe("createVideoChainPlugin", () => {
 	it("stashes videoPrompt and animates the still via the video connector", async () => {
 		generateMock.mockReset();
 		generateMock.mockResolvedValue({
-			url: "https://example.com/video.mp4",
+			videoUrl: "https://example.com/video.mp4",
 			durationSec: 5,
 		});
 
@@ -46,7 +46,7 @@ describe("createVideoChainPlugin", () => {
 		expect(ctx.data?.videoPrompt).toBe("slow zoom in");
 
 		const still = {
-			url: "https://example.com/still.png",
+			imageUrl: "https://example.com/still.png",
 			durationSec: 0,
 		} satisfies AssetResult;
 		const result = (await plugin.afterGenerate?.(still, ctx)) as AssetResult;
@@ -56,9 +56,9 @@ describe("createVideoChainPlugin", () => {
 			frameImages: ["https://example.com/still.png"],
 		});
 		expect(result).toEqual({
-			url: "https://example.com/video.mp4",
+			imageUrl: "https://example.com/still.png",
+			videoUrl: "https://example.com/video.mp4",
 			durationSec: 5,
-			previewUrl: "https://example.com/still.png",
 		});
 	});
 
@@ -70,7 +70,7 @@ describe("createVideoChainPlugin", () => {
 		await plugin.beforeGenerate?.({ prompt: "a dark forest" }, ctx);
 
 		const still = {
-			url: "https://example.com/still.png",
+			imageUrl: "https://example.com/still.png",
 			durationSec: 0,
 		} satisfies AssetResult;
 

--- a/lib/connectors/plugins/animated-image-chain.ts
+++ b/lib/connectors/plugins/animated-image-chain.ts
@@ -31,6 +31,11 @@ export function createVideoChainPlugin(
 					"animated_image element is missing required videoPrompt attribute",
 				);
 			}
+			if (!result.imageUrl) {
+				throw new Error(
+					"animated_image chain expected an imageUrl from the still-image generation",
+				);
+			}
 			const { provider, config } = getDefaultConnector(registry, "video");
 			const video = createConnector(
 				"video",
@@ -39,12 +44,12 @@ export function createVideoChainPlugin(
 			);
 			const videoResult = await video.generate({
 				prompt: videoPrompt,
-				frameImages: [result.url],
+				frameImages: [result.imageUrl],
 			});
 			return {
-				url: videoResult.url,
+				imageUrl: result.imageUrl,
+				videoUrl: videoResult.videoUrl,
 				durationSec: videoResult.durationSec,
-				previewUrl: result.url,
 			};
 		},
 	};

--- a/lib/connectors/plugins/character-avatar.ts
+++ b/lib/connectors/plugins/character-avatar.ts
@@ -18,8 +18,11 @@ export function createCharacterAvatarPlugin(
 			].join(". ");
 		},
 		afterGenerate(result) {
+			if (!result.imageUrl) {
+				throw new Error("character-avatar plugin expected an imageUrl result");
+			}
 			store().updateMetadata({
-				characters: { [name]: { avatarUrl: result.url } },
+				characters: { [name]: { avatarUrl: result.imageUrl } },
 			});
 			return result;
 		},

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -57,9 +57,10 @@ export type ConnectorGenerateParams = {
 };
 
 export type AssetResult = {
-	url: string;
 	durationSec: number;
-	previewUrl?: string;
+	imageUrl?: string;
+	audioUrl?: string;
+	videoUrl?: string;
 	textTimestamps?: TextTimestamp[];
 };
 

--- a/lib/generation/__tests__/generateForElement.test.ts
+++ b/lib/generation/__tests__/generateForElement.test.ts
@@ -25,7 +25,7 @@ describe("generateForElement", () => {
 
 	it("creates connector and calls generate with correct params", async () => {
 		const expected: AssetResult = {
-			url: "https://example.com/img.png",
+			imageUrl: "https://example.com/img.png",
 			durationSec: 0,
 		};
 		mockGenerate.mockResolvedValue(expected);
@@ -48,7 +48,7 @@ describe("generateForElement", () => {
 	});
 
 	it("passes default model from config", async () => {
-		mockGenerate.mockResolvedValue({ url: "x", durationSec: 0 });
+		mockGenerate.mockResolvedValue({ audioUrl: "x", durationSec: 0 });
 
 		await generateForElement("music", "openslop", config, "jazz beat", {});
 
@@ -59,7 +59,7 @@ describe("generateForElement", () => {
 	});
 
 	it("merges extra params into generate call", async () => {
-		mockGenerate.mockResolvedValue({ url: "x", durationSec: 5 });
+		mockGenerate.mockResolvedValue({ audioUrl: "x", durationSec: 5 });
 
 		await generateForElement("tts", "openslop", config, "hello world", {
 			voiceId: "voice-1",

--- a/lib/project/__tests__/thumbnail.test.ts
+++ b/lib/project/__tests__/thumbnail.test.ts
@@ -7,16 +7,21 @@ import { pickThumbnailUrl } from "../thumbnail";
 const entry = (
 	id: string,
 	connectorType: ConnectorType | null,
-	url: string | null,
-	previewUrl?: string,
+	imageUrl: string | null,
+	videoUrl?: string,
 ): [string, ElementSnapshot] => [
 	id,
 	{
 		status: "idle",
 		seconds: 0,
-		result: url
-			? { url, durationSec: 0, ...(previewUrl && { previewUrl }) }
-			: null,
+		result:
+			imageUrl || videoUrl
+				? {
+						durationSec: 0,
+						...(imageUrl && { imageUrl }),
+						...(videoUrl && { videoUrl }),
+					}
+				: null,
 		error: null,
 		resultInputs: null,
 		connectorType,
@@ -62,18 +67,18 @@ describe("pickThumbnailUrl", () => {
 		).toBe("scene.png");
 	});
 
-	it("accepts animated_image and prefers previewUrl over the video url", () => {
+	it("uses the still imageUrl for animated_image entries", () => {
 		expect(
 			pickThumbnailUrl([
 				entry("1", "tts", "n.mp3"),
-				entry("2", "animated_image", "video.mp4", "still.png"),
+				entry("2", "animated_image", "still.png", "video.mp4"),
 			]),
 		).toBe("still.png");
 	});
 
-	it("falls back to animated_image url when no previewUrl is present", () => {
-		expect(pickThumbnailUrl([entry("1", "animated_image", "video.mp4")])).toBe(
-			"video.mp4",
-		);
+	it("returns null for animated_image with only a videoUrl", () => {
+		expect(
+			pickThumbnailUrl([entry("1", "animated_image", null, "video.mp4")]),
+		).toBeNull();
 	});
 });

--- a/lib/project/thumbnail.ts
+++ b/lib/project/thumbnail.ts
@@ -11,7 +11,7 @@ export function pickThumbnailUrl(
 			snap.connectorType !== "animated_image"
 		)
 			continue;
-		const url = snap.result?.previewUrl ?? snap.result?.url;
+		const url = snap.result?.imageUrl;
 		if (url) return url;
 	}
 	return null;

--- a/lib/video/__tests__/resolve.test.ts
+++ b/lib/video/__tests__/resolve.test.ts
@@ -32,7 +32,12 @@ function makeSnapshot(
 	return {
 		status: "idle",
 		seconds: 0,
-		result: { url: "https://example.com/asset.mp3", durationSec: 5 },
+		result: {
+			imageUrl: "https://example.com/asset.png",
+			audioUrl: "https://example.com/asset.mp3",
+			videoUrl: "https://example.com/asset.mp4",
+			durationSec: 5,
+		},
 		error: null,
 		resultInputs: null,
 		connectorType: null,
@@ -48,10 +53,10 @@ describe("resolveElements", () => {
 		];
 		const snapshots: Record<string, ElementSnapshot> = {
 			img1: makeSnapshot({
-				result: { url: "https://example.com/img.png", durationSec: 3 },
+				result: { imageUrl: "https://example.com/img.png", durationSec: 3 },
 			}),
 			nar1: makeSnapshot({
-				result: { url: "https://example.com/nar.mp3", durationSec: 8 },
+				result: { audioUrl: "https://example.com/nar.mp3", durationSec: 8 },
 			}),
 		};
 
@@ -89,7 +94,7 @@ describe("resolveElements", () => {
 		];
 		const snapshots: Record<string, ElementSnapshot> = {
 			img1: makeSnapshot({
-				result: { url: "https://example.com/img.png", durationSec: 3 },
+				result: { imageUrl: "https://example.com/img.png", durationSec: 3 },
 			}),
 			nar1: makeSnapshot({ status: "idle", result: null }),
 		};

--- a/lib/video/resolve.ts
+++ b/lib/video/resolve.ts
@@ -1,6 +1,8 @@
 import type { CanvasElement } from "@/lib/canvas/types";
 import { getContentElements } from "@/lib/canvas/scenes";
+import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 import type { ElementSnapshot } from "@/lib/generation/queue";
+import { ELEMENT_CONFIGS } from "@/app/components/canvas/config/elementConfigs";
 import type { ResolvedElement } from "./types";
 import { ELEMENT_ROLES, LAYER_TYPES } from "./types";
 import {
@@ -20,6 +22,12 @@ export function resolveElements(
 		const snapshot = getSnapshot(el.id);
 		if (!snapshot.result) continue;
 
+		const url = getPrimaryUrl(
+			snapshot.result,
+			ELEMENT_CONFIGS[el.type].outputKind,
+		);
+		if (!url) continue;
+
 		const timestamps = snapshot.result.textTimestamps;
 		const captionTimestamps =
 			areCaptionsEnabled(el) && timestamps?.length ? timestamps : undefined;
@@ -29,7 +37,7 @@ export function resolveElements(
 			type: el.type,
 			role: ELEMENT_ROLES[el.type],
 			layer: LAYER_TYPES[el.type],
-			url: snapshot.result.url,
+			url,
 			durationSec: snapshot.result.durationSec,
 			loops: getLoops(el),
 			volume: getVolume(el),


### PR DESCRIPTION
## Summary
- Replace `AssetResult.url`/`previewUrl` with optional `imageUrl`/`audioUrl`/`videoUrl`. Each connector populates the field matching its `assetKey`; `animated_image` chain now returns both `imageUrl` (still) and `videoUrl` (animation).
- When a refine op changes an element's type (e.g. image → animated_image), the prior `imageUrl` survives as the still while only the `videoUrl` regenerates. `AnimatedImagePreview` always renders the Video/Still toggle and shows a placeholder for whichever url is missing.
- Centralize `outputKind` in `ELEMENT_CONFIGS` and add `getPrimaryUrl(result, outputKind)` in `lib/connectors/assetUrl.ts` (consumed by `OutputPreview`, `ForegroundPreview`, `lib/video/resolve.ts`).
- Non-backwards-compatible: existing stored `generation` blobs need migration (script in `/tmp/convert-results.js`).

## Test plan
- [x] `npm run lint && npm run format:check && npm run typecheck && npm run test:run` (767 tests pass)
- [ ] Manual: image element → generate → refine to animated_image → still stays visible, video regenerates and toggle appears
- [ ] Manual: fresh animated_image → both still and video render with working toggle
- [ ] Manual: narration / character / clip / sound / music still render
- [ ] Video export: composited render uses correct url per element type