### PR TITLE
fix: nightly bug fixes 2026-05-23

### DIFF
--- a/lib/providers/__tests__/anthropic-llm.test.ts
+++ b/lib/providers/__tests__/anthropic-llm.test.ts
@@ -97,6 +97,61 @@ describe("AnthropicLLM", () => {
 			]);
 		});
 
+		it("converts base64 data URI reference images into base64 source blocks", async () => {
+			mockCreate.mockResolvedValue({
+				content: [{ type: "text", text: "ok" }],
+				model: "claude-opus-4-7",
+				usage: { input_tokens: 1, output_tokens: 1 },
+			});
+
+			const provider = new AnthropicLLM("test-key");
+			await provider.generate({
+				prompt: "describe",
+				referenceImages: [
+					"data:image/png;base64,iVBORw0KGgo=",
+					"https://a/2.jpg",
+				],
+			});
+
+			expect(mockCreate.mock.calls[0][0].messages[0].content).toEqual([
+				{
+					type: "image",
+					source: {
+						type: "base64",
+						media_type: "image/png",
+						data: "iVBORw0KGgo=",
+					},
+				},
+				{
+					type: "image",
+					source: { type: "url", url: "https://a/2.jpg" },
+				},
+				{ type: "text", text: "describe" },
+			]);
+		});
+
+		it("rejects reference images that are neither URLs nor base64 data URIs", async () => {
+			const provider = new AnthropicLLM("test-key");
+			await expect(
+				provider.generate({
+					prompt: "describe",
+					referenceImages: ["ftp://nope/img.png"],
+				}),
+			).rejects.toThrow(/must be an http\(s\) URL or a base64 data URI/);
+			expect(mockCreate).not.toHaveBeenCalled();
+		});
+
+		it("rejects data URIs with unsupported media types", async () => {
+			const provider = new AnthropicLLM("test-key");
+			await expect(
+				provider.generate({
+					prompt: "describe",
+					referenceImages: ["data:image/svg+xml;base64,PHN2Zy8+"],
+				}),
+			).rejects.toThrow(/media type "image\/svg\+xml" is not supported/);
+			expect(mockCreate).not.toHaveBeenCalled();
+		});
+
 		it("concatenates multiple text blocks", async () => {
 			mockCreate.mockResolvedValue({
 				content: [

--- a/lib/providers/llm/anthropic.ts
+++ b/lib/providers/llm/anthropic.ts
@@ -5,6 +5,41 @@ import type {
 } from "@/lib/connectors/types";
 import { BaseProvider } from "../base";
 
+const SUPPORTED_IMAGE_MEDIA_TYPES = [
+	"image/jpeg",
+	"image/png",
+	"image/gif",
+	"image/webp",
+] as const;
+
+type SupportedImageMediaType = (typeof SUPPORTED_IMAGE_MEDIA_TYPES)[number];
+
+function isSupportedMediaType(value: string): value is SupportedImageMediaType {
+	return (SUPPORTED_IMAGE_MEDIA_TYPES as readonly string[]).includes(value);
+}
+
+function toImageBlock(image: string): Anthropic.ImageBlockParam {
+	if (/^https?:\/\//i.test(image)) {
+		return { type: "image", source: { type: "url", url: image } };
+	}
+	const match = /^data:([a-z]+\/[a-z0-9+.-]+);base64,(.+)$/i.exec(image);
+	if (!match) {
+		throw new Error(
+			"Anthropic reference image must be an http(s) URL or a base64 data URI",
+		);
+	}
+	const mediaType = match[1].toLowerCase();
+	if (!isSupportedMediaType(mediaType)) {
+		throw new Error(
+			`Anthropic reference image media type "${mediaType}" is not supported; expected one of ${SUPPORTED_IMAGE_MEDIA_TYPES.join(", ")}`,
+		);
+	}
+	return {
+		type: "image",
+		source: { type: "base64", media_type: mediaType, data: match[2] },
+	};
+}
+
 export class AnthropicLLM extends BaseProvider<
 	LLMGenerateParams,
 	LLMGenerateResult,
@@ -29,13 +64,7 @@ export class AnthropicLLM extends BaseProvider<
 	private buildRequest(params: LLMGenerateParams) {
 		const images = params.referenceImages ?? [];
 		const content: Anthropic.ContentBlockParam[] = [
-			...images.map(
-				(url) =>
-					({
-						type: "image" as const,
-						source: { type: "url" as const, url },
-					}) satisfies Anthropic.ImageBlockParam,
-			),
+			...images.map(toImageBlock),
 			{ type: "text" as const, text: params.prompt },
 		];
 		return {


### PR DESCRIPTION
## Summary
- Fix Anthropic LLM reference-image request construction for `data:` URIs by emitting base64 image blocks with validated media types.
- Preserve URL behavior for http(s) references and fail loudly on malformed/unsupported reference image inputs.
- Add focused provider tests for mixed URL+data URI requests and rejection paths.

## Validation
- npm test -- --passWithNoTests
- npm run build