### PR TITLE
perf: nightly performance optimizations 2026-06-10

### DIFF
--- a/app/components/video/PlayerControls.tsx
+++ b/app/components/video/PlayerControls.tsx
@@ -6,6 +6,7 @@ import type { VideoLayout } from "@/lib/video/types";
 import { scrollToScene } from "@/app/components/canvas/utils/scrollToScene";
 import { formatTime } from "@/lib/video/timestamps";
 import {
+	FRAME_EVENTS,
 	usePlayerMuted,
 	usePlayerPlaying,
 	usePlayerValue,
@@ -106,7 +107,7 @@ function TimeDisplay({
 }) {
 	const seconds = usePlayerValue(
 		player,
-		["frameupdate"],
+		FRAME_EVENTS,
 		(p) => Math.floor(p.getCurrentFrame() / layout.fps),
 		0,
 	);

--- a/app/components/video/VideoPreview.tsx
+++ b/app/components/video/VideoPreview.tsx
@@ -10,7 +10,7 @@ import { PlayerControls } from "./PlayerControls";
 import { PlayPauseFlash } from "./PlayPauseFlash";
 import { useActiveSceneSync } from "./useActiveSceneSync";
 import { useControlsVisibility } from "./useControlsVisibility";
-import { usePlayerValue } from "./usePlayerState";
+import { FRAME_EVENTS, usePlayerValue } from "./usePlayerState";
 import { findSegmentIndexAt, useSceneSegments } from "./useSceneSegments";
 import styles from "./VideoPlayer.module.css";
 
@@ -58,7 +58,7 @@ export function VideoPreview({ layout }: { layout: VideoLayout }) {
 	const segments = useSceneSegments();
 	const activeIndex = usePlayerValue(
 		player,
-		["frameupdate"],
+		FRAME_EVENTS,
 		(p) => findSegmentIndexAt(segments, p.getCurrentFrame() / layout.fps),
 		-1,
 	);

--- a/app/components/video/usePlayerState.ts
+++ b/app/components/video/usePlayerState.ts
@@ -1,5 +1,5 @@
 import type { PlayerRef } from "@remotion/player";
-import { useSyncExternalStore } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 type PlayerEvent =
 	| "frameupdate"
@@ -8,37 +8,46 @@ type PlayerEvent =
 	| "volumechange"
 	| "mutechange";
 
+export const FRAME_EVENTS: readonly PlayerEvent[] = ["frameupdate"];
+const PLAY_EVENTS: readonly PlayerEvent[] = ["play", "pause"];
+const VOLUME_EVENTS: readonly PlayerEvent[] = ["volumechange"];
+const MUTE_EVENTS: readonly PlayerEvent[] = ["mutechange"];
+
 export function usePlayerValue<T>(
 	player: PlayerRef | null,
-	events: PlayerEvent[],
+	events: readonly PlayerEvent[],
 	read: (p: PlayerRef) => T,
 	fallback: T,
 ): T {
-	return useSyncExternalStore(
-		(notify) => {
+	const subscribe = useCallback(
+		(notify: () => void) => {
 			if (!player) return () => {};
 			for (const event of events) player.addEventListener(event, notify);
 			return () => {
 				for (const event of events) player.removeEventListener(event, notify);
 			};
 		},
+		[player, events],
+	);
+	return useSyncExternalStore(
+		subscribe,
 		() => (player ? read(player) : fallback),
 		() => fallback,
 	);
 }
 
 export function usePlayerFrame(player: PlayerRef | null) {
-	return usePlayerValue(player, ["frameupdate"], (p) => p.getCurrentFrame(), 0);
+	return usePlayerValue(player, FRAME_EVENTS, (p) => p.getCurrentFrame(), 0);
 }
 
 export function usePlayerPlaying(player: PlayerRef | null) {
-	return usePlayerValue(player, ["play", "pause"], (p) => p.isPlaying(), false);
+	return usePlayerValue(player, PLAY_EVENTS, (p) => p.isPlaying(), false);
 }
 
 export function usePlayerVolume(player: PlayerRef | null) {
-	return usePlayerValue(player, ["volumechange"], (p) => p.getVolume(), 1);
+	return usePlayerValue(player, VOLUME_EVENTS, (p) => p.getVolume(), 1);
 }
 
 export function usePlayerMuted(player: PlayerRef | null) {
-	return usePlayerValue(player, ["mutechange"], (p) => p.isMuted(), false);
+	return usePlayerValue(player, MUTE_EVENTS, (p) => p.isMuted(), false);
 }


### PR DESCRIPTION
## Summary
- Stabilizes Remotion player event subscriptions by reusing shared event arrays for frame/playback/volume listeners.
- Memoizes `usePlayerValue`'s `subscribe` callback so `useSyncExternalStore` does not tear down and recreate player listeners on every render.
- Applies the stable frame event constant to the active-scene and time-display frame-driven consumers.

## Why it matters
During playback, Remotion emits `frameupdate` every frame. The seek progress, active-scene tracking, and time display all re-render from that signal. Previously each render recreated the `subscribe` function and inline event arrays, which made `useSyncExternalStore` unsubscribe and resubscribe player listeners on every frame. This keeps the same event semantics while eliminating that listener churn in the playback hot path.

## Open PR overlap check
- Considered open PR #219 (`fix: nightly bug fixes 2026-06-10`), which touches `lib/generation/queue.ts` and `lib/generation/__tests__/queue.test.ts`.
- This PR only touches `app/components/video/*` player subscription code, so it does not overlap #219's generation queue workflow/files.

## Skipped
- Slate.js canvas/editor changes: reviewed but skipped because recent Slate work already covered selection-only state churn, and no further high-confidence runtime win was found without behavior/structure risk.
- Generation queue work: skipped due to open PR #219 overlap guard.
- Bundle/lazy-load churn: skipped because this runbook is runtime UX-first and this Remotion/player frame path is a clearer in-app responsiveness win.
- Speculative abstractions or library removals: skipped per recent feedback to avoid marginal or overengineered nightly PRs.

## Validation
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test -- --passWithNoTests` (89 files / 794 tests)
- [x] Independent pre-commit review: no behavior, hook-dependency, TypeScript, or security issues found.
