### PR TITLE
Show characters in composer + polish character edit modal

### DIFF
--- a/app/components/ComposerHero.tsx
+++ b/app/components/ComposerHero.tsx
@@ -22,7 +22,7 @@ And in that garden… lived a little rabbit named Lumi…`;
 
 export default function ComposerHero() {
 	const { submitPrompt } = useScriptControl();
-	const { mode, applyTemplate } = useConfig();
+	const { mode, applyTemplate, setMode } = useConfig();
 	const [value, setValue] = useState("");
 
 	return (
@@ -51,6 +51,7 @@ export default function ComposerHero() {
 			<TemplateGallery
 				onSelect={(templateId, examplePrompt) => {
 					applyTemplate(templateId);
+					setMode("template");
 					setValue(examplePrompt);
 				}}
 			/>

--- a/app/components/canvas/elements/AssetTile.tsx
+++ b/app/components/canvas/elements/AssetTile.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Pencil, type LucideIcon } from "lucide-react";
+import { Pencil, X, type LucideIcon } from "lucide-react";
 import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
 import { ImageWithShimmer } from "@/lib/components/ImageWithShimmer";
 import { GenerationIndicator } from "./GenerationIndicator";
@@ -11,6 +11,7 @@ export function AssetTile({
 	Icon,
 	elementId,
 	onEdit,
+	onRemove,
 	fallback = "initial",
 }: {
 	name?: string;
@@ -18,6 +19,7 @@ export function AssetTile({
 	Icon: LucideIcon;
 	elementId?: string;
 	onEdit?: () => void;
+	onRemove?: () => void;
 	fallback?: "initial" | "icon";
 }) {
 	const status = useQueueSelector(
@@ -69,6 +71,16 @@ export function AssetTile({
 						className="absolute inset-0 flex items-center justify-center bg-black/45 text-white opacity-0 transition-opacity group-hover/tile:opacity-100 focus:opacity-100 focus:outline-none"
 					>
 						<Pencil className="h-3.5 w-3.5" />
+					</button>
+				)}
+				{onRemove && status !== "generating" && (
+					<button
+						type="button"
+						onClick={onRemove}
+						aria-label={`Remove ${name ?? "asset"}`}
+						className="absolute inset-0 flex items-center justify-center bg-black/45 text-white opacity-0 transition-opacity group-hover/tile:opacity-100 focus:opacity-100 focus:outline-none"
+					>
+						<X className="h-3.5 w-3.5" />
 					</button>
 				)}
 			</div>

--- a/app/components/canvas/elements/AssetsSection.tsx
+++ b/app/components/canvas/elements/AssetsSection.tsx
@@ -16,6 +16,10 @@ export function AssetsSection() {
 	const hydrated = useProjectStore(projectId, (s) => s.hydrated);
 	const characters = useProjectStore(projectId, (s) => s.metadata.characters);
 	const referenceImages = useProjectStore(projectId, (s) => s.referenceImages);
+	const setReferenceImages = useProjectStore(
+		projectId,
+		(s) => s.setReferenceImages,
+	);
 	const [collapsed, setCollapsed] = useState(false);
 	const [editingName, setEditingName] = useState<string | undefined>();
 	const [editingNarrator, setEditingNarrator] = useState(false);
@@ -66,6 +70,9 @@ export function AssetsSection() {
 							name={`Reference ${i + 1}`}
 							previewUrl={url}
 							Icon={Palette}
+							onRemove={() =>
+								setReferenceImages(referenceImages.filter((_, j) => j !== i))
+							}
 						/>
 					))}
 				</div>

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Trash2 } from "lucide-react";
+import { ImagePlus, Loader2, Trash2 } from "lucide-react";
 import {
 	DialogContent,
 	DialogDescription,
@@ -10,6 +10,11 @@ import {
 	DialogTitle,
 	MountedDialog,
 } from "@/components/ui/dialog";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import {
 	useGenerationQueue,
@@ -24,6 +29,7 @@ import {
 } from "@/lib/project/ensureCharacterAvatars";
 import { useProjectStore } from "@/lib/project/store";
 import type { MetadataCharacter } from "@/lib/project/types";
+import { useImageUpload } from "@/lib/upload/useImageUpload";
 import { MediaPlaceholder, MediaPreview } from "../preview/results";
 import { TextAreaField } from "./fields";
 import { VoiceSection } from "./VoiceMetadataFields";
@@ -71,6 +77,15 @@ function CharacterEditDialogBody({
 		q.getElementSnapshot(avatarElementId),
 	);
 
+	const { openPicker, uploading, inputElement } = useImageUpload({
+		onUpload: ([url]) => {
+			if (url && character) {
+				queue.discard(avatarElementId);
+				setCharacter(name, { ...character, avatarUrl: url });
+			}
+		},
+	});
+
 	if (!character) return null;
 
 	const update = (partial: Partial<MetadataCharacter>) =>
@@ -79,13 +94,15 @@ function CharacterEditDialogBody({
 	const regenerateAvatar = () =>
 		queue.enqueue(buildCharacterAvatarJob(projectId, name, connectorConfig));
 
-	const isStale = isStaleResult(
-		avatarSnapshot,
-		getGenerationInputs(
-			characterAvatarElement(name, character.appearance),
-			metadata,
-		),
-	);
+	const isStale =
+		!!avatarSnapshot.result &&
+		isStaleResult(
+			avatarSnapshot,
+			getGenerationInputs(
+				characterAvatarElement(name, character.appearance),
+				metadata,
+			),
+		);
 
 	const handleDelete = () => {
 		if (!confirmDelete) {
@@ -115,26 +132,47 @@ function CharacterEditDialogBody({
 						onChange={(appearance) => update({ appearance })}
 						placeholder="Describe the character's look"
 					/>
-					{character.avatarUrl ? (
-						<MediaPreview
-							key={character.avatarUrl}
-							url={character.avatarUrl}
-							outputKind="image"
-							borderColor="border-white/20"
-							status={avatarSnapshot.status}
-							seconds={avatarSnapshot.seconds}
-							stale={isStale}
-							onRegenerate={regenerateAvatar}
-						/>
-					) : (
-						<MediaPlaceholder
-							status={avatarSnapshot.status}
-							seconds={avatarSnapshot.seconds}
-							error={avatarSnapshot.error}
-							onGenerate={regenerateAvatar}
-							onDiscard={() => queue.discard(avatarElementId)}
-						/>
-					)}
+					<div className="relative">
+						{character.avatarUrl ? (
+							<MediaPreview
+								key={character.avatarUrl}
+								url={character.avatarUrl}
+								outputKind="image"
+								borderColor="border-white/20"
+								status={avatarSnapshot.status}
+								seconds={avatarSnapshot.seconds}
+								stale={isStale}
+								onRegenerate={regenerateAvatar}
+							/>
+						) : (
+							<MediaPlaceholder
+								status={avatarSnapshot.status}
+								seconds={avatarSnapshot.seconds}
+								error={avatarSnapshot.error}
+								onGenerate={regenerateAvatar}
+								onDiscard={() => queue.discard(avatarElementId)}
+							/>
+						)}
+						{inputElement}
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									onClick={openPicker}
+									disabled={uploading}
+									aria-label="Upload image"
+									className="grain grain-light absolute left-2 top-11 z-10 flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-black/55 ring-1 ring-inset ring-white/10 backdrop-blur-xl transition-colors hover:bg-black/70 disabled:opacity-60"
+								>
+									{uploading ? (
+										<Loader2 className="h-3 w-3 animate-spin text-white" />
+									) : (
+										<ImagePlus className="h-3 w-3 text-white" />
+									)}
+								</button>
+							</TooltipTrigger>
+							<TooltipContent>Upload image</TooltipContent>
+						</Tooltip>
+					</div>
 				</div>
 				<VoiceSection voice={character} onChange={update} />
 			</div>

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -79,10 +79,9 @@ function CharacterEditDialogBody({
 
 	const { openPicker, uploading, inputElement } = useImageUpload({
 		onUpload: ([url]) => {
-			if (url && character) {
-				queue.discard(avatarElementId);
-				setCharacter(name, { ...character, avatarUrl: url });
-			}
+			if (!url) return;
+			queue.discard(avatarElementId);
+			setCharacter(name, { ...character, avatarUrl: url });
 		},
 	});
 

--- a/app/components/copilot/ComposerAssets.tsx
+++ b/app/components/copilot/ComposerAssets.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Mic, Palette, User } from "lucide-react";
+import { AssetTile } from "@/app/components/canvas/elements/AssetTile";
+import { characterAvatarElementId } from "@/lib/project/ensureCharacterAvatars";
+import { useConfig } from "@/lib/config/ConfigProvider";
+import { useProject } from "@/lib/project/useProject";
+import { getProjectStore } from "@/lib/project/store";
+
+interface ComposerAssetsProps {
+	uploadingCount: number;
+	onEditCharacter: (name: string) => void;
+	onEditNarrator: () => void;
+}
+
+export function ComposerAssets({
+	uploadingCount,
+	onEditCharacter,
+	onEditNarrator,
+}: ComposerAssetsProps) {
+	const { projectId } = useConfig();
+	const referenceImages = useProject((s) => s.referenceImages);
+	const characters = useProject((s) => s.metadata.characters);
+	const narration = useProject((s) => s.metadata.narration);
+
+	const hasNarration = Object.keys(narration).length > 0;
+	const characterEntries = Object.entries(characters);
+
+	const removeReferenceImage = (index: number) =>
+		getProjectStore(projectId)
+			.getState()
+			.setReferenceImages(referenceImages.filter((_, j) => j !== index));
+
+	return (
+		<div className="flex flex-wrap gap-2 pb-2">
+			{hasNarration && (
+				<AssetTile
+					name="Narrator"
+					Icon={Mic}
+					fallback="icon"
+					onEdit={onEditNarrator}
+				/>
+			)}
+			{characterEntries.map(([name, ch]) => (
+				<AssetTile
+					key={`character:${name}`}
+					name={name}
+					previewUrl={ch.avatarUrl}
+					Icon={User}
+					elementId={characterAvatarElementId(name)}
+					onEdit={() => onEditCharacter(name)}
+				/>
+			))}
+			{referenceImages.map((url, i) => (
+				<AssetTile
+					key={`ref:${url}`}
+					name={`Reference ${i + 1}`}
+					previewUrl={url}
+					Icon={Palette}
+					onRemove={() => removeReferenceImage(i)}
+				/>
+			))}
+			{Array.from({ length: uploadingCount }).map((_, i) => (
+				<div
+					key={i}
+					className="aspect-square w-16 shrink-0 rounded-md shimmer-surface sm:w-20"
+				/>
+			))}
+		</div>
+	);
+}

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -5,7 +5,7 @@ import {
 	CornerDownLeft,
 	ImagePlus,
 	Loader2,
-	Palette,
+	Mic,
 	Plus,
 	User,
 	X,
@@ -19,16 +19,15 @@ import {
 import GlassDropdown, {
 	type GlassDropdownOption,
 } from "@/app/components/GlassDropdown";
-import { AssetTile } from "@/app/components/canvas/elements/AssetTile";
 import { CharacterEditModal } from "@/app/components/canvas/elements/character/CharacterEditModal";
+import { NarratorEditModal } from "@/app/components/canvas/elements/character/NarratorEditModal";
 import { NewCharacterDialog } from "@/app/components/canvas/elements/character/NewCharacterDialog";
-import { characterAvatarElementId } from "@/lib/project/ensureCharacterAvatars";
 import { TEMPLATES, getTemplateById } from "@/lib/templates/templates";
 import { useConfig, type Mode } from "@/lib/config/ConfigProvider";
-import { useProject } from "@/lib/project/useProject";
 import { getProjectStore } from "@/lib/project/store";
 import { useImageUpload } from "@/lib/upload/useImageUpload";
 import { ActionButton } from "./ActionButton";
+import { ComposerAssets } from "./ComposerAssets";
 
 const MODE_OPTIONS: GlassDropdownOption<Mode>[] = [
 	{ value: "story", label: "Describe a story" },
@@ -45,10 +44,12 @@ function AttachMenu({
 	openPicker,
 	uploading,
 	onCreateCharacter,
+	onSelectNarrator,
 }: {
 	openPicker: () => void;
 	uploading: boolean;
 	onCreateCharacter: () => void;
+	onSelectNarrator: () => void;
 }) {
 	return (
 		<DropdownMenu modal={false}>
@@ -87,6 +88,13 @@ function AttachMenu({
 				>
 					<User className="mr-1.5 h-3.5 text-white w-3.5" strokeWidth={1.5} />
 					Create character
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					onClick={onSelectNarrator}
+					className="cursor-pointer rounded-lg px-2 py-1.5 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10"
+				>
+					<Mic className="mr-1.5 h-3.5 text-white w-3.5" strokeWidth={1.5} />
+					Select narrator voice
 				</DropdownMenuItem>
 			</DropdownMenuContent>
 		</DropdownMenu>
@@ -136,24 +144,19 @@ export default function ComposerCopilot({
 }: ComposerCopilotProps) {
 	const { projectId, mode, setMode, selectedTemplateId, applyTemplate } =
 		useConfig();
-	const referenceImages = useProject((s) => s.referenceImages);
-	const characters = useProject((s) => s.metadata.characters);
 	const [creatingCharacter, setCreatingCharacter] = useState(false);
 	const [editingCharacterName, setEditingCharacterName] = useState<
 		string | undefined
 	>();
-
-	const setReferenceImages = (urls: string[]) =>
-		getProjectStore(projectId).getState().setReferenceImages(urls);
+	const [editingNarrator, setEditingNarrator] = useState(false);
 
 	const { openPicker, uploading, uploadingCount, inputElement } =
 		useImageUpload({
 			multiple: true,
-			onUpload: (urls) =>
-				setReferenceImages([
-					...getProjectStore(projectId).getState().referenceImages,
-					...urls,
-				]),
+			onUpload: (urls) => {
+				const store = getProjectStore(projectId).getState();
+				store.setReferenceImages([...store.referenceImages, ...urls]);
+			},
 		});
 	const showPill = mode === "template" && selectedTemplateId !== undefined;
 	const hasText = value.trim().length > 0;
@@ -170,39 +173,11 @@ export default function ComposerCopilot({
 	return (
 		<div className="w-full rounded-xl border border-violet-500/30 bg-white/5 shadow-[0_0_40px_rgba(55,30,100,0.5)]">
 			<div className="px-4 py-3">
-				{(Object.keys(characters).length > 0 ||
-					referenceImages.length > 0 ||
-					uploading) && (
-					<div className="flex flex-wrap gap-2 pb-2">
-						{Object.entries(characters).map(([name, ch]) => (
-							<AssetTile
-								key={`character:${name}`}
-								name={name}
-								previewUrl={ch.avatarUrl}
-								Icon={User}
-								elementId={characterAvatarElementId(name)}
-								onEdit={() => setEditingCharacterName(name)}
-							/>
-						))}
-						{referenceImages.map((url, i) => (
-							<AssetTile
-								key={`ref:${url}`}
-								name={`Reference ${i + 1}`}
-								previewUrl={url}
-								Icon={Palette}
-								onRemove={() =>
-									setReferenceImages(referenceImages.filter((_, j) => j !== i))
-								}
-							/>
-						))}
-						{Array.from({ length: uploadingCount }).map((_, i) => (
-							<div
-								key={i}
-								className="aspect-square w-16 shrink-0 rounded-md shimmer-surface sm:w-20"
-							/>
-						))}
-					</div>
-				)}
+				<ComposerAssets
+					uploadingCount={uploadingCount}
+					onEditCharacter={setEditingCharacterName}
+					onEditNarrator={() => setEditingNarrator(true)}
+				/>
 				<div className="flex flex-col gap-1 sm:flex-row sm:items-baseline">
 					{showPill && (
 						<TemplatePill
@@ -238,6 +213,7 @@ export default function ComposerCopilot({
 							openPicker={openPicker}
 							uploading={uploading}
 							onCreateCharacter={() => setCreatingCharacter(true)}
+							onSelectNarrator={() => setEditingNarrator(true)}
 						/>
 						<GlassDropdown
 							value={mode}
@@ -288,6 +264,10 @@ export default function ComposerCopilot({
 				open={editingCharacterName !== undefined}
 				onOpenChange={(open) => !open && setEditingCharacterName(undefined)}
 				name={editingCharacterName}
+			/>
+			<NarratorEditModal
+				open={editingNarrator}
+				onOpenChange={setEditingNarrator}
 			/>
 		</div>
 	);

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { type ReactNode, useRef, useState } from "react";
-import Image from "next/image";
-import { CornerDownLeft, ImagePlus, Loader2, Plus, X } from "lucide-react";
-import { toast } from "sonner";
+import { type ReactNode, useState } from "react";
+import {
+	CornerDownLeft,
+	ImagePlus,
+	Loader2,
+	Palette,
+	Plus,
+	User,
+	X,
+} from "lucide-react";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -13,12 +19,15 @@ import {
 import GlassDropdown, {
 	type GlassDropdownOption,
 } from "@/app/components/GlassDropdown";
+import { AssetTile } from "@/app/components/canvas/elements/AssetTile";
+import { CharacterEditModal } from "@/app/components/canvas/elements/character/CharacterEditModal";
+import { NewCharacterDialog } from "@/app/components/canvas/elements/character/NewCharacterDialog";
+import { characterAvatarElementId } from "@/lib/project/ensureCharacterAvatars";
 import { TEMPLATES, getTemplateById } from "@/lib/templates/templates";
 import { useConfig, type Mode } from "@/lib/config/ConfigProvider";
 import { useProject } from "@/lib/project/useProject";
 import { getProjectStore } from "@/lib/project/store";
-import { stringifyError } from "@/lib/errors";
-import { uploadImage } from "@/lib/upload/uploadImage";
+import { useImageUpload } from "@/lib/upload/useImageUpload";
 import { ActionButton } from "./ActionButton";
 
 const MODE_OPTIONS: GlassDropdownOption<Mode>[] = [
@@ -32,122 +41,55 @@ const TEMPLATE_OPTIONS: GlassDropdownOption<string>[] = TEMPLATES.map((t) => ({
 	label: t.name,
 }));
 
-function ImageThumbnail({
-	url,
-	onRemove,
-}: {
-	url: string;
-	onRemove: () => void;
-}) {
-	const [loaded, setLoaded] = useState(false);
-
-	return (
-		<div className="group/thumb relative h-14 w-14 shrink-0">
-			<div className="relative h-full w-full overflow-hidden rounded-lg">
-				{!loaded && (
-					<div className="absolute inset-0 rounded-lg shimmer-surface" />
-				)}
-				<Image
-					src={url}
-					alt="Reference"
-					fill
-					sizes="56px"
-					unoptimized
-					className={`object-cover transition-opacity ${loaded ? "opacity-100" : "opacity-0"}`}
-					onLoad={() => setLoaded(true)}
-				/>
-			</div>
-			<button
-				type="button"
-				aria-label="Remove image"
-				onClick={onRemove}
-				className="absolute -right-2 -top-2 flex h-6 w-6 items-center justify-center rounded-full border border-white/10 bg-black/20 backdrop-blur-xl shadow-md shadow-black/8 opacity-0 transition-all hover:bg-black/40 group-hover/thumb:opacity-100"
-			>
-				<X className="h-3.5 w-3.5 text-white/70 transition-colors hover:text-white" />
-			</button>
-		</div>
-	);
-}
-
-function UploadingSkeleton() {
-	return <div className="h-14 w-14 shrink-0 rounded-lg shimmer-surface" />;
-}
-
 function AttachMenu({
-	onUpload,
+	openPicker,
 	uploading,
-	setUploadingCount,
+	onCreateCharacter,
 }: {
-	onUpload: (urls: string[]) => void;
+	openPicker: () => void;
 	uploading: boolean;
-	setUploadingCount: (n: number) => void;
+	onCreateCharacter: () => void;
 }) {
-	const inputRef = useRef<HTMLInputElement>(null);
-
-	const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-		const files = Array.from(e.target.files ?? []);
-		if (files.length === 0) return;
-
-		setUploadingCount(files.length);
-		try {
-			const results = await Promise.allSettled(files.map(uploadImage));
-			const urls: string[] = [];
-			const errors: string[] = [];
-			for (const r of results) {
-				if (r.status === "fulfilled") urls.push(r.value);
-				else errors.push(stringifyError(r.reason));
-			}
-			if (urls.length > 0) onUpload(urls);
-			for (const msg of errors) toast.error(msg);
-		} finally {
-			setUploadingCount(0);
-			if (inputRef.current) inputRef.current.value = "";
-		}
-	};
-
 	return (
-		<>
-			<input
-				ref={inputRef}
-				type="file"
-				accept="image/*"
-				multiple
-				className="hidden"
-				onChange={handleFileChange}
-			/>
-			<DropdownMenu modal={false}>
-				<DropdownMenuTrigger asChild>
-					<button
-						type="button"
-						aria-label="Attach"
-						disabled={uploading}
-						className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-white/40 transition-colors hover:bg-white/10 hover:text-white/70 disabled:pointer-events-none"
-					>
-						{uploading ? (
-							<Loader2 className="h-4 w-4 animate-spin" />
-						) : (
-							<Plus className="h-4 w-4" />
-						)}
-					</button>
-				</DropdownMenuTrigger>
-				<DropdownMenuContent
-					side="bottom"
-					align="start"
-					className="min-w-36 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+		<DropdownMenu modal={false}>
+			<DropdownMenuTrigger asChild>
+				<button
+					type="button"
+					aria-label="Attach"
+					disabled={uploading}
+					className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-white/40 transition-colors hover:bg-white/10 hover:text-white/70 disabled:pointer-events-none"
 				>
-					<DropdownMenuItem
-						onClick={() => inputRef.current?.click()}
-						className="cursor-pointer rounded-lg px-2 py-1.5 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10"
-					>
-						<ImagePlus
-							className="mr-1.5 h-3.5 text-white w-3.5"
-							strokeWidth={1.5}
-						/>
-						Upload Reference Images
-					</DropdownMenuItem>
-				</DropdownMenuContent>
-			</DropdownMenu>
-		</>
+					{uploading ? (
+						<Loader2 className="h-4 w-4 animate-spin" />
+					) : (
+						<Plus className="h-4 w-4" />
+					)}
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent
+				side="bottom"
+				align="start"
+				className="min-w-36 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+			>
+				<DropdownMenuItem
+					onClick={openPicker}
+					className="cursor-pointer rounded-lg px-2 py-1.5 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10"
+				>
+					<ImagePlus
+						className="mr-1.5 h-3.5 text-white w-3.5"
+						strokeWidth={1.5}
+					/>
+					Upload Reference Images
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					onClick={onCreateCharacter}
+					className="cursor-pointer rounded-lg px-2 py-1.5 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10"
+				>
+					<User className="mr-1.5 h-3.5 text-white w-3.5" strokeWidth={1.5} />
+					Create character
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 }
 
@@ -195,12 +137,24 @@ export default function ComposerCopilot({
 	const { projectId, mode, setMode, selectedTemplateId, applyTemplate } =
 		useConfig();
 	const referenceImages = useProject((s) => s.referenceImages);
+	const characters = useProject((s) => s.metadata.characters);
+	const [creatingCharacter, setCreatingCharacter] = useState(false);
+	const [editingCharacterName, setEditingCharacterName] = useState<
+		string | undefined
+	>();
 
 	const setReferenceImages = (urls: string[]) =>
 		getProjectStore(projectId).getState().setReferenceImages(urls);
 
-	const [uploadingCount, setUploadingCount] = useState(0);
-	const uploading = uploadingCount > 0;
+	const { openPicker, uploading, uploadingCount, inputElement } =
+		useImageUpload({
+			multiple: true,
+			onUpload: (urls) =>
+				setReferenceImages([
+					...getProjectStore(projectId).getState().referenceImages,
+					...urls,
+				]),
+		});
 	const showPill = mode === "template" && selectedTemplateId !== undefined;
 	const hasText = value.trim().length > 0;
 
@@ -216,19 +170,36 @@ export default function ComposerCopilot({
 	return (
 		<div className="w-full rounded-xl border border-violet-500/30 bg-white/5 shadow-[0_0_40px_rgba(55,30,100,0.5)]">
 			<div className="px-4 py-3">
-				{(referenceImages.length > 0 || uploading) && (
+				{(Object.keys(characters).length > 0 ||
+					referenceImages.length > 0 ||
+					uploading) && (
 					<div className="flex flex-wrap gap-2 pb-2">
+						{Object.entries(characters).map(([name, ch]) => (
+							<AssetTile
+								key={`character:${name}`}
+								name={name}
+								previewUrl={ch.avatarUrl}
+								Icon={User}
+								elementId={characterAvatarElementId(name)}
+								onEdit={() => setEditingCharacterName(name)}
+							/>
+						))}
 						{referenceImages.map((url, i) => (
-							<ImageThumbnail
-								key={url}
-								url={url}
+							<AssetTile
+								key={`ref:${url}`}
+								name={`Reference ${i + 1}`}
+								previewUrl={url}
+								Icon={Palette}
 								onRemove={() =>
 									setReferenceImages(referenceImages.filter((_, j) => j !== i))
 								}
 							/>
 						))}
 						{Array.from({ length: uploadingCount }).map((_, i) => (
-							<UploadingSkeleton key={i} />
+							<div
+								key={i}
+								className="aspect-square w-16 shrink-0 rounded-md shimmer-surface sm:w-20"
+							/>
 						))}
 					</div>
 				)}
@@ -262,16 +233,20 @@ export default function ComposerCopilot({
 				</div>
 				<div className="flex items-center justify-between pt-2">
 					<div className="flex items-center gap-2">
+						{inputElement}
 						<AttachMenu
-							onUpload={(urls) =>
-								setReferenceImages([...referenceImages, ...urls])
-							}
+							openPicker={openPicker}
 							uploading={uploading}
-							setUploadingCount={setUploadingCount}
+							onCreateCharacter={() => setCreatingCharacter(true)}
 						/>
 						<GlassDropdown
 							value={mode}
-							onChange={setMode}
+							onChange={(mode: Mode) => {
+								setMode(mode);
+								if (mode === "template" && selectedTemplateId) {
+									applyTemplate(selectedTemplateId);
+								}
+							}}
 							options={MODE_OPTIONS}
 							ariaLabel="Composer mode"
 							side="bottom"
@@ -279,7 +254,10 @@ export default function ComposerCopilot({
 						{mode === "template" && selectedTemplateId && (
 							<GlassDropdown
 								value={selectedTemplateId}
-								onChange={applyTemplate}
+								onChange={(templateId: string) => {
+									setMode("template");
+									applyTemplate(templateId);
+								}}
 								options={TEMPLATE_OPTIONS}
 								ariaLabel="Select template"
 								side="bottom"
@@ -298,6 +276,19 @@ export default function ComposerCopilot({
 					/>
 				</div>
 			</div>
+			<NewCharacterDialog
+				open={creatingCharacter}
+				onOpenChange={setCreatingCharacter}
+				onCreated={(name) => {
+					setCreatingCharacter(false);
+					setEditingCharacterName(name);
+				}}
+			/>
+			<CharacterEditModal
+				open={editingCharacterName !== undefined}
+				onOpenChange={(open) => !open && setEditingCharacterName(undefined)}
+				name={editingCharacterName}
+			/>
 		</div>
 	);
 }

--- a/lib/config/ConfigProvider.tsx
+++ b/lib/config/ConfigProvider.tsx
@@ -34,12 +34,12 @@ import { createTemplateModePlugin } from "../connectors/llm/plugins/template-mod
 import { createReferenceStylePlugin } from "../connectors/llm/plugins/reference-style";
 import { TEMPLATES } from "@/lib/templates/templates";
 import * as template from "@/lib/templates/applyTemplate";
-import { getProjectStore } from "@/lib/project/store";
 import { withRegistry } from "./connectorUtils";
 
 export type Mode = "story" | "script" | "template";
 
 interface ModeContext {
+	projectId: string;
 	templateId?: string;
 }
 
@@ -48,7 +48,8 @@ type ModePluginFactory = (ctx: ModeContext) => LLMPlugin;
 const MODE_PLUGIN_FACTORIES: Record<Mode, ModePluginFactory> = {
 	story: () => storyModePlugin,
 	script: () => scriptModePlugin,
-	template: ({ templateId }) => createTemplateModePlugin(templateId),
+	template: ({ projectId, templateId }) =>
+		createTemplateModePlugin(projectId, templateId),
 };
 
 export type ConnectorRegistry = Record<
@@ -105,34 +106,22 @@ export function ConfigProvider({
 	children: ReactNode;
 }) {
 	const [connectorConfig] = useState<ConnectorRegistry>(initialConnectorConfig);
-	const [mode, setModeState] = useState<Mode>("story");
+	const [mode, setMode] = useState<Mode>("story");
 	const [selectedTemplateId, setSelectedTemplateId] = useState<
 		string | undefined
 	>(TEMPLATES[0]?.id);
 
 	const applyTemplate = useCallback(
 		(templateId: string) => {
-			setModeState("template");
 			setSelectedTemplateId(templateId);
 			template.applyTemplate(projectId, templateId);
 		},
 		[projectId],
 	);
 
-	const setMode = useCallback(
-		(next: Mode) => {
-			if (next === "template" && selectedTemplateId) {
-				applyTemplate(selectedTemplateId);
-				return;
-			}
-			getProjectStore(projectId).getState().reset();
-			setModeState(next);
-		},
-		[projectId, selectedTemplateId, applyTemplate],
-	);
-
 	const configWithPlugins = useMemo<ConnectorRegistry>(() => {
 		const modePlugin = MODE_PLUGIN_FACTORIES[mode]({
+			projectId,
 			templateId: selectedTemplateId,
 		});
 		const base = withRegistry(connectorConfig)

--- a/lib/connectors/__tests__/template-mode.test.ts
+++ b/lib/connectors/__tests__/template-mode.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createTemplateModePlugin } from "@/lib/connectors/llm/plugins/template-mode";
+import { clearProjectStore, getProjectStore } from "@/lib/project/store";
 import { TEMPLATES } from "@/lib/templates/templates";
 
 const pickTemplate = (predicate: (id: string) => boolean) => {
@@ -10,10 +11,32 @@ const pickTemplate = (predicate: (id: string) => boolean) => {
 
 const realTemplate = pickTemplate((id) => id === "pov-life");
 
+let projectId: string;
+
+const seedStore = () => {
+	getProjectStore(projectId).getState().updateMetadata({
+		style: realTemplate.style,
+		narration: realTemplate.narration,
+		characters: realTemplate.characters,
+	});
+};
+
+beforeEach(() => {
+	projectId = crypto.randomUUID();
+});
+
+afterEach(() => {
+	clearProjectStore(projectId);
+});
+
 describe("createTemplateModePlugin", () => {
 	describe("beforeGenerate", () => {
 		it("prepends template preamble and systemPrompt when none provided", () => {
-			const { beforeGenerate } = createTemplateModePlugin(realTemplate.id);
+			seedStore();
+			const { beforeGenerate } = createTemplateModePlugin(
+				projectId,
+				realTemplate.id,
+			);
 			const result = beforeGenerate?.({ prompt: "hi" });
 			const sys = (result as { systemPrompt: string }).systemPrompt;
 			expect(sys).toContain(realTemplate.systemPrompt);
@@ -22,7 +45,11 @@ describe("createTemplateModePlugin", () => {
 		});
 
 		it("prepends template systemPrompt before existing systemPrompt", () => {
-			const { beforeGenerate } = createTemplateModePlugin(realTemplate.id);
+			seedStore();
+			const { beforeGenerate } = createTemplateModePlugin(
+				projectId,
+				realTemplate.id,
+			);
 			const result = beforeGenerate?.({
 				prompt: "hi",
 				systemPrompt: "user instructions",
@@ -36,19 +63,26 @@ describe("createTemplateModePlugin", () => {
 		});
 
 		it("returns params unchanged when templateId is null", () => {
-			const { beforeGenerate } = createTemplateModePlugin(undefined);
+			const { beforeGenerate } = createTemplateModePlugin(projectId, undefined);
 			const params = { prompt: "hi", systemPrompt: "keep me" };
 			expect(beforeGenerate?.(params)).toBe(params);
 		});
 
 		it("returns params unchanged when templateId is unknown", () => {
-			const { beforeGenerate } = createTemplateModePlugin("does-not-exist");
+			const { beforeGenerate } = createTemplateModePlugin(
+				projectId,
+				"does-not-exist",
+			);
 			const params = { prompt: "hi" };
 			expect(beforeGenerate?.(params)).toBe(params);
 		});
 
 		it("preserves other params", () => {
-			const { beforeGenerate } = createTemplateModePlugin(realTemplate.id);
+			seedStore();
+			const { beforeGenerate } = createTemplateModePlugin(
+				projectId,
+				realTemplate.id,
+			);
 			const result = beforeGenerate?.({
 				prompt: "hello",
 				model: "claude",
@@ -66,7 +100,10 @@ describe("createTemplateModePlugin", () => {
 		>[1];
 
 		it("wraps user prompt with the template's example", async () => {
-			const { transformPrompt } = createTemplateModePlugin(realTemplate.id);
+			const { transformPrompt } = createTemplateModePlugin(
+				projectId,
+				realTemplate.id,
+			);
 			const result = await transformPrompt?.("a tech CEO", fakeCtx);
 			expect(result).toContain("a tech CEO");
 			expect(result).toContain("Pastiche this story format");
@@ -74,19 +111,28 @@ describe("createTemplateModePlugin", () => {
 		});
 
 		it("returns prompt unchanged when templateId is null", async () => {
-			const { transformPrompt } = createTemplateModePlugin(undefined);
+			const { transformPrompt } = createTemplateModePlugin(
+				projectId,
+				undefined,
+			);
 			const result = await transformPrompt?.("anything", fakeCtx);
 			expect(result).toBe("anything");
 		});
 
 		it("returns prompt unchanged when templateId is unknown", async () => {
-			const { transformPrompt } = createTemplateModePlugin("does-not-exist");
+			const { transformPrompt } = createTemplateModePlugin(
+				projectId,
+				"does-not-exist",
+			);
 			const result = await transformPrompt?.("anything", fakeCtx);
 			expect(result).toBe("anything");
 		});
 
 		it("throws when gateway context is missing for a real template", async () => {
-			const { transformPrompt } = createTemplateModePlugin(realTemplate.id);
+			const { transformPrompt } = createTemplateModePlugin(
+				projectId,
+				realTemplate.id,
+			);
 			await expect(transformPrompt?.("x")).rejects.toThrow(/gateway context/i);
 		});
 	});

--- a/lib/connectors/llm/plugins/template-mode.ts
+++ b/lib/connectors/llm/plugins/template-mode.ts
@@ -5,8 +5,13 @@ import type {
 	LLMPlugin,
 	PluginContext,
 } from "@/lib/connectors/types";
-import type { MetadataCharacter, MetadataVoice } from "@/lib/project/types";
-import { getTemplateById, type Template } from "@/lib/templates/templates";
+import { getProjectStore } from "@/lib/project/store";
+import type {
+	Metadata,
+	MetadataCharacter,
+	MetadataVoice,
+} from "@/lib/project/types";
+import { getTemplateById } from "@/lib/templates/templates";
 import { compact } from "lodash";
 
 const VOICE_FIELDS: (keyof MetadataVoice)[] = [
@@ -37,22 +42,22 @@ function renderCharacter(name: string, character: MetadataCharacter): string {
 	${body}`;
 }
 
-function buildPreamble(template: Template): string {
+function buildPreamble(metadata: Metadata): string {
 	const sections: string[] = [];
 
-	if (template.style) {
-		sections.push(`# Art Style\n${template.style}`);
+	if (metadata.style) {
+		sections.push(`# Art Style\n${metadata.style}`);
 	}
 
-	if (template.narration) {
-		const voice = renderVoice(template.narration);
+	if (metadata.narration) {
+		const voice = renderVoice(metadata.narration);
 		if (voice)
 			sections.push(dedent`# Narration Voice
-			
+
 			${voice}`);
 	}
 
-	const characterEntries = Object.entries(template.characters ?? {});
+	const characterEntries = Object.entries(metadata.characters ?? {});
 	if (characterEntries.length > 0) {
 		const blocks = characterEntries.map(([name, character]) =>
 			renderCharacter(name, character),
@@ -60,7 +65,7 @@ function buildPreamble(template: Template): string {
 		sections.push(dedent`# Characters
 
 			Include the following characters (and others if needed):
-			
+
 			${blocks.join("\n\n")}`);
 	}
 
@@ -68,17 +73,18 @@ function buildPreamble(template: Template): string {
 }
 
 export function createTemplateModePlugin(
+	projectId: string,
 	templateId: string | undefined,
 ): LLMPlugin {
 	const template = templateId ? getTemplateById(templateId) : undefined;
-	const preamble = template ? buildPreamble(template) : "";
 
 	return {
 		name: "templateMode",
 		beforeGenerate(params) {
 			if (!template) return params;
+			const metadata = getProjectStore(projectId).getState().metadata;
 			const segments = compact([
-				preamble,
+				buildPreamble(metadata),
 				template.systemPrompt,
 				params.systemPrompt,
 			]);

--- a/lib/upload/useImageUpload.tsx
+++ b/lib/upload/useImageUpload.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { toast } from "sonner";
+import { stringifyError } from "@/lib/errors";
+import { uploadImage } from "@/lib/upload/uploadImage";
+
+export function useImageUpload({
+	onUpload,
+	multiple = false,
+}: {
+	onUpload: (urls: string[]) => void;
+	multiple?: boolean;
+}) {
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [uploadingCount, setUploadingCount] = useState(0);
+
+	const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+		const files = Array.from(e.target.files ?? []);
+		if (files.length === 0) return;
+		setUploadingCount(files.length);
+		try {
+			const results = await Promise.allSettled(files.map(uploadImage));
+			const urls: string[] = [];
+			for (const r of results) {
+				if (r.status === "fulfilled") urls.push(r.value);
+				else toast.error(stringifyError(r.reason));
+			}
+			if (urls.length > 0) onUpload(urls);
+		} finally {
+			setUploadingCount(0);
+			if (inputRef.current) inputRef.current.value = "";
+		}
+	};
+
+	const inputElement = (
+		<input
+			ref={inputRef}
+			type="file"
+			accept="image/*"
+			multiple={multiple}
+			className="hidden"
+			onChange={handleFileChange}
+		/>
+	);
+
+	return {
+		openPicker: () => inputRef.current?.click(),
+		uploading: uploadingCount > 0,
+		uploadingCount,
+		inputElement,
+	};
+}


### PR DESCRIPTION
## Summary
- Composer copilot now shows characters in its tile row (click → `CharacterEditModal`), reusing `AssetTile` for both characters and reference images.
- `AssetTile` gains an optional `onRemove` overlay so the same component drives both the edit (pencil) and remove (X) hover affordances.
- Character edit modal's "Upload image" is now an icon overlay placed below the generate/regenerate indicator on the avatar preview, styled to match `GenerationIndicator` (grain, ring, `text-white`).
- Template-mode prompt now reads characters/style/narration from the live project metadata each generation, so per-project edits flow through.
- `ComposerHero` explicitly sets `mode="template"` when selecting from the template gallery.
- `isStaleResult` treats avatars with no snapshot as fresh, so uploaded avatars don't show the stale flag.
- `ensureCharacterAvatars` moves `appearance` into the avatar element's child text so it participates in generation input hashing.

## Test plan
- [ ] In the composer, upload a reference image → hover shows X, click removes.
- [ ] Create a character via the + menu → character tile appears next to references; hover shows pencil; click opens `CharacterEditModal`.
- [ ] In `CharacterEditModal`, the Upload icon sits below the generate indicator on the preview, matching its color/stroke; clicking opens the file picker and replaces the avatar.
- [ ] Editing a character's appearance, then regenerating, updates the avatar; uploading a custom image does not flag as stale.
- [ ] Selecting a template from the gallery on the hero applies it and switches mode to `template`.
- [ ] `AssetsSection` still renders identically (no regressions).
- [ ] `npm run lint && npm run typecheck && npm test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)