### PR TITLE
fix: nightly bug fixes 2026-06-10

### DIFF
--- a/lib/generation/__tests__/queue.test.ts
+++ b/lib/generation/__tests__/queue.test.ts
@@ -11,6 +11,21 @@ vi.mock("../generateForElement", () => ({
 	generateForElement: (...args: unknown[]) => generateMock(...args),
 }));
 
+vi.mock("../getGenerationInputs", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../getGenerationInputs")>();
+	return {
+		getGenerationInputs: (
+			...args: Parameters<typeof actual.getGenerationInputs>
+		) =>
+			getInputsMock
+				? getInputsMock(...args)
+				: actual.getGenerationInputs(...args),
+	};
+});
+
+let getInputsMock: ((...args: unknown[]) => GenerationInputs) | null = null;
+
 function makeElement(
 	id: string,
 	inputs: GenerationInputs,
@@ -52,6 +67,7 @@ describe("GenerationQueue", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
 		generateMock = vi.fn();
+		getInputsMock = null;
 		generationQueue = new GenerationQueue({ batchSize: 3 });
 	});
 
@@ -213,6 +229,60 @@ describe("GenerationQueue", () => {
 			expect(generationQueue.getElementSnapshot("err2").error).toBe(
 				"string error",
 			);
+		});
+
+		it("fails loudly when input computation throws synchronously", () => {
+			const consoleError = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			getInputsMock = () => {
+				throw new Error("bad inputs");
+			};
+
+			generationQueue.enqueue(makeJob("sync-err"));
+
+			const snap = generationQueue.getElementSnapshot("sync-err");
+			expect(snap.status).toBe("idle");
+			expect(snap.result).toBeNull();
+			expect(snap.error).toBe("bad inputs");
+			expect(generateMock).not.toHaveBeenCalled();
+
+			consoleError.mockRestore();
+		});
+
+		it("releases the batch slot so queued jobs proceed when inputs throw", () => {
+			const consoleError = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			generateMock.mockReturnValue(new Promise(() => {}));
+			// First job's input computation throws; the rest are valid.
+			getInputsMock = (element: unknown) => {
+				if ((element as { id: string }).id === "leak1") {
+					throw new Error("bad inputs");
+				}
+				return { prompt: "ok", attributes: {} };
+			};
+
+			generationQueue.enqueueAll([
+				makeJob("leak1"),
+				makeJob("leak2"),
+				makeJob("leak3"),
+				makeJob("leak4"),
+			]);
+
+			// leak1 failed synchronously, freeing its slot, so leak4 promotes
+			// instead of being stuck behind a leaked controller.
+			expect(generationQueue.getElementSnapshot("leak1").error).toBe(
+				"bad inputs",
+			);
+			expect(generationQueue.getElementSnapshot("leak4").status).toBe(
+				"generating",
+			);
+
+			generationQueue.discard("leak2");
+			generationQueue.discard("leak3");
+			generationQueue.discard("leak4");
+			consoleError.mockRestore();
 		});
 	});
 

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -278,8 +278,16 @@ export class GenerationQueue {
 		this.notify();
 		this.startElapsedTimer(elementId);
 
-		const { metadata } = getProjectStore(job.projectId).getState();
-		const inputs = getGenerationInputs(job.element, metadata);
+		let inputs: GenerationInputs;
+		try {
+			const { metadata } = getProjectStore(job.projectId).getState();
+			inputs = getGenerationInputs(job.element, metadata);
+		} catch (err) {
+			this.handleJobError(elementId, err, controller);
+			this.finalizeJob(elementId, controller);
+			return;
+		}
+
 		generateForElement(job, inputs)
 			.then((result) => this.handleJobSuccess(job, inputs, result, controller))
 			.catch((err) => this.handleJobError(elementId, err, controller))


### PR DESCRIPTION
## Summary
- Routes synchronous generation input-computation failures through the queue's normal job error/finalization path.
- Prevents malformed/stale element input data from leaving an item stuck in `generating` or leaking a batch slot.
- Adds regression coverage for fail-loud error state and queued-job promotion after a synchronous input failure.

## Bugs fixed
- `getGenerationInputs()` could throw before `generateForElement()` attached its async `.catch()`/`.finally()` handling. That left the job marked `generating`, kept its abort controller registered, and could block later jobs in the same batch. The queue now reports the error on the element and finalizes the job so the batch can continue.

## Tests added
- `lib/generation/__tests__/queue.test.ts`: verifies synchronous input-computation failures set the element back to idle with an actionable error and never call the generator.
- `lib/generation/__tests__/queue.test.ts`: verifies a failed synchronous input computation releases the batch slot so queued jobs continue.

## Open PR overlap check
- Considered open PRs immediately before implementation and before commit: none were open.
- This PR only touches generation queue error handling and generation queue tests, so it is non-overlapping.

## Validation
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm test -- --passWithNoTests` (89 files / 796 tests)
- [x] `npm run test:run` (89 files / 796 tests)
- [x] `npm run build`

## Skipped items
- Left investigated but speculative candidates untouched (`String(undefined)` cache keys, voice similarity fallback behavior, OAuth catch handling, and script op path edge cases) because this run only changes verified correctness bugs with focused regression tests.