### PR TITLE
fix: nightly bug fixes 2026-05-25

### DIFF
--- a/app/api/render/progress/__tests__/route.test.ts
+++ b/app/api/render/progress/__tests__/route.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetRenderProgress = vi.fn();
+const mockGetUser = vi.fn();
+
+vi.mock("@remotion/lambda/client", () => ({
+	getRenderProgress: (...args: unknown[]) => mockGetRenderProgress(...args),
+	speculateFunctionName: vi.fn(() => "remotion-fn"),
+}));
+
+vi.mock("@/lib/api/auth", () => ({
+	getUser: () => mockGetUser(),
+}));
+
+import { POST } from "../route";
+
+const makeRequest = (body: unknown) =>
+	new NextRequest(new URL("/api/render/progress", "http://localhost:3000"), {
+		method: "POST",
+		body: JSON.stringify(body),
+	});
+
+describe("POST /api/render/progress", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetUser.mockResolvedValue({ id: "user-1" });
+	});
+
+	it("returns unauthorized when user is not authenticated", async () => {
+		mockGetUser.mockResolvedValue(null);
+
+		const response = await POST(
+			makeRequest({ renderId: "r1", bucketName: "b1" }),
+		);
+
+		expect(response.status).toBe(401);
+		expect(mockGetRenderProgress).not.toHaveBeenCalled();
+	});
+
+	it("returns an explicit error when render is done but output metadata is missing", async () => {
+		mockGetRenderProgress.mockResolvedValue({
+			done: true,
+			fatalErrorEncountered: false,
+			outputFile: undefined,
+			outputSizeInBytes: undefined,
+		});
+
+		const response = await POST(
+			makeRequest({ renderId: "r1", bucketName: "b1" }),
+		);
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toEqual({
+			type: "error",
+			message: "Render completed without output metadata",
+		});
+	});
+
+	it("returns done payload when output metadata is present", async () => {
+		mockGetRenderProgress.mockResolvedValue({
+			done: true,
+			fatalErrorEncountered: false,
+			outputFile: "https://cdn.example.com/video.mp4",
+			outputSizeInBytes: 2048,
+		});
+
+		const response = await POST(
+			makeRequest({ renderId: "r1", bucketName: "b1" }),
+		);
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toEqual({
+			type: "done",
+			url: "https://cdn.example.com/video.mp4",
+			size: 2048,
+		});
+	});
+});

--- a/app/api/render/progress/route.ts
+++ b/app/api/render/progress/route.ts
@@ -44,10 +44,19 @@ export async function POST(req: NextRequest) {
 		});
 	}
 	if (progress.done) {
+		if (
+			!progress.outputFile ||
+			typeof progress.outputSizeInBytes !== "number"
+		) {
+			return NextResponse.json<ProgressResponse>({
+				type: "error",
+				message: "Render completed without output metadata",
+			});
+		}
 		return NextResponse.json<ProgressResponse>({
 			type: "done",
-			url: progress.outputFile as string,
-			size: progress.outputSizeInBytes as number,
+			url: progress.outputFile,
+			size: progress.outputSizeInBytes,
 		});
 	}
 	return NextResponse.json<ProgressResponse>({


### PR DESCRIPTION
## Summary
- Fixes a correctness issue in render progress where completed renders could return `done` with missing output metadata (`undefined` URL/size).
- Adds route-level tests for `/api/render/progress` to cover auth gating and done-state metadata handling.

## Test Plan
- npm test -- --passWithNoTests
- npm run build