### PR TITLE
refactor: nightly maintainability 2026-06-09

### DIFF
--- a/lib/connectors/__tests__/plugins.test.ts
+++ b/lib/connectors/__tests__/plugins.test.ts
@@ -54,6 +54,35 @@ describe("plugins", () => {
 		expect(result).toBe("[prefix] hello [suffix]");
 	});
 
+	it("preserves plugin method context", async () => {
+		const plugin: ConnectorPlugin = {
+			name: "named",
+			beforeGenerate(this: ConnectorPlugin, p) {
+				return { ...(p as object), beforePlugin: this.name };
+			},
+			afterGenerate(this: ConnectorPlugin, result) {
+				return { ...(result as object), afterPlugin: this.name };
+			},
+			transformPrompt(this: ConnectorPlugin, prompt) {
+				return `${this.name}:${prompt}`;
+			},
+			onError(this: ConnectorPlugin, error) {
+				throw new Error(`${this.name}:${error}`);
+			},
+		};
+
+		await expect(runBeforeGenerate([plugin], {})).resolves.toMatchObject({
+			beforePlugin: "named",
+		});
+		await expect(runAfterGenerate([plugin], {})).resolves.toMatchObject({
+			afterPlugin: "named",
+		});
+		await expect(runTransformPrompt([plugin], "prompt")).resolves.toBe(
+			"named:prompt",
+		);
+		await expect(runOnError([plugin], "fail")).rejects.toThrow("named:fail");
+	});
+
 	it("runs onError for all plugins", async () => {
 		const errors: string[] = [];
 		const plugins: ConnectorPlugin[] = [

--- a/lib/connectors/base.ts
+++ b/lib/connectors/base.ts
@@ -42,17 +42,34 @@ export abstract class BaseConnector<
 		return runBeforeGenerate(this.plugins, { ...params, prompt }, ctx);
 	}
 
-	async generate(params: TParams): Promise<TResult> {
+	protected async reportError(
+		error: unknown,
+		ctx: PluginContext<TParams, TResult>,
+	): Promise<void> {
+		await runOnError(this.plugins, stringifyError(error), ctx);
+	}
+
+	protected async withPlugins<T>(
+		params: TParams,
+		body: (
+			prepared: TParams,
+			ctx: PluginContext<TParams, TResult>,
+		) => Promise<T>,
+	): Promise<T> {
 		const ctx = this.pluginContext();
 		try {
-			const prepared = await this.prepareParams(params, ctx);
-			let result = await this._generate(prepared);
-			result = await runAfterGenerate(this.plugins, result, ctx);
-			return result;
+			return await body(await this.prepareParams(params, ctx), ctx);
 		} catch (error) {
-			await runOnError(this.plugins, stringifyError(error), ctx);
+			await this.reportError(error, ctx);
 			throw error;
 		}
+	}
+
+	async generate(params: TParams): Promise<TResult> {
+		return this.withPlugins(params, async (prepared, ctx) => {
+			const result = await this._generate(prepared);
+			return runAfterGenerate(this.plugins, result, ctx);
+		});
 	}
 
 	protected abstract _generate(params: TParams): Promise<TResult>;

--- a/lib/connectors/llm/connector.ts
+++ b/lib/connectors/llm/connector.ts
@@ -1,7 +1,5 @@
 import type { GatewayClient } from "@/lib/gateway/base";
-import { stringifyError } from "@/lib/errors";
 import { BaseConnector } from "../base";
-import { runOnError } from "../plugins";
 import type {
 	ConnectorConfig,
 	LLMConnector,
@@ -38,10 +36,9 @@ export abstract class BaseLLMConnector<
 	async *stream(params: LLMGenerateParams): AsyncGenerator<LLMStreamChunk> {
 		const ctx = this.pluginContext();
 		try {
-			const prepared = await this.prepareParams(params, ctx);
-			yield* this._stream(prepared);
+			yield* this._stream(await this.prepareParams(params, ctx));
 		} catch (error) {
-			await runOnError(this.plugins, stringifyError(error), ctx);
+			await this.reportError(error, ctx);
 			throw error;
 		}
 	}

--- a/lib/connectors/plugins.ts
+++ b/lib/connectors/plugins.ts
@@ -1,17 +1,29 @@
 import type { ConnectorPlugin, PluginContext } from "./types";
 
+type ReducibleHook = "beforeGenerate" | "afterGenerate" | "transformPrompt";
+
+async function reducePlugins<T>(
+	plugins: ConnectorPlugin[],
+	hook: ReducibleHook,
+	value: T,
+	ctx?: PluginContext,
+): Promise<T> {
+	let current = value;
+	for (const plugin of plugins) {
+		const fn = plugin[hook] as
+			| ((v: unknown, c?: PluginContext) => unknown)
+			| undefined;
+		if (fn) current = (await fn.call(plugin, current, ctx)) as T;
+	}
+	return current;
+}
+
 export async function runBeforeGenerate<T>(
 	plugins: ConnectorPlugin[],
 	params: T,
 	ctx?: PluginContext,
 ): Promise<T> {
-	let result = params;
-	for (const plugin of plugins) {
-		if (plugin.beforeGenerate) {
-			result = (await plugin.beforeGenerate(result, ctx)) as T;
-		}
-	}
-	return result;
+	return reducePlugins(plugins, "beforeGenerate", params, ctx);
 }
 
 export async function runAfterGenerate<T>(
@@ -19,13 +31,7 @@ export async function runAfterGenerate<T>(
 	result: T,
 	ctx?: PluginContext,
 ): Promise<T> {
-	let current = result;
-	for (const plugin of plugins) {
-		if (plugin.afterGenerate) {
-			current = (await plugin.afterGenerate(current, ctx)) as T;
-		}
-	}
-	return current;
+	return reducePlugins(plugins, "afterGenerate", result, ctx);
 }
 
 export async function runTransformPrompt(
@@ -33,13 +39,7 @@ export async function runTransformPrompt(
 	prompt: string,
 	ctx?: PluginContext,
 ): Promise<string> {
-	let current = prompt;
-	for (const plugin of plugins) {
-		if (plugin.transformPrompt) {
-			current = await plugin.transformPrompt(current, ctx);
-		}
-	}
-	return current;
+	return reducePlugins(plugins, "transformPrompt", prompt, ctx);
 }
 
 export async function runOnError(
@@ -48,8 +48,6 @@ export async function runOnError(
 	ctx?: PluginContext,
 ): Promise<void> {
 	for (const plugin of plugins) {
-		if (plugin.onError) {
-			await plugin.onError(error, ctx);
-		}
+		await plugin.onError?.(error, ctx);
 	}
 }


### PR DESCRIPTION
## Summary
- Consolidates connector plugin value reducers behind one shared `reducePlugins` helper while preserving sequential async execution and plugin method `this` binding.
- Extracts BaseConnector error reporting into a protected `reportError` contract and wraps prepared-params execution through `withPlugins`.
- Reuses the shared error-reporting path from LLM streaming so `generate()` and `stream()` cannot drift in how plugin `onError` hooks are notified.
- Adds regression coverage for plugin method context across reducible hooks and `onError`.

## Architecture changes
- `lib/connectors/plugins.ts` now owns the common plugin-folding primitive for `beforeGenerate`, `afterGenerate`, and `transformPrompt`.
- `lib/connectors/base.ts` exposes a narrow template-method boundary for plugin preparation/error handling; subclasses focus on connector-specific generation/streaming work.
- `lib/connectors/llm/connector.ts` depends on the base connector error contract instead of duplicating `runOnError` + `stringifyError` wiring.

## Maintainability changes
- Removes repeated plugin loop bodies and duplicated generate/stream error plumbing.
- Keeps public runner functions and behavior unchanged, including hook order, awaiting, method context, and error propagation.
- Adds a focused test to lock in plugin method-context behavior after the reducer extraction.

## Complexity delta
- 4 files changed; connector plugin orchestration gained one shared reducer/template method and removed three duplicated reducer loops plus duplicated stream error-reporting imports/plumbing.
- Net diff: +76/-35, mostly the regression test and deeper shared connector contracts.

## Validation
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test -- --passWithNoTests` (89 files / 793 tests)
- [x] Independent code review: no security concerns or logic errors after preserving plugin method binding.

## Open PR overlap check
Considered open PRs #210, #211, #212, #213, and #215. This PR only touches connector plugin orchestration and connector plugin tests (`lib/connectors/base.ts`, `lib/connectors/llm/connector.ts`, `lib/connectors/plugins.ts`, `lib/connectors/__tests__/plugins.test.ts`), so it does not overlap their video player/playQueue/performance/canvas metadata/video-resolution/API-validation work.

## Skipped items
- Video player/control simplifications: skipped because open PRs #210, #211, and #212 already cover that area.
- Canvas element metadata/generation boundary work: skipped because open PR #213 covers that area.
- API request validation cleanup: skipped because open PR #215 covers that area.
- UI/composer state cleanup: skipped to avoid overlap with recently closed #214/#209 themes and because the connector plugin layer offered a safer non-overlapping maintainability target.
