### PR TITLE
add aspect ratio dropdown and switch to 24fps

### DIFF
--- a/app/components/GlassDropdown.tsx
+++ b/app/components/GlassDropdown.tsx
@@ -18,6 +18,7 @@ export default function GlassDropdown<T extends string>({
 	onChange,
 	options,
 	ariaLabel,
+	triggerIcon,
 	side = "bottom",
 	align = "start",
 	className,
@@ -27,6 +28,7 @@ export default function GlassDropdown<T extends string>({
 	onChange: (value: T) => void;
 	options: GlassDropdownOption<T>[];
 	ariaLabel?: string;
+	triggerIcon?: ReactNode;
 	side?: "top" | "bottom";
 	align?: "start" | "center" | "end";
 	className?: string;
@@ -42,7 +44,7 @@ export default function GlassDropdown<T extends string>({
 					style={style}
 					className={`inline-flex items-center gap-1 bg-white/15 text-white text-[12px] px-2 py-0.5 rounded-full hover:bg-white/25 transition-colors ${className ?? ""}`}
 				>
-					{selected?.icon}
+					{triggerIcon ?? selected?.icon}
 					{selected?.label}
 					<ChevronDown className="w-2.5 h-2.5 text-white/70" />
 				</button>

--- a/app/components/canvas/__tests__/useGenerateAll.test.ts
+++ b/app/components/canvas/__tests__/useGenerateAll.test.ts
@@ -135,7 +135,10 @@ describe("useGenerateAll", () => {
 			seconds: 0,
 			result: id === "a" ? { url: "https://example.com/img.png" } : null,
 			error: null,
-			resultInputs: id === "a" ? { prompt: "sunset", attributes: {} } : null,
+			resultInputs:
+				id === "a"
+					? { prompt: "sunset", attributes: { width: 2560, height: 1440 } }
+					: null,
 		}));
 
 		const { useGenerateAll } = await import("../hooks/useGenerateAll");
@@ -221,9 +224,9 @@ describe("useGenerateAll", () => {
 		getElementSnapshotSpy.mockImplementation((id: string) => {
 			const inputs: Record<
 				string,
-				{ prompt: string; attributes: Record<string, string> }
+				{ prompt: string; attributes: Record<string, string | number> }
 			> = {
-				a: { prompt: "sunset", attributes: {} },
+				a: { prompt: "sunset", attributes: { width: 2560, height: 1440 } },
 				b: { prompt: "hello", attributes: {} },
 			};
 			return {

--- a/app/components/canvas/elements/MediaWithSkeleton.tsx
+++ b/app/components/canvas/elements/MediaWithSkeleton.tsx
@@ -8,6 +8,7 @@ interface MediaWithSkeletonProps {
 	src: string;
 	alt: string;
 	videoInteractive?: boolean;
+	objectFit?: "cover" | "contain";
 }
 
 export function MediaWithSkeleton({
@@ -15,8 +16,10 @@ export function MediaWithSkeleton({
 	src,
 	alt,
 	videoInteractive = false,
+	objectFit = "cover",
 }: MediaWithSkeletonProps) {
 	const [videoLoaded, setVideoLoaded] = useState(false);
+	const fitClass = objectFit === "contain" ? "object-contain" : "object-cover";
 
 	if (outputKind === "image") {
 		return (
@@ -24,7 +27,7 @@ export function MediaWithSkeleton({
 				src={src}
 				alt={alt}
 				fill
-				className="object-cover"
+				className={fitClass}
 				unoptimized
 			/>
 		);
@@ -34,11 +37,7 @@ export function MediaWithSkeleton({
 			<video
 				src={src}
 				controls={videoInteractive}
-				className={
-					videoInteractive
-						? "w-full h-full object-cover"
-						: "w-full h-full object-cover pointer-events-none"
-				}
+				className={`w-full h-full ${fitClass} ${videoInteractive ? "" : "pointer-events-none"}`}
 				onLoadedData={() => setVideoLoaded(true)}
 			/>
 			{!videoLoaded && (

--- a/app/components/canvas/elements/preview/results.tsx
+++ b/app/components/canvas/elements/preview/results.tsx
@@ -108,6 +108,7 @@ export function MediaPreview({
 				src={url}
 				alt="Generated"
 				videoInteractive
+				objectFit="contain"
 			/>
 			<ResultOverlay
 				status={status}

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -7,6 +7,7 @@ import {
 	Loader2,
 	Mic,
 	Plus,
+	Proportions,
 	User,
 	X,
 } from "lucide-react";
@@ -26,6 +27,8 @@ import { TEMPLATES, getTemplateById } from "@/lib/templates/templates";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getProjectStore } from "@/lib/project/store";
 import type { Mode } from "@/lib/project/types";
+import type { AspectRatio } from "@/lib/video/aspectRatio";
+import { useAspectRatio } from "@/lib/video/useAspectRatio";
 import { useImageUpload } from "@/lib/upload/useImageUpload";
 import { ActionButton } from "./ActionButton";
 import { ComposerAssets } from "./ComposerAssets";
@@ -34,6 +37,11 @@ const MODE_OPTIONS: GlassDropdownOption<Mode>[] = [
 	{ value: "story", label: "Describe a story" },
 	{ value: "script", label: "Paste in a script" },
 	{ value: "template", label: "Use a template" },
+];
+
+const ASPECT_RATIO_OPTIONS: GlassDropdownOption<AspectRatio>[] = [
+	{ value: "16:9", label: "16:9" },
+	{ value: "9:16", label: "9:16" },
 ];
 
 const TEMPLATE_OPTIONS: GlassDropdownOption<string>[] = TEMPLATES.map((t) => ({
@@ -145,6 +153,7 @@ export default function ComposerCopilot({
 }: ComposerCopilotProps) {
 	const { projectId, mode, setMode, selectedTemplateId, applyTemplate } =
 		useConfig();
+	const aspectRatio = useAspectRatio();
 	const [creatingCharacter, setCreatingCharacter] = useState(false);
 	const [editingCharacterName, setEditingCharacterName] = useState<
 		string | undefined
@@ -226,6 +235,20 @@ export default function ComposerCopilot({
 							}}
 							options={MODE_OPTIONS}
 							ariaLabel="Composer mode"
+							side="bottom"
+						/>
+						<GlassDropdown
+							value={aspectRatio}
+							onChange={(next: AspectRatio) => {
+								getProjectStore(projectId)
+									.getState()
+									.updateMetadata({ videoSettings: { aspectRatio: next } });
+							}}
+							options={ASPECT_RATIO_OPTIONS}
+							ariaLabel="Aspect ratio"
+							triggerIcon={
+								<Proportions className="mr-1 h-3 w-3" strokeWidth={2} />
+							}
 							side="bottom"
 						/>
 						{mode === "template" && selectedTemplateId && (

--- a/app/components/video/PlayerControls.tsx
+++ b/app/components/video/PlayerControls.tsx
@@ -49,7 +49,7 @@ export function PlayerControls({
 
 	return (
 		<div
-			className={`absolute inset-x-0 bottom-0 z-10 flex flex-col gap-1.5 bg-gradient-to-t from-black/80 via-black/50 to-transparent px-3 pb-2 pt-8 text-sm text-white transition-opacity duration-200 ${visible ? "opacity-100" : "pointer-events-none opacity-0"}`}
+			className={`@container absolute inset-x-0 bottom-0 z-10 flex flex-col gap-1.5 bg-gradient-to-t from-black/80 via-black/50 to-transparent px-3 pb-2 pt-8 text-sm text-white transition-opacity duration-200 ${visible ? "opacity-100" : "pointer-events-none opacity-0"}`}
 		>
 			<SegmentedSeekBar player={player} layout={layout} segments={segments} />
 			<div className="flex items-center gap-2">
@@ -61,7 +61,9 @@ export function PlayerControls({
 					)}
 				</IconButton>
 				<TimeDisplay player={player} layout={layout} />
-				<ScenePill player={player} layout={layout} segments={segments} />
+				<div className="hidden @[280px]:contents">
+					<ScenePill player={player} layout={layout} segments={segments} />
+				</div>
 				<div className="flex-1" />
 				<div className="flex shrink-0 items-center gap-1.5">
 					<IconButton
@@ -82,7 +84,7 @@ export function PlayerControls({
 						value={muted ? 0 : volume}
 						onChange={(e) => onVolumeChange(Number(e.target.value))}
 						aria-label="Volume"
-						className={styles.volume}
+						className={`hidden @[240px]:block ${styles.volume}`}
 					/>
 				</div>
 				<IconButton onClick={onFullscreen} ariaLabel="Fullscreen">

--- a/app/components/video/PlayerPanel.tsx
+++ b/app/components/video/PlayerPanel.tsx
@@ -1,16 +1,43 @@
 "use client";
 
+import type { ReactNode } from "react";
+import { getAspectRatioValue } from "@/lib/video/aspectRatio";
+import { useAspectRatio } from "@/lib/video/useAspectRatio";
 import { ResizeHandle } from "./ResizeHandle";
 import { useResize } from "./useResize";
 import { VideoPanel } from "./VideoPanel";
 
 const TOP_DEFAULT = 300;
 const SIDE_DEFAULT = 560;
-const HANDLE_PX = 16;
+
+function FitToAspectRatio({
+	ratio,
+	children,
+}: {
+	ratio: number;
+	children: ReactNode;
+}) {
+	return (
+		<div
+			className="flex h-full w-full items-center justify-center"
+			style={{ containerType: "size" }}
+		>
+			<div
+				style={{
+					width: `min(100cqw, calc(100cqh * ${ratio}))`,
+					height: `min(100cqh, calc(100cqw / ${ratio}))`,
+				}}
+			>
+				{children}
+			</div>
+		</div>
+	);
+}
 
 export function TopPlayerPanel() {
 	const maxSize =
 		typeof window !== "undefined" ? window.innerHeight * 0.6 : 500;
+	const aspectRatio = useAspectRatio();
 
 	const { size, handleMouseDown, resizing } = useResize({
 		axis: "vertical",
@@ -19,15 +46,12 @@ export function TopPlayerPanel() {
 		maxSize,
 	});
 
-	const videoMaxWidth = (size - HANDLE_PX) * (16 / 9);
-
 	return (
 		<div className="shrink-0" style={{ height: size }}>
-			<div
-				className="relative mx-auto h-[calc(100%-0.5rem)] max-w-6xl p-2"
-				style={{ maxWidth: videoMaxWidth }}
-			>
-				<VideoPanel />
+			<div className="relative mx-auto h-[calc(100%-0.5rem)] max-w-6xl p-2">
+				<FitToAspectRatio ratio={getAspectRatioValue(aspectRatio)}>
+					<VideoPanel />
+				</FitToAspectRatio>
 			</div>
 			<ResizeHandle
 				axis="vertical"
@@ -40,6 +64,7 @@ export function TopPlayerPanel() {
 
 export function SidePlayerPanel() {
 	const maxSize = typeof window !== "undefined" ? window.innerWidth * 0.5 : 600;
+	const aspectRatio = useAspectRatio();
 
 	const { size, handleMouseDown, resizing } = useResize({
 		axis: "horizontal",
@@ -56,7 +81,9 @@ export function SidePlayerPanel() {
 				onMouseDown={handleMouseDown}
 			/>
 			<div className="flex flex-1 flex-col justify-center overflow-hidden p-4">
-				<VideoPanel />
+				<FitToAspectRatio ratio={getAspectRatioValue(aspectRatio)}>
+					<VideoPanel />
+				</FitToAspectRatio>
 			</div>
 		</div>
 	);

--- a/app/components/video/PlayerShimmer.tsx
+++ b/app/components/video/PlayerShimmer.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 
 export function PlayerShimmer({ children }: { children?: ReactNode }) {
 	return (
-		<div className="shimmer-surface flex aspect-video w-full items-center justify-center">
+		<div className="shimmer-surface flex h-full w-full items-center justify-center">
 			{children}
 		</div>
 	);

--- a/app/components/video/SeekTooltip.tsx
+++ b/app/components/video/SeekTooltip.tsx
@@ -37,7 +37,7 @@ export function SeekTooltip({
 						<img
 							src={thumbnail.url}
 							alt=""
-							className="h-full w-full object-cover"
+							className="h-full w-full object-contain"
 						/>
 					) : (
 						<video
@@ -45,7 +45,7 @@ export function SeekTooltip({
 							preload="metadata"
 							muted
 							playsInline
-							className="h-full w-full object-cover"
+							className="h-full w-full object-contain"
 						/>
 					)
 				) : null}

--- a/app/components/video/VideoPanel.tsx
+++ b/app/components/video/VideoPanel.tsx
@@ -20,7 +20,7 @@ function VideoPanelBody() {
 	}
 	if (!layout?.series.length) {
 		return (
-			<div className="flex aspect-video items-center justify-center px-4 text-center text-sm text-white/40">
+			<div className="flex h-full w-full items-center justify-center px-4 text-center text-sm text-white/40">
 				Generate elements to playback
 			</div>
 		);
@@ -35,9 +35,9 @@ export function VideoPanel() {
 	const showControls = !scriptLoading && !!layout?.series.length && ready;
 
 	return (
-		<div className="group relative overflow-hidden rounded-lg border border-white/10 bg-white/5 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12)]">
+		<div className="group relative h-full w-full overflow-hidden rounded-lg border border-white/10 bg-white/5 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12)]">
 			<div className="grain grain-light absolute inset-0" aria-hidden="true" />
-			<div className="relative z-[2]">
+			<div className="relative z-[2] h-full w-full">
 				<VideoPanelBody />
 			</div>
 			{showControls && (

--- a/app/components/video/VideoPreview.tsx
+++ b/app/components/video/VideoPreview.tsx
@@ -13,7 +13,7 @@ import { useControlsVisibility } from "./useControlsVisibility";
 import { useSceneSegments } from "./useSceneSegments";
 import styles from "./VideoPlayer.module.css";
 
-const fullWidthStyle = { width: "100%" };
+const fullSizeStyle = { width: "100%", height: "100%" };
 
 const RemotionPlayer = dynamic(
 	async () => {
@@ -38,7 +38,7 @@ const RemotionPlayer = dynamic(
 					fps={layout.fps}
 					compositionWidth={layout.width}
 					compositionHeight={layout.height}
-					style={fullWidthStyle}
+					style={fullSizeStyle}
 					clickToPlay={false}
 					acknowledgeRemotionLicense
 					numberOfSharedAudioTags={10}
@@ -71,7 +71,7 @@ export function VideoPreview({ layout }: { layout: VideoLayout }) {
 	};
 	return (
 		<div
-			className={`relative ${styles.player}`}
+			className={`relative h-full w-full ${styles.player}`}
 			onPointerMove={ping}
 			onPointerDown={ping}
 			onFocus={ping}

--- a/app/components/video/useVideoLayout.ts
+++ b/app/components/video/useVideoLayout.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/generation/GenerationQueueProvider";
 import { resolveElements } from "@/lib/video/resolve";
 import { buildVideoLayout } from "@/lib/video/scene-builder";
+import { useAspectRatio } from "@/lib/video/useAspectRatio";
 import { useTransitionType } from "@/lib/video/useTransitionType";
 import type { VideoLayout } from "@/lib/video/types";
 
@@ -22,6 +23,7 @@ export function useVideoLayout(
 	const queue = useGenerationQueue();
 	const resultVersion = useQueueSelector((q) => q.getResultVersion());
 	const transitionType = useTransitionType();
+	const aspectRatio = useAspectRatio();
 
 	const { layout, scenes } = useMemo(() => {
 		const editor = getEditor();
@@ -29,11 +31,11 @@ export function useVideoLayout(
 		const elements = editor.children as CanvasElement[];
 		const resolved = resolveElements(elements, queue.getElementSnapshot);
 		return {
-			layout: buildVideoLayout(resolved, { transitionType }),
+			layout: buildVideoLayout(resolved, { transitionType, aspectRatio }),
 			scenes: elements.filter(isSceneElement),
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [getEditor, layoutKey, resultVersion, transitionType, queue]);
+	}, [getEditor, layoutKey, resultVersion, transitionType, aspectRatio, queue]);
 
 	return { layout, playerKey: `${layoutKey}-${resultVersion}`, scenes };
 }

--- a/lib/connectors/animated_image/plugins/__tests__/animated-image-chain.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/animated-image-chain.test.ts
@@ -38,12 +38,18 @@ describe("createVideoChainPlugin", () => {
 		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
 
 		const cleaned = (await plugin.beforeGenerate?.(
-			{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
+			{
+				prompt: "a dark forest",
+				videoPrompt: "slow zoom in",
+				videoWidth: 1280,
+				videoHeight: 720,
+			},
 			ctx,
 		)) as AnimatedImageGenerateParams;
 
 		expect(cleaned).not.toHaveProperty("videoPrompt");
-		expect(ctx.data?.videoPrompt).toBe("slow zoom in");
+		expect(cleaned).not.toHaveProperty("videoWidth");
+		expect(cleaned).not.toHaveProperty("videoHeight");
 
 		const still = {
 			imageUrl: "https://example.com/still.png",
@@ -54,6 +60,8 @@ describe("createVideoChainPlugin", () => {
 		expect(generateMock).toHaveBeenCalledWith({
 			prompt: "slow zoom in",
 			frameImages: ["https://example.com/still.png"],
+			width: 1280,
+			height: 720,
 		});
 		expect(result).toEqual({
 			imageUrl: "https://example.com/still.png",

--- a/lib/connectors/animated_image/plugins/animated-image-chain.ts
+++ b/lib/connectors/animated_image/plugins/animated-image-chain.ts
@@ -9,7 +9,13 @@ import type {
 	ConnectorPlugin,
 } from "@/lib/connectors/types";
 
-const STASH_KEY = "videoPrompt";
+const STASH_KEY = "videoChain";
+
+type Stashed = {
+	videoPrompt: string;
+	videoWidth?: number;
+	videoHeight?: number;
+};
 
 export function createVideoChainPlugin(
 	registry: ConnectorRegistry,
@@ -17,16 +23,20 @@ export function createVideoChainPlugin(
 	return {
 		name: "video-chain",
 		beforeGenerate(params, ctx) {
-			const { videoPrompt, ...rest } = params;
+			const { videoPrompt, videoWidth, videoHeight, ...rest } = params;
 			if (videoPrompt && ctx) {
 				ctx.data ??= {};
-				ctx.data[STASH_KEY] = videoPrompt;
+				ctx.data[STASH_KEY] = {
+					videoPrompt,
+					videoWidth,
+					videoHeight,
+				} satisfies Stashed;
 			}
 			return rest as AnimatedImageGenerateParams;
 		},
 		async afterGenerate(result, ctx) {
-			const videoPrompt = ctx?.data?.[STASH_KEY] as string | undefined;
-			if (!videoPrompt) {
+			const stashed = ctx?.data?.[STASH_KEY] as Stashed | undefined;
+			if (!stashed?.videoPrompt) {
 				throw new Error(
 					"animated_image element is missing required videoPrompt attribute",
 				);
@@ -43,8 +53,10 @@ export function createVideoChainPlugin(
 				set("plugins", [], config),
 			);
 			const videoResult = await video.generate({
-				prompt: videoPrompt,
+				prompt: stashed.videoPrompt,
 				frameImages: [result.imageUrl],
+				width: stashed.videoWidth,
+				height: stashed.videoHeight,
 			});
 			return {
 				imageUrl: result.imageUrl,

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -122,6 +122,8 @@ export type ImageGenerateParams = ConnectorGenerateParams & {
 
 export type AnimatedImageGenerateParams = ImageGenerateParams & {
 	videoPrompt?: string;
+	videoWidth?: number;
+	videoHeight?: number;
 };
 
 // TTS types

--- a/lib/generation/__tests__/getGenerationInputs.test.ts
+++ b/lib/generation/__tests__/getGenerationInputs.test.ts
@@ -36,6 +36,8 @@ describe("getGenerationInputs", () => {
 			model: "Slop Video v1",
 			duration: "5",
 			provider: "openslop",
+			width: 1280,
+			height: 720,
 		});
 	});
 
@@ -50,7 +52,11 @@ describe("getGenerationInputs", () => {
 		for (const key of LAYOUT_ATTRIBUTE_KEYS) {
 			expect(attributes).not.toHaveProperty(key);
 		}
-		expect(attributes).toEqual({ model: "Slop Video v1" });
+		expect(attributes).toEqual({
+			model: "Slop Video v1",
+			width: 1280,
+			height: 720,
+		});
 	});
 
 	it("merges characterAvatars from metadata for image elements", () => {
@@ -89,7 +95,7 @@ describe("getGenerationInputs", () => {
 			characters: { Alice: { appearance: "tall", voiceId: "voice-1" } },
 		};
 		const { attributes } = getGenerationInputs(
-			element({ name: "Alice" }, "clip"),
+			element({ name: "Alice" }, "music"),
 			metadata,
 		);
 		expect(attributes).not.toHaveProperty("voiceId");

--- a/lib/generation/__tests__/queue.test.ts
+++ b/lib/generation/__tests__/queue.test.ts
@@ -17,8 +17,10 @@ function makeElement(
 ): CanvasContentElement {
 	return {
 		id,
-		type: "image",
-		customAttributes: inputs.attributes,
+		type: "sound",
+		customAttributes: Object.fromEntries(
+			Object.entries(inputs.attributes).map(([k, v]) => [k, String(v)]),
+		),
 		children: [{ id: `${id}-t`, type: "image", text: inputs.prompt }],
 	};
 }

--- a/lib/generation/elementMetadataInputs.ts
+++ b/lib/generation/elementMetadataInputs.ts
@@ -4,13 +4,17 @@ import type {
 	CanvasElementType,
 } from "@/lib/canvas/types";
 import type { Metadata } from "@/lib/project/types";
+import {
+	ASPECT_RATIO_DIMENSIONS,
+	DEFAULT_ASPECT_RATIO,
+} from "@/lib/video/aspectRatio";
 
 type MetadataAttributes = (
 	element: CanvasContentElement,
 	metadata: Metadata,
-) => Record<string, string>;
+) => Record<string, string | number>;
 
-const NONE: Record<string, string> = {};
+const NONE: Record<string, string | number> = {};
 
 const characterAvatars: MetadataAttributes = (element, metadata) => {
 	const urls = compact(
@@ -34,11 +38,38 @@ const characterVoiceId: MetadataAttributes = (element, metadata) => {
 const narratorVoiceId: MetadataAttributes = (_, { narration }) =>
 	narration.voiceId ? { voiceId: narration.voiceId } : NONE;
 
+const getAspectDims = (metadata: Metadata) =>
+	ASPECT_RATIO_DIMENSIONS[
+		metadata.videoSettings?.aspectRatio ?? DEFAULT_ASPECT_RATIO
+	];
+
+const imageDims: MetadataAttributes = (_, metadata) =>
+	getAspectDims(metadata).image;
+
+const videoDims: MetadataAttributes = (_, metadata) =>
+	getAspectDims(metadata).video;
+
+const animatedImageDims: MetadataAttributes = (_, metadata) => {
+	const { image, video } = getAspectDims(metadata);
+	return {
+		width: image.width,
+		height: image.height,
+		videoWidth: video.width,
+		videoHeight: video.height,
+	};
+};
+
+const combine =
+	(...fns: MetadataAttributes[]): MetadataAttributes =>
+	(element, metadata) =>
+		Object.assign({}, ...fns.map((fn) => fn(element, metadata)));
+
 export const ELEMENT_METADATA_INPUTS: Partial<
 	Record<CanvasElementType, MetadataAttributes>
 > = {
-	image: characterAvatars,
-	animated_image: characterAvatars,
+	image: combine(imageDims, characterAvatars),
+	animated_image: combine(animatedImageDims, characterAvatars),
+	clip: videoDims,
 	character: characterVoiceId,
 	narration: narratorVoiceId,
 };

--- a/lib/generation/generationInputs.ts
+++ b/lib/generation/generationInputs.ts
@@ -1,6 +1,6 @@
 export type GenerationInputs = {
 	prompt: string;
-	attributes: Record<string, string>;
+	attributes: Record<string, string | number>;
 };
 
 export function serializeInputs(inputs: GenerationInputs): string {

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -6,6 +6,7 @@ import {
 	TTS_LANGUAGES,
 	TTS_PITCHES,
 } from "@/lib/connectors/tts/enums";
+import type { AspectRatio } from "@/lib/video/aspectRatio";
 import type { TransitionType } from "@/lib/video/transitions";
 
 const optionalString = z.string().min(1).optional().catch(undefined);
@@ -49,6 +50,7 @@ export type MetadataCharacter = MetadataVoice & {
 
 export type VideoSettings = {
 	transitionType?: TransitionType;
+	aspectRatio?: AspectRatio;
 };
 
 export type Mode = "story" | "script" | "template";

--- a/lib/providers/tts/cartesia.ts
+++ b/lib/providers/tts/cartesia.ts
@@ -165,6 +165,7 @@ export class CartesiaTTS extends BaseProvider<TTSGenerateParams, RawTTSResult> {
 				add_timestamps: true,
 				generation_config: {
 					speed: CARTESIA_SPEED[params.speed ?? "medium"],
+					volume: params.volume ?? 2.0,
 				},
 			};
 			for await (const response of ws.generate(req)) {

--- a/lib/video/aspectRatio.ts
+++ b/lib/video/aspectRatio.ts
@@ -1,0 +1,28 @@
+export type AspectRatio = "16:9" | "9:16";
+
+export const DEFAULT_ASPECT_RATIO: AspectRatio = "16:9";
+
+export const ASPECT_RATIO_DIMENSIONS: Record<
+	AspectRatio,
+	{
+		image: { width: number; height: number };
+		video: { width: number; height: number };
+		output: { width: number; height: number };
+	}
+> = {
+	"16:9": {
+		image: { width: 2560, height: 1440 },
+		video: { width: 1280, height: 720 },
+		output: { width: 1920, height: 1080 },
+	},
+	"9:16": {
+		image: { width: 1440, height: 2560 },
+		video: { width: 720, height: 1280 },
+		output: { width: 1080, height: 1920 },
+	},
+};
+
+export function getAspectRatioValue(ratio: AspectRatio): number {
+	const { width, height } = ASPECT_RATIO_DIMENSIONS[ratio].video;
+	return width / height;
+}

--- a/lib/video/scene-builder.ts
+++ b/lib/video/scene-builder.ts
@@ -5,6 +5,7 @@ import type {
 	VideoLayout,
 } from "./types";
 import { DEFAULT_CONFIG } from "./types";
+import { type AspectRatio, ASPECT_RATIO_DIMENSIONS } from "./aspectRatio";
 import {
 	DEFAULT_TRANSITION,
 	TRANSITION_DURATION_SEC,
@@ -13,6 +14,7 @@ import {
 
 export type BuildLayoutOptions = Partial<VideoConfig> & {
 	transitionType?: TransitionType;
+	aspectRatio?: AspectRatio;
 };
 
 const MIN_DURATION_SEC = 1;
@@ -73,7 +75,10 @@ export function buildVideoLayout(
 	elements: ResolvedElement[],
 	options?: BuildLayoutOptions,
 ): VideoLayout {
-	const cfg = { ...DEFAULT_CONFIG, ...options };
+	const aspectDims = options?.aspectRatio
+		? ASPECT_RATIO_DIMENSIONS[options.aspectRatio].output
+		: undefined;
+	const cfg = { ...DEFAULT_CONFIG, ...aspectDims, ...options };
 	const transitionType = options?.transitionType ?? DEFAULT_TRANSITION;
 	const series: Sequence[] = [];
 	const sequences: Record<string, Sequence[]> = {};

--- a/lib/video/types.ts
+++ b/lib/video/types.ts
@@ -68,7 +68,7 @@ export type VideoConfig = {
 };
 
 export const DEFAULT_CONFIG: VideoConfig = {
-	fps: 30,
+	fps: 24,
 	width: 1920,
 	height: 1080,
 };

--- a/lib/video/useAspectRatio.ts
+++ b/lib/video/useAspectRatio.ts
@@ -1,0 +1,11 @@
+import { useConfig } from "@/lib/config/ConfigProvider";
+import { useProjectStore } from "@/lib/project/store";
+import { type AspectRatio, DEFAULT_ASPECT_RATIO } from "./aspectRatio";
+
+export function useAspectRatio(): AspectRatio {
+	const { projectId } = useConfig();
+	return useProjectStore(
+		projectId,
+		(s) => s.metadata.videoSettings?.aspectRatio ?? DEFAULT_ASPECT_RATIO,
+	);
+}


### PR DESCRIPTION
## Summary
- New 16:9 / 9:16 selector next to the mode dropdown in the composer hero; persists per project (`metadata.videoSettings.aspectRatio`).
- Selection threads through image (2560×1440 / 1440×2560), video (1280×720 / 720×1280), and animated_image (image+video dims) generation, plus the Remotion composition. Single `ASPECT_RATIO_DIMENSIONS` map is the source of truth.
- Player panel uses container-query units (`100cqw` / `100cqh`) to fit aspect-correctly so 9:16 no longer overflows the panel and clips the controls. Output preview and seek tooltip stay 16:9 with `object-contain` letterboxing for portrait media.
- Default fps bumped 30 → 24.

## Test plan
- [ ] Open a project, toggle the new dropdown between 16:9 and 9:16; player panel reshapes with side bars in portrait, no clipped controls.
- [ ] Generate an image / animated_image / clip in each ratio; verify outbound dims match `ASPECT_RATIO_DIMENSIONS`.
- [ ] Output preview and seek tooltip stay landscape — portrait media letterboxed with side bars.
- [ ] Confirm fps=24 via Remotion `calculateMetadata` / rendered output.
- [ ] Reload page — selection persists.