### PR TITLE
fix: nightly bug fixes 2026-05-21

### DIFF
--- a/app/api/validate-code/__tests__/route.test.ts
+++ b/app/api/validate-code/__tests__/route.test.ts
@@ -38,6 +38,16 @@ describe("POST /api/validate-code", () => {
 		expect((await res.json()).error).toContain("Invalid code format");
 	});
 
+	it("returns 400 (not 500) when the body is malformed JSON", async () => {
+		const req = new NextRequest(
+			new URL("/api/validate-code", "http://localhost:3000"),
+			{ method: "POST", body: "{not json" },
+		);
+		const res = await POST(req);
+		expect(res.status).toBe(400);
+		expect((await res.json()).error).toContain("Invalid code format");
+	});
+
 	it("returns 400 when code is not a string", async () => {
 		const res = await POST(makeRequest({ code: 123456 }));
 		expect(res.status).toBe(400);

--- a/app/api/validate-code/route.ts
+++ b/app/api/validate-code/route.ts
@@ -8,8 +8,16 @@ const ERROR_MESSAGES: Record<string, string> = {
 };
 
 export async function POST(request: NextRequest) {
-	const body = await request.json();
-	const { code } = body;
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return NextResponse.json({ error: "Invalid code format" }, { status: 400 });
+	}
+	const code =
+		body && typeof body === "object" && "code" in body
+			? (body as { code: unknown }).code
+			: undefined;
 
 	if (!code || typeof code !== "string" || code.length !== 6) {
 		return NextResponse.json({ error: "Invalid code format" }, { status: 400 });

--- a/lib/api/__tests__/route-handler.test.ts
+++ b/lib/api/__tests__/route-handler.test.ts
@@ -49,6 +49,20 @@ describe("createRouteHandler", () => {
 		expect(handle).not.toHaveBeenCalled();
 	});
 
+	it("returns 400 (not 500) when the body is malformed JSON", async () => {
+		const handle = vi.fn(async () => NextResponse.json({}));
+		const handler = makeHandler(handle);
+		const req = new NextRequest("http://localhost/api/test", {
+			method: "POST",
+			body: "{not valid json",
+			headers: { "Content-Type": "application/json" },
+		});
+		const res = await handler(req);
+		expect(res.status).toBe(400);
+		expect((await res.json()).error).toBe("Request body must be valid JSON");
+		expect(handle).not.toHaveBeenCalled();
+	});
+
 	it("returns 400 when prompt is missing", async () => {
 		const handler = makeHandler();
 		const res = await handler(makeRequest({}));

--- a/lib/api/parse.ts
+++ b/lib/api/parse.ts
@@ -12,7 +12,17 @@ export async function parseBody<TSchema extends z.ZodType>(
 	schema: TSchema,
 	label: string,
 ): Promise<ParseResult<z.infer<TSchema>>> {
-	const parsed = schema.safeParse(await request.json());
+	let raw: unknown;
+	try {
+		raw = await request.json();
+	} catch {
+		logger.warn(`${label}: malformed JSON body`);
+		return {
+			ok: false,
+			response: badRequest("Request body must be valid JSON"),
+		};
+	}
+	const parsed = schema.safeParse(raw);
 	if (parsed.success) return { ok: true, data: parsed.data };
 	const message = parsed.error.issues[0]?.message ?? "Invalid request body";
 	logger.warn(`${label}: ${message}`);

--- a/lib/providers/__tests__/cartesia-tts.test.ts
+++ b/lib/providers/__tests__/cartesia-tts.test.ts
@@ -73,6 +73,35 @@ describe("CartesiaTTS", () => {
 			expect(mockClose).toHaveBeenCalled();
 		});
 
+		it("ignores trailing timestamps when arrays are mismatched lengths", async () => {
+			const responses = [
+				{
+					type: "timestamps",
+					word_timestamps: {
+						words: ["a", "b", "c"],
+						start: [0, 1],
+						end: [0.5, 1.5],
+					},
+				},
+				{ type: "done", done: true },
+			];
+			mockGenerate.mockReturnValue({
+				[Symbol.asyncIterator]: async function* () {
+					for (const r of responses) yield r;
+				},
+			});
+
+			const provider = new CartesiaTTS("test-key");
+			const result = await provider.generate({
+				prompt: "a b c",
+				voiceId: "v1",
+			});
+
+			// Only the two fully-defined timestamps survive, so durationSec is the
+			// finite end of the last paired timestamp (1.5) + 1, not NaN.
+			expect(result.metadata?.durationSec).toBe(2.5);
+		});
+
 		it("passes custom model", async () => {
 			mockGenerate.mockReturnValue({
 				[Symbol.asyncIterator]: async function* () {
@@ -289,6 +318,37 @@ describe("CartesiaTTS", () => {
 
 			const provider = new CartesiaTTS("test-key");
 			const voices = await provider.search({ description: "anything" });
+
+			expect(voices.map((v) => v.id)).toEqual(["v1", "v2"]);
+		});
+
+		it("ranks voices last when their embedding vector is missing", async () => {
+			mockVoicesList.mockResolvedValue({
+				data: [
+					{
+						id: "v1",
+						name: "A",
+						language: "en",
+						gender: "feminine",
+						description: "first",
+						preview_file_url: null,
+					},
+					{
+						id: "v2",
+						name: "B",
+						language: "en",
+						gender: "feminine",
+						description: "second",
+						preview_file_url: null,
+					},
+				],
+			});
+			mockEmbed.mockResolvedValue({ embedding: [1, 0] });
+			// Embedder returns fewer vectors than voices: v2 has no vector.
+			mockEmbedMany.mockResolvedValue({ embeddings: [[1, 0]] });
+
+			const provider = new CartesiaTTS("test-key");
+			const voices = await provider.search({ description: "warm" });
 
 			expect(voices.map((v) => v.id)).toEqual(["v1", "v2"]);
 		});

--- a/lib/providers/tts/cartesia.ts
+++ b/lib/providers/tts/cartesia.ts
@@ -162,7 +162,8 @@ export class CartesiaTTS extends BaseProvider<TTSGenerateParams, RawTTSResult> {
 				}
 				if (response.type === "timestamps" && response.word_timestamps) {
 					const { words, start, end } = response.word_timestamps;
-					for (let i = 0; i < words.length; i++) {
+					const count = Math.min(words.length, start.length, end.length);
+					for (let i = 0; i < count; i++) {
 						textTimestamps.push({
 							text: words[i],
 							start: start[i],

--- a/lib/providers/tts/voiceSimilarity.ts
+++ b/lib/providers/tts/voiceSimilarity.ts
@@ -29,7 +29,10 @@ export async function rankBySimilarity(
 	]);
 
 	const scores = new Map(
-		voices.map((v, i) => [v.id, cosineSimilarity(query, voiceVecs[i])]),
+		voices.map((v, i) => {
+			const vec = voiceVecs[i];
+			return [v.id, vec ? cosineSimilarity(query, vec) : -Infinity] as const;
+		}),
 	);
 	return [...voices].sort(
 		(a, b) => (scores.get(b.id) ?? -Infinity) - (scores.get(a.id) ?? -Infinity),


### PR DESCRIPTION
## Summary
Nightly correctness pass with focused bug fixes and high-value test additions.

### Bugs fixed
- Return explicit 400 for malformed JSON in shared API parsing path (`lib/api/parse.ts`) instead of bubbling to 500.
- Return explicit 400 for malformed JSON in validate-code route (`app/api/validate-code/route.ts`) with safer body handling.
- Prevent invalid timestamp pairing from producing `NaN` duration in Cartesia TTS timestamp mapping.
- Guard missing embedding vectors in voice similarity ranking to avoid runtime throws and rank missing vectors last.

### Tests added
- Malformed JSON -> 400 coverage for route handler shared parsing path.
- Malformed JSON -> 400 coverage for validate-code route.
- Cartesia mismatched timestamp arrays produce finite duration.
- Voice similarity handles missing vector inputs safely.

### Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm test -- --passWithNoTests
- npm run build