### PR TITLE
Add language to voice metadata and drop gender_neutral

### DIFF
--- a/lib/connectors/llm/plugins/osml.ts
+++ b/lib/connectors/llm/plugins/osml.ts
@@ -6,6 +6,7 @@ import {
 	TTS_ACCENTS,
 	TTS_AGES,
 	TTS_GENDERS,
+	TTS_LANGUAGES,
 	TTS_PITCHES,
 	TTSEmotion,
 } from "@/lib/connectors/tts/enums";
@@ -109,12 +110,12 @@ const OSML_SYSTEM_PROMPT = dedent`
 
 	### Metadata Narration XML tags
 	- Right after the metadata_style tag, emit a single, empty metadata_narration tag that describes the narrator voice. Example:
-		 <metadata_narration gender="masculine" age="adult" pitch="low" accent="british" description="wise"></metadata_narration>
+		 <metadata_narration gender="masculine" age="adult" pitch="low" accent="british" description="wise" language="en"></metadata_narration>
 	- The attributes should be from the metadata Character/Narration attributes section
 
   ### Metadata Character XML tags
 	- Right after the metadata_narration tag, emit short <metadata_character>...</metadata_character> tags that describe each character's visual appearance (excluding the narrator) from the story in detail as if prompting an image model. Example:
-		<metadata_character name="Mia" gender="feminine" age="child" pitch="high" accent="american" description="wise">A girl around ten years old with warm brown skin, dark curly hair falling
+		<metadata_character name="Mia" gender="feminine" age="child" pitch="high" accent="american" description="wise" language="en">A girl around ten years old with warm brown skin, dark curly hair falling
 		just past her shoulders, bright hazel eyes, a small gap between her front
 		teeth. Wearing a mustard-yellow cardigan over a white tee, rolled-up denim
 		overalls, scuffed red sneakers, a canvas satchel slung across one shoulder.
@@ -128,6 +129,7 @@ const OSML_SYSTEM_PROMPT = dedent`
   - pitch: ${TTS_PITCHES.join(", ")}.
   - accent: ${TTS_ACCENTS.join(", ")}.
   - description: A simple descriptor of the voice. Examples: Charming, Confident, Approachable, Friendly, Energetic, Casual, Mature, Warm, Clear, Upbeat, Deep, Soft, etc.
+  - language: ISO 639-1 code of the spoken language. Allowed values: ${TTS_LANGUAGES.join(", ")}. Default to "en" when unspecified.
 
   ### General XML Tag Rules
   - NEVER nest XML tags within other XML tags.

--- a/lib/connectors/tts/enums.ts
+++ b/lib/connectors/tts/enums.ts
@@ -2,7 +2,7 @@
  * TTS attribute enums
  * These enums are used for text-to-speech (TTS) generation
  */
-export const TTS_GENDERS = ["masculine", "feminine", "gender_neutral"] as const;
+export const TTS_GENDERS = ["masculine", "feminine"] as const;
 export type TTSGender = (typeof TTS_GENDERS)[number];
 
 export const TTS_AGES = ["child", "adult"] as const;
@@ -13,6 +13,52 @@ export type TTSPitch = (typeof TTS_PITCHES)[number];
 
 export const TTS_SPEEDS = ["slow", "medium", "fast"] as const;
 export type TTSSpeed = (typeof TTS_SPEEDS)[number];
+
+export const TTS_LANGUAGES = [
+	"en",
+	"fr",
+	"de",
+	"es",
+	"pt",
+	"zh",
+	"ja",
+	"hi",
+	"it",
+	"ko",
+	"nl",
+	"pl",
+	"ru",
+	"sv",
+	"tr",
+	"tl",
+	"bg",
+	"ro",
+	"ar",
+	"cs",
+	"el",
+	"fi",
+	"hr",
+	"ms",
+	"sk",
+	"da",
+	"ta",
+	"uk",
+	"hu",
+	"no",
+	"vi",
+	"bn",
+	"th",
+	"he",
+	"ka",
+	"id",
+	"te",
+	"gu",
+	"kn",
+	"ml",
+	"mr",
+	"pa",
+] as const;
+export type TTSLanguage = (typeof TTS_LANGUAGES)[number];
 
 export const TTS_ACCENTS = [
 	"american",

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
-import { TTS_GENDERS } from "@/lib/connectors/tts/enums";
+import { TTS_GENDERS, TTS_LANGUAGES } from "@/lib/connectors/tts/enums";
 import type { TransitionType } from "@/lib/video/transitions";
 
 const optionalString = z.string().min(1).optional().catch(undefined);
 
 export const genderSchema = z.enum(TTS_GENDERS).optional().catch(undefined);
+export const languageSchema = z.enum(TTS_LANGUAGES).optional().catch(undefined);
 
 export const MetadataVoiceSchema = z.object({
 	gender: genderSchema,
@@ -12,6 +13,7 @@ export const MetadataVoiceSchema = z.object({
 	pitch: optionalString,
 	accent: optionalString,
 	description: optionalString,
+	language: languageSchema,
 });
 
 export const voiceSearchParamsSchema = z.object({
@@ -22,7 +24,7 @@ export const voiceSearchParamsSchema = z.object({
 	accent: optionalString,
 	description: optionalString,
 	name: optionalString,
-	language: optionalString,
+	language: languageSchema,
 });
 
 export type MetadataVoice = z.infer<typeof MetadataVoiceSchema>;

--- a/lib/providers/llm/mock.ts
+++ b/lib/providers/llm/mock.ts
@@ -9,15 +9,15 @@ const MOCK_SCRIPT = `<metadata_title>Little Red</metadata_title>
 
 <metadata_style>Warm, earth tones. Whimsical storybook illustration with soft watercolors, gentle brush strokes, warm lighting.</metadata_style>
 
-<metadata_narration gender="feminine" age="adult" pitch="medium" accent="american" description="warm, grandmotherly, kind"></metadata_narration>
+<metadata_narration gender="feminine" age="adult" pitch="medium" accent="american" description="warm, grandmotherly, kind" language="en"></metadata_narration>
 
-<metadata_character name="Red" gender="feminine" age="child" pitch="high" accent="american" description="bright, cheerful, youthful">A cheerful girl around eight years old with warm brown skin, dark curly hair in two puffs, bright brown eyes, wearing a bright red hooded cloak over a white dress, small brown leather boots.</metadata_character>
+<metadata_character name="Red" gender="feminine" age="child" pitch="high" accent="american" description="bright, cheerful, youthful" language="en">A cheerful girl around eight years old with warm brown skin, dark curly hair in two puffs, bright brown eyes, wearing a bright red hooded cloak over a white dress, small brown leather boots.</metadata_character>
 
-<metadata_character name="Wolf" gender="masculine" age="adult" pitch="low" accent="american" description="gentle, soft-spoken, kind">A large gray wolf with kind amber eyes, soft thick fur, wearing a worn brown vest with wooden buttons, slightly hunched posture, gentle expression despite sharp teeth.</metadata_character>
+<metadata_character name="Wolf" gender="masculine" age="adult" pitch="low" accent="american" description="gentle, soft-spoken, kind" language="en">A large gray wolf with kind amber eyes, soft thick fur, wearing a worn brown vest with wooden buttons, slightly hunched posture, gentle expression despite sharp teeth.</metadata_character>
 
-<metadata_character name="Mother" gender="feminine" age="adult" pitch="medium" accent="american" description="caring, gentle, melodic">Red's mother, a tall woman with warm brown skin, long black braided hair tied back with a green ribbon, kind dark eyes, wearing a long blue dress and a flour-dusted apron.</metadata_character>
+<metadata_character name="Mother" gender="feminine" age="adult" pitch="medium" accent="american" description="caring, gentle, melodic" language="en">Red's mother, a tall woman with warm brown skin, long black braided hair tied back with a green ribbon, kind dark eyes, wearing a long blue dress and a flour-dusted apron.</metadata_character>
 
-<metadata_character name="Granny" gender="feminine" age="adult" pitch="medium" accent="american" description="caring, gentle, melodic">Red's grandmother, a small elderly woman with deep brown skin, silver hair in a bun, twinkling hazel eyes behind round spectacles, wearing a soft purple shawl.</metadata_character>
+<metadata_character name="Granny" gender="feminine" age="adult" pitch="medium" accent="american" description="caring, gentle, melodic" language="en">Red's grandmother, a small elderly woman with deep brown skin, silver hair in a bun, twinkling hazel eyes behind round spectacles, wearing a soft purple shawl.</metadata_character>
 
 <animated_image videoPrompt="slow pan across the village to the forest path" motion="kenBurnsOut">A peaceful village at the edge of a lush green forest on a sunny morning. A cozy cottage with a red door sits near the forest path. Birds fly overhead. Flowers bloom along the dirt path leading into the woods.</animated_image>
 

--- a/lib/providers/tts/cartesia.ts
+++ b/lib/providers/tts/cartesia.ts
@@ -5,7 +5,11 @@ import type {
 	VoiceInfo,
 	VoiceSearchParams,
 } from "@/lib/connectors/types";
-import type { TTSGender, TTSSpeed } from "@/lib/connectors/tts/enums";
+import {
+	TTS_GENDERS,
+	type TTSGender,
+	type TTSSpeed,
+} from "@/lib/connectors/tts/enums";
 import type { BundleFile } from "@/lib/api/asset-bundle";
 import { logger } from "@/lib/api/logger";
 import { BaseProvider, type WithMetadata } from "../base";
@@ -123,7 +127,7 @@ export class CartesiaTTS extends BaseProvider<TTSGenerateParams, RawTTSResult> {
 				id: voice.id,
 				name: voice.name,
 				language: voice.language,
-				gender: voice.gender ?? undefined,
+				gender: TTS_GENDERS.find((g) => g === voice.gender),
 				description: voice.description,
 				previewUrl: voice.preview_file_url ?? undefined,
 			}))


### PR DESCRIPTION
## Summary
- Add `language` attribute to `metadata_narration` and `metadata_character` OSML tags, backed by a new `TTS_LANGUAGES` enum (42 ISO 639-1 codes). Threaded through `MetadataVoiceSchema` → metadata-voice plugin → voice-search plugin → `searchVoices()` (falls back to `"en"`).
- OSML system prompt documents the new attribute and example tags include `language="en"`. Mock LLM script updated accordingly.
- Remove `gender_neutral` from `TTS_GENDERS`; Cartesia voice mapping now resolves gender via `TTS_GENDERS.find(...)` so unknown values become `undefined`.

## Test plan
- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run test:run` all pass
- [ ] Generate a story with non-English language and confirm `searchVoices` receives the right language code
- [ ] Confirm Cartesia voices tagged `gender_neutral` upstream still load with `gender: undefined`