### PR TITLE
describe uploaded character avatars to the llm

### DIFF
--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -81,7 +81,11 @@ function CharacterEditDialogBody({
 		onUpload: ([url]) => {
 			if (!url) return;
 			queue.discard(avatarElementId);
-			setCharacter(name, { ...character, avatarUrl: url });
+			setCharacter(name, {
+				...character,
+				avatarUrl: url,
+				avatarUploaded: true,
+			});
 		},
 	});
 
@@ -90,10 +94,15 @@ function CharacterEditDialogBody({
 	const update = (partial: Partial<MetadataCharacter>) =>
 		setCharacter(name, { ...character, ...partial });
 
-	const regenerateAvatar = () =>
+	const regenerateAvatar = () => {
+		if (character.avatarUploaded) {
+			setCharacter(name, { ...character, avatarUploaded: false });
+		}
 		queue.enqueue(buildCharacterAvatarJob(projectId, name, connectorConfig));
+	};
 
 	const isStale =
+		!character.avatarUploaded &&
 		!!avatarSnapshot.result &&
 		isStaleResult(
 			avatarSnapshot,

--- a/lib/config/ConfigProvider.tsx
+++ b/lib/config/ConfigProvider.tsx
@@ -33,6 +33,7 @@ import { storyModePlugin } from "../connectors/llm/plugins/story-mode";
 import { createTemplateModePlugin } from "../connectors/llm/plugins/template-mode";
 import { createProjectMetadataPlugin } from "../connectors/llm/plugins/project-metadata";
 import { createReferenceStylePlugin } from "../connectors/llm/plugins/reference-style";
+import { createCharacterAvatarStylePlugin } from "../connectors/llm/plugins/character-avatar-style";
 import { TEMPLATES } from "@/lib/templates/templates";
 import * as template from "@/lib/templates/applyTemplate";
 import { withRegistry } from "./connectorUtils";
@@ -130,6 +131,7 @@ export function ConfigProvider({
 				createProjectMetadataPlugin(projectId),
 				modePlugin,
 				createReferenceStylePlugin(projectId),
+				createCharacterAvatarStylePlugin(projectId),
 			)
 			.appendPlugins("image", ...buildImagePlugins(projectId))
 			.appendPlugins("video", createReferenceImagesPlugin(projectId))

--- a/lib/connectors/llm/plugins/character-avatar-style.ts
+++ b/lib/connectors/llm/plugins/character-avatar-style.ts
@@ -1,0 +1,46 @@
+import dedent from "dedent";
+import { getProjectStore } from "@/lib/project/store";
+import type {
+	LLMGenerateParams,
+	LLMGenerateResult,
+	LLMPlugin,
+	PluginContext,
+} from "@/lib/connectors/types";
+
+export function createCharacterAvatarStylePlugin(projectId: string): LLMPlugin {
+	return {
+		name: "character-avatar-style",
+		async transformPrompt(
+			prompt: string,
+			ctx?: PluginContext<LLMGenerateParams, LLMGenerateResult>,
+		) {
+			const characters =
+				getProjectStore(projectId).getState().metadata.characters ?? {};
+			const uploaded = Object.entries(characters).flatMap(([name, c]) =>
+				c.avatarUploaded && c.avatarUrl ? [{ name, url: c.avatarUrl }] : [],
+			);
+			if (uploaded.length === 0) return prompt;
+			const gateway = ctx?.gateway;
+			if (!gateway)
+				throw new Error(
+					"character-avatar-style plugin requires gateway context",
+				);
+
+			const described = await Promise.all(
+				uploaded.map(async ({ name, url }) => {
+					const { text } = await gateway.generate({
+						prompt: dedent`Concisely describe the visual appearance of the character in the attached reference image in a short sentence. Focus on gender, ethnicity, face, hair, body type, art style, and any distinctive features. Do not describe the background.`,
+						referenceImages: [url],
+						maxTokens: 4096,
+					});
+					return `- ${name}: ${text.trim()}`;
+				}),
+			);
+
+			return dedent`Character appearances (preserve these appearance descriptions exactly for these characters):
+			${described.join("\n")}
+
+			${prompt}`;
+		},
+	};
+}

--- a/lib/connectors/llm/plugins/osml.ts
+++ b/lib/connectors/llm/plugins/osml.ts
@@ -64,7 +64,7 @@ const OSML_SYSTEM_PROMPT = dedent`
 	).join(", ")}
   - Image descriptions should describe the time of day, the background, the weather (if outdoors), and objects in detail.
   - Each <image> description must be written as a standalone prompt, as if the generative image model has absolutely no knowledge of the story, prior images, or previous prompts.
-	- Reference characters by their names in the image description, no need to redescribe their appearance
+	- Reference characters by their names in the image description, NEVER describe their appearance in the image description
   - Each image description should include all relevant details about the scene (except for art style and character descriptions), even if this requires repeating details from previous descriptions or the story.
 
   ### Animated Image XML Tags

--- a/lib/connectors/llm/plugins/project-metadata.ts
+++ b/lib/connectors/llm/plugins/project-metadata.ts
@@ -27,9 +27,10 @@ function renderVoice(voice: MetadataVoice): string {
 
 function renderCharacter(name: string, character: MetadataCharacter): string {
 	const voiceLines = renderVoice(character);
-	const appearanceLine = character.appearance
-		? `- appearance: ${character.appearance}`
-		: "";
+	const appearanceLine =
+		character.appearance && !character.avatarUploaded
+			? `- appearance: ${character.appearance}`
+			: "";
 	const body = [voiceLines, appearanceLine].filter(Boolean).join("\n");
 	return `## ${name}\n\n${body}`;
 }

--- a/lib/connectors/llm/plugins/reference-style.ts
+++ b/lib/connectors/llm/plugins/reference-style.ts
@@ -22,6 +22,7 @@ export function createReferenceStylePlugin(projectId: string): LLMPlugin {
 			const { text: style } = await ctx.gateway.generate({
 				prompt: dedent`Vividly and concisely describe the visual art style of the attached reference image(s) in 1–2 concise sentences. Include ultra specific detail on character art style and overall art style.`,
 				referenceImages,
+				maxTokens: 4096,
 			});
 			return dedent`Art style reference: ${style}
 

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -44,6 +44,7 @@ export type MetadataVoice = z.infer<typeof MetadataVoiceSchema>;
 export type MetadataCharacter = MetadataVoice & {
 	appearance: string;
 	avatarUrl?: string;
+	avatarUploaded?: boolean;
 };
 
 export type VideoSettings = {

--- a/lib/providers/llm/mock.ts
+++ b/lib/providers/llm/mock.ts
@@ -156,6 +156,9 @@ function extractIds(prompt: string): string[] {
 const MOCK_STYLE =
 	"Warm, painterly storybook illustration with soft watercolor washes, gentle outlines, and golden hour lighting; whimsical and nostalgic.";
 
+const MOCK_CHARACTER_APPEARANCE =
+	"A cheerful young person with warm brown skin, dark curly hair, bright expressive eyes, wearing a simple colorful outfit; soft painterly storybook style.";
+
 const MOCK_OUTLINE = `Premise: In a village at the edge of an enchanted forest, a cheerful girl named Red sets out to deliver vegetables to her ailing grandmother and unexpectedly befriends a gentle, vegetarian wolf gathering berries for his own sick mother.
 
 Characters: Red (curious, kind); Wolf (gentle, misunderstood); Mother and Granny (warm anchors of home); Hunter (a watchful protector); Owl (the forest's quiet conscience).
@@ -176,12 +179,17 @@ function isStyleRequest(params: LLMGenerateParams): boolean {
 	return /describe the visual art style/i.test(params.prompt);
 }
 
+function isCharacterAppearanceRequest(params: LLMGenerateParams): boolean {
+	return /describe the visual appearance of the character/i.test(params.prompt);
+}
+
 function isOutlineRequest(params: LLMGenerateParams): boolean {
 	return params.prompt.startsWith("Briefly outline an engaging story");
 }
 
 function mockResponse(params: LLMGenerateParams): string {
 	if (isStyleRequest(params)) return MOCK_STYLE;
+	if (isCharacterAppearanceRequest(params)) return MOCK_CHARACTER_APPEARANCE;
 	if (isOutlineRequest(params)) return MOCK_OUTLINE;
 	if (isRefineRequest(params)) return buildRefineResponse(params);
 	return MOCK_SCRIPT;


### PR DESCRIPTION
## Summary
- New `character-avatar-style` LLM plugin: for every character with an uploaded avatar, sends the avatar URL through the gateway for a concise visual description and prepends a per-character `Character appearances:` block to the prompt — mirrors the existing `reference-style` plugin.
- Adds `avatarUploaded?: boolean` to `MetadataCharacter`; `CharacterEditModal` sets it on upload (and no longer discards the queue snapshot), clears it on regenerate, and skips the `isStale` check when an uploaded avatar is in place.
- Updates `osml` prompt to instruct the model to reference characters by name and never re-describe their appearance in image descriptions; mock LLM now returns a short canned response for character-appearance prompts; `reference-style` bumps `maxTokens` to 4096.

## Test plan
- [ ] Lint / format / typecheck / tests pass (CI).
- [ ] Upload a distinct avatar on a character — stale indicator does not appear even after editing `appearance`.
- [ ] Trigger an LLM generation with one uploaded + one generated character; verify only the uploaded one appears in the `Character appearances:` block of the outgoing prompt.
- [ ] Press regenerate on an uploaded avatar — flag clears, queue runs, stale behavior resumes once the new result lands.
- [ ] Reload the project: uploaded characters keep `avatarUploaded: true` and remain non-stale.