### PR TITLE
fix: nightly bug fixes 2026-06-05

### DIFF
--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -143,8 +143,14 @@ export default function ComposerCopilot({
 	onSubmit,
 	placeholder,
 }: ComposerCopilotProps) {
-	const { projectId, mode, setMode, selectedTemplateId, applyTemplate } =
-		useConfig();
+	const {
+		projectId,
+		mode,
+		setMode,
+		selectedTemplateId,
+		applyTemplate,
+		clearTemplate,
+	} = useConfig();
 	const [creatingCharacter, setCreatingCharacter] = useState(false);
 	const [editingCharacterName, setEditingCharacterName] = useState<
 		string | undefined
@@ -183,7 +189,7 @@ export default function ComposerCopilot({
 					{showPill && (
 						<TemplatePill
 							templateId={selectedTemplateId}
-							onRemove={() => setMode("story")}
+							onRemove={clearTemplate}
 						/>
 					)}
 					<div className="min-w-0 flex-1 grid [&>*]:[grid-area:1/1]">

--- a/lib/config/ConfigProvider.tsx
+++ b/lib/config/ConfigProvider.tsx
@@ -89,6 +89,7 @@ type ConfigContextValue = {
 	setMode: (mode: Mode) => void;
 	selectedTemplateId: string | undefined;
 	applyTemplate: (templateId: string) => void;
+	clearTemplate: () => void;
 };
 
 const ConfigContext = createContext<ConfigContextValue | null>(null);
@@ -119,6 +120,11 @@ export function ConfigProvider({
 		},
 		[projectId],
 	);
+
+	const clearTemplate = useCallback(() => {
+		template.clearTemplate(projectId);
+		setMode("story");
+	}, [projectId]);
 
 	const configWithPlugins = useMemo<ConnectorRegistry>(() => {
 		const modePlugin = MODE_PLUGIN_FACTORIES[mode]({
@@ -155,6 +161,7 @@ export function ConfigProvider({
 			setMode,
 			selectedTemplateId,
 			applyTemplate,
+			clearTemplate,
 		}),
 		[
 			projectId,
@@ -163,6 +170,7 @@ export function ConfigProvider({
 			setMode,
 			selectedTemplateId,
 			applyTemplate,
+			clearTemplate,
 		],
 	);
 

--- a/lib/project/__tests__/applyTemplate.test.ts
+++ b/lib/project/__tests__/applyTemplate.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { applyTemplate } from "@/lib/templates/applyTemplate";
+import { applyTemplate, clearTemplate } from "@/lib/templates/applyTemplate";
 import { getTemplateById } from "@/lib/templates/templates";
 import { clearProjectStore, getProjectStore } from "../store";
 
@@ -51,6 +51,20 @@ describe("applyTemplate", () => {
 		expect(getProjectStore(PROJECT_ID).getState().referenceImages).toEqual(
 			getTemplateById("sleep-story")?.referenceImages,
 		);
+	});
+
+	it("clearTemplate wipes template-seeded reference images, characters and narration", () => {
+		applyTemplate(PROJECT_ID, "pov-life");
+		const seeded = getProjectStore(PROJECT_ID).getState();
+		expect(seeded.referenceImages.length).toBeGreaterThan(0);
+		expect(Object.keys(seeded.metadata.characters).length).toBeGreaterThan(0);
+
+		clearTemplate(PROJECT_ID);
+		const cleared = getProjectStore(PROJECT_ID).getState();
+		expect(cleared.referenceImages).toEqual([]);
+		expect(cleared.metadata.characters).toEqual({});
+		expect(cleared.metadata.narration).toEqual({});
+		expect(cleared.metadata.style).toBe("");
 	});
 
 	it("wipes user-set narration before applying", () => {

--- a/lib/templates/applyTemplate.ts
+++ b/lib/templates/applyTemplate.ts
@@ -13,3 +13,7 @@ export function applyTemplate(projectId: string, templateId: string) {
 		narration: template.narration,
 	});
 }
+
+export function clearTemplate(projectId: string) {
+	getProjectStore(projectId).getState().reset();
+}


### PR DESCRIPTION
## Summary
- Fixes template removal so clearing the composer template pill also resets template-seeded project state instead of only switching back to story mode.
- Adds regression coverage for clearing template-seeded reference images, characters, narration, and style.

## Test Plan
- [x] npm test -- --passWithNoTests
- [x] npm run lint
- [x] npm run format:check
- [x] npm run typecheck
- [x] npm run build

## Notes
- Verified recent PR #202 review concern still reproduced on master before fixing.
- No cosmetic-only changes.