### PR TITLE
Gate /api/v1/* on app_metadata.api_access + global error toaster

### DIFF
--- a/app/api/v1/__tests__/routes.test.ts
+++ b/app/api/v1/__tests__/routes.test.ts
@@ -50,7 +50,10 @@ function makeRequest(
 describe("API routes", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		mockGetUser.mockResolvedValue({ id: "user-1" });
+		mockGetUser.mockResolvedValue({
+			id: "user-1",
+			app_metadata: { api_access: true },
+		});
 		mockCreateJob.mockResolvedValue({ id: "job-abc" });
 		mockEnqueueJob.mockResolvedValue(undefined);
 	});

--- a/app/api/v1/tts/voices/preview/route.ts
+++ b/app/api/v1/tts/voices/preview/route.ts
@@ -1,14 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getUser } from "@/lib/api/auth";
-import { logger } from "@/lib/api/logger";
 import { getTTSProvider } from "@/lib/api/providers";
-import { badRequest, serverError, unauthorized } from "@/lib/api/response";
+import { badRequest } from "@/lib/api/response";
+import { withAuth } from "@/lib/api/with-auth";
 
 export async function GET(request: NextRequest) {
-	try {
-		const user = await getUser();
-		if (!user) return unauthorized();
-
+	return withAuth("Voice preview fetch", async () => {
 		const url = request.nextUrl.searchParams.get("url");
 		if (!url) return badRequest("Missing url");
 
@@ -27,8 +23,5 @@ export async function GET(request: NextRequest) {
 				"Cache-Control": "public, max-age=3600",
 			},
 		});
-	} catch (error) {
-		logger.error(error, "Voice preview fetch failed");
-		return serverError("Voice preview fetch failed");
-	}
+	});
 }

--- a/app/api/v1/tts/voices/route.ts
+++ b/app/api/v1/tts/voices/route.ts
@@ -1,24 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getUser } from "@/lib/api/auth";
-import { logger } from "@/lib/api/logger";
 import { getTTSProvider } from "@/lib/api/providers";
-import { serverError, unauthorized } from "@/lib/api/response";
+import { withAuth } from "@/lib/api/with-auth";
 import { voiceSearchParamsSchema } from "@/lib/project/types";
 
 export async function GET(request: NextRequest) {
-	try {
-		const user = await getUser();
-		if (!user) return unauthorized();
-
+	return withAuth("Voice search", async () => {
 		const params = voiceSearchParamsSchema.parse(
 			Object.fromEntries(request.nextUrl.searchParams),
 		);
-
 		const voices = await getTTSProvider().search(params);
-
 		return NextResponse.json({ voices });
-	} catch (error) {
-		logger.error(error, "Voice search failed");
-		return serverError("Voice search failed");
-	}
+	});
 }

--- a/app/components/GlobalErrorToaster.tsx
+++ b/app/components/GlobalErrorToaster.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { toast } from "sonner";
+import { stringifyError } from "@/lib/errors";
+
+export function GlobalErrorToaster() {
+	useEffect(() => {
+		const onRejection = (e: PromiseRejectionEvent) => {
+			toast.error(stringifyError(e.reason));
+		};
+		const onError = (e: ErrorEvent) => {
+			toast.error(stringifyError(e.error ?? e.message));
+		};
+		window.addEventListener("unhandledrejection", onRejection);
+		window.addEventListener("error", onError);
+		return () => {
+			window.removeEventListener("unhandledrejection", onRejection);
+			window.removeEventListener("error", onError);
+		};
+	}, []);
+
+	return null;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,8 @@ import { Geist, Instrument_Serif } from "next/font/google";
 import { Toaster } from "sonner";
 import "./globals.css";
 import BackgroundGradientAnimation from "./components/BackgroundGradientAnimation";
+import { GlobalErrorToaster } from "./components/GlobalErrorToaster";
+import { ToastErrorBoundary } from "./components/ToastErrorBoundary";
 
 const geistSans = Geist({
 	variable: "--font-geist-sans",
@@ -51,7 +53,10 @@ export default function RootLayout({
 			>
 				<BackgroundGradientAnimation />
 
-				<div className="relative">{children}</div>
+				<div className="relative">
+					<ToastErrorBoundary>{children}</ToastErrorBoundary>
+				</div>
+				<GlobalErrorToaster />
 				<Toaster theme="dark" position="bottom-center" richColors />
 			</body>
 		</html>

--- a/lib/api/__tests__/route-handler.test.ts
+++ b/lib/api/__tests__/route-handler.test.ts
@@ -12,7 +12,10 @@ vi.mock("../auth", () => ({
 }));
 
 beforeEach(() => {
-	mockGetUser.mockResolvedValue({ id: "user-1" });
+	mockGetUser.mockResolvedValue({
+		id: "user-1",
+		app_metadata: { api_access: true },
+	});
 });
 
 function makeRequest(body: unknown) {
@@ -102,7 +105,7 @@ describe("createRouteHandler", () => {
 
 		expect(handle).toHaveBeenCalledWith(
 			expect.objectContaining({
-				user: { id: "user-1" },
+				user: expect.objectContaining({ id: "user-1" }),
 				body: expect.objectContaining({ prompt: "hello", model: "slug-a" }),
 			}),
 		);

--- a/lib/api/response.ts
+++ b/lib/api/response.ts
@@ -11,3 +11,13 @@ export function serverError(message: string) {
 export function unauthorized() {
 	return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 }
+
+export function forbidden() {
+	return NextResponse.json(
+		{
+			error: `Forbidden, your API access has been revoked.
+		Please contact hi@openslop.ai or post on our Discord server for help.`,
+		},
+		{ status: 403 },
+	);
+}

--- a/lib/api/with-auth.ts
+++ b/lib/api/with-auth.ts
@@ -2,7 +2,7 @@ import type { User } from "@supabase/supabase-js";
 import { stringifyError } from "../errors";
 import { getUser } from "./auth";
 import { logger } from "./logger";
-import { serverError, unauthorized } from "./response";
+import { forbidden, serverError, unauthorized } from "./response";
 
 // Wraps a route handler with auth + a uniform error envelope. The handler only
 // runs for authenticated users; thrown errors are logged and returned as 500.
@@ -13,6 +13,7 @@ export async function withAuth(
 	try {
 		const user = await getUser();
 		if (!user) return unauthorized();
+		if (!user.app_metadata?.api_access) return forbidden();
 		return await run(user);
 	} catch (error) {
 		logger.error(error, `${label} failed`);


### PR DESCRIPTION
## Summary
- Users were bypassing the invite-code landing by signing in with Google OAuth and gaining full access to internal `/api/v1/*` endpoints. `withAuth` now also requires `user.app_metadata.api_access === true`, returning 403 with a contact message when missing. Access is toggled manually per user via SQL against `auth.users.raw_app_meta_data` — no new tables, no extra queries. Designed to be cheap to delete when the proper onboarding lands.
- Migrated `/api/v1/tts/voices` and `/api/v1/tts/voices/preview` from inline `getUser()` to `withAuth` so the gate applies uniformly.
- Frontend: mounted the existing `ToastErrorBoundary` at the root layout, plus a new `GlobalErrorToaster` client component that listens for `unhandledrejection`/`error` events and surfaces them via the existing sonner Toaster. The new 403 message reaches the user instead of getting swallowed.

## Granting access
```sql
update auth.users
set raw_app_meta_data = coalesce(raw_app_meta_data, '{}'::jsonb) || '{"api_access": true}'::jsonb
where email = 'approved@example.com';
```
User must refresh their session for the new claim to land in the JWT.

## Test plan
- [ ] Sign in as a non-allowlisted user via Google OAuth, hit any `/api/v1/*` route, confirm 403 + toast with contact message
- [ ] Run the SQL above for that user, refresh session, confirm normal 2xx
- [ ] Hit `/api/v1/*` with no session, confirm 401 (not collapsed into 403)
- [ ] Confirm `/api/v1/tts/voices` and `/api/v1/tts/voices/preview` also gate correctly
- [ ] Throw a sample error from a client event handler, confirm `GlobalErrorToaster` surfaces it
- [ ] CI: lint, format, typecheck, 792 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)