### PR TITLE
fix: nightly bug fixes 2026-06-07

### DIFF
--- a/app/components/video/PlayerControlContext.tsx
+++ b/app/components/video/PlayerControlContext.tsx
@@ -1,48 +1,17 @@
 "use client";
 
-import type { PlayerRef } from "@remotion/player";
-import {
-	createContext,
-	use,
-	useCallback,
-	useMemo,
-	useRef,
-	type ReactNode,
-} from "react";
+import { createContext, use, useMemo, type ReactNode } from "react";
 import { usePlayerPosition } from "./PlayerPositionContext";
+import { createPlayQueue, type PlayQueue } from "./playQueue";
 
-type PlayerControl = {
-	registerPlayer: (player: PlayerRef | null) => void;
-	playFromFrame: (frame: number) => void;
-};
-
-const Ctx = createContext<PlayerControl>({
+const Ctx = createContext<PlayQueue>({
 	registerPlayer: () => {},
 	playFromFrame: () => {},
 });
 
 export function PlayerControlProvider({ children }: { children: ReactNode }) {
-	const playerRef = useRef<PlayerRef | null>(null);
 	const { showPlayer } = usePlayerPosition();
-
-	const registerPlayer = useCallback((p: PlayerRef | null) => {
-		playerRef.current = p;
-	}, []);
-
-	const playFromFrame = useCallback(
-		(frame: number) => {
-			showPlayer();
-			playerRef.current?.seekTo(frame);
-			playerRef.current?.play();
-		},
-		[showPlayer],
-	);
-
-	const value = useMemo(
-		() => ({ registerPlayer, playFromFrame }),
-		[registerPlayer, playFromFrame],
-	);
-
+	const value = useMemo(() => createPlayQueue(showPlayer), [showPlayer]);
 	return <Ctx value={value}>{children}</Ctx>;
 }
 

--- a/app/components/video/PlayerControlContext.tsx
+++ b/app/components/video/PlayerControlContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, use, useMemo, type ReactNode } from "react";
+import { createContext, use, useState, type ReactNode } from "react";
 import { usePlayerPosition } from "./PlayerPositionContext";
 import { createPlayQueue, type PlayQueue } from "./playQueue";
 
@@ -11,8 +11,8 @@ const Ctx = createContext<PlayQueue>({
 
 export function PlayerControlProvider({ children }: { children: ReactNode }) {
 	const { showPlayer } = usePlayerPosition();
-	const value = useMemo(() => createPlayQueue(showPlayer), [showPlayer]);
-	return <Ctx value={value}>{children}</Ctx>;
+	const [queue] = useState(() => createPlayQueue(showPlayer));
+	return <Ctx value={queue}>{children}</Ctx>;
 }
 
 export function usePlayerControl() {

--- a/app/components/video/VideoPreview.tsx
+++ b/app/components/video/VideoPreview.tsx
@@ -2,7 +2,7 @@
 
 import type { PlayerRef } from "@remotion/player";
 import dynamic from "next/dynamic";
-import { useEffect, useState, type PointerEvent, type Ref } from "react";
+import { useEffect, useState, type Ref } from "react";
 import type { VideoLayout } from "@/lib/video/types";
 import { ToastErrorBoundary } from "../ToastErrorBoundary";
 import { ActiveSceneSync } from "./ActiveSceneSync";
@@ -69,32 +69,20 @@ export function VideoPreview({ layout }: { layout: VideoLayout }) {
 		player.toggle();
 		setFlash((f) => ({ key: (f?.key ?? 0) + 1, playing: willPlay }));
 	};
-	const handlePointerLeave = (e: PointerEvent<HTMLDivElement>) => {
-		if (e.pointerType !== "mouse") return;
-		leave();
-	};
-	const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-		if (e.key !== " " && e.key !== "Enter") return;
-		e.preventDefault();
-		toggleAndFlash();
-	};
 	return (
 		<div
-			className={`relative ${styles.player}`}
+			className={`relative h-full w-full ${styles.player}`}
 			onPointerMove={ping}
 			onPointerDown={ping}
 			onFocus={ping}
-			onPointerLeave={handlePointerLeave}
+			onPointerLeave={leave}
 		>
 			<ToastErrorBoundary label="Player">
 				<RemotionPlayer layout={layout} playerRef={setPlayer} />
 			</ToastErrorBoundary>
-			<button
-				type="button"
-				aria-label="Play or pause"
+			<div
+				className="absolute inset-0 cursor-pointer"
 				onClick={toggleAndFlash}
-				onKeyDown={handleKeyDown}
-				className="absolute inset-0 cursor-pointer bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
 			/>
 			<PlayPauseFlash flash={flash} />
 			<ActiveSceneSync player={player} layout={layout} segments={segments} />

--- a/app/components/video/VideoPreview.tsx
+++ b/app/components/video/VideoPreview.tsx
@@ -2,7 +2,7 @@
 
 import type { PlayerRef } from "@remotion/player";
 import dynamic from "next/dynamic";
-import { useEffect, useState, type Ref } from "react";
+import { useEffect, useState, type PointerEvent, type Ref } from "react";
 import type { VideoLayout } from "@/lib/video/types";
 import { ToastErrorBoundary } from "../ToastErrorBoundary";
 import { ActiveSceneSync } from "./ActiveSceneSync";
@@ -69,20 +69,32 @@ export function VideoPreview({ layout }: { layout: VideoLayout }) {
 		player.toggle();
 		setFlash((f) => ({ key: (f?.key ?? 0) + 1, playing: willPlay }));
 	};
+	const handlePointerLeave = (e: PointerEvent<HTMLDivElement>) => {
+		if (e.pointerType !== "mouse") return;
+		leave();
+	};
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+		if (e.key !== " " && e.key !== "Enter") return;
+		e.preventDefault();
+		toggleAndFlash();
+	};
 	return (
 		<div
 			className={`relative ${styles.player}`}
 			onPointerMove={ping}
 			onPointerDown={ping}
 			onFocus={ping}
-			onPointerLeave={leave}
+			onPointerLeave={handlePointerLeave}
 		>
 			<ToastErrorBoundary label="Player">
 				<RemotionPlayer layout={layout} playerRef={setPlayer} />
 			</ToastErrorBoundary>
-			<div
-				className="absolute inset-0 cursor-pointer"
+			<button
+				type="button"
+				aria-label="Play or pause"
 				onClick={toggleAndFlash}
+				onKeyDown={handleKeyDown}
+				className="absolute inset-0 cursor-pointer bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
 			/>
 			<PlayPauseFlash flash={flash} />
 			<ActiveSceneSync player={player} layout={layout} segments={segments} />

--- a/app/components/video/__tests__/playQueue.test.ts
+++ b/app/components/video/__tests__/playQueue.test.ts
@@ -1,0 +1,69 @@
+import type { PlayerRef } from "@remotion/player";
+import { describe, expect, it, vi } from "vitest";
+import { createPlayQueue } from "../playQueue";
+
+const makePlayer = () =>
+	({
+		seekTo: vi.fn(),
+		play: vi.fn(),
+	}) as unknown as PlayerRef & {
+		seekTo: ReturnType<typeof vi.fn>;
+		play: ReturnType<typeof vi.fn>;
+	};
+
+describe("createPlayQueue", () => {
+	it("plays immediately when a player is already registered", () => {
+		const showPlayer = vi.fn();
+		const queue = createPlayQueue(showPlayer);
+		const player = makePlayer();
+		queue.registerPlayer(player);
+
+		queue.playFromFrame(42);
+
+		expect(showPlayer).toHaveBeenCalledOnce();
+		expect(player.seekTo).toHaveBeenCalledWith(42);
+		expect(player.play).toHaveBeenCalledOnce();
+	});
+
+	it("defers play until the player registers", () => {
+		const showPlayer = vi.fn();
+		const queue = createPlayQueue(showPlayer);
+
+		queue.playFromFrame(120);
+		expect(showPlayer).toHaveBeenCalledOnce();
+
+		const player = makePlayer();
+		queue.registerPlayer(player);
+
+		expect(player.seekTo).toHaveBeenCalledWith(120);
+		expect(player.play).toHaveBeenCalledOnce();
+	});
+
+	it("does not replay the pending frame on subsequent re-registers", () => {
+		const queue = createPlayQueue(vi.fn());
+		queue.playFromFrame(7);
+
+		const player = makePlayer();
+		queue.registerPlayer(player);
+		expect(player.play).toHaveBeenCalledOnce();
+
+		queue.registerPlayer(null);
+		const next = makePlayer();
+		queue.registerPlayer(next);
+
+		expect(next.seekTo).not.toHaveBeenCalled();
+		expect(next.play).not.toHaveBeenCalled();
+	});
+
+	it("uses the latest pending frame when playFromFrame is called multiple times before mount", () => {
+		const queue = createPlayQueue(vi.fn());
+		queue.playFromFrame(10);
+		queue.playFromFrame(99);
+
+		const player = makePlayer();
+		queue.registerPlayer(player);
+
+		expect(player.seekTo).toHaveBeenCalledExactlyOnceWith(99);
+		expect(player.play).toHaveBeenCalledOnce();
+	});
+});

--- a/app/components/video/__tests__/playQueue.test.ts
+++ b/app/components/video/__tests__/playQueue.test.ts
@@ -55,6 +55,24 @@ describe("createPlayQueue", () => {
 		expect(next.play).not.toHaveBeenCalled();
 	});
 
+	it("warns and drops the pending frame when the player unregisters before it plays", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const queue = createPlayQueue(vi.fn());
+		queue.playFromFrame(55);
+
+		queue.registerPlayer(null);
+
+		expect(warn).toHaveBeenCalledOnce();
+		expect(warn.mock.calls[0]?.[0]).toContain("55");
+
+		const player = makePlayer();
+		queue.registerPlayer(player);
+		expect(player.seekTo).not.toHaveBeenCalled();
+		expect(player.play).not.toHaveBeenCalled();
+
+		warn.mockRestore();
+	});
+
 	it("uses the latest pending frame when playFromFrame is called multiple times before mount", () => {
 		const queue = createPlayQueue(vi.fn());
 		queue.playFromFrame(10);

--- a/app/components/video/playQueue.ts
+++ b/app/components/video/playQueue.ts
@@ -1,0 +1,35 @@
+import type { PlayerRef } from "@remotion/player";
+
+export type PlayQueue = {
+	registerPlayer: (player: PlayerRef | null) => void;
+	playFromFrame: (frame: number) => void;
+};
+
+/**
+ * Defers play() until the lazy-loaded Remotion Player has registered itself.
+ * Without this, a playFromFrame() fired before mount silently no-ops.
+ */
+export function createPlayQueue(showPlayer: () => void): PlayQueue {
+	let player: PlayerRef | null = null;
+	let pendingFrame: number | null = null;
+	return {
+		registerPlayer(p) {
+			player = p;
+			if (p && pendingFrame != null) {
+				const frame = pendingFrame;
+				pendingFrame = null;
+				p.seekTo(frame);
+				p.play();
+			}
+		},
+		playFromFrame(frame) {
+			showPlayer();
+			if (player) {
+				player.seekTo(frame);
+				player.play();
+			} else {
+				pendingFrame = frame;
+			}
+		},
+	};
+}

--- a/app/components/video/playQueue.ts
+++ b/app/components/video/playQueue.ts
@@ -14,6 +14,12 @@ export function createPlayQueue(showPlayer: () => void): PlayQueue {
 	let pendingFrame: number | null = null;
 	return {
 		registerPlayer(p) {
+			if (!p && pendingFrame != null) {
+				console.warn(
+					`[playQueue] dropping pending frame ${pendingFrame}: player unregistered before it could play`,
+				);
+				pendingFrame = null;
+			}
 			player = p;
 			if (p && pendingFrame != null) {
 				const frame = pendingFrame;


### PR DESCRIPTION
## Summary
- Queue play-from-frame requests until the lazy Remotion player registers so first-click playback from the canvas does not silently no-op.
- Make the click-to-play overlay keyboard/screen-reader accessible.
- Keep controls visible after touch pointer interactions instead of hiding them immediately on touch leave.
- Add focused unit coverage for deferred player command behavior.

## Test Plan
- npm test -- --passWithNoTests
- npm run build
- npm run lint
- npm run format:check
- npm run typecheck