### PR TITLE
refactor: rethink openslop architecture 2026-06-07

### DIFF
--- a/app/components/canvas/__tests__/insertElement.test.ts
+++ b/app/components/canvas/__tests__/insertElement.test.ts
@@ -22,6 +22,23 @@ vi.mock("../config/elementConfigs", () => ({
 	},
 }));
 
+vi.mock("@/lib/canvas/elementMetadata", () => ({
+	ELEMENT_METADATA: {
+		image: {
+			type: "image",
+			connector: "image",
+			outputKind: "image",
+			defaultAttributes: undefined,
+		},
+		narration: {
+			type: "narration",
+			connector: "tts",
+			outputKind: "audio",
+			defaultAttributes: { emotion: "neutral" },
+		},
+	},
+}));
+
 vi.mock("../utils/hydrateConnectorConfig", () => ({
 	hydrateConnectorConfig: () => (node: Record<string, unknown>) => ({
 		...node,

--- a/app/components/canvas/__tests__/insertElement.test.ts
+++ b/app/components/canvas/__tests__/insertElement.test.ts
@@ -1,37 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { createEditor, Editor } from "slate";
 
-vi.mock("../config/elementConfigs", () => ({
-	ELEMENT_CONFIGS: {
-		image: {
-			type: "image",
-			connector: "image",
-			outputKind: "image",
-			label: "Image",
-			defaultAttributes: undefined,
-			visibleAttributes: {},
-		},
-		narration: {
-			type: "narration",
-			connector: "tts",
-			outputKind: "audio",
-			label: "Narration",
-			defaultAttributes: { emotion: "neutral" },
-			visibleAttributes: {},
-		},
-	},
-}));
-
 vi.mock("@/lib/canvas/elementMetadata", () => ({
 	ELEMENT_METADATA: {
 		image: {
-			type: "image",
 			connector: "image",
 			outputKind: "image",
-			defaultAttributes: undefined,
 		},
 		narration: {
-			type: "narration",
 			connector: "tts",
 			outputKind: "audio",
 			defaultAttributes: { emotion: "neutral" },

--- a/app/components/canvas/config/elementConfigs.tsx
+++ b/app/components/canvas/config/elementConfigs.tsx
@@ -7,11 +7,9 @@ import {
 	Volume2,
 	Music,
 } from "lucide-react";
-import type { CanvasElementType } from "@/lib/canvas/types";
-import {
-	ELEMENT_METADATA,
-	type ElementMetadata,
-} from "@/lib/canvas/elementMetadata";
+import type { CanvasElementType, ResultKind } from "@/lib/canvas/types";
+import type { ConnectorType } from "@/lib/connectors/types";
+import { ELEMENT_METADATA } from "@/lib/canvas/elementMetadata";
 import { TTSEmotion, TTS_SPEEDS } from "@/lib/connectors/tts/enums";
 import { MOTION_EFFECTS } from "@/lib/video/motionEffects";
 
@@ -25,11 +23,15 @@ export interface AttributeSpec {
 	edit?: AttributeEdit;
 }
 
-export interface ElementConfig extends ElementMetadata {
+export interface ElementConfig {
+	type: CanvasElementType;
+	connector: ConnectorType;
+	outputKind: ResultKind;
 	label: string;
 	icon: React.ReactNode;
 	bgColor: string;
 	placeholder: string;
+	defaultAttributes?: Record<string, string>;
 	visibleAttributes: Record<string, AttributeSpec>;
 }
 
@@ -90,10 +92,10 @@ const emotionSpec: AttributeSpec = {
 	edit: { kind: "enum", options: EMOTION_OPTIONS },
 };
 
-type UIConfig = Omit<ElementConfig, keyof ElementMetadata>;
-
-const UI_CONFIG: Record<CanvasElementType, UIConfig> = {
+export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 	narration: {
+		type: "narration",
+		...ELEMENT_METADATA.narration,
 		label: "Narration",
 		icon: <BookOpen size={16} className="text-white" />,
 		bgColor: "bg-slate-600",
@@ -106,6 +108,8 @@ const UI_CONFIG: Record<CanvasElementType, UIConfig> = {
 		},
 	},
 	character: {
+		type: "character",
+		...ELEMENT_METADATA.character,
 		label: "Character",
 		icon: <User size={16} className="text-white" />,
 		bgColor: "bg-amber-600",
@@ -118,6 +122,8 @@ const UI_CONFIG: Record<CanvasElementType, UIConfig> = {
 		},
 	},
 	image: {
+		type: "image",
+		...ELEMENT_METADATA.image,
 		label: "Image",
 		icon: <ImageIcon size={16} className="text-white" />,
 		bgColor: "bg-cyan-600",
@@ -127,6 +133,8 @@ const UI_CONFIG: Record<CanvasElementType, UIConfig> = {
 		},
 	},
 	animated_image: {
+		type: "animated_image",
+		...ELEMENT_METADATA.animated_image,
 		label: "Animated image",
 		icon: <Sparkles size={16} className="text-white" />,
 		bgColor: "bg-fuchsia-600",
@@ -137,6 +145,8 @@ const UI_CONFIG: Record<CanvasElementType, UIConfig> = {
 		},
 	},
 	clip: {
+		type: "clip",
+		...ELEMENT_METADATA.clip,
 		label: "Clip",
 		icon: <Film size={16} className="text-white" />,
 		bgColor: "bg-indigo-600",
@@ -148,6 +158,8 @@ const UI_CONFIG: Record<CanvasElementType, UIConfig> = {
 		},
 	},
 	sound: {
+		type: "sound",
+		...ELEMENT_METADATA.sound,
 		label: "Sound",
 		icon: <Volume2 size={16} className="text-white" />,
 		bgColor: "bg-emerald-600",
@@ -162,6 +174,8 @@ const UI_CONFIG: Record<CanvasElementType, UIConfig> = {
 		},
 	},
 	music: {
+		type: "music",
+		...ELEMENT_METADATA.music,
 		label: "Music",
 		icon: <Music size={16} className="text-white" />,
 		bgColor: "bg-violet-600",
@@ -176,13 +190,5 @@ const UI_CONFIG: Record<CanvasElementType, UIConfig> = {
 		},
 	},
 };
-
-export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> =
-	Object.fromEntries(
-		(Object.keys(UI_CONFIG) as CanvasElementType[]).map((type) => [
-			type,
-			{ ...ELEMENT_METADATA[type], ...UI_CONFIG[type] },
-		]),
-	) as Record<CanvasElementType, ElementConfig>;
 
 export const ELEMENT_LIST = Object.values(ELEMENT_CONFIGS);

--- a/app/components/canvas/config/elementConfigs.tsx
+++ b/app/components/canvas/config/elementConfigs.tsx
@@ -7,8 +7,11 @@ import {
 	Volume2,
 	Music,
 } from "lucide-react";
-import type { CanvasElementType, ResultKind } from "@/lib/canvas/types";
-import type { ConnectorType } from "@/lib/connectors/types";
+import type { CanvasElementType } from "@/lib/canvas/types";
+import {
+	ELEMENT_METADATA,
+	type ElementMetadata,
+} from "@/lib/canvas/elementMetadata";
 import { TTSEmotion, TTS_SPEEDS } from "@/lib/connectors/tts/enums";
 import { MOTION_EFFECTS } from "@/lib/video/motionEffects";
 
@@ -22,15 +25,11 @@ export interface AttributeSpec {
 	edit?: AttributeEdit;
 }
 
-export interface ElementConfig {
-	type: CanvasElementType;
-	connector: ConnectorType;
-	outputKind: ResultKind;
+export interface ElementConfig extends ElementMetadata {
 	label: string;
 	icon: React.ReactNode;
 	bgColor: string;
 	placeholder: string;
-	defaultAttributes?: Record<string, string>;
 	visibleAttributes: Record<string, AttributeSpec>;
 }
 
@@ -85,101 +84,63 @@ const videoPromptSpec = (color: string): AttributeSpec => ({
 	},
 });
 
-export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
+const emotionSpec: AttributeSpec = {
+	color: "bg-pink-500",
+	label: "Emotion",
+	edit: { kind: "enum", options: EMOTION_OPTIONS },
+};
+
+type UIConfig = Omit<ElementConfig, keyof ElementMetadata>;
+
+const UI_CONFIG: Record<CanvasElementType, UIConfig> = {
 	narration: {
-		type: "narration",
-		connector: "tts",
-		outputKind: "audio",
 		label: "Narration",
 		icon: <BookOpen size={16} className="text-white" />,
 		bgColor: "bg-slate-600",
 		placeholder: "Write the narration...",
-		defaultAttributes: {
-			volume: "10",
-			speed: "medium",
-			captions: "on",
-		},
 		visibleAttributes: {
-			emotion: {
-				color: "bg-pink-500",
-				label: "Emotion",
-				edit: { kind: "enum", options: EMOTION_OPTIONS },
-			},
+			emotion: emotionSpec,
 			speed: speedSpec("bg-slate-500"),
 			volume: volumeSpec("bg-slate-500"),
 			captions: captionsSpec("bg-slate-500"),
 		},
 	},
 	character: {
-		type: "character",
-		connector: "tts",
-		outputKind: "audio",
 		label: "Character",
 		icon: <User size={16} className="text-white" />,
 		bgColor: "bg-amber-600",
 		placeholder: "What does this character say?",
-		defaultAttributes: {
-			volume: "10",
-			speed: "medium",
-			captions: "on",
-		},
 		visibleAttributes: {
-			emotion: {
-				color: "bg-pink-500",
-				label: "Emotion",
-				edit: { kind: "enum", options: EMOTION_OPTIONS },
-			},
+			emotion: emotionSpec,
 			speed: speedSpec("bg-amber-600"),
 			volume: volumeSpec("bg-amber-600"),
 			captions: captionsSpec("bg-amber-600"),
 		},
 	},
 	image: {
-		type: "image",
-		connector: "image",
-		outputKind: "image",
 		label: "Image",
 		icon: <ImageIcon size={16} className="text-white" />,
 		bgColor: "bg-cyan-600",
 		placeholder: "Describe the image...",
-		defaultAttributes: {
-			motion: "none",
-		},
 		visibleAttributes: {
 			motion: motionSpec("bg-cyan-500"),
 		},
 	},
 	animated_image: {
-		type: "animated_image",
-		connector: "animated_image",
-		outputKind: "video",
 		label: "Animated image",
 		icon: <Sparkles size={16} className="text-white" />,
 		bgColor: "bg-fuchsia-600",
 		placeholder: "Describe the still image...",
-		defaultAttributes: {
-			motion: "none",
-			videoPrompt: "slow cinematic pan",
-		},
 		visibleAttributes: {
 			videoPrompt: videoPromptSpec("bg-fuchsia-500"),
 			motion: motionSpec("bg-fuchsia-500"),
 		},
 	},
 	clip: {
-		type: "clip",
-		connector: "video",
-		outputKind: "video",
 		label: "Clip",
 		icon: <Film size={16} className="text-white" />,
 		bgColor: "bg-indigo-600",
 		placeholder: "Describe the video clip...",
-
-		defaultAttributes: {
-			duration: "5",
-			volume: "5",
-			motion: "none",
-		},
 		visibleAttributes: {
 			duration: { color: "bg-indigo-500", label: "Duration" },
 			volume: volumeSpec("bg-indigo-500"),
@@ -187,18 +148,10 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		},
 	},
 	sound: {
-		type: "sound",
-		connector: "sfx",
-		outputKind: "audio",
 		label: "Sound",
 		icon: <Volume2 size={16} className="text-white" />,
 		bgColor: "bg-emerald-600",
 		placeholder: "Describe the sound effect...",
-
-		defaultAttributes: {
-			loops: "1",
-			volume: "2",
-		},
 		visibleAttributes: {
 			loops: {
 				color: "bg-teal-500",
@@ -209,17 +162,10 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		},
 	},
 	music: {
-		type: "music",
-		connector: "music",
-		outputKind: "audio",
 		label: "Music",
 		icon: <Music size={16} className="text-white" />,
 		bgColor: "bg-violet-600",
 		placeholder: "Describe the music...",
-		defaultAttributes: {
-			loops: "1",
-			volume: "2",
-		},
 		visibleAttributes: {
 			loops: {
 				color: "bg-violet-500",
@@ -230,5 +176,13 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		},
 	},
 };
+
+export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> =
+	Object.fromEntries(
+		(Object.keys(UI_CONFIG) as CanvasElementType[]).map((type) => [
+			type,
+			{ ...ELEMENT_METADATA[type], ...UI_CONFIG[type] },
+		]),
+	) as Record<CanvasElementType, ElementConfig>;
 
 export const ELEMENT_LIST = Object.values(ELEMENT_CONFIGS);

--- a/app/components/canvas/utils/__tests__/createCanvasNode.test.ts
+++ b/app/components/canvas/utils/__tests__/createCanvasNode.test.ts
@@ -1,31 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("../../config/elementConfigs", () => ({
-	ELEMENT_CONFIGS: {
+vi.mock("@/lib/canvas/elementMetadata", () => ({
+	ELEMENT_METADATA: {
 		sound: {
-			type: "sound",
 			connector: "sfx",
 			outputKind: "audio",
-			label: "Sound",
 			defaultAttributes: { loops: "1" },
-			visibleAttributes: {},
 		},
-		narration: {
-			type: "narration",
-			connector: "tts",
-			outputKind: "audio",
-			label: "Narration",
-			defaultAttributes: undefined,
-			visibleAttributes: {},
-		},
-		image: {
-			type: "image",
-			connector: "image",
-			outputKind: "image",
-			label: "Image",
-			defaultAttributes: undefined,
-			visibleAttributes: {},
-		},
+		narration: { connector: "tts", outputKind: "audio" },
+		image: { connector: "image", outputKind: "image" },
 	},
 }));
 

--- a/app/components/canvas/utils/buildGenerationJob.ts
+++ b/app/components/canvas/utils/buildGenerationJob.ts
@@ -3,7 +3,7 @@ import type { ProviderKey } from "@/lib/connectors/types";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import type { GenerationJob } from "@/lib/generation/queue";
 import type { CanvasContentElement } from "@/lib/canvas/types";
-import { ELEMENT_CONFIGS } from "../config/elementConfigs";
+import { ELEMENT_METADATA } from "@/lib/canvas/elementMetadata";
 
 export function buildGenerationJob(
 	element: CanvasContentElement,
@@ -11,7 +11,7 @@ export function buildGenerationJob(
 	projectId: string,
 ): GenerationJob {
 	const customAttributes = element.customAttributes ?? {};
-	const connectorType = ELEMENT_CONFIGS[element.type].connector;
+	const connectorType = ELEMENT_METADATA[element.type].connector;
 	const provider = (customAttributes.provider as ProviderKey) ?? "openslop";
 	const { config } = getDefaultConnector(connectorConfig, connectorType);
 

--- a/app/components/canvas/utils/createCanvasNode.ts
+++ b/app/components/canvas/utils/createCanvasNode.ts
@@ -3,7 +3,7 @@ import type {
 	CanvasElementType,
 } from "@/lib/canvas/types";
 import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
-import { ELEMENT_CONFIGS } from "../config/elementConfigs";
+import { ELEMENT_METADATA } from "@/lib/canvas/elementMetadata";
 import { ZERO_WIDTH_SPACE } from "../config/constants";
 import { makeNodeId } from "./nodeUtils";
 import { hydrateConnectorConfig } from "./hydrateConnectorConfig";
@@ -19,7 +19,7 @@ export function createCanvasNode(
 	connectors: ConnectorRegistry,
 	opts: Opts = {},
 ): CanvasContentElement {
-	const config = ELEMENT_CONFIGS[type];
+	const config = ELEMENT_METADATA[type];
 	const node: CanvasContentElement = {
 		id: opts.id ?? makeNodeId(),
 		type,

--- a/app/components/canvas/utils/hydrateConnectorConfig.ts
+++ b/app/components/canvas/utils/hydrateConnectorConfig.ts
@@ -1,11 +1,11 @@
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
-import { ELEMENT_CONFIGS } from "../config/elementConfigs";
+import { ELEMENT_METADATA } from "@/lib/canvas/elementMetadata";
 
 export function hydrateConnectorConfig(registry: ConnectorRegistry) {
 	return (node: CanvasContentElement): CanvasContentElement => {
-		const connectorType = ELEMENT_CONFIGS[node.type]?.connector;
+		const connectorType = ELEMENT_METADATA[node.type]?.connector;
 		const { provider, config } = getDefaultConnector(registry, connectorType);
 		if (!config?.defaultModel) return node;
 		return {

--- a/lib/canvas/elementMetadata.ts
+++ b/lib/canvas/elementMetadata.ts
@@ -2,39 +2,36 @@ import type { CanvasElementType, ResultKind } from "./types";
 import type { ConnectorType } from "@/lib/connectors/types";
 
 export interface ElementMetadata {
-	type: CanvasElementType;
 	connector: ConnectorType;
 	outputKind: ResultKind;
 	defaultAttributes?: Record<string, string>;
 }
 
-const NARRATION_AUDIO_DEFAULTS = {
-	volume: "10",
-	speed: "medium",
-	captions: "on",
-};
-
 export const ELEMENT_METADATA: Record<CanvasElementType, ElementMetadata> = {
 	narration: {
-		type: "narration",
 		connector: "tts",
 		outputKind: "audio",
-		defaultAttributes: NARRATION_AUDIO_DEFAULTS,
+		defaultAttributes: {
+			volume: "10",
+			speed: "medium",
+			captions: "on",
+		},
 	},
 	character: {
-		type: "character",
 		connector: "tts",
 		outputKind: "audio",
-		defaultAttributes: NARRATION_AUDIO_DEFAULTS,
+		defaultAttributes: {
+			volume: "10",
+			speed: "medium",
+			captions: "on",
+		},
 	},
 	image: {
-		type: "image",
 		connector: "image",
 		outputKind: "image",
 		defaultAttributes: { motion: "none" },
 	},
 	animated_image: {
-		type: "animated_image",
 		connector: "animated_image",
 		outputKind: "video",
 		defaultAttributes: {
@@ -43,7 +40,6 @@ export const ELEMENT_METADATA: Record<CanvasElementType, ElementMetadata> = {
 		},
 	},
 	clip: {
-		type: "clip",
 		connector: "video",
 		outputKind: "video",
 		defaultAttributes: {
@@ -53,13 +49,11 @@ export const ELEMENT_METADATA: Record<CanvasElementType, ElementMetadata> = {
 		},
 	},
 	sound: {
-		type: "sound",
 		connector: "sfx",
 		outputKind: "audio",
 		defaultAttributes: { loops: "1", volume: "2" },
 	},
 	music: {
-		type: "music",
 		connector: "music",
 		outputKind: "audio",
 		defaultAttributes: { loops: "1", volume: "2" },

--- a/lib/canvas/elementMetadata.ts
+++ b/lib/canvas/elementMetadata.ts
@@ -1,0 +1,67 @@
+import type { CanvasElementType, ResultKind } from "./types";
+import type { ConnectorType } from "@/lib/connectors/types";
+
+export interface ElementMetadata {
+	type: CanvasElementType;
+	connector: ConnectorType;
+	outputKind: ResultKind;
+	defaultAttributes?: Record<string, string>;
+}
+
+const NARRATION_AUDIO_DEFAULTS = {
+	volume: "10",
+	speed: "medium",
+	captions: "on",
+};
+
+export const ELEMENT_METADATA: Record<CanvasElementType, ElementMetadata> = {
+	narration: {
+		type: "narration",
+		connector: "tts",
+		outputKind: "audio",
+		defaultAttributes: NARRATION_AUDIO_DEFAULTS,
+	},
+	character: {
+		type: "character",
+		connector: "tts",
+		outputKind: "audio",
+		defaultAttributes: NARRATION_AUDIO_DEFAULTS,
+	},
+	image: {
+		type: "image",
+		connector: "image",
+		outputKind: "image",
+		defaultAttributes: { motion: "none" },
+	},
+	animated_image: {
+		type: "animated_image",
+		connector: "animated_image",
+		outputKind: "video",
+		defaultAttributes: {
+			motion: "none",
+			videoPrompt: "slow cinematic pan",
+		},
+	},
+	clip: {
+		type: "clip",
+		connector: "video",
+		outputKind: "video",
+		defaultAttributes: {
+			duration: "5",
+			volume: "5",
+			motion: "none",
+		},
+	},
+	sound: {
+		type: "sound",
+		connector: "sfx",
+		outputKind: "audio",
+		defaultAttributes: { loops: "1", volume: "2" },
+	},
+	music: {
+		type: "music",
+		connector: "music",
+		outputKind: "audio",
+		defaultAttributes: { loops: "1", volume: "2" },
+	},
+};

--- a/lib/script/refine/__tests__/applyOps.test.ts
+++ b/lib/script/refine/__tests__/applyOps.test.ts
@@ -56,6 +56,47 @@ vi.mock("@/app/components/canvas/config/elementConfigs", () => ({
 	},
 }));
 
+vi.mock("@/lib/canvas/elementMetadata", () => ({
+	ELEMENT_METADATA: {
+		narration: {
+			type: "narration",
+			connector: "tts",
+			outputKind: "audio",
+			defaultAttributes: { emotion: "neutral" },
+		},
+		sound: {
+			type: "sound",
+			connector: "sfx",
+			outputKind: "audio",
+			defaultAttributes: { loops: "1" },
+		},
+		image: {
+			type: "image",
+			connector: "image",
+			outputKind: "image",
+			defaultAttributes: undefined,
+		},
+		character: {
+			type: "character",
+			connector: "tts",
+			outputKind: "audio",
+			defaultAttributes: { emotion: "neutral" },
+		},
+		music: {
+			type: "music",
+			connector: "music",
+			outputKind: "audio",
+			defaultAttributes: undefined,
+		},
+		clip: {
+			type: "clip",
+			connector: "video",
+			outputKind: "video",
+			defaultAttributes: undefined,
+		},
+	},
+}));
+
 vi.mock("@/app/components/canvas/utils/hydrateConnectorConfig", () => ({
 	hydrateConnectorConfig: () => (node: Record<string, unknown>) => node,
 }));

--- a/lib/script/refine/__tests__/applyOps.test.ts
+++ b/lib/script/refine/__tests__/applyOps.test.ts
@@ -3,97 +3,26 @@ import { createEditor, Editor, Element } from "slate";
 import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import type { CanvasContentElement, SceneElement } from "@/lib/canvas/types";
 
-vi.mock("@/app/components/canvas/config/elementConfigs", () => ({
-	ELEMENT_CONFIGS: {
-		narration: {
-			type: "narration",
-			connector: "tts",
-			outputKind: "audio",
-			label: "Narration",
-			defaultAttributes: { emotion: "neutral" },
-			visibleAttributes: {},
-		},
-		sound: {
-			type: "sound",
-			connector: "sfx",
-			outputKind: "audio",
-			label: "Sound",
-			defaultAttributes: { loops: "1" },
-			visibleAttributes: {},
-		},
-		image: {
-			type: "image",
-			connector: "image",
-			outputKind: "image",
-			label: "Image",
-			defaultAttributes: undefined,
-			visibleAttributes: {},
-		},
-		character: {
-			type: "character",
-			connector: "tts",
-			outputKind: "audio",
-			label: "Character",
-			defaultAttributes: { emotion: "neutral" },
-			visibleAttributes: {},
-		},
-		music: {
-			type: "music",
-			connector: "music",
-			outputKind: "audio",
-			label: "Music",
-			defaultAttributes: undefined,
-			visibleAttributes: {},
-		},
-		clip: {
-			type: "clip",
-			connector: "video",
-			outputKind: "video",
-			label: "Clip",
-			defaultAttributes: undefined,
-			visibleAttributes: {},
-		},
-	},
-}));
-
 vi.mock("@/lib/canvas/elementMetadata", () => ({
 	ELEMENT_METADATA: {
 		narration: {
-			type: "narration",
 			connector: "tts",
 			outputKind: "audio",
 			defaultAttributes: { emotion: "neutral" },
 		},
 		sound: {
-			type: "sound",
 			connector: "sfx",
 			outputKind: "audio",
 			defaultAttributes: { loops: "1" },
 		},
-		image: {
-			type: "image",
-			connector: "image",
-			outputKind: "image",
-			defaultAttributes: undefined,
-		},
+		image: { connector: "image", outputKind: "image" },
 		character: {
-			type: "character",
 			connector: "tts",
 			outputKind: "audio",
 			defaultAttributes: { emotion: "neutral" },
 		},
-		music: {
-			type: "music",
-			connector: "music",
-			outputKind: "audio",
-			defaultAttributes: undefined,
-		},
-		clip: {
-			type: "clip",
-			connector: "video",
-			outputKind: "video",
-			defaultAttributes: undefined,
-		},
+		music: { connector: "music", outputKind: "audio" },
+		clip: { connector: "video", outputKind: "video" },
 	},
 }));
 

--- a/lib/video/resolve.ts
+++ b/lib/video/resolve.ts
@@ -2,7 +2,7 @@ import type { CanvasElement } from "@/lib/canvas/types";
 import { getContentElements } from "@/lib/canvas/scenes";
 import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 import type { ElementSnapshot } from "@/lib/generation/queue";
-import { ELEMENT_CONFIGS } from "@/app/components/canvas/config/elementConfigs";
+import { ELEMENT_METADATA } from "@/lib/canvas/elementMetadata";
 import type { ResolvedElement } from "./types";
 import { ELEMENT_ROLES, LAYER_TYPES } from "./types";
 import {
@@ -24,7 +24,7 @@ export function resolveElements(
 
 		const url = getPrimaryUrl(
 			snapshot.result,
-			ELEMENT_CONFIGS[el.type].outputKind,
+			ELEMENT_METADATA[el.type].outputKind,
 		);
 		if (!url) continue;
 


### PR DESCRIPTION
## App understanding

openslop is a Next.js app for creating AI-generated video projects from an editable canvas/script. Users sign up or log in, create/open projects, add scene elements such as narration, characters, images, animated images, clips, sound effects, and music, configure connector/provider settings, generate media assets through API routes/queue jobs, preview synchronized scenes in the Remotion-backed player, and render/export videos.

## From-scratch architecture

A lean rebuild would keep domain contracts in `lib/*` and leave React components focused on presentation and interaction. Canvas element metadata that drives generation, defaults, and render resolution would live in the canvas domain, while UI-specific labels/icons/attribute controls would live beside the canvas UI. Generation, refinement, and video resolution would depend on domain metadata instead of importing React UI config across architectural boundaries.

## Implemented simplifications

- Added `lib/canvas/elementMetadata.ts` as a domain-level source of truth for each canvas element's connector type, output kind, and default attributes.
- Reduced `app/components/canvas/config/elementConfigs.tsx` to UI-only configuration and composed it with domain metadata, removing repeated type/connector/output/default fields from the React config object.
- Updated generation job creation, node creation, connector hydration, and video resolution to consume domain metadata directly instead of depending on the React element config module.
- Updated tests to mock the new metadata boundary where they previously mocked UI element config.

## Validation

- `npm run` — inspected available scripts.
- `npm run lint` — passed.
- `npm run format:check` — passed.
- `npm run typecheck` — passed.
- `npm run build` — passed. Build emitted the existing Vercel Queue region warning when running locally.
- `npm run test:run` — passed: 89 files / 792 tests.

## Skipped items / risks

- Claude Code reached the configured `--max-turns 40` before completing PR creation, so Hermes completed validation, commit, push, and PR creation manually.
- No behavior-changing simplifications were attempted in generation providers, auth, Supabase persistence, or rendering APIs to keep this nightly change safe and reviewable.