### PR TITLE
perf: nightly performance optimizations 2026-06-09

### DIFF
--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -18,6 +18,7 @@ import { DragOverlayContent } from "./dnd/DragOverlay";
 import Sidebar from "./panel/Sidebar";
 import { renderCanvasElement } from "./elements/ElementContainer";
 import { AssetsSection } from "./elements/AssetsSection";
+import { affectsDocument } from "./utils/slateChange";
 import { PreviewCacheProvider } from "./PreviewCacheContext";
 import { ViewModeProvider } from "./ViewModeContext";
 
@@ -82,6 +83,15 @@ export default function Canvas({
 		return entry?.[0] as Descendant;
 	}, [editor, activeId]);
 
+	const handleSlateChange = useCallback(
+		(nextValue: Descendant[]) => {
+			if (affectsDocument(editor.operations)) {
+				setValue(nextValue);
+			}
+		},
+		[editor, setValue],
+	);
+
 	return (
 		<ViewModeProvider sceneIds={sceneItems}>
 			<PreviewCacheProvider>
@@ -96,7 +106,11 @@ export default function Canvas({
 					>
 						<Sidebar />
 
-						<Slate editor={editor} initialValue={value} onChange={setValue}>
+						<Slate
+							editor={editor}
+							initialValue={value}
+							onChange={handleSlateChange}
+						>
 							<AssetsSection />
 							<SortableContext
 								items={sceneItems}

--- a/app/components/canvas/__tests__/slateChange.test.ts
+++ b/app/components/canvas/__tests__/slateChange.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { Operation } from "slate";
+import { affectsDocument } from "../utils/slateChange";
+
+describe("affectsDocument", () => {
+	it("ignores selection-only Slate operations", () => {
+		const operations: Operation[] = [
+			{
+				type: "set_selection",
+				properties: null,
+				newProperties: {
+					anchor: { path: [0, 0], offset: 0 },
+					focus: { path: [0, 0], offset: 0 },
+				},
+			},
+		];
+
+		expect(affectsDocument(operations)).toBe(false);
+	});
+
+	it("detects document edits", () => {
+		const operations: Operation[] = [
+			{
+				type: "set_selection",
+				properties: null,
+				newProperties: {
+					anchor: { path: [0, 0], offset: 0 },
+					focus: { path: [0, 0], offset: 0 },
+				},
+			},
+			{ type: "insert_text", path: [0, 0], offset: 0, text: "a" },
+		];
+
+		expect(affectsDocument(operations)).toBe(true);
+	});
+});

--- a/app/components/canvas/utils/slateChange.ts
+++ b/app/components/canvas/utils/slateChange.ts
@@ -1,0 +1,5 @@
+import type { Operation } from "slate";
+
+export function affectsDocument(operations: Operation[]): boolean {
+	return operations.some((operation) => operation.type !== "set_selection");
+}


### PR DESCRIPTION
## Summary
- Filters Slate `onChange` handling so selection-only operations no longer push a new canvas value into React state.
- Adds a small `affectsDocument` helper with focused regression coverage for selection-only versus document-edit operations.

## Why it matters
Cursor movement and selection changes are among the hottest Slate interactions. They do not modify the document tree, but previously they still called `setValue`, forcing `PostPromptViewInner` and downstream canvas/video layout state to re-render and recompute from the full canvas value. This keeps document edits flowing exactly as before while avoiding React work for selection-only editor activity.

## Open PR overlap check
Considered open PRs #210, #211, #212, #213, #215, and #216. This PR only touches Slate canvas change propagation (`app/components/canvas/Canvas.tsx`, `app/components/canvas/utils/slateChange.ts`, and `app/components/canvas/__tests__/slateChange.test.ts`) and does not overlap the open video player/playQueue/active-segment/player-subscription, canvas metadata/video-resolution, API validation, or connector plugin work.

## Skipped
- Video player/control subscription and active-segment changes: skipped due to open PRs #210, #211, and #212.
- Canvas metadata/generation/video resolution boundaries: skipped due to open PR #213.
- API request validation and connector plugin orchestration: skipped due to open PRs #215 and #216.
- Bundle/lazy-load churn: skipped because this runbook is runtime UX-first and the Slate selection hot path is a clearer in-app responsiveness win.

## Validation
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test -- --passWithNoTests` (90 files / 794 tests)

## Automation notes
- The required Claude Code core-pass invocation hung with no output and no diff after several minutes, so Hermes killed it and completed the same runbook directly.