### PR TITLE
Extract project metadata plugin; normalize character names; observability

### DIFF
--- a/app/components/canvas/elements/character/NewCharacterDialog.tsx
+++ b/app/components/canvas/elements/character/NewCharacterDialog.tsx
@@ -10,6 +10,7 @@ import {
 	MountedDialog,
 } from "@/components/ui/dialog";
 import { useConfig } from "@/lib/config/ConfigProvider";
+import { normalizeCharacterName } from "@/lib/project/characterName";
 import { useProjectStore } from "@/lib/project/store";
 
 export function NewCharacterDialog({
@@ -38,15 +39,15 @@ function NewCharacterDialogBody({
 	const setCharacter = useProjectStore(projectId, (s) => s.setCharacter);
 	const [name, setName] = useState("");
 
-	const trimmed = name.trim();
-	const collision = !!trimmed && !!characters[trimmed];
-	const canSubmit = !!trimmed && !collision;
+	const normalized = normalizeCharacterName(name);
+	const collision = !!normalized && !!characters[normalized];
+	const canSubmit = !!normalized && !collision;
 
 	const handleSubmit = (event: React.FormEvent) => {
 		event.preventDefault();
 		if (!canSubmit) return;
-		setCharacter(trimmed, { appearance: "" });
-		onCreated(trimmed);
+		setCharacter(normalized, { appearance: "" });
+		onCreated(normalized);
 	};
 
 	return (
@@ -71,7 +72,7 @@ function NewCharacterDialogBody({
 
 				{collision && (
 					<span className="text-[11px] text-rose-400" role="alert">
-						A character named &quot;{trimmed}&quot; already exists.
+						A character named &quot;{normalized}&quot; already exists.
 					</span>
 				)}
 

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -23,8 +23,9 @@ import { CharacterEditModal } from "@/app/components/canvas/elements/character/C
 import { NarratorEditModal } from "@/app/components/canvas/elements/character/NarratorEditModal";
 import { NewCharacterDialog } from "@/app/components/canvas/elements/character/NewCharacterDialog";
 import { TEMPLATES, getTemplateById } from "@/lib/templates/templates";
-import { useConfig, type Mode } from "@/lib/config/ConfigProvider";
+import { useConfig } from "@/lib/config/ConfigProvider";
 import { getProjectStore } from "@/lib/project/store";
+import type { Mode } from "@/lib/project/types";
 import { useImageUpload } from "@/lib/upload/useImageUpload";
 import { ActionButton } from "./ActionButton";
 import { ComposerAssets } from "./ComposerAssets";

--- a/lib/config/ConfigProvider.tsx
+++ b/lib/config/ConfigProvider.tsx
@@ -37,7 +37,8 @@ import { TEMPLATES } from "@/lib/templates/templates";
 import * as template from "@/lib/templates/applyTemplate";
 import { withRegistry } from "./connectorUtils";
 
-export type Mode = "story" | "script" | "template";
+import type { Mode } from "@/lib/project/types";
+export type { Mode };
 
 interface ModeContext {
 	projectId: string;

--- a/lib/config/ConfigProvider.tsx
+++ b/lib/config/ConfigProvider.tsx
@@ -38,7 +38,6 @@ import * as template from "@/lib/templates/applyTemplate";
 import { withRegistry } from "./connectorUtils";
 
 import type { Mode } from "@/lib/project/types";
-export type { Mode };
 
 interface ModeContext {
 	projectId: string;

--- a/lib/config/ConfigProvider.tsx
+++ b/lib/config/ConfigProvider.tsx
@@ -31,6 +31,7 @@ import { scriptModePlugin } from "../connectors/llm/plugins/script-mode";
 import { osmlPlugin } from "../connectors/llm/plugins/osml";
 import { storyModePlugin } from "../connectors/llm/plugins/story-mode";
 import { createTemplateModePlugin } from "../connectors/llm/plugins/template-mode";
+import { createProjectMetadataPlugin } from "../connectors/llm/plugins/project-metadata";
 import { createReferenceStylePlugin } from "../connectors/llm/plugins/reference-style";
 import { TEMPLATES } from "@/lib/templates/templates";
 import * as template from "@/lib/templates/applyTemplate";
@@ -48,8 +49,7 @@ type ModePluginFactory = (ctx: ModeContext) => LLMPlugin;
 const MODE_PLUGIN_FACTORIES: Record<Mode, ModePluginFactory> = {
 	story: () => storyModePlugin,
 	script: () => scriptModePlugin,
-	template: ({ projectId, templateId }) =>
-		createTemplateModePlugin(projectId, templateId),
+	template: ({ templateId }) => createTemplateModePlugin(templateId),
 };
 
 export type ConnectorRegistry = Record<
@@ -125,7 +125,12 @@ export function ConfigProvider({
 			templateId: selectedTemplateId,
 		});
 		const base = withRegistry(connectorConfig)
-			.appendPlugins("llm", modePlugin, createReferenceStylePlugin(projectId))
+			.appendPlugins(
+				"llm",
+				createProjectMetadataPlugin(projectId),
+				modePlugin,
+				createReferenceStylePlugin(projectId),
+			)
 			.appendPlugins("image", ...buildImagePlugins(projectId))
 			.appendPlugins("video", createReferenceImagesPlugin(projectId))
 			.appendPlugins("tts", createMetadataVoicePlugin(projectId))

--- a/lib/connectors/__tests__/project-metadata.test.ts
+++ b/lib/connectors/__tests__/project-metadata.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createProjectMetadataPlugin } from "@/lib/connectors/llm/plugins/project-metadata";
+import { clearProjectStore, getProjectStore } from "@/lib/project/store";
+import { TEMPLATES } from "@/lib/templates/templates";
+
+const template = TEMPLATES.find((t) => t.id === "pov-life");
+if (!template) throw new Error("expected pov-life template fixture");
+
+let projectId: string;
+
+const seedStore = () => {
+	getProjectStore(projectId).getState().updateMetadata({
+		style: template.style,
+		narration: template.narration,
+		characters: template.characters,
+	});
+};
+
+beforeEach(() => {
+	projectId = crypto.randomUUID();
+});
+
+afterEach(() => {
+	clearProjectStore(projectId);
+});
+
+describe("createProjectMetadataPlugin", () => {
+	it("injects style, narration, and characters into systemPrompt", () => {
+		seedStore();
+		const { beforeGenerate } = createProjectMetadataPlugin(projectId);
+		const result = beforeGenerate?.({ prompt: "hi" });
+		const sys = (result as { systemPrompt: string }).systemPrompt;
+		expect(sys).toContain("# Art Style");
+		expect(sys).toContain(template.style);
+		expect(sys).toContain("# Narration Voice");
+		expect(sys).toContain("# Characters");
+	});
+
+	it("prepends preamble before existing systemPrompt", () => {
+		seedStore();
+		const { beforeGenerate } = createProjectMetadataPlugin(projectId);
+		const result = beforeGenerate?.({
+			prompt: "hi",
+			systemPrompt: "user instructions",
+		});
+		const sys = (result as { systemPrompt: string }).systemPrompt;
+		expect(sys).toContain("user instructions");
+		expect(sys.indexOf("# Art Style")).toBeLessThan(
+			sys.indexOf("user instructions"),
+		);
+	});
+
+	it("returns params unchanged when metadata is empty", () => {
+		const { beforeGenerate } = createProjectMetadataPlugin(projectId);
+		const params = { prompt: "hi", systemPrompt: "keep me" };
+		expect(beforeGenerate?.(params)).toBe(params);
+	});
+
+	it("preserves other params", () => {
+		seedStore();
+		const { beforeGenerate } = createProjectMetadataPlugin(projectId);
+		const result = beforeGenerate?.({
+			prompt: "hello",
+			model: "claude",
+		}) as Record<string, unknown>;
+		expect(result.prompt).toBe("hello");
+		expect(result.model).toBe("claude");
+	});
+});

--- a/lib/connectors/__tests__/script-mode.test.ts
+++ b/lib/connectors/__tests__/script-mode.test.ts
@@ -39,7 +39,6 @@ describe("scriptModePlugin", () => {
 		const result = beforeGenerate({ prompt: "x" });
 		const sys = (result as { systemPrompt: string }).systemPrompt;
 		expect(sys).toContain("ALL CAPS");
-		expect(sys).toContain("NARRATOR");
 		expect(sys).toContain("stage directions");
 	});
 });

--- a/lib/connectors/__tests__/template-mode.test.ts
+++ b/lib/connectors/__tests__/template-mode.test.ts
@@ -1,6 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createTemplateModePlugin } from "@/lib/connectors/llm/plugins/template-mode";
-import { clearProjectStore, getProjectStore } from "@/lib/project/store";
 import { TEMPLATES } from "@/lib/templates/templates";
 
 const pickTemplate = (predicate: (id: string) => boolean) => {
@@ -11,45 +10,17 @@ const pickTemplate = (predicate: (id: string) => boolean) => {
 
 const realTemplate = pickTemplate((id) => id === "pov-life");
 
-let projectId: string;
-
-const seedStore = () => {
-	getProjectStore(projectId).getState().updateMetadata({
-		style: realTemplate.style,
-		narration: realTemplate.narration,
-		characters: realTemplate.characters,
-	});
-};
-
-beforeEach(() => {
-	projectId = crypto.randomUUID();
-});
-
-afterEach(() => {
-	clearProjectStore(projectId);
-});
-
 describe("createTemplateModePlugin", () => {
 	describe("beforeGenerate", () => {
-		it("prepends template preamble and systemPrompt when none provided", () => {
-			seedStore();
-			const { beforeGenerate } = createTemplateModePlugin(
-				projectId,
-				realTemplate.id,
-			);
+		it("uses template systemPrompt when none provided", () => {
+			const { beforeGenerate } = createTemplateModePlugin(realTemplate.id);
 			const result = beforeGenerate?.({ prompt: "hi" });
 			const sys = (result as { systemPrompt: string }).systemPrompt;
 			expect(sys).toContain(realTemplate.systemPrompt);
-			expect(sys).toContain(realTemplate.style);
-			expect(sys).toContain("# Art Style");
 		});
 
 		it("prepends template systemPrompt before existing systemPrompt", () => {
-			seedStore();
-			const { beforeGenerate } = createTemplateModePlugin(
-				projectId,
-				realTemplate.id,
-			);
+			const { beforeGenerate } = createTemplateModePlugin(realTemplate.id);
 			const result = beforeGenerate?.({
 				prompt: "hi",
 				systemPrompt: "user instructions",
@@ -63,26 +34,19 @@ describe("createTemplateModePlugin", () => {
 		});
 
 		it("returns params unchanged when templateId is null", () => {
-			const { beforeGenerate } = createTemplateModePlugin(projectId, undefined);
+			const { beforeGenerate } = createTemplateModePlugin(undefined);
 			const params = { prompt: "hi", systemPrompt: "keep me" };
 			expect(beforeGenerate?.(params)).toBe(params);
 		});
 
 		it("returns params unchanged when templateId is unknown", () => {
-			const { beforeGenerate } = createTemplateModePlugin(
-				projectId,
-				"does-not-exist",
-			);
+			const { beforeGenerate } = createTemplateModePlugin("does-not-exist");
 			const params = { prompt: "hi" };
 			expect(beforeGenerate?.(params)).toBe(params);
 		});
 
 		it("preserves other params", () => {
-			seedStore();
-			const { beforeGenerate } = createTemplateModePlugin(
-				projectId,
-				realTemplate.id,
-			);
+			const { beforeGenerate } = createTemplateModePlugin(realTemplate.id);
 			const result = beforeGenerate?.({
 				prompt: "hello",
 				model: "claude",
@@ -100,10 +64,7 @@ describe("createTemplateModePlugin", () => {
 		>[1];
 
 		it("wraps user prompt with the template's example", async () => {
-			const { transformPrompt } = createTemplateModePlugin(
-				projectId,
-				realTemplate.id,
-			);
+			const { transformPrompt } = createTemplateModePlugin(realTemplate.id);
 			const result = await transformPrompt?.("a tech CEO", fakeCtx);
 			expect(result).toContain("a tech CEO");
 			expect(result).toContain("Pastiche this story format");
@@ -111,28 +72,19 @@ describe("createTemplateModePlugin", () => {
 		});
 
 		it("returns prompt unchanged when templateId is null", async () => {
-			const { transformPrompt } = createTemplateModePlugin(
-				projectId,
-				undefined,
-			);
+			const { transformPrompt } = createTemplateModePlugin(undefined);
 			const result = await transformPrompt?.("anything", fakeCtx);
 			expect(result).toBe("anything");
 		});
 
 		it("returns prompt unchanged when templateId is unknown", async () => {
-			const { transformPrompt } = createTemplateModePlugin(
-				projectId,
-				"does-not-exist",
-			);
+			const { transformPrompt } = createTemplateModePlugin("does-not-exist");
 			const result = await transformPrompt?.("anything", fakeCtx);
 			expect(result).toBe("anything");
 		});
 
 		it("throws when gateway context is missing for a real template", async () => {
-			const { transformPrompt } = createTemplateModePlugin(
-				projectId,
-				realTemplate.id,
-			);
+			const { transformPrompt } = createTemplateModePlugin(realTemplate.id);
 			await expect(transformPrompt?.("x")).rejects.toThrow(/gateway context/i);
 		});
 	});

--- a/lib/connectors/llm/plugins/project-metadata.ts
+++ b/lib/connectors/llm/plugins/project-metadata.ts
@@ -1,0 +1,89 @@
+import dedent from "dedent";
+import type { LLMPlugin } from "@/lib/connectors/types";
+import { getProjectStore } from "@/lib/project/store";
+import type {
+	Metadata,
+	MetadataCharacter,
+	MetadataVoice,
+} from "@/lib/project/types";
+import { compact } from "lodash";
+
+const VOICE_FIELDS: (keyof MetadataVoice)[] = [
+	"gender",
+	"age",
+	"pitch",
+	"accent",
+	"language",
+	"description",
+];
+
+function renderVoice(voice: MetadataVoice): string {
+	const lines = VOICE_FIELDS.flatMap((field) => {
+		const value = voice[field];
+		return value ? [`- ${field}: ${value}`] : [];
+	});
+	return lines.join("\n");
+}
+
+function renderCharacter(name: string, character: MetadataCharacter): string {
+	const voiceLines = renderVoice(character);
+	const appearanceLine = character.appearance
+		? `- appearance: ${character.appearance}`
+		: "";
+	const body = [voiceLines, appearanceLine].filter(Boolean).join("\n");
+	return `## ${name}\n\n${body}`;
+}
+
+function buildPreamble(metadata: Metadata): string {
+	const sections: string[] = [];
+
+	if (metadata.style) {
+		sections.push(`
+			# Art Style
+
+			Below is the exact art style description for the story. Do not change it.
+
+			${metadata.style}`);
+	}
+
+	if (metadata.narration) {
+		const voice = renderVoice(metadata.narration);
+		if (voice)
+			sections.push(dedent`
+				# Narration Voice
+
+				Below is the exact voice description for the narrator. Do not change it.
+
+				${voice}`);
+	}
+
+	const characterEntries = Object.entries(metadata.characters ?? {});
+	if (characterEntries.length > 0) {
+		const blocks = characterEntries.map(([name, character]) =>
+			renderCharacter(name, character),
+		);
+		sections.push(dedent`
+			# Characters
+
+			Include the following characters exactly (and others if needed). Do not modify any of the below attributes of these characters (including the name):
+
+			${blocks.join("\n\n")}`);
+	}
+
+	return sections.join("\n\n");
+}
+
+export function createProjectMetadataPlugin(projectId: string): LLMPlugin {
+	return {
+		name: "projectMetadata",
+		beforeGenerate(params) {
+			const metadata = getProjectStore(projectId).getState().metadata;
+			const preamble = buildPreamble(metadata);
+			if (!preamble) return params;
+			return {
+				...params,
+				systemPrompt: compact([preamble, params.systemPrompt]).join("\n\n"),
+			};
+		},
+	};
+}

--- a/lib/connectors/llm/plugins/script-mode.ts
+++ b/lib/connectors/llm/plugins/script-mode.ts
@@ -5,12 +5,13 @@ const SCRIPT_MODE_SYSTEM_PROMPT = dedent`
   You are a script-to-XML converter.
   The user will provide some text, and you will return that text with
   annotations according to the XML format described below. Do NOT modify the script
-  itself, simply conform the text to the XML format described below.
+  itself, simply conform the text to the XML format described below. If the script doesn't contain
+	any explicit narration/image/character/music/sound annotations, assume the text is all narration
+	and fill in the blanks with the appropriate non-narration XML tags to make this an engaging script for a video.
 
   ### Miscellaneous Rules
   - Omit non-narrative text from the final output like stage directions (e.g. CONT'd), character names, etc.
   - Convert any words in ALL CAPS to regular case.
-  - Never say the word "NARRATOR" in the text.
   - Never add dialogue or narrative text to the story that is not in the original script.
 `;
 

--- a/lib/connectors/llm/plugins/story-mode.ts
+++ b/lib/connectors/llm/plugins/story-mode.ts
@@ -27,7 +27,7 @@ export const storyModePlugin: LLMPlugin = {
 		if (!ctx?.gateway)
 			throw new Error("story mode plugin requires gateway context");
 		const { text: outline } = await ctx.gateway.generate({
-			prompt: dedent`Briefly outline an engaging story with a high-concept premise, characters, themes, conflict, twists, and a resolution. The story should be about the following: ${prompt}`,
+			prompt: dedent`Briefly outline an engaging story with a high-concept premise, characters, themes, conflict, twists, and a resolution. The story should be about the following: ${prompt}. Do not write anything else, just the outline.`,
 		});
 		return dedent`Write a super short, complete, engaging, and simple story for a 5th-grade reading level about the following: ${outline}`;
 	},

--- a/lib/connectors/llm/plugins/template-mode.ts
+++ b/lib/connectors/llm/plugins/template-mode.ts
@@ -5,75 +5,10 @@ import type {
 	LLMPlugin,
 	PluginContext,
 } from "@/lib/connectors/types";
-import { getProjectStore } from "@/lib/project/store";
-import type {
-	Metadata,
-	MetadataCharacter,
-	MetadataVoice,
-} from "@/lib/project/types";
 import { getTemplateById } from "@/lib/templates/templates";
 import { compact } from "lodash";
 
-const VOICE_FIELDS: (keyof MetadataVoice)[] = [
-	"gender",
-	"age",
-	"pitch",
-	"accent",
-	"language",
-	"description",
-];
-
-function renderVoice(voice: MetadataVoice): string {
-	const lines = VOICE_FIELDS.flatMap((field) => {
-		const value = voice[field];
-		return value ? [`- ${field}: ${value}`] : [];
-	});
-	return lines.join("\n");
-}
-
-function renderCharacter(name: string, character: MetadataCharacter): string {
-	const voiceLines = renderVoice(character);
-	const appearanceLine = character.appearance
-		? `- appearance: ${character.appearance}`
-		: "";
-	const body = [voiceLines, appearanceLine].filter(Boolean).join("\n");
-	return `## ${name}
-	
-	${body}`;
-}
-
-function buildPreamble(metadata: Metadata): string {
-	const sections: string[] = [];
-
-	if (metadata.style) {
-		sections.push(`# Art Style\n${metadata.style}`);
-	}
-
-	if (metadata.narration) {
-		const voice = renderVoice(metadata.narration);
-		if (voice)
-			sections.push(dedent`# Narration Voice
-
-			${voice}`);
-	}
-
-	const characterEntries = Object.entries(metadata.characters ?? {});
-	if (characterEntries.length > 0) {
-		const blocks = characterEntries.map(([name, character]) =>
-			renderCharacter(name, character),
-		);
-		sections.push(dedent`# Characters
-
-			Include the following characters (and others if needed):
-
-			${blocks.join("\n\n")}`);
-	}
-
-	return sections.join("\n\n");
-}
-
 export function createTemplateModePlugin(
-	projectId: string,
 	templateId: string | undefined,
 ): LLMPlugin {
 	const template = templateId ? getTemplateById(templateId) : undefined;
@@ -82,12 +17,7 @@ export function createTemplateModePlugin(
 		name: "templateMode",
 		beforeGenerate(params) {
 			if (!template) return params;
-			const metadata = getProjectStore(projectId).getState().metadata;
-			const segments = compact([
-				buildPreamble(metadata),
-				template.systemPrompt,
-				params.systemPrompt,
-			]);
+			const segments = compact([template.systemPrompt, params.systemPrompt]);
 			if (segments.length === 0) return params;
 			return { ...params, systemPrompt: segments.join("\n\n") };
 		},

--- a/lib/project/__tests__/characterName.test.ts
+++ b/lib/project/__tests__/characterName.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCharacterName } from "../characterName";
+
+describe("normalizeCharacterName", () => {
+	it("capitalizes single names", () => {
+		expect(normalizeCharacterName("alice")).toBe("Alice");
+	});
+
+	it("lowercases shouted names", () => {
+		expect(normalizeCharacterName("ALICE")).toBe("Alice");
+	});
+
+	it("normalizes each word in multi-word names", () => {
+		expect(normalizeCharacterName("alice SMITH")).toBe("Alice Smith");
+		expect(normalizeCharacterName("MARY jane WATSON")).toBe("Mary Jane Watson");
+	});
+
+	it("collapses surrounding and inner whitespace", () => {
+		expect(normalizeCharacterName("  alice   smith  ")).toBe("Alice Smith");
+	});
+
+	it("returns empty string for blank input", () => {
+		expect(normalizeCharacterName("")).toBe("");
+		expect(normalizeCharacterName("   ")).toBe("");
+	});
+});

--- a/lib/project/characterName.ts
+++ b/lib/project/characterName.ts
@@ -1,0 +1,4 @@
+import capitalize from "lodash/capitalize";
+
+export const normalizeCharacterName = (raw: string): string =>
+	raw.trim().split(/\s+/).filter(Boolean).map(capitalize).join(" ");

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -50,13 +50,15 @@ export type VideoSettings = {
 	transitionType?: TransitionType;
 };
 
+export type Mode = "story" | "script" | "template";
+
 export type Metadata = {
 	title: string;
 	style: string;
 	narration: MetadataVoice;
 	characters: Record<string, MetadataCharacter>;
 	videoSettings?: VideoSettings;
-	lastMode?: "story" | "script" | "template";
+	lastMode?: Mode;
 	lastPrompt?: string;
 };
 

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -56,6 +56,8 @@ export type Metadata = {
 	narration: MetadataVoice;
 	characters: Record<string, MetadataCharacter>;
 	videoSettings?: VideoSettings;
+	lastMode?: "story" | "script" | "template";
+	lastPrompt?: string;
 };
 
 export type DeepPartial<T> = T extends object

--- a/lib/providers/__tests__/anthropic-llm.test.ts
+++ b/lib/providers/__tests__/anthropic-llm.test.ts
@@ -34,7 +34,7 @@ describe("AnthropicLLM", () => {
 			});
 			expect(mockCreate).toHaveBeenCalledWith({
 				model: "claude-opus-4-8",
-				max_tokens: 8192,
+				max_tokens: 32768,
 				temperature: undefined,
 				system: undefined,
 				messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],

--- a/lib/providers/llm/anthropic.ts
+++ b/lib/providers/llm/anthropic.ts
@@ -69,7 +69,7 @@ export class AnthropicLLM extends BaseProvider<
 		];
 		return {
 			model: params.model || "claude-opus-4-8",
-			max_tokens: params.maxTokens || 8192,
+			max_tokens: params.maxTokens || 32768,
 			temperature: params.temperature,
 			system: params.systemPrompt || undefined,
 			messages: [{ role: "user" as const, content }],

--- a/lib/script/ScriptProvider.tsx
+++ b/lib/script/ScriptProvider.tsx
@@ -13,6 +13,7 @@ import type { ParsedElement } from "@/lib/canvas/types";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import { createConnector } from "@/lib/connectors/factory";
+import { getProjectStore } from "@/lib/project/store";
 import { useOSMLSerializer } from "@/app/components/canvas/hooks/useOSMLSerializer";
 
 type ScriptControl = {
@@ -61,7 +62,7 @@ export function ScriptProvider({
 	initialScript?: string;
 	children: ReactNode;
 }) {
-	const { connectorConfig } = useConfig();
+	const { connectorConfig, projectId, mode } = useConfig();
 	const [hasContent, setHasContent] = useState(initialScript.length > 0);
 	const [loading, setLoading] = useState(false);
 	const abortRef = useRef<AbortController | null>(null);
@@ -86,6 +87,9 @@ export function ScriptProvider({
 
 			setHasContent(false);
 			setLoading(true);
+			getProjectStore(projectId)
+				.getState()
+				.updateMetadata({ lastMode: mode, lastPrompt: prompt });
 			try {
 				const connector = createConnector("llm", llmProvider, llmConfig);
 				for await (const chunk of connector.stream({ prompt })) {
@@ -101,7 +105,7 @@ export function ScriptProvider({
 				}
 			}
 		},
-		[llmProvider, llmConfig, appendChunk],
+		[llmProvider, llmConfig, appendChunk, projectId, mode],
 	);
 
 	const control = useMemo<ScriptControl>(


### PR DESCRIPTION
## Summary
- **Project metadata plugin**: extracts the style/narration/character preamble out of `template-mode` into a dedicated `projectMetadata` LLM plugin that runs across all modes (story, script, template), so the same context is available regardless of how the user starts.
- **Character name normalization**: new-character creation now passes input through a small lodash-backed helper (`normalizeCharacterName`) so casing/whitespace variants ("alice", "ALICE", "  Alice  ") collapse to a single canonical key. Collision check runs against the normalized form.
- **Observability fields**: `Metadata.lastMode` and `Metadata.lastPrompt` are saved on submit. Not consumed anywhere yet — purely for inspection.
- Minor: tighter story/script-mode prompts, Anthropic `max_tokens` default bumped to 32768, tests updated to match.

## Test plan
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run test:run` all pass
- [ ] Create a new character with mixed casing — verify single canonical entry
- [ ] Submit a prompt in each mode (story/script/template) — verify `metadata.lastMode` and `metadata.lastPrompt` reflect the submission
- [ ] Verify project metadata (style, narration, characters) is present in the system prompt across all three modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)