### PR TITLE
refactor: nightly maintainability 2026-05-26

### DIFF
--- a/lib/connectors/base.ts
+++ b/lib/connectors/base.ts
@@ -42,16 +42,26 @@ export abstract class BaseConnector<
 		return runBeforeGenerate(this.plugins, { ...params, prompt }, ctx);
 	}
 
+	/**
+	 * Notifies onError plugins and rethrows. Subclasses use this to share the
+	 * try/catch pattern across `generate` and any other operations (e.g. `stream`).
+	 */
+	protected async reportError(
+		ctx: PluginContext<TParams, TResult>,
+		error: unknown,
+	): Promise<never> {
+		await runOnError(this.plugins, stringifyError(error), ctx);
+		throw error;
+	}
+
 	async generate(params: TParams): Promise<TResult> {
 		const ctx = this.pluginContext();
 		try {
 			const prepared = await this.prepareParams(params, ctx);
-			let result = await this._generate(prepared);
-			result = await runAfterGenerate(this.plugins, result, ctx);
-			return result;
+			const result = await this._generate(prepared);
+			return runAfterGenerate(this.plugins, result, ctx);
 		} catch (error) {
-			await runOnError(this.plugins, stringifyError(error), ctx);
-			throw error;
+			return this.reportError(ctx, error);
 		}
 	}
 

--- a/lib/connectors/llm/connector.ts
+++ b/lib/connectors/llm/connector.ts
@@ -1,7 +1,5 @@
 import type { GatewayClient } from "@/lib/gateway/base";
-import { stringifyError } from "@/lib/errors";
 import { BaseConnector } from "../base";
-import { runOnError } from "../plugins";
 import type {
 	ConnectorConfig,
 	LLMConnector,
@@ -41,8 +39,7 @@ export abstract class BaseLLMConnector<
 			const prepared = await this.prepareParams(params, ctx);
 			yield* this._stream(prepared);
 		} catch (error) {
-			await runOnError(this.plugins, stringifyError(error), ctx);
-			throw error;
+			await this.reportError(ctx, error);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- centralize connector plugin-error reporting into BaseConnector helper
- remove duplicated error handling in LLM connector stream path
- preserve behavior and error propagation contract while reducing coupling/duplication

## Validation
- npm run build
- npm test -- --passWithNoTests