### PR TITLE
Template preamble + art style override + voiceId override

### DIFF
--- a/app/api/v1/tts/voices/preview/route.ts
+++ b/app/api/v1/tts/voices/preview/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUser } from "@/lib/api/auth";
+import { logger } from "@/lib/api/logger";
+import { getTTSProvider } from "@/lib/api/providers";
+import { badRequest, serverError, unauthorized } from "@/lib/api/response";
+
+export async function GET(request: NextRequest) {
+	try {
+		const user = await getUser();
+		if (!user) return unauthorized();
+
+		const url = request.nextUrl.searchParams.get("url");
+		if (!url) return badRequest("Missing url");
+
+		const upstream = await getTTSProvider().fetchVoicePreview(url);
+		if (!upstream.ok) {
+			return new NextResponse(null, { status: upstream.status });
+		}
+
+		const body = await upstream.arrayBuffer();
+		return new NextResponse(body, {
+			status: 200,
+			headers: {
+				"Content-Type":
+					upstream.headers.get("Content-Type") ?? "application/octet-stream",
+				"Content-Length": String(body.byteLength),
+				"Cache-Control": "public, max-age=3600",
+			},
+		});
+	} catch (error) {
+		logger.error(error, "Voice preview fetch failed");
+		return serverError("Voice preview fetch failed");
+	}
+}

--- a/app/components/canvas/elements/AssetTile.tsx
+++ b/app/components/canvas/elements/AssetTile.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type LucideIcon } from "lucide-react";
+import { Pencil, type LucideIcon } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
 import { GenerationIndicator } from "./GenerationIndicator";
@@ -10,18 +10,20 @@ export function AssetTile({
 	previewUrl,
 	Icon,
 	elementId,
+	onEdit,
 }: {
 	name?: string;
 	previewUrl?: string;
 	Icon: LucideIcon;
 	elementId?: string;
+	onEdit?: () => void;
 }) {
 	const status = useQueueSelector(
 		(q) => q.getElementSnapshot(elementId).status,
 	);
 	const initial = name?.trim().charAt(0).toUpperCase();
 	return (
-		<div className="flex w-16 flex-col gap-1 sm:w-20">
+		<div className="group/tile flex w-16 flex-col gap-1 sm:w-20">
 			<div className="relative aspect-square overflow-hidden rounded-md border border-white/10">
 				<Avatar className="size-full rounded-md bg-white/5">
 					{previewUrl && (
@@ -51,6 +53,16 @@ export function AssetTile({
 						size="sm"
 						className="absolute right-1 top-1"
 					/>
+				)}
+				{onEdit && status !== "generating" && (
+					<button
+						type="button"
+						onClick={onEdit}
+						aria-label={`Edit ${name ?? "asset"}`}
+						className="absolute inset-0 flex items-center justify-center bg-black/45 text-white opacity-0 transition-opacity group-hover/tile:opacity-100 focus:opacity-100 focus:outline-none"
+					>
+						<Pencil className="h-3.5 w-3.5" />
+					</button>
 				)}
 			</div>
 			{name && (

--- a/app/components/canvas/elements/AssetTile.tsx
+++ b/app/components/canvas/elements/AssetTile.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Pencil, type LucideIcon } from "lucide-react";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
+import { ImageWithShimmer } from "@/lib/components/ImageWithShimmer";
 import { GenerationIndicator } from "./GenerationIndicator";
 
 export function AssetTile({
@@ -11,48 +11,55 @@ export function AssetTile({
 	Icon,
 	elementId,
 	onEdit,
+	fallback = "initial",
 }: {
 	name?: string;
 	previewUrl?: string;
 	Icon: LucideIcon;
 	elementId?: string;
 	onEdit?: () => void;
+	fallback?: "initial" | "icon";
 }) {
 	const status = useQueueSelector(
 		(q) => q.getElementSnapshot(elementId).status,
 	);
 	const initial = name?.trim().charAt(0).toUpperCase();
+	const fallbackContent =
+		fallback === "icon" || !initial ? <Icon className="h-4 w-4" /> : initial;
 	return (
 		<div className="group/tile flex w-16 flex-col gap-1 sm:w-20">
-			<div className="relative aspect-square overflow-hidden rounded-md border border-white/10">
-				<Avatar className="size-full rounded-md bg-white/5">
-					{previewUrl && (
-						<AvatarImage
-							src={previewUrl}
-							alt={name ?? ""}
-							className="object-cover"
-						/>
-					)}
-					<AvatarFallback className="rounded-md bg-white/5 text-base text-white/60">
-						{initial || <Icon className="h-4 w-4" />}
-					</AvatarFallback>
-				</Avatar>
+			<div className="relative aspect-square overflow-hidden rounded-md border border-white/10 bg-white/5">
+				{previewUrl ? (
+					<ImageWithShimmer
+						key={previewUrl}
+						src={previewUrl}
+						alt={name ?? ""}
+						fill
+						unoptimized
+						className="object-cover"
+					/>
+				) : (
+					<div className="flex size-full items-center justify-center text-base text-white/60">
+						{fallbackContent}
+					</div>
+				)}
 				{status === "generating" && (
 					<div
 						className="shimmer-surface absolute inset-0 rounded-md"
 						aria-hidden
 					/>
 				)}
-				{status === "idle" ? (
-					<div className="absolute right-1 top-1 flex h-4 w-4 items-center justify-center rounded-full bg-black/40 text-white/80">
-						<Icon className="h-2.5 w-2.5" />
-					</div>
-				) : (
+				{status !== "idle" && (
 					<GenerationIndicator
 						status={status}
 						size="sm"
 						className="absolute right-1 top-1"
 					/>
+				)}
+				{status === "idle" && previewUrl && (
+					<div className="absolute right-1 top-1 flex h-4 w-4 items-center justify-center rounded-full bg-black/40 text-white/80">
+						<Icon className="h-2.5 w-2.5" />
+					</div>
 				)}
 				{onEdit && status !== "generating" && (
 					<button

--- a/app/components/canvas/elements/AssetsSection.tsx
+++ b/app/components/canvas/elements/AssetsSection.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import { Palette, Plus, User } from "lucide-react";
+import { Mic, Palette, Plus, User } from "lucide-react";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useProjectStore } from "@/lib/project/store";
 import { characterAvatarElementId } from "@/lib/project/ensureCharacterAvatars";
 import { AssetTile } from "./AssetTile";
 import { CharacterEditModal } from "./character/CharacterEditModal";
+import { NarratorEditModal } from "./character/NarratorEditModal";
 import { NewCharacterDialog } from "./character/NewCharacterDialog";
 import { CollapsibleHeader } from "./CollapsibleHeader";
 
@@ -17,6 +18,7 @@ export function AssetsSection() {
 	const referenceImages = useProjectStore(projectId, (s) => s.referenceImages);
 	const [collapsed, setCollapsed] = useState(false);
 	const [editingName, setEditingName] = useState<string | undefined>();
+	const [editingNarrator, setEditingNarrator] = useState(false);
 	const [creating, setCreating] = useState(false);
 
 	if (!hydrated) return null;
@@ -31,6 +33,12 @@ export function AssetsSection() {
 			/>
 			{!collapsed && (
 				<div className="flex flex-wrap gap-2">
+					<AssetTile
+						name="Narrator"
+						Icon={Mic}
+						fallback="icon"
+						onEdit={() => setEditingNarrator(true)}
+					/>
 					<button
 						type="button"
 						onClick={() => setCreating(true)}
@@ -74,6 +82,10 @@ export function AssetsSection() {
 				open={editingName !== undefined}
 				onOpenChange={(open) => !open && setEditingName(undefined)}
 				name={editingName}
+			/>
+			<NarratorEditModal
+				open={editingNarrator}
+				onOpenChange={setEditingNarrator}
 			/>
 		</section>
 	);

--- a/app/components/canvas/elements/AssetsSection.tsx
+++ b/app/components/canvas/elements/AssetsSection.tsx
@@ -1,22 +1,25 @@
 "use client";
 
 import { useState } from "react";
-import { Palette, User } from "lucide-react";
+import { Palette, Plus, User } from "lucide-react";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useProjectStore } from "@/lib/project/store";
 import { characterAvatarElementId } from "@/lib/project/ensureCharacterAvatars";
 import { AssetTile } from "./AssetTile";
+import { CharacterEditModal } from "./character/CharacterEditModal";
+import { NewCharacterDialog } from "./character/NewCharacterDialog";
 import { CollapsibleHeader } from "./CollapsibleHeader";
 
 export function AssetsSection() {
 	const { projectId } = useConfig();
+	const hydrated = useProjectStore(projectId, (s) => s.hydrated);
 	const characters = useProjectStore(projectId, (s) => s.metadata.characters);
 	const referenceImages = useProjectStore(projectId, (s) => s.referenceImages);
 	const [collapsed, setCollapsed] = useState(false);
+	const [editingName, setEditingName] = useState<string | undefined>();
+	const [creating, setCreating] = useState(false);
 
-	if (Object.keys(characters).length === 0 && referenceImages.length === 0) {
-		return null;
-	}
+	if (!hydrated) return null;
 
 	return (
 		<section className="group/collapsible mb-4 select-none" aria-label="Assets">
@@ -28,6 +31,17 @@ export function AssetsSection() {
 			/>
 			{!collapsed && (
 				<div className="flex flex-wrap gap-2">
+					<button
+						type="button"
+						onClick={() => setCreating(true)}
+						aria-label="Add character"
+						className="flex w-16 flex-col gap-1 sm:w-20"
+					>
+						<div className="flex aspect-square items-center justify-center rounded-md border border-dashed border-white/15 bg-white/[0.02] text-white/50 transition-colors hover:border-white/30 hover:bg-white/[0.05] hover:text-white/80">
+							<Plus className="h-4 w-4" />
+						</div>
+						<span className="truncate text-[10px] text-white/40">New</span>
+					</button>
 					{Object.entries(characters).map(([name, ch]) => (
 						<AssetTile
 							key={`character:${name}`}
@@ -35,6 +49,7 @@ export function AssetsSection() {
 							previewUrl={ch.avatarUrl}
 							Icon={User}
 							elementId={characterAvatarElementId(name)}
+							onEdit={() => setEditingName(name)}
 						/>
 					))}
 					{referenceImages.map((url, i) => (
@@ -47,6 +62,19 @@ export function AssetsSection() {
 					))}
 				</div>
 			)}
+			<NewCharacterDialog
+				open={creating}
+				onOpenChange={setCreating}
+				onCreated={(name) => {
+					setCreating(false);
+					setEditingName(name);
+				}}
+			/>
+			<CharacterEditModal
+				open={editingName !== undefined}
+				onOpenChange={(open) => !open && setEditingName(undefined)}
+				name={editingName}
+			/>
 		</section>
 	);
 }

--- a/app/components/canvas/elements/AudioPlayer.tsx
+++ b/app/components/canvas/elements/AudioPlayer.tsx
@@ -36,9 +36,9 @@ export function AudioPlayer({
 					<button
 						type="button"
 						aria-label={playing ? "Pause" : "Play"}
-						className="shrink-0 relative w-7 h-7 rounded-full bg-white/10 hover:bg-white/20 grain grain-light flex items-center justify-center transition-colors overflow-hidden"
 						onClick={() => waveformRef.current?.toggle()}
 						disabled={duration === 0}
+						className="shrink-0 relative w-7 h-7 rounded-full bg-white/10 hover:bg-white/20 grain grain-light flex items-center justify-center transition-colors overflow-hidden disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-white/10"
 					>
 						{playing ? (
 							<Pause className="w-3 h-3 text-white" />

--- a/app/components/canvas/elements/ForegroundPreview.tsx
+++ b/app/components/canvas/elements/ForegroundPreview.tsx
@@ -11,14 +11,14 @@ export function ForegroundPreview({
 }: {
 	element: CanvasContentElement;
 }) {
-	const { result, generating, stale, generate } = useGenerate(element);
+	const { result, status, stale, generate } = useGenerate(element);
 	const { outputKind } = ELEMENT_CONFIGS[element.type];
 	const url = getPrimaryUrl(result, outputKind);
 
 	if (!url) {
 		return (
 			<div className="relative w-full h-full rounded-lg overflow-hidden border bg-white/[0.03]">
-				<PlaceholderBallsLoader generating={generating} />
+				<PlaceholderBallsLoader generating={status === "generating"} />
 			</div>
 		);
 	}

--- a/app/components/canvas/elements/MediaWithSkeleton.tsx
+++ b/app/components/canvas/elements/MediaWithSkeleton.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import Image from "next/image";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ImageWithShimmer } from "@/lib/components/ImageWithShimmer";
 import type { ResultKind } from "../types";
 
 interface MediaWithSkeletonProps {
@@ -16,32 +16,32 @@ export function MediaWithSkeleton({
 	alt,
 	videoInteractive = false,
 }: MediaWithSkeletonProps) {
-	const [loaded, setLoaded] = useState(false);
+	const [videoLoaded, setVideoLoaded] = useState(false);
 
+	if (outputKind === "image") {
+		return (
+			<ImageWithShimmer
+				src={src}
+				alt={alt}
+				fill
+				className="object-cover"
+				unoptimized
+			/>
+		);
+	}
 	return (
 		<>
-			{outputKind === "image" ? (
-				<Image
-					src={src}
-					alt={alt}
-					fill
-					className="object-cover"
-					unoptimized
-					onLoad={() => setLoaded(true)}
-				/>
-			) : (
-				<video
-					src={src}
-					controls={videoInteractive}
-					className={
-						videoInteractive
-							? "w-full h-full object-cover"
-							: "w-full h-full object-cover pointer-events-none"
-					}
-					onLoadedData={() => setLoaded(true)}
-				/>
-			)}
-			{!loaded && (
+			<video
+				src={src}
+				controls={videoInteractive}
+				className={
+					videoInteractive
+						? "w-full h-full object-cover"
+						: "w-full h-full object-cover pointer-events-none"
+				}
+				onLoadedData={() => setVideoLoaded(true)}
+			/>
+			{!videoLoaded && (
 				<Skeleton className="absolute inset-0 animate-none shimmer-surface" />
 			)}
 		</>

--- a/app/components/canvas/elements/OutputPreview.tsx
+++ b/app/components/canvas/elements/OutputPreview.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 import type { CanvasContentElement } from "../types";
 import { ELEMENT_CONFIGS } from "../config/elementConfigs";
 import { useGenerate } from "../hooks/useGenerate";
-import { deriveStatus, BORDER_COLORS } from "./preview/status";
+import { BORDER_COLORS } from "./preview/status";
 import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 import {
 	AudioResult,
@@ -19,17 +19,8 @@ function OutputPreviewComponent({
 }) {
 	const type = element.type;
 	const { outputKind } = ELEMENT_CONFIGS[type];
-	const {
-		generating,
-		queued,
-		seconds,
-		result,
-		error,
-		stale,
-		generate,
-		discard,
-	} = useGenerate(element);
-	const status = deriveStatus(generating, queued);
+	const { status, seconds, result, error, stale, generate, discard } =
+		useGenerate(element);
 
 	if (outputKind === "audio") {
 		if (result?.audioUrl) {

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+import { useMemo, useState, type ReactNode } from "react";
+import { Check, ChevronDown, Trash2 } from "lucide-react";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useConfig } from "@/lib/config/ConfigProvider";
+import {
+	TTS_ACCENTS,
+	TTS_AGES,
+	TTS_GENDERS,
+	TTS_LANGUAGES,
+	TTS_PITCHES,
+} from "@/lib/connectors/tts/enums";
+import {
+	useGenerationQueue,
+	useQueueSelector,
+} from "@/lib/generation/GenerationQueueProvider";
+import {
+	buildCharacterAvatarJob,
+	characterAvatarElementId,
+} from "@/lib/project/ensureCharacterAvatars";
+import { useProjectStore } from "@/lib/project/store";
+import type { MetadataCharacter } from "@/lib/project/types";
+import { MediaPlaceholder, MediaPreview } from "../preview/results";
+import { VoicePicker } from "./VoicePicker";
+
+const FIELD_CLS =
+	"w-full rounded-md border border-white/10 bg-white/5 px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30";
+
+export function CharacterEditModal({
+	open,
+	onOpenChange,
+	name,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	name?: string;
+}) {
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			{open && name && (
+				<CharacterEditDialogBody
+					key={name}
+					name={name}
+					onClose={() => onOpenChange(false)}
+				/>
+			)}
+		</Dialog>
+	);
+}
+
+function CharacterEditDialogBody({
+	name,
+	onClose,
+}: {
+	name: string;
+	onClose: () => void;
+}) {
+	const { projectId, connectorConfig } = useConfig();
+	const queue = useGenerationQueue();
+	const character = useProjectStore(
+		projectId,
+		(s) => s.metadata.characters[name],
+	);
+	const setCharacter = useProjectStore(projectId, (s) => s.setCharacter);
+	const removeCharacter = useProjectStore(projectId, (s) => s.removeCharacter);
+
+	const [initialAppearance] = useState(() => character?.appearance ?? "");
+	const [initialAvatarUrl] = useState(() => character?.avatarUrl);
+	const [confirmDelete, setConfirmDelete] = useState(false);
+
+	const update = <K extends keyof MetadataCharacter>(
+		key: K,
+		value: MetadataCharacter[K],
+	) => {
+		if (!character) return;
+		setCharacter(name, { ...character, [key]: value });
+	};
+
+	const avatarElementId = characterAvatarElementId(name);
+	const avatarSnapshot = useQueueSelector((q) =>
+		q.getElementSnapshot(avatarElementId),
+	);
+	const status = avatarSnapshot.status;
+	const seconds = avatarSnapshot.seconds;
+	const avatarError = avatarSnapshot.error;
+
+	const regenerateAvatar = () => {
+		queue.enqueueAll([
+			buildCharacterAvatarJob(projectId, name, connectorConfig),
+		]);
+	};
+
+	const avatarRegenerated =
+		(character?.avatarUrl ?? null) !== (initialAvatarUrl ?? null);
+	const isStale =
+		!!character &&
+		character.appearance !== initialAppearance &&
+		!avatarRegenerated;
+
+	const voiceFilters = useMemo(
+		() => ({
+			gender: character?.gender,
+			age: character?.age,
+			pitch: character?.pitch,
+			accent: character?.accent,
+			description: character?.description,
+			language: character?.language,
+		}),
+		[
+			character?.gender,
+			character?.age,
+			character?.pitch,
+			character?.accent,
+			character?.description,
+			character?.language,
+		],
+	);
+
+	if (!character) return null;
+
+	const handleDelete = () => {
+		if (!confirmDelete) {
+			setConfirmDelete(true);
+			return;
+		}
+		queue.discard(avatarElementId);
+		removeCharacter(name);
+		onClose();
+	};
+
+	return (
+		<DialogContent className="max-w-2xl">
+			<DialogHeader>
+				<DialogTitle>{name}</DialogTitle>
+				<DialogDescription>
+					Edits save automatically. Regenerate the avatar after changing the
+					appearance.
+				</DialogDescription>
+			</DialogHeader>
+
+			<div className="grid gap-4 sm:grid-cols-2">
+				<div className="flex flex-col gap-2">
+					{character.avatarUrl ? (
+						<MediaPreview
+							key={character.avatarUrl}
+							url={character.avatarUrl}
+							outputKind="image"
+							borderColor="border-white/20"
+							status={status}
+							seconds={seconds}
+							stale={isStale}
+							onRegenerate={regenerateAvatar}
+						/>
+					) : (
+						<MediaPlaceholder
+							status={status}
+							seconds={seconds}
+							error={avatarError}
+							onGenerate={regenerateAvatar}
+							onDiscard={() => queue.discard(avatarElementId)}
+						/>
+					)}
+					<TextAreaField
+						label="Appearance"
+						value={character.appearance}
+						onChange={(v) => update("appearance", v)}
+						placeholder="Describe the character's look"
+					/>
+				</div>
+
+				<div className="flex flex-col gap-2">
+					<div className="grid grid-cols-2 gap-2">
+						<EnumField
+							label="Gender"
+							options={TTS_GENDERS}
+							value={character.gender}
+							onChange={(v) => update("gender", v)}
+						/>
+						<EnumField
+							label="Language"
+							options={TTS_LANGUAGES}
+							value={character.language}
+							onChange={(v) => update("language", v)}
+						/>
+						<EnumField
+							label="Age"
+							options={TTS_AGES}
+							value={character.age}
+							onChange={(v) => update("age", v)}
+						/>
+						<EnumField
+							label="Pitch"
+							options={TTS_PITCHES}
+							value={character.pitch}
+							onChange={(v) => update("pitch", v)}
+						/>
+						<EnumField
+							label="Accent"
+							options={TTS_ACCENTS}
+							value={character.accent}
+							onChange={(v) => update("accent", v)}
+						/>
+						<TextField
+							label="Description"
+							value={character.description}
+							onChange={(v) => update("description", v)}
+							placeholder="Free-text"
+						/>
+					</div>
+				</div>
+			</div>
+
+			<VoicePicker
+				filters={voiceFilters}
+				selectedVoiceId={character.voiceId}
+				onSelect={(voice) => update("voiceId", voice.id)}
+			/>
+
+			<DialogFooter>
+				<button
+					type="button"
+					onClick={handleDelete}
+					className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[12px] transition-colors ${
+						confirmDelete
+							? "border-rose-500/60 bg-rose-500/20 text-rose-200 hover:bg-rose-500/30"
+							: "border-white/10 bg-white/5 text-white/70 hover:bg-white/10"
+					}`}
+				>
+					<Trash2 className="h-3 w-3" />
+					{confirmDelete ? "Confirm delete" : "Delete"}
+				</button>
+			</DialogFooter>
+		</DialogContent>
+	);
+}
+
+function FieldLabel({ children }: { children: ReactNode }) {
+	return (
+		<span className="text-[11px] uppercase tracking-wide text-white/50">
+			{children}
+		</span>
+	);
+}
+
+function TextField({
+	label,
+	value,
+	onChange,
+	placeholder,
+}: {
+	label: string;
+	value: string | undefined;
+	onChange: (value: string) => void;
+	placeholder?: string;
+}) {
+	return (
+		<label className="flex flex-col gap-1">
+			<FieldLabel>{label}</FieldLabel>
+			<input
+				type="text"
+				value={value ?? ""}
+				onChange={(e) => onChange(e.target.value)}
+				placeholder={placeholder}
+				className={FIELD_CLS}
+			/>
+		</label>
+	);
+}
+
+function TextAreaField({
+	label,
+	value,
+	onChange,
+	placeholder,
+	rows = 4,
+}: {
+	label: string;
+	value: string;
+	onChange: (value: string) => void;
+	placeholder?: string;
+	rows?: number;
+}) {
+	return (
+		<label className="flex flex-col gap-1">
+			<FieldLabel>{label}</FieldLabel>
+			<textarea
+				rows={rows}
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				placeholder={placeholder}
+				className={FIELD_CLS}
+			/>
+		</label>
+	);
+}
+
+function EnumField<T extends string>({
+	label,
+	options,
+	value,
+	onChange,
+}: {
+	label: string;
+	options: readonly T[];
+	value: T | undefined;
+	onChange: (value: T | undefined) => void;
+}) {
+	return (
+		<div className="flex flex-col gap-1">
+			<FieldLabel>{label}</FieldLabel>
+			<DropdownMenu modal={false}>
+				<DropdownMenuTrigger
+					aria-label={label}
+					className={`${FIELD_CLS} flex items-center justify-between text-left`}
+				>
+					<span className={value ? "text-white" : "text-white/30"}>
+						{value ?? "—"}
+					</span>
+					<ChevronDown className="h-3 w-3 shrink-0 text-white/60" />
+				</DropdownMenuTrigger>
+				<DropdownMenuContent
+					align="start"
+					className="max-h-64 min-w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto rounded-xl border border-white/10 bg-white/5 p-0.5 shadow-md shadow-black/40 backdrop-blur-xl"
+				>
+					<EnumOption
+						selected={value === undefined}
+						onSelect={() => onChange(undefined)}
+					>
+						<span className="text-white/50">—</span>
+					</EnumOption>
+					{options.map((option) => (
+						<EnumOption
+							key={option}
+							selected={option === value}
+							onSelect={() => onChange(option)}
+						>
+							{option}
+						</EnumOption>
+					))}
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
+	);
+}
+
+function EnumOption({
+	selected,
+	onSelect,
+	children,
+}: {
+	selected: boolean;
+	onSelect: () => void;
+	children: ReactNode;
+}) {
+	return (
+		<DropdownMenuItem
+			onClick={onSelect}
+			className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-[12px] text-white/70 hover:text-white focus:bg-white/10 focus:text-white"
+		>
+			<span className="flex w-3.5 shrink-0 items-center justify-center">
+				{selected && <Check className="h-3 w-3 text-white" aria-hidden />}
+			</span>
+			{children}
+		</DropdownMenuItem>
+	);
+}

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -1,44 +1,31 @@
 "use client";
 
-import { useMemo, useState, type ReactNode } from "react";
-import { Check, ChevronDown, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
 import {
-	Dialog,
 	DialogContent,
 	DialogDescription,
 	DialogFooter,
 	DialogHeader,
 	DialogTitle,
+	MountedDialog,
 } from "@/components/ui/dialog";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { useConfig } from "@/lib/config/ConfigProvider";
-import {
-	TTS_ACCENTS,
-	TTS_AGES,
-	TTS_GENDERS,
-	TTS_LANGUAGES,
-	TTS_PITCHES,
-} from "@/lib/connectors/tts/enums";
 import {
 	useGenerationQueue,
 	useQueueSelector,
 } from "@/lib/generation/GenerationQueueProvider";
+import { isStaleResult } from "@/lib/generation/queue";
 import {
 	buildCharacterAvatarJob,
 	characterAvatarElementId,
+	characterAvatarInputs,
 } from "@/lib/project/ensureCharacterAvatars";
 import { useProjectStore } from "@/lib/project/store";
 import type { MetadataCharacter } from "@/lib/project/types";
 import { MediaPlaceholder, MediaPreview } from "../preview/results";
-import { VoicePicker } from "./VoicePicker";
-
-const FIELD_CLS =
-	"w-full rounded-md border border-white/10 bg-white/5 px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30";
+import { TextAreaField } from "./fields";
+import { VoiceSection } from "./VoiceMetadataFields";
 
 export function CharacterEditModal({
 	open,
@@ -50,15 +37,15 @@ export function CharacterEditModal({
 	name?: string;
 }) {
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
-			{open && name && (
+		<MountedDialog open={open && !!name} onOpenChange={onOpenChange}>
+			{name && (
 				<CharacterEditDialogBody
 					key={name}
 					name={name}
 					onClose={() => onOpenChange(false)}
 				/>
 			)}
-		</Dialog>
+		</MountedDialog>
 	);
 }
 
@@ -78,59 +65,25 @@ function CharacterEditDialogBody({
 	const setCharacter = useProjectStore(projectId, (s) => s.setCharacter);
 	const removeCharacter = useProjectStore(projectId, (s) => s.removeCharacter);
 
-	const [initialAppearance] = useState(() => character?.appearance ?? "");
-	const [initialAvatarUrl] = useState(() => character?.avatarUrl);
 	const [confirmDelete, setConfirmDelete] = useState(false);
-
-	const update = <K extends keyof MetadataCharacter>(
-		key: K,
-		value: MetadataCharacter[K],
-	) => {
-		if (!character) return;
-		setCharacter(name, { ...character, [key]: value });
-	};
 
 	const avatarElementId = characterAvatarElementId(name);
 	const avatarSnapshot = useQueueSelector((q) =>
 		q.getElementSnapshot(avatarElementId),
 	);
-	const status = avatarSnapshot.status;
-	const seconds = avatarSnapshot.seconds;
-	const avatarError = avatarSnapshot.error;
-
-	const regenerateAvatar = () => {
-		queue.enqueueAll([
-			buildCharacterAvatarJob(projectId, name, connectorConfig),
-		]);
-	};
-
-	const avatarRegenerated =
-		(character?.avatarUrl ?? null) !== (initialAvatarUrl ?? null);
-	const isStale =
-		!!character &&
-		character.appearance !== initialAppearance &&
-		!avatarRegenerated;
-
-	const voiceFilters = useMemo(
-		() => ({
-			gender: character?.gender,
-			age: character?.age,
-			pitch: character?.pitch,
-			accent: character?.accent,
-			description: character?.description,
-			language: character?.language,
-		}),
-		[
-			character?.gender,
-			character?.age,
-			character?.pitch,
-			character?.accent,
-			character?.description,
-			character?.language,
-		],
-	);
 
 	if (!character) return null;
+
+	const update = (partial: Partial<MetadataCharacter>) =>
+		setCharacter(name, { ...character, ...partial });
+
+	const regenerateAvatar = () =>
+		queue.enqueue(buildCharacterAvatarJob(projectId, name, connectorConfig));
+
+	const isStale = isStaleResult(
+		avatarSnapshot,
+		characterAvatarInputs(name, character.appearance),
+	);
 
 	const handleDelete = () => {
 		if (!confirmDelete) {
@@ -144,7 +97,7 @@ function CharacterEditDialogBody({
 
 	return (
 		<DialogContent className="max-w-2xl">
-			<DialogHeader>
+			<DialogHeader className="shrink-0">
 				<DialogTitle>{name}</DialogTitle>
 				<DialogDescription>
 					Edits save automatically. Regenerate the avatar after changing the
@@ -152,85 +105,39 @@ function CharacterEditDialogBody({
 				</DialogDescription>
 			</DialogHeader>
 
-			<div className="grid gap-4 sm:grid-cols-2">
-				<div className="flex flex-col gap-2">
+			<div className="-mx-1 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-1">
+				<div className="grid gap-4 sm:grid-cols-2">
+					<TextAreaField
+						label="Appearance"
+						value={character.appearance}
+						onChange={(appearance) => update({ appearance })}
+						placeholder="Describe the character's look"
+					/>
 					{character.avatarUrl ? (
 						<MediaPreview
 							key={character.avatarUrl}
 							url={character.avatarUrl}
 							outputKind="image"
 							borderColor="border-white/20"
-							status={status}
-							seconds={seconds}
+							status={avatarSnapshot.status}
+							seconds={avatarSnapshot.seconds}
 							stale={isStale}
 							onRegenerate={regenerateAvatar}
 						/>
 					) : (
 						<MediaPlaceholder
-							status={status}
-							seconds={seconds}
-							error={avatarError}
+							status={avatarSnapshot.status}
+							seconds={avatarSnapshot.seconds}
+							error={avatarSnapshot.error}
 							onGenerate={regenerateAvatar}
 							onDiscard={() => queue.discard(avatarElementId)}
 						/>
 					)}
-					<TextAreaField
-						label="Appearance"
-						value={character.appearance}
-						onChange={(v) => update("appearance", v)}
-						placeholder="Describe the character's look"
-					/>
 				</div>
-
-				<div className="flex flex-col gap-2">
-					<div className="grid grid-cols-2 gap-2">
-						<EnumField
-							label="Gender"
-							options={TTS_GENDERS}
-							value={character.gender}
-							onChange={(v) => update("gender", v)}
-						/>
-						<EnumField
-							label="Language"
-							options={TTS_LANGUAGES}
-							value={character.language}
-							onChange={(v) => update("language", v)}
-						/>
-						<EnumField
-							label="Age"
-							options={TTS_AGES}
-							value={character.age}
-							onChange={(v) => update("age", v)}
-						/>
-						<EnumField
-							label="Pitch"
-							options={TTS_PITCHES}
-							value={character.pitch}
-							onChange={(v) => update("pitch", v)}
-						/>
-						<EnumField
-							label="Accent"
-							options={TTS_ACCENTS}
-							value={character.accent}
-							onChange={(v) => update("accent", v)}
-						/>
-						<TextField
-							label="Description"
-							value={character.description}
-							onChange={(v) => update("description", v)}
-							placeholder="Free-text"
-						/>
-					</div>
-				</div>
+				<VoiceSection voice={character} onChange={update} />
 			</div>
 
-			<VoicePicker
-				filters={voiceFilters}
-				selectedVoiceId={character.voiceId}
-				onSelect={(voice) => update("voiceId", voice.id)}
-			/>
-
-			<DialogFooter>
+			<DialogFooter className="shrink-0">
 				<button
 					type="button"
 					onClick={handleDelete}
@@ -245,136 +152,5 @@ function CharacterEditDialogBody({
 				</button>
 			</DialogFooter>
 		</DialogContent>
-	);
-}
-
-function FieldLabel({ children }: { children: ReactNode }) {
-	return (
-		<span className="text-[11px] uppercase tracking-wide text-white/50">
-			{children}
-		</span>
-	);
-}
-
-function TextField({
-	label,
-	value,
-	onChange,
-	placeholder,
-}: {
-	label: string;
-	value: string | undefined;
-	onChange: (value: string) => void;
-	placeholder?: string;
-}) {
-	return (
-		<label className="flex flex-col gap-1">
-			<FieldLabel>{label}</FieldLabel>
-			<input
-				type="text"
-				value={value ?? ""}
-				onChange={(e) => onChange(e.target.value)}
-				placeholder={placeholder}
-				className={FIELD_CLS}
-			/>
-		</label>
-	);
-}
-
-function TextAreaField({
-	label,
-	value,
-	onChange,
-	placeholder,
-	rows = 4,
-}: {
-	label: string;
-	value: string;
-	onChange: (value: string) => void;
-	placeholder?: string;
-	rows?: number;
-}) {
-	return (
-		<label className="flex flex-col gap-1">
-			<FieldLabel>{label}</FieldLabel>
-			<textarea
-				rows={rows}
-				value={value}
-				onChange={(e) => onChange(e.target.value)}
-				placeholder={placeholder}
-				className={FIELD_CLS}
-			/>
-		</label>
-	);
-}
-
-function EnumField<T extends string>({
-	label,
-	options,
-	value,
-	onChange,
-}: {
-	label: string;
-	options: readonly T[];
-	value: T | undefined;
-	onChange: (value: T | undefined) => void;
-}) {
-	return (
-		<div className="flex flex-col gap-1">
-			<FieldLabel>{label}</FieldLabel>
-			<DropdownMenu modal={false}>
-				<DropdownMenuTrigger
-					aria-label={label}
-					className={`${FIELD_CLS} flex items-center justify-between text-left`}
-				>
-					<span className={value ? "text-white" : "text-white/30"}>
-						{value ?? "—"}
-					</span>
-					<ChevronDown className="h-3 w-3 shrink-0 text-white/60" />
-				</DropdownMenuTrigger>
-				<DropdownMenuContent
-					align="start"
-					className="max-h-64 min-w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto rounded-xl border border-white/10 bg-white/5 p-0.5 shadow-md shadow-black/40 backdrop-blur-xl"
-				>
-					<EnumOption
-						selected={value === undefined}
-						onSelect={() => onChange(undefined)}
-					>
-						<span className="text-white/50">—</span>
-					</EnumOption>
-					{options.map((option) => (
-						<EnumOption
-							key={option}
-							selected={option === value}
-							onSelect={() => onChange(option)}
-						>
-							{option}
-						</EnumOption>
-					))}
-				</DropdownMenuContent>
-			</DropdownMenu>
-		</div>
-	);
-}
-
-function EnumOption({
-	selected,
-	onSelect,
-	children,
-}: {
-	selected: boolean;
-	onSelect: () => void;
-	children: ReactNode;
-}) {
-	return (
-		<DropdownMenuItem
-			onClick={onSelect}
-			className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-[12px] text-white/70 hover:text-white focus:bg-white/10 focus:text-white"
-		>
-			<span className="flex w-3.5 shrink-0 items-center justify-center">
-				{selected && <Check className="h-3 w-3 text-white" aria-hidden />}
-			</span>
-			{children}
-		</DropdownMenuItem>
 	);
 }

--- a/app/components/canvas/elements/character/NarratorEditModal.tsx
+++ b/app/components/canvas/elements/character/NarratorEditModal.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import {
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	MountedDialog,
+} from "@/components/ui/dialog";
+import { useConfig } from "@/lib/config/ConfigProvider";
+import { useProjectStore } from "@/lib/project/store";
+import type { MetadataVoice } from "@/lib/project/types";
+import { VoiceSection } from "./VoiceMetadataFields";
+
+export function NarratorEditModal({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	return (
+		<MountedDialog open={open} onOpenChange={onOpenChange}>
+			<NarratorEditDialogBody />
+		</MountedDialog>
+	);
+}
+
+function NarratorEditDialogBody() {
+	const { projectId } = useConfig();
+	const narration = useProjectStore(projectId, (s) => s.metadata.narration);
+	const setNarration = useProjectStore(projectId, (s) => s.setNarration);
+
+	const update = (partial: Partial<MetadataVoice>) =>
+		setNarration({ ...narration, ...partial });
+
+	return (
+		<DialogContent className="max-w-2xl">
+			<DialogHeader className="shrink-0">
+				<DialogTitle>Narrator</DialogTitle>
+				<DialogDescription>Change how the narrator sounds</DialogDescription>
+			</DialogHeader>
+
+			<div className="-mx-1 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-1">
+				<VoiceSection voice={narration} onChange={update} />
+			</div>
+		</DialogContent>
+	);
+}

--- a/app/components/canvas/elements/character/NewCharacterDialog.tsx
+++ b/app/components/canvas/elements/character/NewCharacterDialog.tsx
@@ -2,12 +2,12 @@
 
 import { useState } from "react";
 import {
-	Dialog,
 	DialogContent,
 	DialogDescription,
 	DialogFooter,
 	DialogHeader,
 	DialogTitle,
+	MountedDialog,
 } from "@/components/ui/dialog";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useProjectStore } from "@/lib/project/store";
@@ -22,9 +22,9 @@ export function NewCharacterDialog({
 	onCreated: (name: string) => void;
 }) {
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
-			{open && <NewCharacterDialogBody onCreated={onCreated} />}
-		</Dialog>
+		<MountedDialog open={open} onOpenChange={onOpenChange}>
+			<NewCharacterDialogBody onCreated={onCreated} />
+		</MountedDialog>
 	);
 }
 

--- a/app/components/canvas/elements/character/NewCharacterDialog.tsx
+++ b/app/components/canvas/elements/character/NewCharacterDialog.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState } from "react";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { useConfig } from "@/lib/config/ConfigProvider";
+import { useProjectStore } from "@/lib/project/store";
+
+export function NewCharacterDialog({
+	open,
+	onOpenChange,
+	onCreated,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onCreated: (name: string) => void;
+}) {
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			{open && <NewCharacterDialogBody onCreated={onCreated} />}
+		</Dialog>
+	);
+}
+
+function NewCharacterDialogBody({
+	onCreated,
+}: {
+	onCreated: (name: string) => void;
+}) {
+	const { projectId } = useConfig();
+	const characters = useProjectStore(projectId, (s) => s.metadata.characters);
+	const setCharacter = useProjectStore(projectId, (s) => s.setCharacter);
+	const [name, setName] = useState("");
+
+	const trimmed = name.trim();
+	const collision = !!trimmed && !!characters[trimmed];
+	const canSubmit = !!trimmed && !collision;
+
+	const handleSubmit = (event: React.FormEvent) => {
+		event.preventDefault();
+		if (!canSubmit) return;
+		setCharacter(trimmed, { appearance: "" });
+		onCreated(trimmed);
+	};
+
+	return (
+		<DialogContent className="max-w-sm">
+			<form onSubmit={handleSubmit} className="flex flex-col gap-3">
+				<DialogHeader>
+					<DialogTitle>New character</DialogTitle>
+					<DialogDescription>
+						Pick a name. You can fill in the details next.
+					</DialogDescription>
+				</DialogHeader>
+
+				<input
+					type="text"
+					autoFocus
+					value={name}
+					onChange={(e) => setName(e.target.value)}
+					placeholder="Character name"
+					aria-label="Character name"
+					className="w-full rounded-md border border-white/10 bg-white/5 px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
+				/>
+
+				{collision && (
+					<span className="text-[11px] text-rose-400" role="alert">
+						A character named &quot;{trimmed}&quot; already exists.
+					</span>
+				)}
+
+				<DialogFooter>
+					<button
+						type="submit"
+						disabled={!canSubmit}
+						className="rounded-md border border-white/20 bg-white/15 px-3 py-1 text-[12px] font-medium text-white hover:bg-white/25 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-white/15"
+					>
+						Create
+					</button>
+				</DialogFooter>
+			</form>
+		</DialogContent>
+	);
+}

--- a/app/components/canvas/elements/character/VoiceMetadataFields.tsx
+++ b/app/components/canvas/elements/character/VoiceMetadataFields.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+	TTS_ACCENTS,
+	TTS_AGES,
+	TTS_GENDERS,
+	TTS_LANGUAGES,
+	TTS_PITCHES,
+} from "@/lib/connectors/tts/enums";
+import type { MetadataVoice } from "@/lib/project/types";
+import { EnumField, FieldLabel, TextField } from "./fields";
+import { VoicePicker } from "./VoicePicker";
+
+export function VoiceSection({
+	voice,
+	onChange,
+}: {
+	voice: MetadataVoice;
+	onChange: (partial: Partial<MetadataVoice>) => void;
+}) {
+	return (
+		<section className="flex flex-col gap-2 rounded-lg border border-white/10 p-3">
+			<div className="flex flex-col gap-0.5">
+				<FieldLabel>Voice</FieldLabel>
+				<p className="text-[11px] text-white/40">
+					These fields filter the voice list. The next generation picks the top
+					match unless you select one below.
+				</p>
+			</div>
+			<VoiceMetadataGrid voice={voice} onChange={onChange} />
+			<MetadataVoicePicker voice={voice} onChange={onChange} />
+		</section>
+	);
+}
+
+export function VoiceMetadataGrid({
+	voice,
+	onChange,
+}: {
+	voice: MetadataVoice;
+	onChange: (partial: Partial<MetadataVoice>) => void;
+}) {
+	return (
+		<div className="grid grid-cols-2 content-start gap-2">
+			<EnumField
+				label="Gender"
+				options={TTS_GENDERS}
+				value={voice.gender}
+				onChange={(gender) => onChange({ gender })}
+			/>
+			<EnumField
+				label="Language"
+				options={TTS_LANGUAGES}
+				value={voice.language}
+				onChange={(language) => onChange({ language })}
+			/>
+			<EnumField
+				label="Age"
+				options={TTS_AGES}
+				value={voice.age}
+				onChange={(age) => onChange({ age })}
+			/>
+			<EnumField
+				label="Pitch"
+				options={TTS_PITCHES}
+				value={voice.pitch}
+				onChange={(pitch) => onChange({ pitch })}
+			/>
+			<EnumField
+				label="Accent"
+				options={TTS_ACCENTS}
+				value={voice.accent}
+				onChange={(accent) => onChange({ accent })}
+			/>
+			<TextField
+				label="Description"
+				value={voice.description}
+				onChange={(description) => onChange({ description })}
+				placeholder="Free-text"
+			/>
+		</div>
+	);
+}
+
+export function MetadataVoicePicker({
+	voice,
+	onChange,
+}: {
+	voice: MetadataVoice;
+	onChange: (partial: Partial<MetadataVoice>) => void;
+}) {
+	const { gender, age, pitch, accent, description, language } = voice;
+	const filters = useMemo(
+		() => ({ gender, age, pitch, accent, description, language }),
+		[gender, age, pitch, accent, description, language],
+	);
+
+	return (
+		<VoicePicker
+			filters={filters}
+			selectedVoiceId={voice.voiceId ?? voice.resolvedVoiceId}
+			onSelect={(picked) => onChange({ voiceId: picked.id })}
+		/>
+	);
+}

--- a/app/components/canvas/elements/character/VoicePicker.tsx
+++ b/app/components/canvas/elements/character/VoicePicker.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Check, Loader2 } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useConfig } from "@/lib/config/ConfigProvider";
+import { getDefaultConnector } from "@/lib/config/connectorUtils";
+import { createConnector } from "@/lib/connectors/factory";
+import type { VoiceInfo } from "@/lib/connectors/types";
+import { errorMessage } from "@/lib/errors";
+import { AudioPlayer } from "../AudioPlayer";
+import type { MetadataVoice } from "@/lib/project/types";
+
+const DEBOUNCE_MS = 300;
+const SKELETON_ROWS = 5;
+const VOICE_LIMIT = 10;
+
+export function VoicePicker({
+	filters,
+	selectedVoiceId,
+	onSelect,
+}: {
+	filters: MetadataVoice;
+	selectedVoiceId?: string;
+	onSelect: (voice: VoiceInfo) => void;
+}) {
+	const { connectorConfig } = useConfig();
+	const ttsConnector = useMemo(() => {
+		const { provider, config } = getDefaultConnector(connectorConfig, "tts");
+		return createConnector("tts", provider, config);
+	}, [connectorConfig]);
+
+	const [voices, setVoices] = useState<VoiceInfo[]>([]);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		const handle = setTimeout(async () => {
+			setLoading(true);
+			setError(null);
+			try {
+				const result = await ttsConnector.searchVoices({
+					...filters,
+					limit: VOICE_LIMIT,
+				});
+				if (!cancelled) setVoices(result);
+			} catch (err) {
+				if (!cancelled) setError(errorMessage(err));
+			} finally {
+				if (!cancelled) setLoading(false);
+			}
+		}, DEBOUNCE_MS);
+
+		return () => {
+			cancelled = true;
+			clearTimeout(handle);
+		};
+	}, [filters, ttsConnector]);
+
+	const showSkeletons = loading && voices.length === 0;
+
+	return (
+		<div className="flex min-w-0 flex-col gap-1.5">
+			<div className="flex items-center justify-between">
+				<span className="text-[11px] uppercase tracking-wide text-white/50">
+					Voices
+				</span>
+				{loading && <Loader2 className="h-3 w-3 animate-spin text-white/40" />}
+			</div>
+			{error && <span className="text-[11px] text-rose-400">{error}</span>}
+			<div className="flex h-64 min-w-0 flex-col gap-1.5 overflow-y-auto rounded-lg border border-white/10 bg-black/20 p-1.5">
+				{showSkeletons &&
+					Array.from({ length: SKELETON_ROWS }).map((_, i) => (
+						<Skeleton
+							key={`skel-${i}`}
+							className="h-16 shrink-0 rounded-md border border-white/5 bg-white/[0.03]"
+						/>
+					))}
+				{voices.length === 0 && !loading && !error && (
+					<span className="px-2 py-3 text-center text-[11px] text-white/40">
+						No voices match these filters.
+					</span>
+				)}
+				{voices.map((voice) => {
+					const selected = voice.id === selectedVoiceId;
+					return (
+						<div
+							key={voice.id}
+							className={`flex min-w-0 flex-col gap-1 rounded-md border px-2 py-1.5 transition-colors ${
+								selected
+									? "border-white/40 bg-white/10"
+									: "border-white/5 bg-white/[0.03]"
+							}`}
+						>
+							<button
+								type="button"
+								onClick={() => onSelect(voice)}
+								className="flex min-w-0 items-center gap-1.5 text-left"
+							>
+								<span className="min-w-0 flex-1 truncate text-[12px] font-medium text-white">
+									{voice.name}
+								</span>
+								{voice.language && (
+									<span className="shrink-0 rounded bg-white/10 px-1 py-px text-[9px] uppercase text-white/60">
+										{voice.language}
+									</span>
+								)}
+								{voice.gender && (
+									<span className="shrink-0 rounded bg-white/10 px-1 py-px text-[9px] uppercase text-white/60">
+										{voice.gender}
+									</span>
+								)}
+								{selected && (
+									<Check className="h-3 w-3 shrink-0 text-white/80" />
+								)}
+							</button>
+							{voice.description && (
+								<span className="block truncate text-[10px] text-white/50">
+									{voice.description}
+								</span>
+							)}
+							{voice.previewUrl && (
+								<div className="flex min-w-0 items-center gap-2">
+									<AudioPlayer src={voice.previewUrl} />
+								</div>
+							)}
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/app/components/canvas/elements/character/VoicePicker.tsx
+++ b/app/components/canvas/elements/character/VoicePicker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Check, Loader2 } from "lucide-react";
+import { Check } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
@@ -10,6 +10,7 @@ import type { VoiceInfo } from "@/lib/connectors/types";
 import { errorMessage } from "@/lib/errors";
 import { AudioPlayer } from "../AudioPlayer";
 import type { MetadataVoice } from "@/lib/project/types";
+import { FieldLabel } from "./fields";
 
 const DEBOUNCE_MS = 300;
 const SKELETON_ROWS = 5;
@@ -58,76 +59,70 @@ export function VoicePicker({
 		};
 	}, [filters, ttsConnector]);
 
-	const showSkeletons = loading && voices.length === 0;
-
 	return (
 		<div className="flex min-w-0 flex-col gap-1.5">
-			<div className="flex items-center justify-between">
-				<span className="text-[11px] uppercase tracking-wide text-white/50">
-					Voices
-				</span>
-				{loading && <Loader2 className="h-3 w-3 animate-spin text-white/40" />}
-			</div>
+			<FieldLabel>Voices</FieldLabel>
 			{error && <span className="text-[11px] text-rose-400">{error}</span>}
 			<div className="flex h-64 min-w-0 flex-col gap-1.5 overflow-y-auto rounded-lg border border-white/10 bg-black/20 p-1.5">
-				{showSkeletons &&
+				{loading &&
 					Array.from({ length: SKELETON_ROWS }).map((_, i) => (
 						<Skeleton
 							key={`skel-${i}`}
 							className="h-16 shrink-0 rounded-md border border-white/5 bg-white/[0.03]"
 						/>
 					))}
-				{voices.length === 0 && !loading && !error && (
+				{!loading && voices.length === 0 && !error && (
 					<span className="px-2 py-3 text-center text-[11px] text-white/40">
 						No voices match these filters.
 					</span>
 				)}
-				{voices.map((voice) => {
-					const selected = voice.id === selectedVoiceId;
-					return (
-						<div
-							key={voice.id}
-							className={`flex min-w-0 flex-col gap-1 rounded-md border px-2 py-1.5 transition-colors ${
-								selected
-									? "border-white/40 bg-white/10"
-									: "border-white/5 bg-white/[0.03]"
-							}`}
-						>
-							<button
-								type="button"
-								onClick={() => onSelect(voice)}
-								className="flex min-w-0 items-center gap-1.5 text-left"
+				{!loading &&
+					voices.map((voice) => {
+						const selected = voice.id === selectedVoiceId;
+						return (
+							<div
+								key={voice.id}
+								className={`flex min-w-0 flex-col gap-1 rounded-md border px-2 py-1.5 transition-colors ${
+									selected
+										? "border-white/40 bg-white/10"
+										: "border-white/5 bg-white/[0.03]"
+								}`}
 							>
-								<span className="min-w-0 flex-1 truncate text-[12px] font-medium text-white">
-									{voice.name}
-								</span>
-								{voice.language && (
-									<span className="shrink-0 rounded bg-white/10 px-1 py-px text-[9px] uppercase text-white/60">
-										{voice.language}
+								<button
+									type="button"
+									onClick={() => onSelect(voice)}
+									className="flex min-w-0 items-center gap-1.5 text-left"
+								>
+									<span className="min-w-0 flex-1 truncate text-[12px] font-medium text-white">
+										{voice.name}
+									</span>
+									{voice.language && (
+										<span className="shrink-0 rounded bg-white/10 px-1 py-px text-[9px] uppercase text-white/60">
+											{voice.language}
+										</span>
+									)}
+									{voice.gender && (
+										<span className="shrink-0 rounded bg-white/10 px-1 py-px text-[9px] uppercase text-white/60">
+											{voice.gender}
+										</span>
+									)}
+									{selected && (
+										<Check className="h-3 w-3 shrink-0 text-white/80" />
+									)}
+								</button>
+								{voice.description && (
+									<span className="block truncate text-[10px] text-white/50">
+										{voice.description}
 									</span>
 								)}
-								{voice.gender && (
-									<span className="shrink-0 rounded bg-white/10 px-1 py-px text-[9px] uppercase text-white/60">
-										{voice.gender}
-									</span>
+								{voice.previewUrl && (
+									<div className="flex min-w-0 items-center gap-2">
+										<AudioPlayer src={voice.previewUrl} />
+									</div>
 								)}
-								{selected && (
-									<Check className="h-3 w-3 shrink-0 text-white/80" />
-								)}
-							</button>
-							{voice.description && (
-								<span className="block truncate text-[10px] text-white/50">
-									{voice.description}
-								</span>
-							)}
-							{voice.previewUrl && (
-								<div className="flex min-w-0 items-center gap-2">
-									<AudioPlayer src={voice.previewUrl} />
-								</div>
-							)}
-						</div>
-					);
-				})}
+							</div>
+						);
+					})}
 			</div>
 		</div>
 	);

--- a/app/components/canvas/elements/character/fields.tsx
+++ b/app/components/canvas/elements/character/fields.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { Check, ChevronDown } from "lucide-react";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export const FIELD_CLS =
+	"w-full rounded-md border border-white/10 bg-white/5 px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30";
+
+export function FieldLabel({ children }: { children: ReactNode }) {
+	return (
+		<span className="text-[11px] uppercase tracking-wide text-white/50">
+			{children}
+		</span>
+	);
+}
+
+export function TextField({
+	label,
+	value,
+	onChange,
+	placeholder,
+}: {
+	label: string;
+	value: string | undefined;
+	onChange: (value: string) => void;
+	placeholder?: string;
+}) {
+	return (
+		<label className="flex flex-col gap-1">
+			<FieldLabel>{label}</FieldLabel>
+			<input
+				type="text"
+				value={value ?? ""}
+				onChange={(e) => onChange(e.target.value)}
+				placeholder={placeholder}
+				className={FIELD_CLS}
+			/>
+		</label>
+	);
+}
+
+export function TextAreaField({
+	label,
+	value,
+	onChange,
+	placeholder,
+	rows = 4,
+}: {
+	label: string;
+	value: string;
+	onChange: (value: string) => void;
+	placeholder?: string;
+	rows?: number;
+}) {
+	return (
+		<label className="flex flex-col gap-1">
+			<FieldLabel>{label}</FieldLabel>
+			<textarea
+				rows={rows}
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				placeholder={placeholder}
+				className={`${FIELD_CLS} grow resize-none`}
+			/>
+		</label>
+	);
+}
+
+export function EnumField<T extends string>({
+	label,
+	options,
+	value,
+	onChange,
+}: {
+	label: string;
+	options: readonly T[];
+	value: T | undefined;
+	onChange: (value: T | undefined) => void;
+}) {
+	return (
+		<div className="flex flex-col gap-1">
+			<FieldLabel>{label}</FieldLabel>
+			<DropdownMenu modal={false}>
+				<DropdownMenuTrigger
+					aria-label={label}
+					className={`${FIELD_CLS} flex items-center justify-between text-left`}
+				>
+					<span className={value ? "text-white" : "text-white/30"}>
+						{value ?? "—"}
+					</span>
+					<ChevronDown className="h-3 w-3 shrink-0 text-white/60" />
+				</DropdownMenuTrigger>
+				<DropdownMenuContent
+					align="start"
+					className="max-h-64 min-w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto rounded-xl border border-white/10 bg-white/5 p-0.5 shadow-md shadow-black/40 backdrop-blur-xl"
+				>
+					<EnumOption
+						selected={value === undefined}
+						onSelect={() => onChange(undefined)}
+					>
+						<span className="text-white/50">—</span>
+					</EnumOption>
+					{options.map((option) => (
+						<EnumOption
+							key={option}
+							selected={option === value}
+							onSelect={() => onChange(option)}
+						>
+							{option}
+						</EnumOption>
+					))}
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
+	);
+}
+
+function EnumOption({
+	selected,
+	onSelect,
+	children,
+}: {
+	selected: boolean;
+	onSelect: () => void;
+	children: ReactNode;
+}) {
+	return (
+		<DropdownMenuItem
+			onClick={onSelect}
+			className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-[12px] text-white/70 hover:text-white focus:bg-white/10 focus:text-white"
+		>
+			<span className="flex w-3.5 shrink-0 items-center justify-center">
+				{selected && <Check className="h-3 w-3 text-white" aria-hidden />}
+			</span>
+			{children}
+		</DropdownMenuItem>
+	);
+}

--- a/app/components/canvas/elements/preview/status.ts
+++ b/app/components/canvas/elements/preview/status.ts
@@ -12,15 +12,6 @@ export type PlaceholderProps = GenerationState & {
 	onDiscard: () => void;
 };
 
-export function deriveStatus(
-	generating: boolean,
-	queued: boolean,
-): ElementSnapshot["status"] {
-	if (queued) return "queued";
-	if (generating) return "generating";
-	return "idle";
-}
-
 export const BORDER_COLORS: Record<CanvasElementType, string> = {
 	character: "border-amber-500/30",
 	image: "border-cyan-500/30",

--- a/app/components/canvas/hooks/useGenerate.ts
+++ b/app/components/canvas/hooks/useGenerate.ts
@@ -6,6 +6,7 @@ import {
 	useQueueSelector,
 } from "@/lib/generation/GenerationQueueProvider";
 import { scheduleGeneration } from "@/lib/generation/scheduleGeneration";
+import { useProjectStore } from "@/lib/project/store";
 import type { CanvasContentElement } from "../types";
 import { buildGenerationJob } from "../utils/buildGenerationJob";
 import { getGenerationInputs } from "../utils/getGenerationInputs";
@@ -14,7 +15,11 @@ export function useGenerate(element: CanvasContentElement) {
 	const { projectId, connectorConfig } = useConfig();
 	const queue = useGenerationQueue();
 	const snapshot = useQueueSelector((q) => q.getElementSnapshot(element.id));
-	const currentInputs = useMemo(() => getGenerationInputs(element), [element]);
+	const metadata = useProjectStore(projectId, (s) => s.metadata);
+	const currentInputs = useMemo(
+		() => getGenerationInputs(element, metadata),
+		[element, metadata],
+	);
 	const stale = isStaleResult(snapshot, currentInputs);
 
 	useEffect(() => {
@@ -36,8 +41,7 @@ export function useGenerate(element: CanvasContentElement) {
 	}, [queue, element.id]);
 
 	return {
-		generating: snapshot.status === "generating",
-		queued: snapshot.status === "queued",
+		status: snapshot.status,
 		seconds: snapshot.seconds,
 		result: snapshot.result,
 		error: snapshot.error,

--- a/app/components/canvas/hooks/useGenerateAll.ts
+++ b/app/components/canvas/hooks/useGenerateAll.ts
@@ -4,6 +4,7 @@ import { useConfig } from "@/lib/config/ConfigProvider";
 import { isStaleResult } from "@/lib/generation/queue";
 import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
 import { scheduleGeneration } from "@/lib/generation/scheduleGeneration";
+import { getProjectStore } from "@/lib/project/store";
 import { buildGenerationJob } from "../utils/buildGenerationJob";
 import { getGenerationInputs } from "../utils/getGenerationInputs";
 import { getContentElements } from "../utils/nodeUtils";
@@ -13,10 +14,13 @@ export function useGenerateAll(editor: Editor) {
 	const queue = useGenerationQueue();
 
 	const generateAll = useCallback(() => {
+		const { metadata } = getProjectStore(projectId).getState();
 		const jobs = getContentElements(editor.children)
 			.filter((el) => {
 				const snap = queue.getElementSnapshot(el.id);
-				return !snap.result || isStaleResult(snap, getGenerationInputs(el));
+				return (
+					!snap.result || isStaleResult(snap, getGenerationInputs(el, metadata))
+				);
 			})
 			.map((el) => buildGenerationJob(el, connectorConfig, projectId))
 			.filter((job): job is NonNullable<typeof job> => job !== null);

--- a/app/components/canvas/utils/__tests__/getGenerationInputs.test.ts
+++ b/app/components/canvas/utils/__tests__/getGenerationInputs.test.ts
@@ -64,7 +64,7 @@ describe("getGenerationInputs", () => {
 			metadata,
 		);
 		expect(attributes.characterAvatars).toBe(
-			"Alice:https://a/img.png,Bob:https://b/img.png",
+			"https://a/img.png,https://b/img.png",
 		);
 	});
 

--- a/app/components/canvas/utils/__tests__/getGenerationInputs.test.ts
+++ b/app/components/canvas/utils/__tests__/getGenerationInputs.test.ts
@@ -1,21 +1,32 @@
 import { describe, expect, it } from "vitest";
+import type { Metadata } from "@/lib/project/types";
 import { LAYOUT_ATTRIBUTE_KEYS } from "@/lib/video/elementAttributes";
-import type { CanvasContentElement } from "../../types";
+import type { CanvasContentElement, CanvasElementType } from "../../types";
 import { getGenerationInputs } from "../getGenerationInputs";
+
+const emptyMetadata: Metadata = {
+	title: "",
+	style: "",
+	narration: {},
+	characters: {},
+};
 
 const element = (
 	customAttributes: Record<string, string>,
+	type: CanvasElementType = "clip",
+	text = "a dragon flying",
 ): CanvasContentElement => ({
 	id: "el-1",
-	type: "clip",
+	type,
 	customAttributes,
-	children: [{ id: "t-1", type: "clip", text: "a dragon flying" }],
+	children: [{ id: "t-1", type, text }],
 });
 
 describe("getGenerationInputs", () => {
 	it("keeps generation-affecting attributes", () => {
 		const { prompt, attributes } = getGenerationInputs(
 			element({ model: "Slop Video v1", duration: "5", provider: "openslop" }),
+			emptyMetadata,
 		);
 		expect(prompt).toBe("a dragon flying");
 		expect(attributes).toEqual({
@@ -31,10 +42,58 @@ describe("getGenerationInputs", () => {
 		);
 		const { attributes } = getGenerationInputs(
 			element({ ...layoutOnly, model: "Slop Video v1" }),
+			emptyMetadata,
 		);
 		for (const key of LAYOUT_ATTRIBUTE_KEYS) {
 			expect(attributes).not.toHaveProperty(key);
 		}
 		expect(attributes).toEqual({ model: "Slop Video v1" });
+	});
+
+	it("adds characterAvatars on image elements via contributor", () => {
+		const metadata: Metadata = {
+			...emptyMetadata,
+			characters: {
+				Alice: { appearance: "tall", avatarUrl: "https://a/img.png" },
+				Bob: { appearance: "short", avatarUrl: "https://b/img.png" },
+				Eve: { appearance: "missing" },
+			},
+		};
+		const { attributes } = getGenerationInputs(
+			element({ characters: "Bob, Alice, Eve" }, "image"),
+			metadata,
+		);
+		expect(attributes.characterAvatars).toBe(
+			"Alice:https://a/img.png,Bob:https://b/img.png",
+		);
+	});
+
+	it("adds voiceId on character elements via contributor", () => {
+		const metadata: Metadata = {
+			...emptyMetadata,
+			characters: {
+				Alice: { appearance: "tall", voiceId: "voice-1" },
+			},
+		};
+		const { attributes } = getGenerationInputs(
+			element({ name: "Alice" }, "character"),
+			metadata,
+		);
+		expect(attributes.voiceId).toBe("voice-1");
+	});
+
+	it("skips contributors whose appliesTo excludes the type", () => {
+		const metadata: Metadata = {
+			...emptyMetadata,
+			characters: {
+				Alice: { appearance: "tall", voiceId: "voice-1" },
+			},
+		};
+		const { attributes } = getGenerationInputs(
+			element({ name: "Alice" }, "clip"),
+			metadata,
+		);
+		expect(attributes).not.toHaveProperty("voiceId");
+		expect(attributes).not.toHaveProperty("characterAvatars");
 	});
 });

--- a/app/components/canvas/utils/buildGenerationJob.ts
+++ b/app/components/canvas/utils/buildGenerationJob.ts
@@ -2,6 +2,7 @@ import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import type { ProviderKey } from "@/lib/connectors/types";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import type { GenerationJob } from "@/lib/generation/queue";
+import { getProjectStore } from "@/lib/project/store";
 import type { CanvasContentElement } from "../types";
 import { ELEMENT_CONFIGS } from "../config/elementConfigs";
 import { getGenerationInputs } from "./getGenerationInputs";
@@ -12,7 +13,8 @@ export function buildGenerationJob(
 	projectId: string,
 	overrides: Partial<GenerationJob> = {},
 ): GenerationJob | null {
-	const inputs = getGenerationInputs(element);
+	const { metadata } = getProjectStore(projectId).getState();
+	const inputs = getGenerationInputs(element, metadata);
 	if (!inputs.prompt) return null;
 
 	const elementConfig = ELEMENT_CONFIGS[element.type];

--- a/app/components/canvas/utils/contributors/characterAvatars.ts
+++ b/app/components/canvas/utils/contributors/characterAvatars.ts
@@ -1,0 +1,29 @@
+import type { Metadata } from "@/lib/project/types";
+import type { CanvasContentElement, CanvasElementType } from "../../types";
+import type { AttributeContributor } from "../inputContributors";
+
+const APPLIES_TO: CanvasElementType[] = ["image", "animated_image"];
+
+function parseNames(raw: string | undefined): string[] {
+	return (raw ?? "")
+		.split(",")
+		.map((s) => s.trim())
+		.filter(Boolean);
+}
+
+export const characterAvatarsContributor: AttributeContributor = {
+	name: "characterAvatars",
+	appliesTo: APPLIES_TO,
+	derive: (element: CanvasContentElement, metadata: Metadata) => {
+		const names = parseNames(element.customAttributes?.characters);
+		if (names.length === 0) return {};
+		const pairs = names
+			.map((name) => {
+				const url = metadata.characters[name]?.avatarUrl;
+				return url ? `${name}:${url}` : null;
+			})
+			.filter((p): p is string => p !== null)
+			.sort();
+		return { characterAvatars: pairs.join(",") || undefined };
+	},
+};

--- a/app/components/canvas/utils/contributors/characterAvatars.ts
+++ b/app/components/canvas/utils/contributors/characterAvatars.ts
@@ -1,14 +1,17 @@
 import type { Metadata } from "@/lib/project/types";
 import type { CanvasContentElement, CanvasElementType } from "../../types";
 import type { AttributeContributor } from "../inputContributors";
+import { compact } from "lodash";
 
 const APPLIES_TO: CanvasElementType[] = ["image", "animated_image"];
 
-function parseNames(raw: string | undefined): string[] {
-	return (raw ?? "")
-		.split(",")
-		.map((s) => s.trim())
-		.filter(Boolean);
+function parseNames(raw: string | undefined = ""): string[] {
+	return compact(
+		raw
+			.split(",")
+			.map((s) => s.trim())
+			.sort(),
+	);
 }
 
 export const characterAvatarsContributor: AttributeContributor = {
@@ -17,13 +20,7 @@ export const characterAvatarsContributor: AttributeContributor = {
 	derive: (element: CanvasContentElement, metadata: Metadata) => {
 		const names = parseNames(element.customAttributes?.characters);
 		if (names.length === 0) return {};
-		const pairs = names
-			.map((name) => {
-				const url = metadata.characters[name]?.avatarUrl;
-				return url ? `${name}:${url}` : null;
-			})
-			.filter((p): p is string => p !== null)
-			.sort();
-		return { characterAvatars: pairs.join(",") || undefined };
+		const pairs = names.map((name) => metadata.characters[name]?.avatarUrl);
+		return { characterAvatars: compact(pairs).join(",") };
 	},
 };

--- a/app/components/canvas/utils/contributors/characterVoiceId.ts
+++ b/app/components/canvas/utils/contributors/characterVoiceId.ts
@@ -1,0 +1,15 @@
+import type { Metadata } from "@/lib/project/types";
+import type { CanvasContentElement, CanvasElementType } from "../../types";
+import type { AttributeContributor } from "../inputContributors";
+
+const APPLIES_TO: CanvasElementType[] = ["character"];
+
+export const characterVoiceIdContributor: AttributeContributor = {
+	name: "characterVoiceId",
+	appliesTo: APPLIES_TO,
+	derive: (element: CanvasContentElement, metadata: Metadata) => {
+		const name = element.customAttributes?.name;
+		if (!name) return {};
+		return { voiceId: metadata.characters[name]?.voiceId };
+	},
+};

--- a/app/components/canvas/utils/contributors/narratorVoiceId.ts
+++ b/app/components/canvas/utils/contributors/narratorVoiceId.ts
@@ -1,0 +1,13 @@
+import type { Metadata } from "@/lib/project/types";
+import type { CanvasElementType } from "../../types";
+import type { AttributeContributor } from "../inputContributors";
+
+const APPLIES_TO: CanvasElementType[] = ["narration"];
+
+export const narratorVoiceIdContributor: AttributeContributor = {
+	name: "narratorVoiceId",
+	appliesTo: APPLIES_TO,
+	derive: (_element, metadata: Metadata) => ({
+		voiceId: metadata.narration.voiceId,
+	}),
+};

--- a/app/components/canvas/utils/getGenerationInputs.ts
+++ b/app/components/canvas/utils/getGenerationInputs.ts
@@ -1,14 +1,27 @@
 import omit from "lodash/omit";
 import type { GenerationInputs } from "@/lib/generation/queue";
+import type { Metadata } from "@/lib/project/types";
 import { LAYOUT_ATTRIBUTE_KEYS } from "@/lib/video/elementAttributes";
 import type { CanvasContentElement } from "../types";
+import { INPUT_CONTRIBUTORS } from "./inputContributors";
 import { getPromptText } from "./getPromptText";
 
 export function getGenerationInputs(
 	element: CanvasContentElement,
+	metadata: Metadata,
 ): GenerationInputs {
-	return {
-		prompt: getPromptText(element),
-		attributes: omit(element.customAttributes ?? {}, LAYOUT_ATTRIBUTE_KEYS),
-	};
+	const attributes: Record<string, string> = omit(
+		element.customAttributes ?? {},
+		LAYOUT_ATTRIBUTE_KEYS,
+	);
+	for (const contributor of INPUT_CONTRIBUTORS) {
+		if (contributor.appliesTo && !contributor.appliesTo.includes(element.type))
+			continue;
+		for (const [key, value] of Object.entries(
+			contributor.derive(element, metadata),
+		)) {
+			if (value !== undefined) attributes[key] = value;
+		}
+	}
+	return { prompt: getPromptText(element), attributes };
 }

--- a/app/components/canvas/utils/inputContributors.ts
+++ b/app/components/canvas/utils/inputContributors.ts
@@ -2,6 +2,7 @@ import type { Metadata } from "@/lib/project/types";
 import type { CanvasContentElement, CanvasElementType } from "../types";
 import { characterAvatarsContributor } from "./contributors/characterAvatars";
 import { characterVoiceIdContributor } from "./contributors/characterVoiceId";
+import { narratorVoiceIdContributor } from "./contributors/narratorVoiceId";
 
 export type AttributeContributor = {
 	name: string;
@@ -15,4 +16,5 @@ export type AttributeContributor = {
 export const INPUT_CONTRIBUTORS: AttributeContributor[] = [
 	characterAvatarsContributor,
 	characterVoiceIdContributor,
+	narratorVoiceIdContributor,
 ];

--- a/app/components/canvas/utils/inputContributors.ts
+++ b/app/components/canvas/utils/inputContributors.ts
@@ -1,0 +1,18 @@
+import type { Metadata } from "@/lib/project/types";
+import type { CanvasContentElement, CanvasElementType } from "../types";
+import { characterAvatarsContributor } from "./contributors/characterAvatars";
+import { characterVoiceIdContributor } from "./contributors/characterVoiceId";
+
+export type AttributeContributor = {
+	name: string;
+	appliesTo?: CanvasElementType[];
+	derive: (
+		element: CanvasContentElement,
+		metadata: Metadata,
+	) => Record<string, string | undefined>;
+};
+
+export const INPUT_CONTRIBUTORS: AttributeContributor[] = [
+	characterAvatarsContributor,
+	characterVoiceIdContributor,
+];

--- a/app/components/projects/ProjectsList.tsx
+++ b/app/components/projects/ProjectsList.tsx
@@ -1,30 +1,13 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { createProject, deleteProject } from "@/lib/project/api";
 import type { ProjectRow } from "@/lib/project/api";
+import { ImageWithShimmer } from "@/lib/components/ImageWithShimmer";
 import UserProfile from "@/app/components/UserProfile";
-
-function ProjectThumbnail({ src, alt }: { src: string; alt: string }) {
-	const [loaded, setLoaded] = useState(false);
-	return (
-		<>
-			<Image
-				src={src}
-				alt={alt}
-				fill
-				sizes="(min-width: 1024px) 320px, (min-width: 640px) 50vw, 100vw"
-				className="object-cover"
-				onLoad={() => setLoaded(true)}
-			/>
-			{!loaded && <div className="absolute inset-0 shimmer-surface" />}
-		</>
-	);
-}
 
 function relativeTime(iso: string): string {
 	const diff = Date.now() - new Date(iso).getTime();
@@ -108,9 +91,12 @@ export default function ProjectsList({
 								>
 									<div className="relative aspect-video bg-white/[0.04]">
 										{project.thumbnail_url ? (
-											<ProjectThumbnail
+											<ImageWithShimmer
 												src={project.thumbnail_url}
 												alt={project.name}
+												fill
+												sizes="(min-width: 1024px) 320px, (min-width: 640px) 50vw, 100vw"
+												className="object-cover"
 											/>
 										) : (
 											<div className="absolute inset-0 flex items-center justify-center text-white/30 text-xs">

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -12,6 +12,27 @@ function Dialog({
 	return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
+/**
+ * Dialog that only mounts its children while open. Use when the body
+ * subscribes to expensive state (store, queue) so the subscriptions are
+ * torn down on close.
+ */
+function MountedDialog({
+	open,
+	onOpenChange,
+	children,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	children: React.ReactNode;
+}) {
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			{open && children}
+		</Dialog>
+	);
+}
+
 function DialogTrigger({
 	...props
 }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
@@ -60,7 +81,7 @@ function DialogContent({
 			<DialogPrimitive.Content
 				data-slot="dialog-content"
 				className={cn(
-					"fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border border-white/10 bg-white/5 p-5 text-white shadow-md shadow-black/40 backdrop-blur-xl outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+					"fixed left-[50%] top-[50%] z-50 flex max-h-[calc(100dvh-2rem)] w-[calc(100vw-1rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] flex-col gap-4 overflow-hidden rounded-xl border border-white/10 bg-white/5 p-5 text-white shadow-md shadow-black/40 backdrop-blur-xl outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:w-full",
 					className,
 				)}
 				{...props}
@@ -68,7 +89,7 @@ function DialogContent({
 				{children}
 				{showCloseButton && (
 					<DialogPrimitive.Close
-						className="absolute right-3 top-3 rounded-md p-1 text-white/60 transition-colors hover:bg-white/10 hover:text-white focus:outline-none focus:ring-1 focus:ring-white/30"
+						className="absolute right-3 top-3 z-10 rounded-md p-1 text-white/60 transition-colors hover:bg-white/10 hover:text-white focus:outline-none focus:ring-1 focus:ring-white/30"
 						aria-label="Close"
 					>
 						<X className="h-4 w-4" />
@@ -130,6 +151,7 @@ function DialogDescription({
 
 export {
 	Dialog,
+	MountedDialog,
 	DialogTrigger,
 	DialogPortal,
 	DialogClose,

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import * as React from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Dialog({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+	return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+	return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+	return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+	return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+	return (
+		<DialogPrimitive.Overlay
+			data-slot="dialog-overlay"
+			className={cn(
+				"fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DialogContent({
+	className,
+	children,
+	showCloseButton = true,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+	showCloseButton?: boolean;
+}) {
+	return (
+		<DialogPortal>
+			<DialogOverlay />
+			<DialogPrimitive.Content
+				data-slot="dialog-content"
+				className={cn(
+					"fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border border-white/10 bg-white/5 p-5 text-white shadow-md shadow-black/40 backdrop-blur-xl outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+					className,
+				)}
+				{...props}
+			>
+				{children}
+				{showCloseButton && (
+					<DialogPrimitive.Close
+						className="absolute right-3 top-3 rounded-md p-1 text-white/60 transition-colors hover:bg-white/10 hover:text-white focus:outline-none focus:ring-1 focus:ring-white/30"
+						aria-label="Close"
+					>
+						<X className="h-4 w-4" />
+					</DialogPrimitive.Close>
+				)}
+			</DialogPrimitive.Content>
+		</DialogPortal>
+	);
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="dialog-header"
+			className={cn("flex flex-col gap-1 pr-8", className)}
+			{...props}
+		/>
+	);
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="dialog-footer"
+			className={cn(
+				"flex flex-col-reverse gap-2 border-t border-white/10 pt-3 sm:flex-row sm:justify-end",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DialogTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+	return (
+		<DialogPrimitive.Title
+			data-slot="dialog-title"
+			className={cn("text-sm font-semibold text-white", className)}
+			{...props}
+		/>
+	);
+}
+
+function DialogDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+	return (
+		<DialogPrimitive.Description
+			data-slot="dialog-description"
+			className={cn("text-xs text-white/60", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Dialog,
+	DialogTrigger,
+	DialogPortal,
+	DialogClose,
+	DialogOverlay,
+	DialogContent,
+	DialogHeader,
+	DialogFooter,
+	DialogTitle,
+	DialogDescription,
+};

--- a/lib/components/ImageWithShimmer.tsx
+++ b/lib/components/ImageWithShimmer.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState, type SyntheticEvent } from "react";
+import Image, { type ImageProps } from "next/image";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * `next/image` with a shimmer overlay that hides once the image loads.
+ */
+export function ImageWithShimmer({ alt, onLoad, ...props }: ImageProps) {
+	const [loaded, setLoaded] = useState(false);
+	return (
+		<>
+			<Image
+				{...props}
+				alt={alt}
+				onLoad={(event: SyntheticEvent<HTMLImageElement>) => {
+					onLoad?.(event);
+					setLoaded(true);
+				}}
+			/>
+			{!loaded && (
+				<Skeleton className="absolute inset-0 animate-none shimmer-surface" />
+			)}
+		</>
+	);
+}

--- a/lib/components/Waveform.tsx
+++ b/lib/components/Waveform.tsx
@@ -140,11 +140,12 @@ export function Waveform({
 	const [loadedSrc, setLoadedSrc] = useState<string | null>(() =>
 		peaksCache?.has(src) ? src : null,
 	);
-	const loading = loadedSrc !== src;
+	const [metadataReadyFor, setMetadataReadyFor] = useState<string | null>(null);
+	const loading = loadedSrc !== src || metadataReadyFor !== src;
 
 	// Adjust state during render when src changes to a cached value
 	// (React-supported pattern for deriving state from props)
-	if (loading && peaksCache?.has(src)) {
+	if (loadedSrc !== src && peaksCache?.has(src)) {
 		setLoadedSrc(src);
 	}
 
@@ -281,7 +282,11 @@ export function Waveform({
 				}}
 				onLoadedMetadata={() => {
 					const a = audioRef.current;
-					if (a) onTimeUpdate?.(0, a.duration || 0);
+					if (!a) return;
+					if (Number.isFinite(a.duration) && a.duration > 0) {
+						setMetadataReadyFor(src);
+					}
+					onTimeUpdate?.(0, a.duration || 0);
 				}}
 				onPlay={onPlay}
 				onPause={onPause}

--- a/lib/config/ConfigProvider.tsx
+++ b/lib/config/ConfigProvider.tsx
@@ -25,6 +25,7 @@ import { buildImagePlugins } from "../connectors/image/plugins/imageChain";
 import { buildAnimatedImagePlugins } from "../connectors/animated_image/plugins/animated-image-chain";
 import { createMetadataVoicePlugin } from "../connectors/tts/plugins/metadata-voice";
 import { createReferenceImagesPlugin } from "../connectors/image/plugins/reference-images";
+import { createVoiceHydratePlugin } from "../connectors/tts/plugins/voice-hydrate";
 import { createVoiceSearchPlugin } from "../connectors/tts/plugins/voice-search";
 import { scriptModePlugin } from "../connectors/llm/plugins/script-mode";
 import { osmlPlugin } from "../connectors/llm/plugins/osml";
@@ -140,6 +141,7 @@ export function ConfigProvider({
 			.appendPlugins("video", createReferenceImagesPlugin(projectId))
 			.appendPlugins("tts", createMetadataVoicePlugin(projectId))
 			.appendPlugins("tts", createVoiceSearchPlugin())
+			.appendPlugins("tts", createVoiceHydratePlugin(projectId))
 			.build();
 		return withRegistry(base)
 			.appendPlugins(

--- a/lib/connectors/__tests__/character-avatar.test.ts
+++ b/lib/connectors/__tests__/character-avatar.test.ts
@@ -36,4 +36,20 @@ describe("character-avatar plugin", () => {
 			"https://img/alice.png",
 		);
 	});
+
+	it("does not resurrect a character that was removed mid-flight", () => {
+		const store = getProjectStore(PROJECT_ID);
+		store
+			.getState()
+			.updateMetadata({ characters: { Alice: { appearance: "A girl" } } });
+
+		const plugin = createCharacterAvatarPlugin(PROJECT_ID, "Alice");
+		store.getState().removeCharacter("Alice");
+		plugin.afterGenerate?.({
+			imageUrl: "https://img/alice.png",
+			durationSec: 0,
+		});
+
+		expect(store.getState().metadata.characters["Alice"]).toBeUndefined();
+	});
 });

--- a/lib/connectors/__tests__/template-mode.test.ts
+++ b/lib/connectors/__tests__/template-mode.test.ts
@@ -12,14 +12,20 @@ const realTemplate = pickTemplate((id) => id === "pov-life");
 
 describe("createTemplateModePlugin", () => {
 	describe("beforeGenerate", () => {
-		it("prepends template systemPrompt when none provided", () => {
+		it("prepends template preamble (art style, narration, characters, systemPrompt) when none provided", () => {
 			const { beforeGenerate } = createTemplateModePlugin(realTemplate.id);
 			const result = beforeGenerate?.({ prompt: "hi" });
 			const sys = (result as { systemPrompt: string }).systemPrompt;
-			expect(sys).toBe(realTemplate.systemPrompt);
+			expect(sys).toContain(realTemplate.systemPrompt);
+			if (realTemplate.artStyle) expect(sys).toContain(realTemplate.artStyle);
+			if (realTemplate.narration?.gender)
+				expect(sys).toContain(realTemplate.narration.gender);
+			for (const name of Object.keys(realTemplate.characters)) {
+				expect(sys).toContain(name);
+			}
 		});
 
-		it("prepends template systemPrompt before existing systemPrompt", () => {
+		it("prepends template preamble before existing systemPrompt", () => {
 			const { beforeGenerate } = createTemplateModePlugin(realTemplate.id);
 			const result = beforeGenerate?.({
 				prompt: "hi",

--- a/lib/connectors/__tests__/voice-hydrate.test.ts
+++ b/lib/connectors/__tests__/voice-hydrate.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMetadataVoicePlugin } from "@/lib/connectors/tts/plugins/metadata-voice";
+import { createVoiceHydratePlugin } from "@/lib/connectors/tts/plugins/voice-hydrate";
+import { createVoiceSearchPlugin } from "@/lib/connectors/tts/plugins/voice-search";
+import type {
+	PluginContext,
+	TTSGenerateParams,
+	VoiceInfo,
+} from "@/lib/connectors/types";
+import { clearProjectStore, getProjectStore } from "@/lib/project/store";
+
+const projectId = "voice-hydrate-test-project";
+
+afterEach(() => {
+	clearProjectStore(projectId);
+});
+
+function ctxWith(voices: VoiceInfo[]): PluginContext<TTSGenerateParams> {
+	return { searchVoices: vi.fn(async () => voices) };
+}
+
+async function runPipeline(
+	params: TTSGenerateParams,
+	ctx: PluginContext<TTSGenerateParams>,
+): Promise<TTSGenerateParams> {
+	const plugins = [
+		createMetadataVoicePlugin(projectId),
+		createVoiceSearchPlugin(),
+		createVoiceHydratePlugin(projectId),
+	];
+	let current = params;
+	for (const plugin of plugins) {
+		current = (await plugin.beforeGenerate?.(current, ctx)) ?? current;
+	}
+	return current;
+}
+
+describe("voice-hydrate end-to-end", () => {
+	it("caches resolved voice on the character (not narration) when params.name is set", async () => {
+		getProjectStore(projectId)
+			.getState()
+			.updateMetadata({
+				characters: {
+					Red: { appearance: "A girl", gender: "feminine" },
+				},
+			});
+		const ctx = ctxWith([{ id: "v-red", name: "Red Voice", description: "" }]);
+
+		await runPipeline({ prompt: "hi", name: "Red" }, ctx);
+
+		const state = getProjectStore(projectId).getState();
+		expect(state.metadata.characters["Red"]?.resolvedVoiceId).toBe("v-red");
+		expect(state.metadata.narration.resolvedVoiceId).toBeUndefined();
+	});
+
+	it("caches resolved voice on narration when params.name is absent", async () => {
+		getProjectStore(projectId)
+			.getState()
+			.updateMetadata({ narration: { gender: "masculine" } });
+		const ctx = ctxWith([
+			{ id: "v-narrator", name: "Narrator Voice", description: "" },
+		]);
+
+		await runPipeline({ prompt: "hi" }, ctx);
+
+		const state = getProjectStore(projectId).getState();
+		expect(state.metadata.narration.resolvedVoiceId).toBe("v-narrator");
+	});
+});

--- a/lib/connectors/__tests__/voice-search.test.ts
+++ b/lib/connectors/__tests__/voice-search.test.ts
@@ -60,7 +60,7 @@ describe("createVoiceSearchPlugin", () => {
 		});
 	});
 
-	it("assigns first voice's id and strips descriptor/lookup fields", async () => {
+	it("assigns first voice's id, strips descriptors, and preserves name", async () => {
 		const { ctx } = ctxWith([
 			{ id: "v-1", name: "First", description: "" },
 			{ id: "v-2", name: "Second", description: "" },
@@ -84,6 +84,7 @@ describe("createVoiceSearchPlugin", () => {
 		expect(result).toEqual({
 			prompt: "hi",
 			model: "test-model",
+			name: "Red",
 			voiceId: "v-1",
 		});
 	});

--- a/lib/connectors/image/plugins/character-avatar.ts
+++ b/lib/connectors/image/plugins/character-avatar.ts
@@ -21,9 +21,10 @@ export function createCharacterAvatarPlugin(
 			if (!result.imageUrl) {
 				throw new Error("character-avatar plugin expected an imageUrl result");
 			}
-			store().updateMetadata({
-				characters: { [name]: { avatarUrl: result.imageUrl } },
-			});
+			const state = store();
+			const existing = state.metadata.characters[name];
+			if (!existing) return result;
+			state.setCharacter(name, { ...existing, avatarUrl: result.imageUrl });
 			return result;
 		},
 	};

--- a/lib/connectors/llm/plugins/template-mode.ts
+++ b/lib/connectors/llm/plugins/template-mode.ts
@@ -5,22 +5,84 @@ import type {
 	LLMPlugin,
 	PluginContext,
 } from "@/lib/connectors/types";
-import { getTemplateById } from "@/lib/templates/templates";
+import type { MetadataCharacter, MetadataVoice } from "@/lib/project/types";
+import { getTemplateById, type Template } from "@/lib/templates/templates";
+
+const VOICE_TRAIT_KEYS = [
+	"gender",
+	"age",
+	"pitch",
+	"accent",
+	"description",
+	"language",
+] as const satisfies readonly (keyof MetadataVoice)[];
+
+function formatVoiceTraits(voice: MetadataVoice): string {
+	return VOICE_TRAIT_KEYS.filter((key) => voice[key])
+		.map((key) => `- ${key}: ${voice[key]}`)
+		.join("\n");
+}
+
+function formatCharacter(name: string, character: MetadataCharacter): string {
+	const lines = [`${name}:`];
+	if (character.appearance) lines.push(`- appearance: ${character.appearance}`);
+	const traits = formatVoiceTraits(character);
+	if (traits) lines.push(traits);
+	return lines.join("\n");
+}
+
+function buildPreamble(template: Template): string {
+	const sections: string[] = [];
+
+	if (template.artStyle) {
+		sections.push(dedent`
+			The art style is pre-configured. Use this style for metadata — do not deviate from it or invent a different style:
+			${template.artStyle}
+		`);
+	}
+
+	if (template.narration) {
+		const traits = formatVoiceTraits(template.narration);
+		if (traits) {
+			sections.push(dedent`
+				The narrator is pre-configured. Use these traits exactly — do not introduce a different narrator or change their voice:
+				${traits}
+			`);
+		}
+	}
+
+	const characters = Object.entries(template.characters);
+	if (characters.length > 0) {
+		const block = characters
+			.map(([name, character]) => formatCharacter(name, character))
+			.join("\n\n");
+		sections.push(dedent`
+			The following characters are pre-configured. Use them as-is — do not invent new characters or change their traits:
+
+			${block}
+		`);
+	}
+
+	if (template.systemPrompt) sections.push(template.systemPrompt);
+
+	return sections.join("\n\n");
+}
 
 export function createTemplateModePlugin(
 	templateId: string | undefined,
 ): LLMPlugin {
 	const template = templateId ? getTemplateById(templateId) : undefined;
+	const preamble = template ? buildPreamble(template) : "";
 
 	return {
 		name: "templateMode",
 		beforeGenerate(params) {
-			if (!template?.systemPrompt) return params;
+			if (!preamble) return params;
 			return {
 				...params,
 				systemPrompt: params.systemPrompt
-					? `${template.systemPrompt}\n\n${params.systemPrompt}`
-					: template.systemPrompt,
+					? `${preamble}\n\n${params.systemPrompt}`
+					: preamble,
 			};
 		},
 		async transformPrompt(

--- a/lib/connectors/tts/plugins/metadata-voice.ts
+++ b/lib/connectors/tts/plugins/metadata-voice.ts
@@ -15,7 +15,12 @@ export function createMetadataVoicePlugin(
 				getProjectStore(projectId).getState().metadata;
 			const voice = params.name ? characters[params.name] : narration;
 			if (!voice) return params;
-			return { ...params, ...MetadataVoiceSchema.parse(voice) };
+			const { resolvedVoiceId, ...fields } = MetadataVoiceSchema.parse(voice);
+			return {
+				...params,
+				...fields,
+				voiceId: fields.voiceId ?? resolvedVoiceId,
+			};
 		},
 	};
 }

--- a/lib/connectors/tts/plugins/voice-hydrate.ts
+++ b/lib/connectors/tts/plugins/voice-hydrate.ts
@@ -1,0 +1,35 @@
+import { getProjectStore } from "@/lib/project/store";
+import type {
+	ConnectorPlugin,
+	TTSGenerateParams,
+} from "@/lib/connectors/types";
+
+/**
+ * Persists the voiceId resolved by voice-search back to the project store as
+ * `resolvedVoiceId` so subsequent generations skip the search. Writes to the
+ * matching character (when `params.name` is set) or to narration.
+ */
+export function createVoiceHydratePlugin(
+	projectId: string,
+): ConnectorPlugin<TTSGenerateParams> {
+	return {
+		name: "voice-hydrate",
+		beforeGenerate(params) {
+			if (!params.voiceId) return params;
+			const store = getProjectStore(projectId);
+			const { metadata, setCharacter, updateMetadata } = store.getState();
+			if (params.name) {
+				const character = metadata.characters[params.name];
+				if (character && character.resolvedVoiceId !== params.voiceId) {
+					setCharacter(params.name, {
+						...character,
+						resolvedVoiceId: params.voiceId,
+					});
+				}
+			} else if (metadata.narration.resolvedVoiceId !== params.voiceId) {
+				updateMetadata({ narration: { resolvedVoiceId: params.voiceId } });
+			}
+			return params;
+		},
+	};
+}

--- a/lib/connectors/tts/plugins/voice-search.ts
+++ b/lib/connectors/tts/plugins/voice-search.ts
@@ -4,13 +4,16 @@ import type {
 	TTSGenerateParams,
 } from "@/lib/connectors/types";
 
+// Search inputs consumed when resolving a voice. `name` is intentionally
+// excluded — it's the identifier of the character target that downstream
+// plugins (voice-hydrate) need to write the resolved voiceId back to the
+// correct slot in metadata.
 const VOICE_DESCRIPTOR_KEYS = [
 	"gender",
 	"age",
 	"pitch",
 	"accent",
 	"description",
-	"name",
 	"query",
 	"language",
 ] as const;

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -166,6 +166,7 @@ export type VoiceSearchParams = {
 	description?: string;
 	name?: string;
 	language?: string;
+	limit?: number;
 };
 
 export interface TTSConnector extends Connector {

--- a/lib/project/__tests__/applyTemplate.test.ts
+++ b/lib/project/__tests__/applyTemplate.test.ts
@@ -56,7 +56,7 @@ describe("applyTemplate", () => {
 	it("wipes user-set narration before applying", () => {
 		getProjectStore(PROJECT_ID)
 			.getState()
-			.updateMetadata({ narration: { accent: "user-accent" } });
+			.updateMetadata({ narration: { accent: "british" } });
 
 		applyTemplate(PROJECT_ID, "pov-life");
 		expect(getProjectStore(PROJECT_ID).getState().metadata.narration).toEqual(

--- a/lib/project/__tests__/applyTemplate.test.ts
+++ b/lib/project/__tests__/applyTemplate.test.ts
@@ -1,7 +1,9 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { applyTemplate } from "@/lib/templates/applyTemplate";
-import { getTemplateById } from "@/lib/templates/templates";
+import * as templates from "@/lib/templates/templates";
 import { clearProjectStore, getProjectStore } from "../store";
+
+const { getTemplateById } = templates;
 
 const PROJECT_ID = "apply-template-test";
 
@@ -39,7 +41,7 @@ describe("applyTemplate", () => {
 
 		const { metadata } = getProjectStore(PROJECT_ID).getState();
 		expect(metadata.title).toBe("");
-		expect(metadata.style).toBe("");
+		expect(metadata.style).toBe(getTemplateById("pov-life")?.artStyle ?? "");
 	});
 
 	it("wipes reference images set outside the template before applying", () => {
@@ -62,5 +64,60 @@ describe("applyTemplate", () => {
 		expect(getProjectStore(PROJECT_ID).getState().metadata.narration).toEqual(
 			getTemplateById("pov-life")?.narration ?? {},
 		);
+	});
+
+	describe("voiceId overrides", () => {
+		afterEach(() => vi.restoreAllMocks());
+
+		const stubTemplate = (
+			overrides: Partial<ReturnType<typeof getTemplateById>>,
+		) => {
+			const base = getTemplateById("pov-life");
+			if (!base) throw new Error("pov-life template missing");
+			vi.spyOn(templates, "getTemplateById").mockReturnValue({
+				...base,
+				...overrides,
+			});
+		};
+
+		it("applies narration voiceId from the template", () => {
+			stubTemplate({
+				narration: { gender: "masculine", voiceId: "tpl-narrator" },
+			});
+
+			applyTemplate(PROJECT_ID, "pov-life");
+
+			expect(
+				getProjectStore(PROJECT_ID).getState().metadata.narration.voiceId,
+			).toBe("tpl-narrator");
+		});
+
+		it("applies character voiceId from the template", () => {
+			stubTemplate({
+				characters: {
+					Alice: { appearance: "A girl", voiceId: "tpl-alice" },
+				},
+			});
+
+			applyTemplate(PROJECT_ID, "pov-life");
+
+			expect(
+				getProjectStore(PROJECT_ID).getState().metadata.characters["Alice"]
+					?.voiceId,
+			).toBe("tpl-alice");
+		});
+
+		it("clears a previously-set narration voiceId when the template does not declare one", () => {
+			getProjectStore(PROJECT_ID)
+				.getState()
+				.setNarration({ voiceId: "stale-narrator" });
+
+			stubTemplate({ narration: { gender: "feminine" } });
+			applyTemplate(PROJECT_ID, "pov-life");
+
+			expect(
+				getProjectStore(PROJECT_ID).getState().metadata.narration.voiceId,
+			).toBeUndefined();
+		});
 	});
 });

--- a/lib/project/__tests__/ensureCharacterAvatars.test.ts
+++ b/lib/project/__tests__/ensureCharacterAvatars.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GenerationQueue, type GenerationJob } from "@/lib/generation/queue";
 import { clearProjectStore, getProjectStore } from "../store";
 import {
+	buildCharacterAvatarJob,
 	characterAvatarElementId,
 	ensureCharacterAvatars,
 } from "../ensureCharacterAvatars";
@@ -117,5 +118,20 @@ describe("ensureCharacterAvatars", () => {
 		ensureCharacterAvatars(queue, PROJECT_ID, registry);
 
 		expect(lastJobs()).toEqual([]);
+	});
+
+	it("buildCharacterAvatarJob produces a job for any character (used for regenerate)", () => {
+		const job = buildCharacterAvatarJob(PROJECT_ID, "Alice", registry);
+		expect(job.elementId).toBe(characterAvatarElementId("Alice"));
+		expect(job.connectorType).toBe("image");
+		expect(job.inputs).toEqual({
+			prompt: "Alice",
+			attributes: { kind: "avatar" },
+		});
+		expect(job.config.plugins?.map((p) => p.name)).toEqual([
+			"character-avatar",
+			"art-style",
+			"reference-images",
+		]);
 	});
 });

--- a/lib/project/__tests__/ensureCharacterAvatars.test.ts
+++ b/lib/project/__tests__/ensureCharacterAvatars.test.ts
@@ -121,12 +121,16 @@ describe("ensureCharacterAvatars", () => {
 	});
 
 	it("buildCharacterAvatarJob produces a job for any character (used for regenerate)", () => {
+		getProjectStore(PROJECT_ID)
+			.getState()
+			.updateMetadata({ characters: { Alice: { appearance: "A girl" } } });
+
 		const job = buildCharacterAvatarJob(PROJECT_ID, "Alice", registry);
 		expect(job.elementId).toBe(characterAvatarElementId("Alice"));
 		expect(job.connectorType).toBe("image");
 		expect(job.inputs).toEqual({
 			prompt: "Alice",
-			attributes: { kind: "avatar" },
+			attributes: { kind: "avatar", appearance: "A girl" },
 		});
 		expect(job.config.plugins?.map((p) => p.name)).toEqual([
 			"character-avatar",

--- a/lib/project/__tests__/store.test.ts
+++ b/lib/project/__tests__/store.test.ts
@@ -79,4 +79,32 @@ describe("project store updateMetadata", () => {
 			"Bob",
 		]);
 	});
+
+	it("setCharacter fully replaces a character (clearing previous keys)", () => {
+		const store = getProjectStore(PROJECT_ID);
+		store.getState().updateMetadata({
+			characters: {
+				Alice: { appearance: "A girl", voiceId: "voice-1", accent: "british" },
+			},
+		});
+		store
+			.getState()
+			.setCharacter("Alice", { appearance: "Updated", accent: "american" });
+
+		expect(store.getState().metadata.characters["Alice"]).toEqual({
+			appearance: "Updated",
+			accent: "american",
+		});
+	});
+
+	it("removeCharacter deletes the entry", () => {
+		const store = getProjectStore(PROJECT_ID);
+		store.getState().setCharacter("Alice", { appearance: "A girl" });
+		store.getState().setCharacter("Bob", { appearance: "A boy" });
+		store.getState().removeCharacter("Alice");
+
+		expect(store.getState().metadata.characters).toEqual({
+			Bob: { appearance: "A boy" },
+		});
+	});
 });

--- a/lib/project/__tests__/storeSnapshot.test.ts
+++ b/lib/project/__tests__/storeSnapshot.test.ts
@@ -26,9 +26,11 @@ describe("storeSnapshot", () => {
 		const sourceId = newProjectId();
 		const targetId = newProjectId();
 		const src = getProjectStore(sourceId);
-		src
-			.getState()
-			.updateMetadata({ title: "T", style: "noir", narration: { age: "30" } });
+		src.getState().updateMetadata({
+			title: "T",
+			style: "noir",
+			narration: { age: "adult" },
+		});
 		src.getState().setReferenceImages(["x", "y"]);
 
 		const snap = extractStoreSnapshot(src);
@@ -38,7 +40,7 @@ describe("storeSnapshot", () => {
 		const after = dest.getState();
 		expect(after.metadata.title).toBe("T");
 		expect(after.metadata.style).toBe("noir");
-		expect(after.metadata.narration.age).toBe("30");
+		expect(after.metadata.narration.age).toBe("adult");
 		expect(after.referenceImages).toEqual(["x", "y"]);
 
 		clearProjectStore(sourceId);

--- a/lib/project/ensureCharacterAvatars.ts
+++ b/lib/project/ensureCharacterAvatars.ts
@@ -1,7 +1,11 @@
 import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import { buildCharacterAvatarPlugins } from "@/lib/connectors/image/plugins/imageChain";
-import type { GenerationJob, GenerationQueue } from "@/lib/generation/queue";
+import type {
+	GenerationInputs,
+	GenerationJob,
+	GenerationQueue,
+} from "@/lib/generation/queue";
 import { getProjectStore } from "./store";
 
 export const CHARACTER_AVATAR_ID_PREFIX = "character-avatar:";
@@ -9,12 +13,22 @@ export const CHARACTER_AVATAR_ID_PREFIX = "character-avatar:";
 export const characterAvatarElementId = (name: string) =>
 	`${CHARACTER_AVATAR_ID_PREFIX}${name}`;
 
+export function characterAvatarInputs(
+	name: string,
+	appearance: string,
+): GenerationInputs {
+	return { prompt: name, attributes: { kind: "avatar", appearance } };
+}
+
 export function buildCharacterAvatarJob(
 	projectId: string,
 	name: string,
 	registry: ConnectorRegistry,
 ): GenerationJob {
 	const { provider, config } = getDefaultConnector(registry, "image");
+	const appearance =
+		getProjectStore(projectId).getState().metadata.characters[name]
+			?.appearance ?? "";
 	return {
 		elementId: characterAvatarElementId(name),
 		connectorType: "image",
@@ -25,7 +39,7 @@ export function buildCharacterAvatarJob(
 		},
 		prompt: "",
 		extraParams: { projectId },
-		inputs: { prompt: name, attributes: { kind: "avatar" } },
+		inputs: characterAvatarInputs(name, appearance),
 	};
 }
 

--- a/lib/project/ensureCharacterAvatars.ts
+++ b/lib/project/ensureCharacterAvatars.ts
@@ -9,28 +9,34 @@ export const CHARACTER_AVATAR_ID_PREFIX = "character-avatar:";
 export const characterAvatarElementId = (name: string) =>
 	`${CHARACTER_AVATAR_ID_PREFIX}${name}`;
 
+export function buildCharacterAvatarJob(
+	projectId: string,
+	name: string,
+	registry: ConnectorRegistry,
+): GenerationJob {
+	const { provider, config } = getDefaultConnector(registry, "image");
+	return {
+		elementId: characterAvatarElementId(name),
+		connectorType: "image",
+		provider,
+		config: {
+			...config,
+			plugins: buildCharacterAvatarPlugins(projectId, name),
+		},
+		prompt: "",
+		extraParams: { projectId },
+		inputs: { prompt: name, attributes: { kind: "avatar" } },
+	};
+}
+
 export function ensureCharacterAvatars(
 	queue: GenerationQueue,
 	projectId: string,
 	registry: ConnectorRegistry,
 ): void {
 	const { characters } = getProjectStore(projectId).getState().metadata;
-	const { provider, config } = getDefaultConnector(registry, "image");
-
 	const jobs: GenerationJob[] = Object.entries(characters)
 		.filter(([, ch]) => !ch.avatarUrl && ch.appearance)
-		.map(([name]) => ({
-			elementId: characterAvatarElementId(name),
-			connectorType: "image",
-			provider,
-			config: {
-				...config,
-				plugins: buildCharacterAvatarPlugins(projectId, name),
-			},
-			prompt: "",
-			extraParams: { projectId },
-			inputs: { prompt: name, attributes: { kind: "avatar" } },
-		}));
-
+		.map(([name]) => buildCharacterAvatarJob(projectId, name, registry));
 	queue.enqueueAll(jobs);
 }

--- a/lib/project/store.ts
+++ b/lib/project/store.ts
@@ -2,7 +2,12 @@ import merge from "lodash/merge";
 import { useStore } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { createStore, type StoreApi } from "zustand/vanilla";
-import type { DeepPartial, Metadata, MetadataCharacter } from "./types";
+import type {
+	DeepPartial,
+	Metadata,
+	MetadataCharacter,
+	MetadataVoice,
+} from "./types";
 
 export type ProjectContext = {
 	hydrated: boolean;
@@ -11,6 +16,7 @@ export type ProjectContext = {
 	updateMetadata: (partial: DeepPartial<Metadata>) => void;
 	setCharacter: (name: string, character: MetadataCharacter) => void;
 	removeCharacter: (name: string) => void;
+	setNarration: (narration: MetadataVoice) => void;
 	setReferenceImages: (urls: string[]) => void;
 	markHydrated: () => void;
 	reset: () => void;
@@ -43,6 +49,10 @@ export function getProjectStore(projectId: string): ProjectStore {
 				removeCharacter: (name) =>
 					set((state) => {
 						delete state.metadata.characters[name];
+					}),
+				setNarration: (narration) =>
+					set((state) => {
+						state.metadata.narration = narration;
 					}),
 				setReferenceImages: (urls) =>
 					set((state) => {

--- a/lib/project/store.ts
+++ b/lib/project/store.ts
@@ -2,13 +2,15 @@ import merge from "lodash/merge";
 import { useStore } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { createStore, type StoreApi } from "zustand/vanilla";
-import type { DeepPartial, Metadata } from "./types";
+import type { DeepPartial, Metadata, MetadataCharacter } from "./types";
 
 export type ProjectContext = {
 	hydrated: boolean;
 	metadata: Metadata;
 	referenceImages: string[];
 	updateMetadata: (partial: DeepPartial<Metadata>) => void;
+	setCharacter: (name: string, character: MetadataCharacter) => void;
+	removeCharacter: (name: string) => void;
 	setReferenceImages: (urls: string[]) => void;
 	markHydrated: () => void;
 	reset: () => void;
@@ -33,6 +35,14 @@ export function getProjectStore(projectId: string): ProjectStore {
 				updateMetadata: (partial) =>
 					set((state) => {
 						merge(state.metadata, partial);
+					}),
+				setCharacter: (name, character) =>
+					set((state) => {
+						state.metadata.characters[name] = character;
+					}),
+				removeCharacter: (name) =>
+					set((state) => {
+						delete state.metadata.characters[name];
 					}),
 				setReferenceImages: (urls) =>
 					set((state) => {

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -1,30 +1,42 @@
 import { z } from "zod";
-import { TTS_GENDERS, TTS_LANGUAGES } from "@/lib/connectors/tts/enums";
+import {
+	TTS_ACCENTS,
+	TTS_AGES,
+	TTS_GENDERS,
+	TTS_LANGUAGES,
+	TTS_PITCHES,
+} from "@/lib/connectors/tts/enums";
 import type { TransitionType } from "@/lib/video/transitions";
 
 const optionalString = z.string().min(1).optional().catch(undefined);
 
 export const genderSchema = z.enum(TTS_GENDERS).optional().catch(undefined);
 export const languageSchema = z.enum(TTS_LANGUAGES).optional().catch(undefined);
+export const ageSchema = z.enum(TTS_AGES).optional().catch(undefined);
+export const pitchSchema = z.enum(TTS_PITCHES).optional().catch(undefined);
+export const accentSchema = z.enum(TTS_ACCENTS).optional().catch(undefined);
 
 export const MetadataVoiceSchema = z.object({
 	gender: genderSchema,
-	age: optionalString,
-	pitch: optionalString,
-	accent: optionalString,
+	age: ageSchema,
+	pitch: pitchSchema,
+	accent: accentSchema,
 	description: optionalString,
 	language: languageSchema,
+	voiceId: optionalString,
+	resolvedVoiceId: optionalString,
 });
 
 export const voiceSearchParamsSchema = z.object({
 	query: optionalString,
 	gender: genderSchema,
-	age: optionalString,
-	pitch: optionalString,
-	accent: optionalString,
+	age: ageSchema,
+	pitch: pitchSchema,
+	accent: accentSchema,
 	description: optionalString,
 	name: optionalString,
 	language: languageSchema,
+	limit: z.coerce.number().int().positive().optional().catch(undefined),
 });
 
 export type MetadataVoice = z.infer<typeof MetadataVoiceSchema>;

--- a/lib/providers/__tests__/cartesia-tts.test.ts
+++ b/lib/providers/__tests__/cartesia-tts.test.ts
@@ -143,7 +143,7 @@ describe("CartesiaTTS", () => {
 					language: "en",
 					gender: "feminine",
 					description: "A warm voice",
-					previewUrl: "https://preview.mp3",
+					previewUrl: `/api/v1/tts/voices/preview?url=${encodeURIComponent("https://preview.mp3")}`,
 				},
 				{
 					id: "v2",
@@ -158,10 +158,11 @@ describe("CartesiaTTS", () => {
 				q: "adult",
 				gender: undefined,
 				limit: 100,
+				expand: ["preview_file_url"],
 			});
 		});
 
-		it("passes gender filter", async () => {
+		it("passes gender filter and always fetches a full page from upstream", async () => {
 			mockVoicesList.mockResolvedValue({ data: [] });
 
 			const provider = new CartesiaTTS("test-key");
@@ -170,8 +171,27 @@ describe("CartesiaTTS", () => {
 			expect(mockVoicesList).toHaveBeenCalledWith({
 				q: undefined,
 				gender: "masculine",
-				limit: 5,
+				limit: 100,
+				expand: ["preview_file_url"],
 			});
+		});
+
+		it("applies limit after upstream + ranking", async () => {
+			mockVoicesList.mockResolvedValue({
+				data: Array.from({ length: 10 }, (_, i) => ({
+					id: `v${i}`,
+					name: `Voice ${i}`,
+					language: "en",
+					gender: "feminine",
+					description: "voice",
+					preview_file_url: null,
+				})),
+			});
+
+			const provider = new CartesiaTTS("test-key");
+			const result = await provider.search({ limit: 3 });
+
+			expect(result).toHaveLength(3);
 		});
 
 		it("re-ranks voices by description similarity when semantic descriptors provided", async () => {

--- a/lib/providers/tts/cartesia.ts
+++ b/lib/providers/tts/cartesia.ts
@@ -64,13 +64,27 @@ function wrapPcmInWav(pcm: Buffer): Buffer {
 	return Buffer.concat([header, pcm]);
 }
 
+const PREVIEW_HOST = "files.cartesia.ai";
+
 export class CartesiaTTS extends BaseProvider<TTSGenerateParams, RawTTSResult> {
 	protected readonly blobConfig = { type: "tts", provider: "cartesia" };
 	private client: Cartesia;
+	private apiKey: string;
 
 	constructor(apiKey: string) {
 		super();
+		this.apiKey = apiKey;
 		this.client = new Cartesia({ apiKey });
+	}
+
+	async fetchVoicePreview(url: string): Promise<Response> {
+		if (new URL(url).hostname !== PREVIEW_HOST) {
+			throw new Error(`Voice preview host not allowed: ${url}`);
+		}
+		return fetch(url, {
+			headers: { Authorization: `Bearer ${this.apiKey}` },
+			redirect: "manual",
+		});
 	}
 
 	protected toFiles(r: RawTTSResult): BundleFile[] {
@@ -90,37 +104,35 @@ export class CartesiaTTS extends BaseProvider<TTSGenerateParams, RawTTSResult> {
 		];
 	}
 
-	async search(
-		params: VoiceSearchParams & { limit?: number },
-	): Promise<VoiceInfo[]> {
+	async search(params: VoiceSearchParams): Promise<VoiceInfo[]> {
 		const { age, gender, limit, language } = params;
-		let results = await this.searchOnce(age, gender, limit, language);
+		let results = await this.searchOnce(age, gender, language);
 		if (results.length === 0 && age) {
-			results = await this.searchOnce(undefined, gender, limit, language);
+			results = await this.searchOnce(undefined, gender, language);
 		}
 		const queryText = buildQueryText(params);
-		if (!queryText) return results;
-		try {
-			return await rankBySimilarity(results, queryText);
-		} catch (err) {
-			logger.warn(
-				{ err },
-				"Voice similarity ranking failed; returning unranked results",
-			);
-			return results;
-		}
+		const ranked = queryText
+			? await rankBySimilarity(results, queryText).catch((err) => {
+					logger.warn(
+						{ err },
+						"Voice similarity ranking failed; returning unranked results",
+					);
+					return results;
+				})
+			: results;
+		return limit ? ranked.slice(0, limit) : ranked;
 	}
 
 	private async searchOnce(
 		query?: string,
 		gender?: TTSGender,
-		limit?: number,
 		language?: string,
 	): Promise<VoiceInfo[]> {
 		const page = await this.client.voices.list({
 			q: query,
 			gender,
-			limit: limit || 100,
+			limit: 100,
+			expand: ["preview_file_url"],
 		});
 		return page.data
 			.map((voice) => ({
@@ -129,7 +141,9 @@ export class CartesiaTTS extends BaseProvider<TTSGenerateParams, RawTTSResult> {
 				language: voice.language,
 				gender: TTS_GENDERS.find((g) => g === voice.gender),
 				description: voice.description,
-				previewUrl: voice.preview_file_url ?? undefined,
+				previewUrl: voice.preview_file_url
+					? `/api/v1/tts/voices/preview?url=${encodeURIComponent(voice.preview_file_url)}`
+					: undefined,
 			}))
 			.filter((voice) => !language || voice.language === language);
 	}

--- a/lib/providers/tts/cartesia.ts
+++ b/lib/providers/tts/cartesia.ts
@@ -13,6 +13,7 @@ import {
 import type { BundleFile } from "@/lib/api/asset-bundle";
 import { logger } from "@/lib/api/logger";
 import { BaseProvider, type WithMetadata } from "../base";
+import { fetchAllowedVoicePreview } from "./voicePreview";
 import { buildQueryText, rankBySimilarity } from "./voiceSimilarity";
 import { GenerationRequest } from "@cartesia/cartesia-js/resources/tts.mjs";
 
@@ -78,12 +79,8 @@ export class CartesiaTTS extends BaseProvider<TTSGenerateParams, RawTTSResult> {
 	}
 
 	async fetchVoicePreview(url: string): Promise<Response> {
-		if (new URL(url).hostname !== PREVIEW_HOST) {
-			throw new Error(`Voice preview host not allowed: ${url}`);
-		}
-		return fetch(url, {
+		return fetchAllowedVoicePreview(url, PREVIEW_HOST, {
 			headers: { Authorization: `Bearer ${this.apiKey}` },
-			redirect: "manual",
 		});
 	}
 

--- a/lib/providers/tts/mock.ts
+++ b/lib/providers/tts/mock.ts
@@ -4,6 +4,7 @@ import type {
 	VoiceSearchParams,
 } from "@/lib/connectors/types";
 import { MockProvider } from "../mock-base";
+import { fetchAllowedVoicePreview } from "./voicePreview";
 
 const BLOB_BASE =
 	"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/tts/mock";
@@ -161,9 +162,6 @@ export class MockTTS extends MockProvider<TTSGenerateParams> {
 	}
 
 	async fetchVoicePreview(url: string): Promise<Response> {
-		if (new URL(url).hostname !== PREVIEW_HOST) {
-			throw new Error(`Voice preview host not allowed: ${url}`);
-		}
-		return fetch(url);
+		return fetchAllowedVoicePreview(url, PREVIEW_HOST);
 	}
 }

--- a/lib/providers/tts/mock.ts
+++ b/lib/providers/tts/mock.ts
@@ -8,6 +8,8 @@ import { MockProvider } from "../mock-base";
 const BLOB_BASE =
 	"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/tts/mock";
 
+const PREVIEW_HOST = new URL(BLOB_BASE).hostname;
+
 export class MockTTS extends MockProvider<TTSGenerateParams> {
 	protected readonly variants = [
 		{
@@ -60,15 +62,108 @@ export class MockTTS extends MockProvider<TTSGenerateParams> {
 		},
 	];
 
-	async search(_params: VoiceSearchParams): Promise<VoiceInfo[]> {
-		return [
-			{
-				id: "mock-voice-1",
-				name: "Mock Voice",
-				language: "en",
-				gender: "feminine",
-				description: "Mock voice",
-			},
-		];
+	private readonly voices: VoiceInfo[] = [
+		{
+			id: "mock-voice-aria",
+			name: "Aria",
+			language: "en",
+			gender: "feminine",
+			accent: "american",
+			description: "Warm, conversational American narrator",
+			previewUrl: `${BLOB_BASE}/1/output.mp3`,
+		},
+		{
+			id: "mock-voice-finn",
+			name: "Finn",
+			language: "en",
+			gender: "masculine",
+			accent: "british",
+			description: "Calm, measured British storyteller",
+			previewUrl: `${BLOB_BASE}/2/output.m4a`,
+		},
+		{
+			id: "mock-voice-luna",
+			name: "Luna",
+			language: "en",
+			gender: "feminine",
+			accent: "australian",
+			description: "Bright, energetic Australian voice",
+			previewUrl: `${BLOB_BASE}/3/output.wav`,
+		},
+		{
+			id: "mock-voice-marcus",
+			name: "Marcus",
+			language: "en",
+			gender: "masculine",
+			accent: "american",
+			description: "Deep, authoritative American baritone",
+			previewUrl: `${BLOB_BASE}/4/output.mp3`,
+		},
+		{
+			id: "mock-voice-claire",
+			name: "Claire",
+			language: "fr",
+			gender: "feminine",
+			accent: "french",
+			description: "Soft, articulate French speaker",
+			previewUrl: `${BLOB_BASE}/5/output.wav`,
+		},
+		{
+			id: "mock-voice-takeshi",
+			name: "Takeshi",
+			language: "ja",
+			gender: "masculine",
+			accent: "japanese",
+			description: "Crisp Japanese newsreader",
+			previewUrl: `${BLOB_BASE}/6/output.m4a`,
+		},
+		{
+			id: "mock-voice-sofia",
+			name: "Sofia",
+			language: "es",
+			gender: "feminine",
+			accent: "spanish",
+			description: "Animated Spanish presenter",
+			previewUrl: `${BLOB_BASE}/1/output.mp3`,
+		},
+		{
+			id: "mock-voice-otto",
+			name: "Otto",
+			language: "de",
+			gender: "masculine",
+			accent: "german",
+			description: "Precise German baritone",
+			previewUrl: `${BLOB_BASE}/2/output.m4a`,
+		},
+		{
+			id: "mock-voice-pip",
+			name: "Pip",
+			language: "en",
+			gender: "feminine",
+			accent: "british",
+			description: "Cheerful child-like British voice",
+			previewUrl: `${BLOB_BASE}/3/output.wav`,
+		},
+		{
+			id: "mock-voice-rex",
+			name: "Rex",
+			language: "en",
+			gender: "masculine",
+			accent: "southern",
+			description: "Gritty Southern drawl",
+			previewUrl: `${BLOB_BASE}/4/output.mp3`,
+		},
+	];
+
+	async search(params: VoiceSearchParams): Promise<VoiceInfo[]> {
+		const shuffled = [...this.voices].sort(() => Math.random() - 0.5);
+		return params.limit ? shuffled.slice(0, params.limit) : shuffled;
+	}
+
+	async fetchVoicePreview(url: string): Promise<Response> {
+		if (new URL(url).hostname !== PREVIEW_HOST) {
+			throw new Error(`Voice preview host not allowed: ${url}`);
+		}
+		return fetch(url);
 	}
 }

--- a/lib/providers/tts/voicePreview.ts
+++ b/lib/providers/tts/voicePreview.ts
@@ -1,0 +1,19 @@
+/**
+ * Fetches a voice preview URL after verifying its origin matches the
+ * provider's allow-list. The origin check covers protocol (HTTPS only),
+ * hostname, and port — preventing the caller from coercing a plaintext
+ * HTTP request that would leak any attached `Authorization` header.
+ * `redirect: "manual"` so any cross-origin redirect is surfaced as a
+ * non-`ok` response instead of replaying credentials.
+ */
+export function fetchAllowedVoicePreview(
+	url: string,
+	allowedHost: string,
+	init?: RequestInit,
+): Promise<Response> {
+	const allowedOrigin = `https://${allowedHost}`;
+	if (new URL(url).origin !== allowedOrigin) {
+		throw new Error(`Voice preview origin not allowed: ${url}`);
+	}
+	return fetch(url, { redirect: "manual", ...init });
+}

--- a/lib/templates/applyTemplate.ts
+++ b/lib/templates/applyTemplate.ts
@@ -8,6 +8,7 @@ export function applyTemplate(projectId: string, templateId: string) {
 	project.reset();
 	project.setReferenceImages(template.referenceImages);
 	project.updateMetadata({
+		style: template.artStyle,
 		characters: template.characters,
 		narration: template.narration,
 	});

--- a/lib/templates/templates.ts
+++ b/lib/templates/templates.ts
@@ -43,7 +43,7 @@ export const TEMPLATES: Template[] = [
 		narration: {
 			gender: "masculine",
 			age: "adult",
-			pitch: "neutral",
+			pitch: "medium",
 			accent: "american",
 			description: "wise",
 		},
@@ -343,7 +343,7 @@ export const TEMPLATES: Template[] = [
 		narration: {
 			gender: "masculine",
 			age: "adult",
-			pitch: "neutral",
+			pitch: "medium",
 			accent: "american",
 			description: "wise",
 		},

--- a/lib/templates/templates.ts
+++ b/lib/templates/templates.ts
@@ -529,6 +529,289 @@ export const TEMPLATES: Template[] = [
 		`,
 	},
 	{
+		id: "true-crime",
+		name: "True Crime",
+		pillText: "A true crime story about",
+		color: "#8A0000",
+		referenceImages: [
+			"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/true-crime-1",
+			"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/true-crime-2",
+			"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/true-crime-3",
+			"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/true-crime-4",
+		],
+		characters: {},
+		narration: {
+			gender: "masculine",
+			age: "adult",
+			pitch: "neutral",
+			accent: "american",
+			description: "casual",
+		},
+		showcase: {
+			image:
+				"https://mqzeech9ugknls54.public.blob.vercel-storage.com/assets/upload/template/true-crime-5",
+			title: "True Crime",
+			description:
+				"Long-form, wild true crime stories told like a buddy spilling the craziest thing he ever heard",
+			examplePrompt: "Andres Escobar",
+		},
+		exampleText: dedent`
+#Music [tense, dramatic intro]
+
+#Image [a soccer ball lying in grass with blood splattered on it]
+#Narration: Imagine getting so mad about a soccer game that you kill someone.
+
+#Image [Andres Escobar smiling in a Colombia jersey, stadium behind him]
+#Narration: So the story starts with this guy, Andreas.
+
+#Image [Andres standing in front of a Colombian flag, looking friendly]
+#Narration: And Andreas is about 27, and he lives in Colombia.
+
+#Image [Andres in a soccer uniform kicking a ball on the field]
+#Narration: And he plays soccer for his country's big team.
+
+#Image [fans cheering and holding up Andres jerseys]
+#Narration: Everyone there loves him because he's a nice dude.
+
+#Image [Andres shaking hands politely with another player after a game]
+#Narration: He doesn't talk trash. He doesn't play dirty. He's just chill.
+
+#Image [a massive crowd of Colombian fans waving yellow flags in a city street]
+#Narration: And in Colombia, soccer is a HUGE deal. Like, a really huge deal.
+
+#Image [Andres on a magazine cover labeled "EL HÉROE"]
+#Narration: So Andreas isn't just famous. He's basically a hero.
+
+#Image [scoreboard showing Colombia 5, Argentina 0]
+#Narration: But then in 1993, his team smashes Argentina five to zero.
+
+#Image [Andres jumping in celebration with his teammates on the field]
+#Narration: Boom. That means Colombia gets to play in the World Cup.
+
+#Sound [crowd cheering, horns blaring]
+#Image [people partying in the streets of Bogotá, confetti everywhere]
+#Narration: And the whole country goes nuts.
+
+#Image [shadowy men in suits watching a small TV in a dim room]
+#Narration: But here's the problem. The bad guys are watching too.
+
+#Image [a chalkboard with betting numbers and stacks of cash on a table, angry cartel men around it]
+#Narration: The Colombian drug cartel, basically a giant crime gang, they bet millions of dollars on Colombia to win.
+
+#Image [Andres looking nervous, hand on his head in a locker room]
+#Narration: So now Andreas isn't just playing for fun. He's playing to keep some very scary people happy.
+
+#Music [music turns darker]
+
+#Image [airplane flying over California palm trees]
+#Narration: So in 1994, the team flies to California for the World Cup.
+
+#Image [scoreboard showing Romania 3, Colombia 1]
+#Narration: First game, Colombia versus Romania. And they lose. Three to one.
+
+#Image [Colombian fans crying in front of a TV at home]
+#Narration: The whole country is bummed.
+
+#Image [angry cartel boss slamming his fist on a desk, money flying]
+#Narration: The drug cartel? They are FURIOUS. They just lost a ton of money.
+
+#Image [a dark hotel hallway with one door slightly open]
+#Narration: And here's where things get really scary.
+
+#Image [hotel room TV glowing with a creepy threatening message on screen]
+#Narration: Back at the team's hotel, somebody hacks into the TVs.
+
+#Image [close-up of the TV screen showing skull and crossbones with a written warning]
+#Narration: And instead of a hello message, there's a threat. It says, "Don't let this one player play, or we'll kill all of you and bomb your families."
+
+#Sound [static, heartbeat]
+#Image [players sitting around the hotel room looking terrified]
+#Narration: The team is freaking out.
+
+#Image [Andres lacing up his cleats with a calm, focused face]
+#Narration: But Andreas, being the chill guy he is, he stays positive. He's gonna give it his all.
+
+#Image [huge packed stadium with Colombia and USA flags everywhere]
+#Narration: Next game. Colombia versus the USA. Ninety thousand fans in the stands.
+
+#Image [empty Colombian street, closed shop signs, only a glowing TV through a window]
+#Narration: Back home, stores are closed. Families are glued to the TV.
+
+#Image [cartel men watching the game intensely in a smoky room]
+#Narration: And yep, the cartel guys are watching too.
+
+#Music [intense game music]
+
+#Image [Andres sprinting on the soccer field, ball at his feet]
+#Narration: The game starts. Andreas is playing hard. Running, kicking, doing his thing.
+
+#Image [stadium clock showing 20 minutes, players mid-play]
+#Narration: But then, about 20 minutes in, something crazy happens.
+
+#Image [American player kicking a long pass across the field]
+#Narration: An American player tries to pass the ball.
+
+#Image [Andres sliding with his leg out toward the ball]
+#Narration: Andreas slides in to stop it.
+
+#Image [slow-motion close-up of ball bouncing off Andres's cleat at a weird angle]
+#Narration: But the ball bounces off his foot at a weird angle...
+
+#Sound [whoosh, then a net swish]
+#Image [the ball hitting the back of the Colombian net, goalie diving the wrong way]
+#Narration: ...and rolls right past his own goalie into his own net.
+
+#Image [Andres on his knees, hands on his head, devastated]
+#Narration: Yep. Andreas just scored on his own team.
+
+#Image [close-up of Andres's face, tears in his eyes]
+#Narration: And he knows right away. This is it. They're done.
+
+#Image [final scoreboard: USA 2, Colombia 1]
+#Narration: And so Colombia loses. And they get kicked out of the World Cup.
+
+#Image [angry Colombian fans burning jerseys in the street]
+#Narration: And the whole country is mad. And everybody starts pointing the finger at Andreas.
+
+#Sound [phone ringing creepily]
+#Image [a hotel phone ringing with a shadowy hand reaching for it]
+#Narration: Pretty quick, the players start getting scary phone calls.
+
+#Image [a player listening to the phone with a horrified face]
+#Narration: Like, "We're gonna hurt you" calls.
+
+#Image [the team eating dinner together at a US restaurant, looking nervous]
+#Narration: So the team decides to stay in America for a bit.
+
+#Image [Andres smiling and signing an autograph for a kid at an airport]
+#Narration: But Andreas? Nah, he's not scared. He's a positive dude.
+
+#Image [Andres walking off a plane in Colombia, suitcase in hand]
+#Narration: So he flies back to Colombia.
+
+#Image [Andres's mom hugging him in a kitchen, looking worried]
+#Narration: His friends, his family, even his coach beg him, "Please stay inside. It's not safe."
+
+#Image [Andres looking out a window with a determined expression]
+#Narration: But Andreas doesn't want to hide.
+
+#Image [a newspaper with Andres's column printed and his photo next to it]
+#Narration: He even writes a public letter saying sorry for the goal, and that "life doesn't end here."
+
+#Image [Andres looking up at the sky, a small sad smile on his face]
+#Narration: Welp. He had no idea how wrong he was about to be.
+
+#Music [darker, slower music]
+
+#Image [neon nightclub sign glowing in the dark]
+#Narration: Ten days later, Andreas goes out to a nightclub with his friends.
+
+#Image [Andres laughing with friends at a club table, drink in hand]
+#Narration: He's finally feeling okay again.
+
+#Image [a group of mean-looking men in fancy shirts glaring across the club]
+#Narration: But across the room, there's a group of bad guys, the Gallon brothers.
+
+#Image [the brothers counting stacks of cash earlier in a dim room]
+#Narration: They're in the cartel. And they bet a TON of money on that game. And they lost.
+
+#Image [the brothers pointing and yelling at Andres across the club]
+#Narration: They see Andreas and start yelling mean stuff at him, making fun of him for that goal.
+
+#Image [Andres calmly sipping his drink, looking the other way]
+#Narration: But Andreas, being chill, just ignores it.
+
+#Image [Andres standing up from his table, putting on his jacket]
+#Narration: Eventually he's like, "I'm out."
+
+#Image [Andres walking through a dark parking lot toward his car]
+#Narration: So he heads to the parking lot and gets in his car.
+
+#Image [the Gallon brothers and a huge bodyguard following him out the door]
+#Narration: But the bad guys follow him outside. They keep yelling.
+
+#Image [Andres holding his hands up, trying to explain himself]
+#Narration: And Andreas tries to explain, "Hey, it was just an accident. It could happen to anybody."
+
+#Sound [tense silence]
+#Image [the brothers' angry faces, fists clenched]
+#Narration: But they don't care. They lost millions. And they want somebody to blame.
+
+#Sound [blam blam blam blam blam blam]
+#Image [the bodyguard pulling a gun from his jacket, muzzle flash lighting up the lot]
+#Narration: And suddenly, their bodyguard pulls out a gun and shoots Andreas six times.
+
+#Image [the bodyguard yelling with a twisted, mocking face]
+#Narration: And after every single shot, he yells, "GOOOAL!" making fun of the mistake.
+
+#Image [crime scene tape stretched across a dark parking lot, car door open]
+#Narration: Then they jump in their car and drive off. And sadly, Andreas doesn't make it.
+
+#Image [a soccer ball sitting alone in an empty stadium]
+#Narration: All that... over a soccer game.
+
+#Image [bodyguard's mug shot under a police number board]
+#Narration: Now, the Gallon brothers ordered the hit, but their bodyguard takes the fall.
+
+#Image [the bodyguard in handcuffs being walked out by police]
+#Narration: And bam, he gets arrested. Here's his mug shot.
+
+#Image [the Gallon brothers smirking and sliding an envelope of cash to a man in a suit]
+#Narration: Now this part is gonna make you mad. The Gallon brothers? The guys who actually ordered the hit? They paid off the prosecutors.
+
+#Image [the brothers walking free outside a courthouse, smiling]
+#Narration: So they never got in trouble. Not one bit.
+
+#Image [the bodyguard walking out of prison with a duffel bag, only 11 years later]
+#Narration: And the bodyguard? He got sentenced to 43 years. But because of his connections, he only served 11.
+
+#Music [somber outro]
+#Image [a memorial statue of Andres Escobar with flowers piled at the base]
+#Narration: And that's the wild, sad story of how a soccer game ended a man's life.`,
+		systemPrompt: dedent`
+You write short narrative scripts in the style of viral YouTube true-story/crime videos. Pastiche these conventions precisely:
+
+# ART STYLE
+Semi-realistic digital comic illustration, cel-shaded with bold ink outlines, muted earthy palette, cinematic dramatic lighting, gritty detailed textures, expressive characters, vertical 9:16 composition, Rockstar Games concept art style
+
+# OPENING HOOK
+Open with a single punchy sentence that previews the wildest part of the story. Examples: "Imagine getting so mad over [X] that you murder someone." / "So this guy is about to [win/lose] [absurd thing] and then he's going to jail." / "So this man's obsession with [random thing] is about to go very wrong."
+
+# PROTAGONIST SETUP
+Immediately introduce the protagonist by first name, approximate age, and location: "Now, the guy's name is [Name]. And [Name] is about [X] when this story starts, and he's living in [Place]." Follow with a one-line problem statement: "And [Name] has a problem."
+
+# VOICE & TONE
+- Casual, conversational, like telling a buddy a wild story at a bar
+- First person narrator addressing the viewer directly ("I mean," "you know," "anyway")
+- Mild profanity
+- Sarcastic asides and dry humor ("Sure, Jan." / "I'm not making that up." / "give it a week or two")
+- Self-aware tangents and rhetorical questions ("And I don't know why this multi-millionaire doesn't have his own place, but whatever.")
+- Editorial reactions ("Damn." / "poor [Name]" / "this part's definitely going to make you mad")
+
+# PACING & STRUCTURE
+- Heavy use of "And," "So," "Now," "But then," "Anyway," and "And here's where things get [crazy/really out of control/scary]" as paragraph engines
+- Run-on sentences chained with "and" mixed with short punchy ones
+- Escalate events in clear beats, each worse or weirder than the last
+- Frequent reset phrases: "And so from there..." / "Here's where things get really out of control."
+- Maintain the rhythm: hook → setup → escalation → climax → fallout.
+
+# ONOMATOPOEIA
+Use written-out sound effects liberally and in clusters: blam blam blam, boom, bam, pow, kaboom, skirt, screech.
+
+# IMAGERY CUES
+The narrator should narrate the images that the viewer sees: "Here's his mug shot." / "Here's a picture of him." / "If you slow the body cam footage way down, you can see..." Use oddly specific numbers and dollar amounts for realism.
+
+# IMAGE MOTION
+Each static image should have a motion attribute, vary these as appropriate
+
+# IMAGE FREQUENCY
+Each narration sentence should have a different image associated with it
+
+# CLOSING
+Wrap up with the aftermath — arrest, trial, sentence, ironic twist, or grim ending — delivered matter-of-factly. Optional dry one-liner to button it ("All that because of a [thing].").
+`,
+	},
+	{
 		id: "kids-animated",
 		name: "Kids Animated",
 		pillText: "A kids animated story about",

--- a/lib/templates/templates.ts
+++ b/lib/templates/templates.ts
@@ -15,6 +15,7 @@ export interface Template {
 	color: string;
 	exampleText: string;
 	systemPrompt: string;
+	artStyle?: string;
 	referenceImages: string[];
 	characters: Record<string, MetadataCharacter>;
 	narration?: MetadataVoice;
@@ -55,10 +56,10 @@ export const TEMPLATES: Template[] = [
 				"Long-form, second-person POV voiceover with cartoon illustrations that walk a viewer through ascending stages of a role, career, or world",
 			examplePrompt: "tech CEO",
 		},
+		artStyle: dedent`2D cartoon illustration, thick black outlines, muted desaturated colors, cinematic night lighting, flat shading, western animation style, no gradients`,
 		systemPrompt: dedent`
 		# Important
 		- The main character (you) is always called Protagonist, and the Protagonist must always be present in the character list of images where appropriate
-		- The art style is: 2D cartoon illustration, thick black outlines, muted desaturated colors, cinematic night lighting, flat shading, western animation style, no gradients
 		- Do not generate character metadata for the Protagonist, but do use him like a regular character in the story
 		- The Protagonist is always male, average build, slightly hunched posture, bald, wearing a worn olive green jacket, grey t-shirt underneath, faded blue jeans, brown work boots
 		- Never mention any specific ages in the image descriptions, just generic ones like young man`,
@@ -276,10 +277,8 @@ export const TEMPLATES: Template[] = [
 				"Long-form, slow, soothing narration designed to lull listeners to sleep",
 			examplePrompt: "a cat who wanders around gardens at night",
 		},
-		systemPrompt: dedent`
-		# Important
-		- The art style is: Hand-painted watercolor/gouache, Ghibli-storybook style. Loose ink lines, moody nocturnal palette (midnight blue, slate, teal, brick accents), moonlight and drifting particles, layered foliage. Painterly, quiet, dreamlike. 
-		`,
+		artStyle: dedent`Hand-painted watercolor/gouache, Ghibli-storybook style. Loose ink lines, moody nocturnal palette (midnight blue, slate, teal, brick accents), moonlight and drifting particles, layered foliage. Painterly, quiet, dreamlike.`,
+		systemPrompt: "",
 		exampleText: dedent`#Music: Soft welcoming ambient pad in C major, slow warm analog synth swells, distant felted piano notes spaced far apart, very low binaural pink noise underneath, no percussion, evokes the moment of pulling a duvet up to your chin. 50 BPM. Loopable for ~3 minutes.
 			#Image: A cozy bedroom at night seen from shouldlow angle, soft amber lamplight on a nightstand, a book turned face-down on a folded quilt, a window with deep indigo sky and a sliver of moon, dreamy painterly style with soft brush textures, warm muted palette of cream, ochre, navy, and dusky rose, cinematic depth of field
 			#Narration: Welcome to Get Sleepy, where we listen, we relax, and we get sleepy. My name is Thomas, and I'm your host.
@@ -355,10 +354,10 @@ export const TEMPLATES: Template[] = [
 			examplePrompt:
 				"Subscriptions, bank fees, impulse buys, unused gym memberships - the money leaks most people ignore",
 		},
+		artStyle: dedent`Flat 2D cartoon, bold black outlines, cel-shaded flat colors, oversized rounded heads with prominent chins, small oval eyes, bean-shaped bodies, stubby limbs. Vector-style props with thick outlines. Saturated colors. Explainer-cartoon aesthetic. Plain white background.`,
 		systemPrompt: dedent`
 			# Important
 			- The main character is always called Ethan, and the Ethan must always be present in the character list of images where relevant
-			- The art style is: Flat 2D cartoon, bold black outlines, cel-shaded flat colors, oversized rounded heads with prominent chins, small oval eyes, bean-shaped bodies, stubby limbs. Vector-style props with thick outlines. Saturated colors. Explainer-cartoon aesthetic. Plain white background.
 			- Do not generate character metadata for Ethan, but do use him like a regular character in the story
 			- Ethan is a man with short light brown hair parted to the side, oversized rounded head with prominent chin and double-chin, small oval eyes with tiny black pupils, thin arched eyebrows, long pointed nose, small mouth. Bean-shaped body with stubby limbs. Wearing a blue hoodie and blue pants with white sneakers`,
 		exampleText: dedent`
@@ -543,9 +542,10 @@ export const TEMPLATES: Template[] = [
 		narration: {
 			gender: "masculine",
 			age: "adult",
-			pitch: "neutral",
+			pitch: "medium",
 			accent: "american",
-			description: "casual",
+			description: "Friendly young adult male",
+			voiceId: "86e30c1d-714b-4074-a1f2-1cb6b552fb49",
 		},
 		showcase: {
 			image:
@@ -768,11 +768,9 @@ export const TEMPLATES: Template[] = [
 #Music [somber outro]
 #Image [a memorial statue of Andres Escobar with flowers piled at the base]
 #Narration: And that's the wild, sad story of how a soccer game ended a man's life.`,
+		artStyle: dedent`Semi-realistic digital comic illustration, cel-shaded with bold ink outlines, muted earthy palette, cinematic dramatic lighting, gritty detailed textures, expressive characters, vertical 9:16 composition, Rockstar Games concept art style`,
 		systemPrompt: dedent`
 You write short narrative scripts in the style of viral YouTube true-story/crime videos. Pastiche these conventions precisely:
-
-# ART STYLE
-Semi-realistic digital comic illustration, cel-shaded with bold ink outlines, muted earthy palette, cinematic dramatic lighting, gritty detailed textures, expressive characters, vertical 9:16 composition, Rockstar Games concept art style
 
 # OPENING HOOK
 Open with a single punchy sentence that previews the wildest part of the story. Examples: "Imagine getting so mad over [X] that you murder someone." / "So this guy is about to [win/lose] [absurd thing] and then he's going to jail." / "So this man's obsession with [random thing] is about to go very wrong."


### PR DESCRIPTION
**Stacked on top of #196 — base is \`umair/edit-characters\`.**

## Summary
- **True Crime template** added to \`TEMPLATES\` with showcase, example text, characters, narration descriptors.
- **\`template-mode\` LLM plugin** prepends a structured preamble to the system prompt: art style + narrator traits + character roster, each introduced with an instruction to use those values as-is rather than inventing new ones. Internal routing fields (\`voiceId\`, \`resolvedVoiceId\`, \`model\`, \`avatarUrl\`) are deliberately omitted from the preamble.
- **New \`artStyle\` field on \`Template\`**. Extracted the art-style string out of \`systemPrompt\` for \`pov-life\`, \`sleep-story\`, \`explainer-style\`, and \`true-crime\`. \`applyTemplate\` writes \`template.artStyle\` to \`metadata.style\`, so the existing \`createArtStylePlugin\` (image) picks it up at generation time — single source of truth, just seeded from the template.
- **\`applyTemplate\` honors \`voiceId\` overrides** from \`narration\` and \`characters[*]\` in the template. Regression tests use \`vi.spyOn(templates, "getTemplateById")\` to inject template variants without baking real Cartesia voice IDs into production data.

## Test plan
- [ ] Apply True Crime template → script editor system prompt opens with the art-style block, narrator-trait block, then the template's prose; \`metadata.style\` equals \`template.artStyle\`.
- [ ] Apply a template that pins \`narration.voiceId\` → that voiceId surfaces as the locked voice in the narrator edit modal.
- [ ] Apply a template, generate an image → image prompt is prepended with the art style (\`createArtStylePlugin\` path).
- [ ] \`npm run lint && npm run format:check && npm run typecheck && npm run test:run && npm run build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)