### PR TITLE
fix: nightly bug fixes 2026-06-09

### DIFF
--- a/app/api/v1/__tests__/routes.test.ts
+++ b/app/api/v1/__tests__/routes.test.ts
@@ -180,6 +180,17 @@ describe("API routes", () => {
 			);
 			expect(res.status).toBe(200);
 		});
+
+		it("returns 400 for blank dimension strings", async () => {
+			const { POST } = await import("@/app/api/v1/image/route");
+			const res = await POST(
+				makeRequest("/api/v1/image", { prompt: "cat", width: "   " }),
+			);
+
+			expect(res.status).toBe(400);
+			expect((await res.json()).error).toContain("must be a finite number");
+			expect(mockCreateJob).not.toHaveBeenCalled();
+		});
 	});
 
 	describe("POST /api/v1/video", () => {
@@ -281,6 +292,17 @@ describe("API routes", () => {
 				makeRequest("/api/v1/video", { prompt: "x", duration: "abc" }),
 			);
 			expect(res.status).toBe(400);
+		});
+
+		it("returns 400 for blank duration strings", async () => {
+			const { POST } = await import("@/app/api/v1/video/route");
+			const res = await POST(
+				makeRequest("/api/v1/video", { prompt: "x", duration: "" }),
+			);
+
+			expect(res.status).toBe(400);
+			expect((await res.json()).error).toContain("must be a finite number");
+			expect(mockCreateJob).not.toHaveBeenCalled();
 		});
 
 		it("returns 500 when createJob fails", async () => {

--- a/lib/api/request-schema-fields.ts
+++ b/lib/api/request-schema-fields.ts
@@ -2,7 +2,9 @@ import { z } from "zod";
 
 const optionalCoercedNumber = z
 	.union([z.number(), z.string()])
-	.transform((v) => (typeof v === "string" ? Number(v) : v))
+	.transform((v) =>
+		typeof v === "string" && v.trim() === "" ? NaN : Number(v),
+	)
 	.refine((v) => Number.isFinite(v), { message: "must be a finite number" })
 	.optional();
 


### PR DESCRIPTION
## Summary
- Reject blank numeric strings for optional API duration/dimension fields instead of coercing them to `0`.
- Keeps valid numeric strings (for example `"5"`, `"1280"`) supported while failing malformed blank inputs before job creation.
- Adds API regression coverage for blank image dimensions and video duration.

## Bugs fixed
- `Number("")`/`Number("   ")` previously let blank request fields pass schema validation as `0`, which could enqueue image/video jobs with unintended dimensions or duration.

## Tests
- [x] `npm test -- --passWithNoTests app/api/v1/__tests__/routes.test.ts`
- [x] `npm test -- --passWithNoTests`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run build`

## Open PR overlap check
Considered open PRs #210, #211, #212, and #213. This PR only touches shared API request validation and API route regression tests (`lib/api/request-schema-fields.ts`, `app/api/v1/__tests__/routes.test.ts`), so it does not overlap their video player/playQueue/performance/canvas architecture/refine/video-resolve work.