### PR TITLE
show scene timestamps in canvas headers

### DIFF
--- a/app/components/canvas/elements/AudioPlayer.tsx
+++ b/app/components/canvas/elements/AudioPlayer.tsx
@@ -8,13 +8,8 @@ import {
 	TooltipContent,
 } from "@/components/ui/tooltip";
 import { Waveform, type WaveformHandle } from "@/lib/components/Waveform";
+import { formatTime } from "@/lib/video/timestamps";
 import { usePreviewCache } from "../PreviewCacheContext";
-
-function formatTime(seconds: number) {
-	const m = Math.floor(seconds / 60);
-	const s = Math.floor(seconds % 60);
-	return `${m}:${s.toString().padStart(2, "0")}`;
-}
 
 export function AudioPlayer({
 	src,

--- a/app/components/canvas/elements/SceneContainer.tsx
+++ b/app/components/canvas/elements/SceneContainer.tsx
@@ -5,6 +5,7 @@ import {
 	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import type { SceneElement } from "@/lib/canvas/types";
+import { useLayout } from "@/app/components/video/VideoLayoutContext";
 import { isForeground } from "../utils/guards";
 import { useDragTransfer } from "../dnd/DragTransferContext";
 import { useSceneIndex } from "../hooks/useSceneIndex";
@@ -12,6 +13,7 @@ import { useViewMode } from "../ViewModeContext";
 import { CollapsibleHeader } from "./CollapsibleHeader";
 import { DeleteButton } from "./DeleteButton";
 import { ForegroundPreview } from "./ForegroundPreview";
+import { SceneTimestamp } from "./SceneTimestamp";
 
 const COLLAPSED_MAX_VISIBLE = 3;
 
@@ -57,9 +59,18 @@ function SceneHeader({
 	onToggle: () => void;
 	element: SceneElement;
 }) {
+	const { layout } = useLayout();
+	const foreground = element.children.find(isForeground);
+	const seq = foreground && layout?.sequenceByElementId.get(foreground.id);
+	const label = (
+		<>
+			Scene {sceneIndex}
+			{seq && <SceneTimestamp start={seq.start} duration={seq.duration} />}
+		</>
+	);
 	return (
 		<CollapsibleHeader
-			label={`Scene ${sceneIndex}`}
+			label={label}
 			collapsed={collapsed}
 			onToggle={onToggle}
 			ariaLabel={collapsed ? "Expand scene" : "Collapse scene"}

--- a/app/components/canvas/elements/SceneTimestamp.tsx
+++ b/app/components/canvas/elements/SceneTimestamp.tsx
@@ -1,0 +1,18 @@
+import { formatDuration, formatTimeRange } from "@/lib/video/timestamps";
+
+export function SceneTimestamp({
+	start,
+	duration,
+}: {
+	start: number;
+	duration: number;
+}) {
+	return (
+		<span className="ml-1.5 flex items-center gap-2 font-normal tabular-nums">
+			<span className="text-white/30">{formatTimeRange(start, duration)}</span>
+			<span className="rounded bg-white/[0.05] px-1.5 py-px text-white/45">
+				{formatDuration(duration)}
+			</span>
+		</span>
+	);
+}

--- a/app/components/video/__tests__/useAssetPrefetch.test.ts
+++ b/app/components/video/__tests__/useAssetPrefetch.test.ts
@@ -27,6 +27,7 @@ function layout(partial: Partial<VideoLayout>): VideoLayout {
 	return {
 		series: [],
 		sequences: {},
+		sequenceByElementId: new Map(),
 		fps: 30,
 		width: 1920,
 		height: 1080,

--- a/lib/video/__tests__/timestamps.test.ts
+++ b/lib/video/__tests__/timestamps.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { formatDuration, formatTime, formatTimeRange } from "../timestamps";
+
+describe("formatTime", () => {
+	it("formats seconds as m:ss", () => {
+		expect(formatTime(0)).toBe("0:00");
+		expect(formatTime(14)).toBe("0:14");
+		expect(formatTime(75)).toBe("1:15");
+		expect(formatTime(3599)).toBe("59:59");
+	});
+
+	it("clamps negative values to zero", () => {
+		expect(formatTime(-1)).toBe("0:00");
+	});
+
+	it("floors fractional seconds", () => {
+		expect(formatTime(14.9)).toBe("0:14");
+	});
+});
+
+describe("formatTimeRange", () => {
+	it("joins start and end with an en-dash", () => {
+		expect(formatTimeRange(0, 14)).toBe("0:00–0:14");
+		expect(formatTimeRange(60, 65)).toBe("1:00–2:05");
+	});
+});
+
+describe("formatDuration", () => {
+	it("rounds to integer seconds", () => {
+		expect(formatDuration(14)).toBe("14s");
+		expect(formatDuration(6.7)).toBe("7s");
+		expect(formatDuration(6.3)).toBe("6s");
+	});
+
+	it("clamps negatives to zero", () => {
+		expect(formatDuration(-1)).toBe("0s");
+	});
+});

--- a/lib/video/scene-builder.ts
+++ b/lib/video/scene-builder.ts
@@ -137,10 +137,16 @@ export function buildVideoLayout(
 		}
 	}
 
+	const sequenceByElementId = new Map<string, Sequence>();
+	for (const seq of series) {
+		if (seq.element) sequenceByElementId.set(seq.element.id, seq);
+	}
+
 	return {
 		...cfg,
 		series,
 		sequences,
+		sequenceByElementId,
 		totalDurationSec,
 		totalFrames: Math.max(2, Math.ceil(totalDurationSec * cfg.fps)),
 		transitionType,

--- a/lib/video/timestamps.ts
+++ b/lib/video/timestamps.ts
@@ -1,0 +1,14 @@
+export function formatTime(seconds: number): string {
+	const safe = Math.max(0, seconds);
+	const m = Math.floor(safe / 60);
+	const s = Math.floor(safe % 60);
+	return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+export function formatTimeRange(start: number, duration: number): string {
+	return `${formatTime(start)}–${formatTime(start + duration)}`;
+}
+
+export function formatDuration(seconds: number): string {
+	return `${Math.round(Math.max(0, seconds))}s`;
+}

--- a/lib/video/types.ts
+++ b/lib/video/types.ts
@@ -49,6 +49,7 @@ export type Sequence = {
 export type VideoLayout = {
 	series: Sequence[];
 	sequences: Partial<Record<CanvasElementType, Sequence[]>>;
+	sequenceByElementId: Map<string, Sequence>;
 	fps: number;
 	width: number;
 	height: number;

--- a/remotion/Root.tsx
+++ b/remotion/Root.tsx
@@ -11,6 +11,7 @@ import {
 const defaultProps: VideoLayout = {
 	series: [],
 	sequences: {},
+	sequenceByElementId: new Map(),
 	fps: DEFAULT_CONFIG.fps,
 	width: DEFAULT_CONFIG.width,
 	height: DEFAULT_CONFIG.height,


### PR DESCRIPTION
## Summary
- Each scene header in the canvas (both expanded and compact views) now shows its playback range and duration — e.g. `Scene 1  0:00–0:14  14s` — sourced from `useLayout().layout.series`.
- New `SceneTimestamp` presentational component plus a shared `lib/video/timestamps` helper module (`formatTime`, `formatTimeRange`, `formatDuration`) with unit tests.
- `AudioPlayer` now reuses the shared `formatTime` instead of carrying a local copy.

## Test plan
- [ ] `npm run lint && npm run typecheck && npm run test:run`
- [ ] Open the canvas with a multi-scene project: each expanded scene header shows the range + duration chip
- [ ] Collapse a scene: same timestamp is visible in the compact header
- [ ] Add/remove an element so a scene's duration changes: timestamps update live
- [ ] Audio waveform still shows current time / duration correctly