### PR TITLE
refactor: make missing context providers fail loudly

### DIFF
--- a/app/components/canvas/PreviewCacheContext.tsx
+++ b/app/components/canvas/PreviewCacheContext.tsx
@@ -1,16 +1,15 @@
 "use client";
 
-import { createContext, useContext, useState, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
+import { createRequiredContext } from "@/lib/components/createRequiredContext";
 
 type PeaksCache = Map<string, number[]>;
 
-const PreviewCacheContext = createContext<PeaksCache>(new Map());
+const [PreviewCacheContext, usePreviewCache] =
+	createRequiredContext<PeaksCache>("PreviewCacheContext");
+export { usePreviewCache };
 
 export function PreviewCacheProvider({ children }: { children: ReactNode }) {
 	const [cache] = useState(() => new Map<string, number[]>());
 	return <PreviewCacheContext value={cache}>{children}</PreviewCacheContext>;
-}
-
-export function usePreviewCache() {
-	return useContext(PreviewCacheContext);
 }

--- a/app/components/canvas/ViewModeContext.tsx
+++ b/app/components/canvas/ViewModeContext.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import {
-	createContext,
 	useCallback,
-	useContext,
 	useEffect,
 	useMemo,
 	useRef,
 	useState,
 	type ReactNode,
 } from "react";
+import { createRequiredContext } from "@/lib/components/createRequiredContext";
 
 type ViewModeValue = {
 	isCollapsed: (sceneId: string) => boolean;
@@ -19,13 +18,9 @@ type ViewModeValue = {
 	collapseAll: () => void;
 };
 
-const ViewModeContext = createContext<ViewModeValue>({
-	isCollapsed: () => false,
-	hasCollapsed: false,
-	toggle: () => {},
-	expandAll: () => {},
-	collapseAll: () => {},
-});
+const [ViewModeContext, useViewMode] =
+	createRequiredContext<ViewModeValue>("ViewModeContext");
+export { useViewMode };
 
 export function ViewModeProvider({
 	sceneIds,
@@ -73,8 +68,4 @@ export function ViewModeProvider({
 	);
 
 	return <ViewModeContext value={value}>{children}</ViewModeContext>;
-}
-
-export function useViewMode() {
-	return useContext(ViewModeContext);
 }

--- a/app/components/scene-selection/ActiveSceneContext.tsx
+++ b/app/components/scene-selection/ActiveSceneContext.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { createContext, use, useState, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
+import { createRequiredContext } from "@/lib/components/createRequiredContext";
 
-const ValueContext = createContext<string | null>(null);
-const SetterContext = createContext<(id: string | null) => void>(() => {});
+const [ValueContext, useActiveSceneId] = createRequiredContext<string | null>(
+	"ActiveSceneValueContext",
+);
+const [SetterContext, useSetActiveSceneId] = createRequiredContext<
+	(id: string | null) => void
+>("ActiveSceneSetterContext");
+export { useActiveSceneId, useSetActiveSceneId };
 
 export function ActiveSceneProvider({ children }: { children: ReactNode }) {
 	const [id, setId] = useState<string | null>(null);
@@ -12,12 +18,4 @@ export function ActiveSceneProvider({ children }: { children: ReactNode }) {
 			<ValueContext value={id}>{children}</ValueContext>
 		</SetterContext>
 	);
-}
-
-export function useActiveSceneId() {
-	return use(ValueContext);
-}
-
-export function useSetActiveSceneId() {
-	return use(SetterContext);
 }

--- a/app/components/video/PlayerControlContext.tsx
+++ b/app/components/video/PlayerControlContext.tsx
@@ -1,14 +1,8 @@
 "use client";
 
 import type { PlayerRef } from "@remotion/player";
-import {
-	createContext,
-	use,
-	useCallback,
-	useMemo,
-	useRef,
-	type ReactNode,
-} from "react";
+import { useCallback, useMemo, useRef, type ReactNode } from "react";
+import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { usePlayerPosition } from "./PlayerPositionContext";
 
 type PlayerControl = {
@@ -16,10 +10,10 @@ type PlayerControl = {
 	playFromFrame: (frame: number) => void;
 };
 
-const Ctx = createContext<PlayerControl>({
-	registerPlayer: () => {},
-	playFromFrame: () => {},
-});
+const [Ctx, usePlayerControl] = createRequiredContext<PlayerControl>(
+	"PlayerControlContext",
+);
+export { usePlayerControl };
 
 export function PlayerControlProvider({ children }: { children: ReactNode }) {
 	const playerRef = useRef<PlayerRef | null>(null);
@@ -44,8 +38,4 @@ export function PlayerControlProvider({ children }: { children: ReactNode }) {
 	);
 
 	return <Ctx value={value}>{children}</Ctx>;
-}
-
-export function usePlayerControl() {
-	return use(Ctx);
 }

--- a/app/components/video/PlayerPositionContext.tsx
+++ b/app/components/video/PlayerPositionContext.tsx
@@ -1,34 +1,22 @@
 "use client";
 
-import {
-	createContext,
-	useCallback,
-	useContext,
-	useEffect,
-	useState,
-	type ReactNode,
-} from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { createRequiredContext } from "@/lib/components/createRequiredContext";
 
 export type PlayerPosition = "top" | "right";
 
 const NARROW_BREAKPOINT = 1066;
 const NARROW_QUERY = `(max-width: ${NARROW_BREAKPOINT}px)`;
 
-const PlayerPositionContext = createContext<{
+const [PlayerPositionContext, usePlayerPosition] = createRequiredContext<{
 	position: PlayerPosition;
 	visible: boolean;
 	setPosition: (position: PlayerPosition) => void;
 	setVisible: (visible: boolean) => void;
 	showPlayer: () => void;
 	narrowViewport: boolean;
-}>({
-	position: "top",
-	visible: false,
-	setPosition: () => {},
-	setVisible: () => {},
-	showPlayer: () => {},
-	narrowViewport: false,
-});
+}>("PlayerPositionContext");
+export { usePlayerPosition };
 
 export function PlayerPositionProvider({ children }: { children: ReactNode }) {
 	const [position, setPosition] = useState<PlayerPosition>("right");
@@ -64,8 +52,4 @@ export function PlayerPositionProvider({ children }: { children: ReactNode }) {
 			{children}
 		</PlayerPositionContext>
 	);
-}
-
-export function usePlayerPosition() {
-	return useContext(PlayerPositionContext);
 }

--- a/app/components/video/VideoLayoutContext.tsx
+++ b/app/components/video/VideoLayoutContext.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { createContext, use, useMemo, type ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 import type { Editor } from "slate";
 import type { SceneElement } from "@/lib/canvas/types";
+import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
 import type { AspectRatio } from "@/lib/video/aspectRatio";
 import type { TransitionType } from "@/lib/video/transitions";
@@ -17,12 +18,9 @@ type VideoLayoutValue = {
 	scenes: SceneElement[];
 };
 
-const VideoLayoutContext = createContext<VideoLayoutValue>({
-	layout: null,
-	ready: false,
-	playerKey: "",
-	scenes: [],
-});
+const [VideoLayoutContext, useLayout] =
+	createRequiredContext<VideoLayoutValue>("VideoLayoutContext");
+export { useLayout };
 
 export function VideoLayoutProvider({
 	editor,
@@ -51,8 +49,4 @@ export function VideoLayoutProvider({
 		[layout, ready, playerKey, scenes],
 	);
 	return <VideoLayoutContext value={value}>{children}</VideoLayoutContext>;
-}
-
-export function useLayout() {
-	return use(VideoLayoutContext);
 }

--- a/lib/components/createRequiredContext.ts
+++ b/lib/components/createRequiredContext.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { createContext, use } from "react";
+
+// undefined is the missing-provider sentinel so contexts may legitimately hold null
+export function createRequiredContext<T>(name: string) {
+	const Context = createContext<T | undefined>(undefined);
+	Context.displayName = name;
+
+	function useRequiredContext(): T {
+		const value = use(Context);
+		if (value === undefined) {
+			throw new Error(`${name} is missing a provider`);
+		}
+		return value;
+	}
+
+	return [Context, useRequiredContext] as const;
+}

--- a/lib/generation/GenerationQueueProvider.tsx
+++ b/lib/generation/GenerationQueueProvider.tsx
@@ -1,30 +1,21 @@
 "use client";
 
 import {
-	createContext,
-	use,
 	useEffect,
 	useState,
 	useSyncExternalStore,
 	type ReactNode,
 } from "react";
+import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import {
 	DEFAULT_BATCH_SIZE,
 	GenerationQueue,
 	type ElementSnapshot,
 } from "./queue";
 
-const GenerationQueueContext = createContext<GenerationQueue | null>(null);
-
-export function useGenerationQueue(): GenerationQueue {
-	const queue = use(GenerationQueueContext);
-	if (!queue) {
-		throw new Error(
-			"useGenerationQueue must be used within a GenerationQueueProvider",
-		);
-	}
-	return queue;
-}
+const [GenerationQueueContext, useGenerationQueue] =
+	createRequiredContext<GenerationQueue>("GenerationQueueContext");
+export { useGenerationQueue };
 
 export function useQueueSelector<T>(
 	selector: (queue: GenerationQueue) => T,
@@ -53,8 +44,6 @@ export function GenerationQueueProvider({
 	);
 	useEffect(() => () => queue.cancelAll(), [queue]);
 	return (
-		<GenerationQueueContext.Provider value={queue}>
-			{children}
-		</GenerationQueueContext.Provider>
+		<GenerationQueueContext value={queue}>{children}</GenerationQueueContext>
 	);
 }


### PR DESCRIPTION
## Summary
- Adds a ~18-line `createRequiredContext<T>(name)` helper (`lib/components/createRequiredContext.ts`) whose hook throws when no provider is mounted, using `undefined` as the sentinel so contexts may legitimately hold `null`
- Migrates 7 contexts off silent no-op defaults: PlayerControl, PlayerPosition, VideoLayout, ViewMode, ActiveScene, PreviewCache, and GenerationQueueProvider (which drops its hand-rolled guard for the shared helper)
- Previously, a consumer rendered outside its provider silently did nothing (no-op setters, fake empty layout); now it throws immediately — net −36 lines

All consumers were statically verified to render inside their providers (PostPromptView and Canvas provider trees), so no behavior changes in the normal flow.

## Test plan
- [x] `npm run lint`, typecheck pass
- [x] `npm run test:run` — 794 tests pass
- [x] Browser smoke test on dev server: opened a project, toggled player position (Top/Right), collapse/expand all scenes, play-from-here — player renders and plays, zero context errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)