### PR TITLE
lower render sandbox to 8 vcpus

### DIFF
--- a/app/api/render/restore-snapshot.ts
+++ b/app/api/render/restore-snapshot.ts
@@ -25,7 +25,7 @@ export async function restoreSnapshot() {
 	}
 
 	return Sandbox.create({
-		resources: { vcpus: 32 },
+		resources: { vcpus: 8 },
 		source: { type: "snapshot", snapshotId: cache.snapshotId },
 		timeout: SANDBOX_TIMEOUT_MS,
 	});

--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -56,7 +56,7 @@ export async function POST(req: Request) {
 			const sandbox = process.env.VERCEL
 				? await restoreSnapshot()
 				: await createSandbox({
-						resources: { vcpus: 32 },
+						resources: { vcpus: 8 },
 						timeoutInMilliseconds: 120 * 60 * 1000,
 						onProgress: async ({ progress, message }) => {
 							await send({


### PR DESCRIPTION
## Summary
- Drop sandbox vCPU allocation from 32 back down to 8 for both snapshot-restore and fresh-create paths

## Test plan
- Trigger a render on Vercel (snapshot path) and verify sandbox provisions with 8 vcpus
- Trigger a local render (createSandbox path) and verify it provisions with 8 vcpus