### PR TITLE
bump render sandbox to 32 vcpus

### DIFF
--- a/app/api/render/restore-snapshot.ts
+++ b/app/api/render/restore-snapshot.ts
@@ -25,6 +25,7 @@ export async function restoreSnapshot() {
 	}
 
 	return Sandbox.create({
+		resources: { vcpus: 32 },
 		source: { type: "snapshot", snapshotId: cache.snapshotId },
 		timeout: SANDBOX_TIMEOUT_MS,
 	});

--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -56,6 +56,7 @@ export async function POST(req: Request) {
 			const sandbox = process.env.VERCEL
 				? await restoreSnapshot()
 				: await createSandbox({
+						resources: { vcpus: 32 },
 						timeoutInMilliseconds: 120 * 60 * 1000,
 						onProgress: async ({ progress, message }) => {
 							await send({


### PR DESCRIPTION
## Summary
- Allocate 32 vCPUs for both snapshot-restored and freshly created render sandboxes

## Test plan
- Trigger a render on Vercel (snapshot path) and verify sandbox provisions successfully
- Trigger a local render (createSandbox path) and verify it provisions with 32 vcpus