### PR TITLE
adjust token limits

### DIFF
--- a/lib/connectors/llm/plugins/story-mode.ts
+++ b/lib/connectors/llm/plugins/story-mode.ts
@@ -28,6 +28,7 @@ export const storyModePlugin: LLMPlugin = {
 			throw new Error("story mode plugin requires gateway context");
 		const { text: outline } = await ctx.gateway.generate({
 			prompt: dedent`Briefly outline an engaging story with a high-concept premise, characters, themes, conflict, twists, and a resolution. The story should be about the following: ${prompt}. Do not write anything else, just the outline.`,
+			maxTokens: 8192,
 		});
 		return dedent`Write a super short, complete, engaging, and simple story for a 5th-grade reading level about the following: ${outline}`;
 	},

--- a/lib/providers/__tests__/anthropic-llm.test.ts
+++ b/lib/providers/__tests__/anthropic-llm.test.ts
@@ -34,7 +34,7 @@ describe("AnthropicLLM", () => {
 			});
 			expect(mockCreate).toHaveBeenCalledWith({
 				model: "claude-opus-4-8",
-				max_tokens: 32768,
+				max_tokens: 65536,
 				temperature: undefined,
 				system: undefined,
 				messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],

--- a/lib/providers/llm/anthropic.ts
+++ b/lib/providers/llm/anthropic.ts
@@ -69,7 +69,7 @@ export class AnthropicLLM extends BaseProvider<
 		];
 		return {
 			model: params.model || "claude-opus-4-8",
-			max_tokens: params.maxTokens || 32768,
+			max_tokens: params.maxTokens || 65536,
 			temperature: params.temperature,
 			system: params.systemPrompt || undefined,
 			messages: [{ role: "user" as const, content }],


### PR DESCRIPTION
## Summary
- Bump anthropic default `max_tokens` from 32768 to 65536
- Cap story-mode outline generation at 8192 tokens

## Test plan
- [ ] Generate a story via story mode and confirm outline + final story complete without truncation
- [ ] Verify long anthropic completions can exceed prior 32k cap