### PR TITLE
chore(prompts): never emit ALL-CAPS for TTS

### DIFF
--- a/lib/connectors/__tests__/osml.test.ts
+++ b/lib/connectors/__tests__/osml.test.ts
@@ -15,4 +15,11 @@ describe("osmlPlugin", () => {
 		const result = beforeGenerate({ prompt: "hello", systemPrompt: "custom" });
 		expect((result as { systemPrompt: string }).systemPrompt).toBe("custom");
 	});
+
+	it("pins the no-all-caps TTS rule (single source for script and story modes)", () => {
+		const result = beforeGenerate({ prompt: "hello" });
+		expect((result as { systemPrompt: string }).systemPrompt).toContain(
+			"ALL CAPS",
+		);
+	});
 });

--- a/lib/connectors/__tests__/script-mode.test.ts
+++ b/lib/connectors/__tests__/script-mode.test.ts
@@ -38,7 +38,8 @@ describe("scriptModePlugin", () => {
 	it("includes key instructions in system prompt", () => {
 		const result = beforeGenerate({ prompt: "x" });
 		const sys = (result as { systemPrompt: string }).systemPrompt;
-		expect(sys).toContain("ALL CAPS");
+		// The all-caps rule now lives solely in the OSML prompt (always present in
+		// script mode), so it is no longer duplicated here.
 		expect(sys).toContain("stage directions");
 	});
 });

--- a/lib/connectors/__tests__/script-mode.test.ts
+++ b/lib/connectors/__tests__/script-mode.test.ts
@@ -38,8 +38,6 @@ describe("scriptModePlugin", () => {
 	it("includes key instructions in system prompt", () => {
 		const result = beforeGenerate({ prompt: "x" });
 		const sys = (result as { systemPrompt: string }).systemPrompt;
-		// The all-caps rule now lives solely in the OSML prompt (always present in
-		// script mode), so it is no longer duplicated here.
 		expect(sys).toContain("stage directions");
 	});
 });

--- a/lib/connectors/llm/plugins/osml.ts
+++ b/lib/connectors/llm/plugins/osml.ts
@@ -17,7 +17,7 @@ const OSML_SYSTEM_PROMPT = dedent`
 	The story script must be written in a special XML format that strictly follows these rules: 
 
   ## **General Guidelines**
-  - Never write any words in ALL CAPS within narration or character (dialogue) text, EXCEPT common acronyms or initialisms (e.g. USA, FBI, NASA, CEO) which must stay capitalized so the TTS engine spells them out correctly. This text is read aloud by a TTS engine, and all-caps regular words are mispronounced. Convey emphasis through word choice or punctuation, never capitalization.
+  - Never write words in ALL CAPS in narration or dialogue — the TTS engine mispronounces them. Acronyms (USA, FBI, NASA) stay capitalized; convey emphasis through word choice or punctuation.
   - Descriptions in image tags are opaque to the reader, so the narrative prose should include some details that are only in the image tags.
 
   ## **XML Tagging**

--- a/lib/connectors/llm/plugins/osml.ts
+++ b/lib/connectors/llm/plugins/osml.ts
@@ -17,7 +17,7 @@ const OSML_SYSTEM_PROMPT = dedent`
 	The story script must be written in a special XML format that strictly follows these rules: 
 
   ## **General Guidelines**
-  - Never write any words in ALL CAPS within narration or character (dialogue) text. This text is read aloud by a TTS engine, and all-caps words are mispronounced. Convey emphasis through word choice or punctuation, never capitalization.
+  - Never write any words in ALL CAPS within narration or character (dialogue) text, EXCEPT common acronyms or initialisms (e.g. USA, FBI, NASA, CEO) which must stay capitalized so the TTS engine spells them out correctly. This text is read aloud by a TTS engine, and all-caps regular words are mispronounced. Convey emphasis through word choice or punctuation, never capitalization.
   - Descriptions in image tags are opaque to the reader, so the narrative prose should include some details that are only in the image tags.
 
   ## **XML Tagging**

--- a/lib/connectors/llm/plugins/osml.ts
+++ b/lib/connectors/llm/plugins/osml.ts
@@ -17,7 +17,7 @@ const OSML_SYSTEM_PROMPT = dedent`
 	The story script must be written in a special XML format that strictly follows these rules: 
 
   ## **General Guidelines**
-  - For text within narration and character tags, never write any words in ALL CAPS.
+  - Never write any words in ALL CAPS within narration or character (dialogue) text. This text is read aloud by a TTS engine, and all-caps words are mispronounced. Convey emphasis through word choice or punctuation, never capitalization.
   - Descriptions in image tags are opaque to the reader, so the narrative prose should include some details that are only in the image tags.
 
   ## **XML Tagging**

--- a/lib/connectors/llm/plugins/script-mode.ts
+++ b/lib/connectors/llm/plugins/script-mode.ts
@@ -11,7 +11,7 @@ const SCRIPT_MODE_SYSTEM_PROMPT = dedent`
 
   ### Miscellaneous Rules
   - Omit non-narrative text from the final output like stage directions (e.g. CONT'd), character names, etc.
-  - Convert any words in ALL CAPS to regular case.
+  - Convert any words in ALL CAPS to regular sentence case, including words the source script capitalized for emphasis. All-caps text is mispronounced by the TTS engine, so this applies to all dialogue and narration.
   - Never add dialogue or narrative text to the story that is not in the original script.
 `;
 

--- a/lib/connectors/llm/plugins/script-mode.ts
+++ b/lib/connectors/llm/plugins/script-mode.ts
@@ -11,7 +11,7 @@ const SCRIPT_MODE_SYSTEM_PROMPT = dedent`
 
   ### Miscellaneous Rules
   - Omit non-narrative text from the final output like stage directions (e.g. CONT'd), character names, etc.
-  - Convert any words in ALL CAPS to regular sentence case, including words the source script capitalized for emphasis. All-caps text is mispronounced by the TTS engine, so this applies to all dialogue and narration.
+  - Convert any words in ALL CAPS to regular sentence case, including words the source script capitalized for emphasis, EXCEPT common acronyms or initialisms (e.g. USA, FBI, NASA, CEO) which must stay capitalized so the TTS engine spells them out correctly. All-caps regular words are mispronounced by the TTS engine, so this applies to all dialogue and narration.
   - Never add dialogue or narrative text to the story that is not in the original script.
 `;
 

--- a/lib/connectors/llm/plugins/script-mode.ts
+++ b/lib/connectors/llm/plugins/script-mode.ts
@@ -11,7 +11,6 @@ const SCRIPT_MODE_SYSTEM_PROMPT = dedent`
 
   ### Miscellaneous Rules
   - Omit non-narrative text from the final output like stage directions (e.g. CONT'd), character names, etc.
-  - Convert any words in ALL CAPS to regular sentence case, including words the source script capitalized for emphasis, EXCEPT common acronyms or initialisms (e.g. USA, FBI, NASA, CEO) which must stay capitalized so the TTS engine spells them out correctly. All-caps regular words are mispronounced by the TTS engine, so this applies to all dialogue and narration.
   - Never add dialogue or narrative text to the story that is not in the original script.
 `;
 


### PR DESCRIPTION
All-caps words are mispronounced by the TTS engine (spelled out letter by letter or mis-stressed). This strengthens the OSML and paste-your-own-script prompts to forbid ALL-CAPS in narration/character text and convert emphasis to sentence case.