### PR TITLE
refactor: nightly maintainability 2026-05-22

### DIFF
--- a/lib/blob.ts
+++ b/lib/blob.ts
@@ -1,0 +1,4 @@
+// Public Vercel Blob store hosting committed mock/template fixtures. Kept as a
+// literal (not NEXT_PUBLIC_BLOB_URL) so these fixtures resolve regardless of env.
+export const BLOB_BASE_URL =
+	"https://mqzeech9ugknls54.public.blob.vercel-storage.com";

--- a/lib/providers/image/mock.ts
+++ b/lib/providers/image/mock.ts
@@ -1,8 +1,8 @@
 import type { ImageGenerateParams } from "@/lib/connectors/types";
+import { BLOB_BASE_URL } from "@/lib/blob";
 import { MockProvider } from "../mock-base";
 
-const BLOB_BASE =
-	"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/image/mock";
+const BLOB_BASE = `${BLOB_BASE_URL}/assets/image/mock`;
 
 export class MockImage extends MockProvider<ImageGenerateParams> {
 	protected readonly delayMs = 2000;

--- a/lib/providers/music/mock.ts
+++ b/lib/providers/music/mock.ts
@@ -1,8 +1,8 @@
 import type { MusicGenerateParams } from "@/lib/connectors/types";
+import { BLOB_BASE_URL } from "@/lib/blob";
 import { MockProvider } from "../mock-base";
 
-const BLOB_BASE =
-	"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/music/mock";
+const BLOB_BASE = `${BLOB_BASE_URL}/assets/music/mock`;
 
 export class MockMusic extends MockProvider<MusicGenerateParams> {
 	protected readonly delayMs = 2000;

--- a/lib/providers/sfx/mock.ts
+++ b/lib/providers/sfx/mock.ts
@@ -1,8 +1,8 @@
 import type { SFXGenerateParams } from "@/lib/connectors/types";
+import { BLOB_BASE_URL } from "@/lib/blob";
 import { MockProvider } from "../mock-base";
 
-const BLOB_BASE =
-	"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/sfx/mock";
+const BLOB_BASE = `${BLOB_BASE_URL}/assets/sfx/mock`;
 
 export class MockSFX extends MockProvider<SFXGenerateParams> {
 	protected readonly variants = [

--- a/lib/providers/tts/mock.ts
+++ b/lib/providers/tts/mock.ts
@@ -3,10 +3,10 @@ import type {
 	VoiceInfo,
 	VoiceSearchParams,
 } from "@/lib/connectors/types";
+import { BLOB_BASE_URL } from "@/lib/blob";
 import { MockProvider } from "../mock-base";
 
-const BLOB_BASE =
-	"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/tts/mock";
+const BLOB_BASE = `${BLOB_BASE_URL}/assets/tts/mock`;
 
 export class MockTTS extends MockProvider<TTSGenerateParams> {
 	protected readonly variants = [

--- a/lib/providers/video/mock.ts
+++ b/lib/providers/video/mock.ts
@@ -1,9 +1,9 @@
 import type { VideoJob, VideoProviderResponse } from "./base";
 import { BaseVideoProvider } from "./base";
+import { BLOB_BASE_URL } from "@/lib/blob";
 import { pickRandom } from "../mock-utils";
 
-const BLOB_BASE =
-	"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/video/mock";
+const BLOB_BASE = `${BLOB_BASE_URL}/assets/video/mock`;
 
 const MOCK_VARIANTS = [
 	{ url: `${BLOB_BASE}/1/output.mp4`, durationSec: 174 },

--- a/lib/templates/templates.ts
+++ b/lib/templates/templates.ts
@@ -1,5 +1,9 @@
 import dedent from "dedent";
+import { BLOB_BASE_URL } from "@/lib/blob";
 import type { MetadataCharacter, MetadataVoice } from "@/lib/project/types";
+
+const templateAsset = (name: string) =>
+	`${BLOB_BASE_URL}/assets/upload/template/${name}`;
 
 export interface TemplateShowcase {
 	image: string;
@@ -28,16 +32,15 @@ export const TEMPLATES: Template[] = [
 		pillText: "POV: Your life at every stage as a",
 		color: "#F59E0B",
 		referenceImages: [
-			"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/pov-life-stages-2",
-			"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/pov-life-stages-3",
+			templateAsset("pov-life-stages-2"),
+			templateAsset("pov-life-stages-3"),
 		],
 		characters: {
 			Protagonist: {
 				description: "American male, neutral accent",
 				appearance:
 					"male, average build, slightly hunched posture, bald, wearing a worn olive green jacket, grey t-shirt underneath, faded blue jeans, brown work boots",
-				avatarUrl:
-					"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/pov-life-stages-4",
+				avatarUrl: templateAsset("pov-life-stages-4"),
 			},
 		},
 		narration: {
@@ -48,8 +51,7 @@ export const TEMPLATES: Template[] = [
 			description: "wise",
 		},
 		showcase: {
-			image:
-				"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/pov-life-stages-1",
+			image: templateAsset("pov-life-stages-1"),
 			title: "POV Your Life as A...",
 			description:
 				"Long-form, second-person POV voiceover with cartoon illustrations that walk a viewer through ascending stages of a role, career, or world",
@@ -263,14 +265,13 @@ export const TEMPLATES: Template[] = [
 		pillText: "A sleep story about",
 		color: "#6366F1",
 		referenceImages: [
-			"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/sleep-story-1",
-			"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/sleep-story-3",
-			"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/sleep-story-4",
+			templateAsset("sleep-story-1"),
+			templateAsset("sleep-story-3"),
+			templateAsset("sleep-story-4"),
 		],
 		characters: {},
 		showcase: {
-			image:
-				"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/sleep-story-1",
+			image: templateAsset("sleep-story-1"),
 			title: "Get Sleepy with...",
 			description:
 				"Long-form, slow, soothing narration designed to lull listeners to sleep",
@@ -327,17 +328,16 @@ export const TEMPLATES: Template[] = [
 		pillText: "Finance tips for...",
 		color: "#3B82F6",
 		referenceImages: [
-			"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/finance-tips-2",
-			"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/finance-tips-3",
-			"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/finance-tips-4",
+			templateAsset("finance-tips-2"),
+			templateAsset("finance-tips-3"),
+			templateAsset("finance-tips-4"),
 		],
 		characters: {
 			Ethan: {
 				description: "American male, neutral accent",
 				appearance:
 					"man with short light brown hair parted to the side, oversized rounded head with prominent chin and double-chin, small oval eyes with tiny black pupils, thin arched eyebrows, long pointed nose, small mouth. Bean-shaped body with stubby limbs. Wearing a blue hoodie and blue pants with white sneakers",
-				avatarUrl:
-					"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/finance-tips-1",
+				avatarUrl: templateAsset("finance-tips-1"),
 			},
 		},
 		narration: {
@@ -348,8 +348,7 @@ export const TEMPLATES: Template[] = [
 			description: "wise",
 		},
 		showcase: {
-			image:
-				"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/finance-tips-4",
+			image: templateAsset("finance-tips-4"),
 			title: "Finance tips",
 			description: "Long-form, stories to teach personal finance lessons",
 			examplePrompt:


### PR DESCRIPTION
## Summary
- centralize Vercel Blob base URL into a single module (`lib/blob.ts`)
- replace duplicated hardcoded URL usage across mock providers and template assets with shared helpers
- keep runtime behavior unchanged while reducing duplication and improving readability

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm test -- --passWithNoTests