### PR TITLE
Tune render route: node runtime, longer timeout, 50% concurrency

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -1,3 +1,6 @@
+export const runtime = "nodejs";
+export const maxDuration = 800;
+
 import {
 	addBundleToSandbox,
 	createSandbox,
@@ -75,6 +78,7 @@ export async function POST(req: Request) {
 				}
 
 				const { sandboxFilePath, contentType } = await renderMediaOnVercel({
+					concurrency: "50%",
 					sandbox,
 					compositionId: COMPOSITION_ID,
 					inputProps: payload.inputProps as Record<string, unknown>,


### PR DESCRIPTION
## Summary
- Pin `app/api/render/route.ts` to the Node.js runtime with `maxDuration` of 800s
- Set Remotion `renderMediaOnVercel` concurrency to `50%`
- Builds on prior commit lowering render sandbox to 8 vCPUs

## Test plan
- [ ] Trigger a render and confirm it completes within new timeout
- [ ] Verify sandbox CPU usage with 50% concurrency on 8 vCPUs

🤖 Generated with [Claude Code](https://claude.com/claude-code)