### PR TITLE
Surface avatar staleness with durable signal + manual regen

### DIFF
--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ImagePlus, Loader2, Trash2 } from "lucide-react";
+import { ImagePlus, Loader2, Trash2, X } from "lucide-react";
 import {
 	DialogContent,
 	DialogDescription,
@@ -20,13 +20,11 @@ import {
 	useGenerationQueue,
 	useQueueSelector,
 } from "@/lib/generation/GenerationQueueProvider";
-import { getGenerationInputs } from "@/lib/generation/getGenerationInputs";
-import { isStaleResult } from "@/lib/generation/queue";
 import {
 	buildCharacterAvatarJob,
-	characterAvatarElement,
 	characterAvatarElementId,
 } from "@/lib/project/ensureCharacterAvatars";
+import { isAvatarStale } from "@/lib/project/avatarInputs";
 import { useProjectStore } from "@/lib/project/store";
 import type { MetadataCharacter } from "@/lib/project/types";
 import { useImageUpload } from "@/lib/upload/useImageUpload";
@@ -66,11 +64,14 @@ function CharacterEditDialogBody({
 	const { projectId, connectorConfig } = useConfig();
 	const queue = useGenerationQueue();
 	const metadata = useProjectStore(projectId, (s) => s.metadata);
+	const referenceImages = useProjectStore(projectId, (s) => s.referenceImages);
 	const character = metadata.characters[name];
 	const setCharacter = useProjectStore(projectId, (s) => s.setCharacter);
 	const removeCharacter = useProjectStore(projectId, (s) => s.removeCharacter);
 
 	const [confirmDelete, setConfirmDelete] = useState(false);
+	const [closeConfirm, setCloseConfirm] = useState(false);
+	const [leftStale, setLeftStale] = useState(false);
 
 	const avatarElementId = characterAvatarElementId(name);
 	const avatarSnapshot = useQueueSelector((q) =>
@@ -101,16 +102,17 @@ function CharacterEditDialogBody({
 		queue.enqueue(buildCharacterAvatarJob(projectId, name, connectorConfig));
 	};
 
+	// Stale = the generated avatar no longer matches its inputs. Durable across
+	// reloads (persisted signature), and suppressed while a regeneration is in
+	// flight.
 	const isStale =
-		!character.avatarUploaded &&
-		!!avatarSnapshot.result &&
-		isStaleResult(
-			avatarSnapshot,
-			getGenerationInputs(
-				characterAvatarElement(name, character.appearance),
-				metadata,
-			),
-		);
+		avatarSnapshot.status !== "generating" &&
+		isAvatarStale(character, metadata.style, referenceImages);
+
+	// While stale, intercept user-initiated closes (escape, outside-click, the X)
+	// to offer a regenerate before leaving. "Leave stale" opts out for this turn.
+	const blockClose = isStale && !leftStale;
+	const requestClose = () => (blockClose ? setCloseConfirm(true) : onClose());
 
 	const handleDelete = () => {
 		if (!confirmDelete) {
@@ -123,7 +125,30 @@ function CharacterEditDialogBody({
 	};
 
 	return (
-		<DialogContent className="max-w-2xl">
+		<DialogContent
+			className="relative max-w-2xl"
+			showCloseButton={false}
+			onEscapeKeyDown={(e) => {
+				if (blockClose) {
+					e.preventDefault();
+					setCloseConfirm(true);
+				}
+			}}
+			onInteractOutside={(e) => {
+				if (blockClose) {
+					e.preventDefault();
+					setCloseConfirm(true);
+				}
+			}}
+		>
+			<button
+				type="button"
+				onClick={requestClose}
+				aria-label="Close"
+				className="absolute right-3 top-3 z-10 rounded-md p-1 text-white/60 transition-colors hover:bg-white/10 hover:text-white focus:outline-none focus:ring-1 focus:ring-accent-violet/50"
+			>
+				<X className="h-4 w-4" />
+			</button>
 			<DialogHeader className="shrink-0">
 				<DialogTitle>{name}</DialogTitle>
 				<DialogDescription>
@@ -131,6 +156,21 @@ function CharacterEditDialogBody({
 					appearance.
 				</DialogDescription>
 			</DialogHeader>
+
+			{isStale && (
+				<div className="flex shrink-0 items-center justify-between gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2">
+					<span className="text-[12px] text-amber-100/90">
+						This avatar no longer matches the appearance.
+					</span>
+					<button
+						type="button"
+						onClick={regenerateAvatar}
+						className="shrink-0 rounded-md bg-accent-violet px-2.5 py-1 text-[12px] font-medium text-white shadow-glow transition hover:brightness-110"
+					>
+						Regenerate
+					</button>
+				</div>
+			)}
 
 			<div className="-mx-1 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-1">
 				<div className="grid gap-4 sm:grid-cols-2">
@@ -199,6 +239,49 @@ function CharacterEditDialogBody({
 					{confirmDelete ? "Confirm delete" : "Delete"}
 				</button>
 			</DialogFooter>
+
+			{closeConfirm && (
+				<div className="absolute inset-0 z-50 flex items-center justify-center rounded-lg bg-black/60 p-4 backdrop-blur-sm">
+					<div className="w-full max-w-sm rounded-xl border border-white/10 bg-[#141414] p-4 shadow-xl">
+						<p className="text-sm font-medium text-white/90">
+							Regenerate avatar before leaving?
+						</p>
+						<p className="mt-1 text-[12px] text-white/50">
+							The appearance changed, so {name}&apos;s avatar is out of date.
+							Your edits are already saved.
+						</p>
+						<div className="mt-4 flex items-center justify-end gap-2">
+							<button
+								type="button"
+								onClick={() => setCloseConfirm(false)}
+								className="rounded-md px-2.5 py-1 text-[12px] text-white/60 transition-colors hover:text-white"
+							>
+								Keep editing
+							</button>
+							<button
+								type="button"
+								onClick={() => {
+									setLeftStale(true);
+									onClose();
+								}}
+								className="rounded-md border border-white/10 px-2.5 py-1 text-[12px] text-white/70 transition-colors hover:bg-white/10"
+							>
+								Leave stale
+							</button>
+							<button
+								type="button"
+								onClick={() => {
+									regenerateAvatar();
+									onClose();
+								}}
+								className="rounded-md bg-accent-violet px-3 py-1 text-[12px] font-medium text-white shadow-glow transition hover:brightness-110"
+							>
+								Regenerate
+							</button>
+						</div>
+					</div>
+				</div>
+			)}
 		</DialogContent>
 	);
 }

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { ImagePlus, Loader2, Trash2, X } from "lucide-react";
 import {
 	DialogContent,
@@ -129,13 +130,15 @@ function CharacterEditDialogBody({
 			className="relative max-w-2xl"
 			showCloseButton={false}
 			onEscapeKeyDown={(e) => {
-				if (blockClose) {
+				// First press while stale: hold and ask. Once the prompt is up, a
+				// second press is the escape hatch — let it close.
+				if (blockClose && !closeConfirm) {
 					e.preventDefault();
 					setCloseConfirm(true);
 				}
 			}}
 			onInteractOutside={(e) => {
-				if (blockClose) {
+				if (blockClose && !closeConfirm) {
 					e.preventDefault();
 					setCloseConfirm(true);
 				}
@@ -240,48 +243,58 @@ function CharacterEditDialogBody({
 				</button>
 			</DialogFooter>
 
-			{closeConfirm && (
-				<div className="absolute inset-0 z-50 flex items-center justify-center rounded-lg bg-black/60 p-4 backdrop-blur-sm">
-					<div className="w-full max-w-sm rounded-xl border border-white/10 bg-[#141414] p-4 shadow-xl">
-						<p className="text-sm font-medium text-white/90">
-							Regenerate avatar before leaving?
-						</p>
-						<p className="mt-1 text-[12px] text-white/50">
-							The appearance changed, so {name}&apos;s avatar is out of date.
-							Your edits are already saved.
-						</p>
-						<div className="mt-4 flex items-center justify-end gap-2">
-							<button
-								type="button"
-								onClick={() => setCloseConfirm(false)}
-								className="rounded-md px-2.5 py-1 text-[12px] text-white/60 transition-colors hover:text-white"
-							>
-								Keep editing
-							</button>
-							<button
-								type="button"
-								onClick={() => {
-									setLeftStale(true);
-									onClose();
-								}}
-								className="rounded-md border border-white/10 px-2.5 py-1 text-[12px] text-white/70 transition-colors hover:bg-white/10"
-							>
-								Leave stale
-							</button>
-							<button
-								type="button"
-								onClick={() => {
-									regenerateAvatar();
-									onClose();
-								}}
-								className="rounded-md bg-accent-violet px-3 py-1 text-[12px] font-medium text-white shadow-glow transition hover:brightness-110"
-							>
-								Regenerate
-							</button>
+			{closeConfirm &&
+				typeof document !== "undefined" &&
+				createPortal(
+					<div
+						className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
+						onClick={() => setCloseConfirm(false)}
+					>
+						<div
+							className="w-full max-w-sm rounded-xl border border-white/10 bg-[#141414] p-4 shadow-xl"
+							onClick={(e) => e.stopPropagation()}
+						>
+							<p className="text-sm font-medium text-white/90">
+								Regenerate avatar before leaving?
+							</p>
+							<p className="mt-1 text-[12px] text-white/50">
+								The appearance changed, so {name}&apos;s avatar is out of date.
+								Your edits are already saved. Press Escape again to leave
+								anyway.
+							</p>
+							<div className="mt-4 flex items-center justify-end gap-2">
+								<button
+									type="button"
+									onClick={() => setCloseConfirm(false)}
+									className="rounded-md px-2.5 py-1 text-[12px] text-white/60 transition-colors hover:text-white"
+								>
+									Keep editing
+								</button>
+								<button
+									type="button"
+									onClick={() => {
+										setLeftStale(true);
+										onClose();
+									}}
+									className="rounded-md border border-white/10 px-2.5 py-1 text-[12px] text-white/70 transition-colors hover:bg-white/10"
+								>
+									Leave stale
+								</button>
+								<button
+									type="button"
+									onClick={() => {
+										regenerateAvatar();
+										onClose();
+									}}
+									className="rounded-md bg-accent-violet px-3 py-1 text-[12px] font-medium text-white shadow-glow transition hover:brightness-110"
+								>
+									Regenerate
+								</button>
+							</div>
 						</div>
-					</div>
-				</div>
-			)}
+					</div>,
+					document.body,
+				)}
 		</DialogContent>
 	);
 }

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import { useState } from "react";
-import { createPortal } from "react-dom";
 import { ImagePlus, Loader2, Trash2, X } from "lucide-react";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import {
 	DialogContent,
 	DialogDescription,
@@ -21,6 +29,7 @@ import {
 	useGenerationQueue,
 	useQueueSelector,
 } from "@/lib/generation/GenerationQueueProvider";
+import { isActive } from "@/lib/generation/queue";
 import {
 	buildCharacterAvatarJob,
 	characterAvatarElementId,
@@ -72,7 +81,6 @@ function CharacterEditDialogBody({
 
 	const [confirmDelete, setConfirmDelete] = useState(false);
 	const [closeConfirm, setCloseConfirm] = useState(false);
-	const [leftStale, setLeftStale] = useState(false);
 
 	const avatarElementId = characterAvatarElementId(name);
 	const avatarSnapshot = useQueueSelector((q) =>
@@ -104,16 +112,15 @@ function CharacterEditDialogBody({
 	};
 
 	// Stale = the generated avatar no longer matches its inputs. Durable across
-	// reloads (persisted signature), and suppressed while a regeneration is in
-	// flight.
+	// reloads (persisted signature), and suppressed while a regeneration is
+	// queued or in flight (not just the generating instant).
 	const isStale =
-		avatarSnapshot.status !== "generating" &&
+		!isActive(avatarSnapshot.status) &&
 		isAvatarStale(character, metadata.style, referenceImages);
 
 	// While stale, intercept user-initiated closes (escape, outside-click, the X)
-	// to offer a regenerate before leaving. "Leave stale" opts out for this turn.
-	const blockClose = isStale && !leftStale;
-	const requestClose = () => (blockClose ? setCloseConfirm(true) : onClose());
+	// to offer a regenerate before leaving.
+	const requestClose = () => (isStale ? setCloseConfirm(true) : onClose());
 
 	const handleDelete = () => {
 		if (!confirmDelete) {
@@ -127,18 +134,19 @@ function CharacterEditDialogBody({
 
 	return (
 		<DialogContent
-			className="relative max-w-2xl"
+			className="max-w-2xl"
 			showCloseButton={false}
 			onEscapeKeyDown={(e) => {
-				// First press while stale: hold and ask. Once the prompt is up, a
-				// second press is the escape hatch — let it close.
-				if (blockClose && !closeConfirm) {
+				// While stale, hold the close and raise the confirm instead. Once
+				// it's up, the nested AlertDialog owns Escape (its Cancel = keep
+				// editing), so this guard no longer fires.
+				if (isStale && !closeConfirm) {
 					e.preventDefault();
 					setCloseConfirm(true);
 				}
 			}}
 			onInteractOutside={(e) => {
-				if (blockClose && !closeConfirm) {
+				if (isStale && !closeConfirm) {
 					e.preventDefault();
 					setCloseConfirm(true);
 				}
@@ -156,14 +164,14 @@ function CharacterEditDialogBody({
 				<DialogTitle>{name}</DialogTitle>
 				<DialogDescription>
 					Edits save automatically. Regenerate the avatar after changing the
-					appearance.
+					appearance, art style, or reference images.
 				</DialogDescription>
 			</DialogHeader>
 
 			{isStale && (
 				<div className="flex shrink-0 items-center justify-between gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2">
 					<span className="text-[12px] text-amber-100/90">
-						This avatar no longer matches the appearance.
+						This avatar is out of date.
 					</span>
 					<button
 						type="button"
@@ -243,58 +251,36 @@ function CharacterEditDialogBody({
 				</button>
 			</DialogFooter>
 
-			{closeConfirm &&
-				typeof document !== "undefined" &&
-				createPortal(
-					<div
-						className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
-						onClick={() => setCloseConfirm(false)}
-					>
-						<div
-							className="w-full max-w-sm rounded-xl border border-white/10 bg-[#141414] p-4 shadow-xl"
-							onClick={(e) => e.stopPropagation()}
+			<AlertDialog open={closeConfirm} onOpenChange={setCloseConfirm}>
+				<AlertDialogContent>
+					<AlertDialogTitle>Avatar is out of date</AlertDialogTitle>
+					<AlertDialogDescription>
+						{name}&apos;s avatar no longer matches its current inputs
+						(appearance, art style, or reference images). Your edits are already
+						saved.
+					</AlertDialogDescription>
+					<AlertDialogFooter>
+						<AlertDialogCancel className="rounded-md px-2.5 py-1 text-[12px] text-white/60 transition-colors hover:text-white">
+							Keep editing
+						</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={onClose}
+							className="rounded-md border border-white/10 px-2.5 py-1 text-[12px] text-white/70 transition-colors hover:bg-white/10"
 						>
-							<p className="text-sm font-medium text-white/90">
-								Regenerate avatar before leaving?
-							</p>
-							<p className="mt-1 text-[12px] text-white/50">
-								The appearance changed, so {name}&apos;s avatar is out of date.
-								Your edits are already saved. Press Escape again to leave
-								anyway.
-							</p>
-							<div className="mt-4 flex items-center justify-end gap-2">
-								<button
-									type="button"
-									onClick={() => setCloseConfirm(false)}
-									className="rounded-md px-2.5 py-1 text-[12px] text-white/60 transition-colors hover:text-white"
-								>
-									Keep editing
-								</button>
-								<button
-									type="button"
-									onClick={() => {
-										setLeftStale(true);
-										onClose();
-									}}
-									className="rounded-md border border-white/10 px-2.5 py-1 text-[12px] text-white/70 transition-colors hover:bg-white/10"
-								>
-									Leave stale
-								</button>
-								<button
-									type="button"
-									onClick={() => {
-										regenerateAvatar();
-										onClose();
-									}}
-									className="rounded-md bg-accent-violet px-3 py-1 text-[12px] font-medium text-white shadow-glow transition hover:brightness-110"
-								>
-									Regenerate
-								</button>
-							</div>
-						</div>
-					</div>,
-					document.body,
-				)}
+							Leave stale
+						</AlertDialogAction>
+						<AlertDialogAction
+							onClick={() => {
+								regenerateAvatar();
+								onClose();
+							}}
+							className="rounded-md bg-accent-violet px-3 py-1 text-[12px] font-medium text-white shadow-glow transition hover:brightness-110"
+						>
+							Regenerate
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 		</DialogContent>
 	);
 }

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import * as React from "react";
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function AlertDialog({
+	...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+	return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogOverlay({
+	className,
+	...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+	return (
+		<AlertDialogPrimitive.Overlay
+			data-slot="alert-dialog-overlay"
+			className={cn(
+				"fixed inset-0 z-[60] bg-black/60 backdrop-blur-sm data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function AlertDialogContent({
+	className,
+	...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+	return (
+		<AlertDialogPrimitive.Portal data-slot="alert-dialog-portal">
+			<AlertDialogOverlay />
+			<AlertDialogPrimitive.Content
+				data-slot="alert-dialog-content"
+				className={cn(
+					"fixed left-[50%] top-[50%] z-[60] flex w-[calc(100vw-2rem)] max-w-sm translate-x-[-50%] translate-y-[-50%] flex-col gap-1 rounded-xl border border-white/10 bg-white/5 p-4 text-white shadow-xl shadow-black/50 backdrop-blur-xl outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+					className,
+				)}
+				{...props}
+			/>
+		</AlertDialogPrimitive.Portal>
+	);
+}
+
+function AlertDialogTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+	return (
+		<AlertDialogPrimitive.Title
+			data-slot="alert-dialog-title"
+			className={cn("text-sm font-medium text-white/90", className)}
+			{...props}
+		/>
+	);
+}
+
+function AlertDialogDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+	return (
+		<AlertDialogPrimitive.Description
+			data-slot="alert-dialog-description"
+			className={cn("text-[12px] text-white/50", className)}
+			{...props}
+		/>
+	);
+}
+
+function AlertDialogFooter({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="alert-dialog-footer"
+			className={cn("mt-4 flex items-center justify-end gap-2", className)}
+			{...props}
+		/>
+	);
+}
+
+function AlertDialogAction({
+	...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+	return (
+		<AlertDialogPrimitive.Action data-slot="alert-dialog-action" {...props} />
+	);
+}
+
+function AlertDialogCancel({
+	...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+	return (
+		<AlertDialogPrimitive.Cancel data-slot="alert-dialog-cancel" {...props} />
+	);
+}
+
+export {
+	AlertDialog,
+	AlertDialogContent,
+	AlertDialogTitle,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogAction,
+	AlertDialogCancel,
+};

--- a/lib/connectors/__tests__/character-avatar.test.ts
+++ b/lib/connectors/__tests__/character-avatar.test.ts
@@ -14,7 +14,11 @@ describe("character-avatar plugin", () => {
 				characters: { Alice: { appearance: "A young girl with red hair" } },
 			});
 
-		const plugin = createCharacterAvatarPlugin(PROJECT_ID, "Alice");
+		const plugin = createCharacterAvatarPlugin(
+			PROJECT_ID,
+			"Alice",
+			"A young girl with red hair",
+		);
 		expect(plugin.transformPrompt?.("ignored")).toBe(
 			'Character portrait of Alice. A young girl with red hair. A small rectangular nameplate at the bottom of the frame reads "Alice" in clean sans-serif lettering. White background',
 		);
@@ -26,7 +30,7 @@ describe("character-avatar plugin", () => {
 			.getState()
 			.updateMetadata({ characters: { Alice: { appearance: "A girl" } } });
 
-		const plugin = createCharacterAvatarPlugin(PROJECT_ID, "Alice");
+		const plugin = createCharacterAvatarPlugin(PROJECT_ID, "Alice", "A girl");
 		plugin.afterGenerate?.({
 			imageUrl: "https://img/alice.png",
 			durationSec: 0,
@@ -37,13 +41,35 @@ describe("character-avatar plugin", () => {
 		);
 	});
 
+	it("records the appearance snapshot it generated from, not the live value", () => {
+		const store = getProjectStore(PROJECT_ID);
+		store
+			.getState()
+			.updateMetadata({ characters: { Alice: { appearance: "A girl" } } });
+
+		// Plugin was built from the "A girl" snapshot; the user edits appearance
+		// while the job is in flight.
+		const plugin = createCharacterAvatarPlugin(PROJECT_ID, "Alice", "A girl");
+		store.getState().setCharacter("Alice", { appearance: "A boy" });
+		plugin.afterGenerate?.({
+			imageUrl: "https://img/alice.png",
+			durationSec: 0,
+		});
+
+		// The recorded source is the snapshot, so the now-divergent live appearance
+		// correctly reads as stale and will auto-regenerate.
+		expect(
+			store.getState().metadata.characters["Alice"].avatarSourceAppearance,
+		).toBe("A girl");
+	});
+
 	it("does not resurrect a character that was removed mid-flight", () => {
 		const store = getProjectStore(PROJECT_ID);
 		store
 			.getState()
 			.updateMetadata({ characters: { Alice: { appearance: "A girl" } } });
 
-		const plugin = createCharacterAvatarPlugin(PROJECT_ID, "Alice");
+		const plugin = createCharacterAvatarPlugin(PROJECT_ID, "Alice", "A girl");
 		store.getState().removeCharacter("Alice");
 		plugin.afterGenerate?.({
 			imageUrl: "https://img/alice.png",

--- a/lib/connectors/__tests__/character-avatar.test.ts
+++ b/lib/connectors/__tests__/character-avatar.test.ts
@@ -18,6 +18,7 @@ describe("character-avatar plugin", () => {
 			PROJECT_ID,
 			"Alice",
 			"A young girl with red hair",
+			"sig",
 		);
 		expect(plugin.transformPrompt?.("ignored")).toBe(
 			'Character portrait of Alice. A young girl with red hair. A small rectangular nameplate at the bottom of the frame reads "Alice" in clean sans-serif lettering. White background',
@@ -30,7 +31,12 @@ describe("character-avatar plugin", () => {
 			.getState()
 			.updateMetadata({ characters: { Alice: { appearance: "A girl" } } });
 
-		const plugin = createCharacterAvatarPlugin(PROJECT_ID, "Alice", "A girl");
+		const plugin = createCharacterAvatarPlugin(
+			PROJECT_ID,
+			"Alice",
+			"A girl",
+			"sig",
+		);
 		plugin.afterGenerate?.({
 			imageUrl: "https://img/alice.png",
 			durationSec: 0,
@@ -41,26 +47,31 @@ describe("character-avatar plugin", () => {
 		);
 	});
 
-	it("records the appearance snapshot it generated from, not the live value", () => {
+	it("records the inputs signature the job carried, not a live recomputation", () => {
 		const store = getProjectStore(PROJECT_ID);
 		store
 			.getState()
 			.updateMetadata({ characters: { Alice: { appearance: "A girl" } } });
 
-		// Plugin was built from the "A girl" snapshot; the user edits appearance
+		// Plugin was built from a snapshot signature; the user edits appearance
 		// while the job is in flight.
-		const plugin = createCharacterAvatarPlugin(PROJECT_ID, "Alice", "A girl");
+		const plugin = createCharacterAvatarPlugin(
+			PROJECT_ID,
+			"Alice",
+			"A girl",
+			"snapshot-sig",
+		);
 		store.getState().setCharacter("Alice", { appearance: "A boy" });
 		plugin.afterGenerate?.({
 			imageUrl: "https://img/alice.png",
 			durationSec: 0,
 		});
 
-		// The recorded source is the snapshot, so the now-divergent live appearance
-		// correctly reads as stale and will auto-regenerate.
+		// The recorded signature is the snapshot, so the now-divergent live inputs
+		// correctly read as stale and will auto-regenerate.
 		expect(
-			store.getState().metadata.characters["Alice"].avatarSourceAppearance,
-		).toBe("A girl");
+			store.getState().metadata.characters["Alice"].avatarInputsSignature,
+		).toBe("snapshot-sig");
 	});
 
 	it("does not resurrect a character that was removed mid-flight", () => {
@@ -69,7 +80,12 @@ describe("character-avatar plugin", () => {
 			.getState()
 			.updateMetadata({ characters: { Alice: { appearance: "A girl" } } });
 
-		const plugin = createCharacterAvatarPlugin(PROJECT_ID, "Alice", "A girl");
+		const plugin = createCharacterAvatarPlugin(
+			PROJECT_ID,
+			"Alice",
+			"A girl",
+			"sig",
+		);
 		store.getState().removeCharacter("Alice");
 		plugin.afterGenerate?.({
 			imageUrl: "https://img/alice.png",

--- a/lib/connectors/image/plugins/__tests__/imageChain.test.ts
+++ b/lib/connectors/image/plugins/__tests__/imageChain.test.ts
@@ -15,7 +15,7 @@ describe("buildCharacterAvatarPlugins", () => {
 				"https://img/style-b.png",
 			]);
 
-		const plugins = buildCharacterAvatarPlugins(PROJECT_ID, "Alice");
+		const plugins = buildCharacterAvatarPlugins(PROJECT_ID, "Alice", "A girl");
 		const refPlugin = plugins.find((p) => p.name === "reference-images");
 		expect(refPlugin).toBeDefined();
 

--- a/lib/connectors/image/plugins/__tests__/imageChain.test.ts
+++ b/lib/connectors/image/plugins/__tests__/imageChain.test.ts
@@ -15,7 +15,12 @@ describe("buildCharacterAvatarPlugins", () => {
 				"https://img/style-b.png",
 			]);
 
-		const plugins = buildCharacterAvatarPlugins(PROJECT_ID, "Alice", "A girl");
+		const plugins = buildCharacterAvatarPlugins(
+			PROJECT_ID,
+			"Alice",
+			"A girl",
+			"sig",
+		);
 		const refPlugin = plugins.find((p) => p.name === "reference-images");
 		expect(refPlugin).toBeDefined();
 

--- a/lib/connectors/image/plugins/character-avatar.ts
+++ b/lib/connectors/image/plugins/character-avatar.ts
@@ -24,7 +24,11 @@ export function createCharacterAvatarPlugin(
 			const state = store();
 			const existing = state.metadata.characters[name];
 			if (!existing) return result;
-			state.setCharacter(name, { ...existing, avatarUrl: result.imageUrl });
+			state.setCharacter(name, {
+				...existing,
+				avatarUrl: result.imageUrl,
+				avatarSourceAppearance: existing.appearance,
+			});
 			return result;
 		},
 	};

--- a/lib/connectors/image/plugins/character-avatar.ts
+++ b/lib/connectors/image/plugins/character-avatar.ts
@@ -5,6 +5,7 @@ export function createCharacterAvatarPlugin(
 	projectId: string,
 	name: string,
 	appearance: string,
+	inputsSignature: string,
 ): ConnectorPlugin<{ prompt: string }, AssetResult> {
 	const store = () => getProjectStore(projectId).getState();
 	return {
@@ -24,13 +25,13 @@ export function createCharacterAvatarPlugin(
 			const state = store();
 			const existing = state.metadata.characters[name];
 			if (!existing) return result;
-			// Record the appearance this image was actually generated from (the
-			// snapshot the job carried), not the live value — which may have been
-			// edited mid-flight — so the recorded source is always honest.
+			// Record the signature of the inputs this image was actually generated
+			// from (the snapshot the job carried), not the live values which may
+			// have been edited mid-flight, so the recorded source is always honest.
 			state.setCharacter(name, {
 				...existing,
 				avatarUrl: result.imageUrl,
-				avatarSourceAppearance: appearance,
+				avatarInputsSignature: inputsSignature,
 			});
 			return result;
 		},

--- a/lib/connectors/image/plugins/character-avatar.ts
+++ b/lib/connectors/image/plugins/character-avatar.ts
@@ -4,12 +4,12 @@ import { getProjectStore } from "@/lib/project/store";
 export function createCharacterAvatarPlugin(
 	projectId: string,
 	name: string,
+	appearance: string,
 ): ConnectorPlugin<{ prompt: string }, AssetResult> {
 	const store = () => getProjectStore(projectId).getState();
 	return {
 		name: "character-avatar",
 		transformPrompt() {
-			const appearance = store().metadata.characters[name]?.appearance ?? "";
 			return [
 				`Character portrait of ${name}`,
 				appearance,
@@ -24,10 +24,13 @@ export function createCharacterAvatarPlugin(
 			const state = store();
 			const existing = state.metadata.characters[name];
 			if (!existing) return result;
+			// Record the appearance this image was actually generated from (the
+			// snapshot the job carried), not the live value — which may have been
+			// edited mid-flight — so the recorded source is always honest.
 			state.setCharacter(name, {
 				...existing,
 				avatarUrl: result.imageUrl,
-				avatarSourceAppearance: existing.appearance,
+				avatarSourceAppearance: appearance,
 			});
 			return result;
 		},

--- a/lib/connectors/image/plugins/imageChain.ts
+++ b/lib/connectors/image/plugins/imageChain.ts
@@ -16,9 +16,15 @@ export function buildCharacterAvatarPlugins(
 	projectId: string,
 	characterName: string,
 	appearance: string,
+	inputsSignature: string,
 ): ConnectorPlugin[] {
 	return [
-		createCharacterAvatarPlugin(projectId, characterName, appearance),
+		createCharacterAvatarPlugin(
+			projectId,
+			characterName,
+			appearance,
+			inputsSignature,
+		),
 		createArtStylePlugin(projectId),
 		createReferenceImagesPlugin(projectId),
 	];

--- a/lib/connectors/image/plugins/imageChain.ts
+++ b/lib/connectors/image/plugins/imageChain.ts
@@ -15,9 +15,10 @@ export function buildImagePlugins(projectId: string): ConnectorPlugin[] {
 export function buildCharacterAvatarPlugins(
 	projectId: string,
 	characterName: string,
+	appearance: string,
 ): ConnectorPlugin[] {
 	return [
-		createCharacterAvatarPlugin(projectId, characterName),
+		createCharacterAvatarPlugin(projectId, characterName, appearance),
 		createArtStylePlugin(projectId),
 		createReferenceImagesPlugin(projectId),
 	];

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -50,7 +50,7 @@ const EMPTY_SNAPSHOT: ElementSnapshot = {
 	connectorType: null,
 };
 
-const isActive = (status: ElementSnapshot["status"]) =>
+export const isActive = (status: ElementSnapshot["status"]) =>
 	status === "queued" || status === "generating";
 
 export class GenerationQueue {

--- a/lib/project/__tests__/avatarInputs.test.ts
+++ b/lib/project/__tests__/avatarInputs.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { MetadataCharacter } from "../types";
+import { avatarInputsSignature, isAvatarStale } from "../avatarInputs";
+
+const character = (over: Partial<MetadataCharacter>): MetadataCharacter => ({
+	appearance: "A girl in red",
+	avatarUrl: "https://img/alice.png",
+	...over,
+});
+
+describe("isAvatarStale", () => {
+	it("is false when the current inputs match the recorded signature", () => {
+		const ch = character({
+			avatarInputsSignature: avatarInputsSignature("A girl in red", "anime", [
+				"ref-a",
+			]),
+		});
+		expect(isAvatarStale(ch, "anime", ["ref-a"])).toBe(false);
+	});
+
+	it("is true when the appearance changed", () => {
+		const ch = character({
+			appearance: "A girl in blue",
+			avatarInputsSignature: avatarInputsSignature(
+				"A girl in red",
+				"anime",
+				[],
+			),
+		});
+		expect(isAvatarStale(ch, "anime", [])).toBe(true);
+	});
+
+	it("is true when the project art style changed", () => {
+		const ch = character({
+			avatarInputsSignature: avatarInputsSignature(
+				"A girl in red",
+				"anime",
+				[],
+			),
+		});
+		expect(isAvatarStale(ch, "watercolor", [])).toBe(true);
+	});
+
+	it("is true when reference images changed", () => {
+		const ch = character({
+			avatarInputsSignature: avatarInputsSignature("A girl in red", "anime", [
+				"ref-a",
+			]),
+		});
+		expect(isAvatarStale(ch, "anime", ["ref-a", "ref-b"])).toBe(true);
+	});
+
+	it("is never stale for an uploaded avatar", () => {
+		const ch = character({
+			avatarUploaded: true,
+			appearance: "A girl in blue",
+			avatarInputsSignature: avatarInputsSignature(
+				"A girl in red",
+				"anime",
+				[],
+			),
+		});
+		expect(isAvatarStale(ch, "anime", [])).toBe(false);
+	});
+
+	it("is not stale for a legacy avatar with no recorded signature", () => {
+		const ch = character({ appearance: "A girl in blue" });
+		expect(isAvatarStale(ch, "anime", [])).toBe(false);
+	});
+
+	it("is not stale when there is no avatar yet", () => {
+		const ch = character({ avatarUrl: undefined });
+		expect(isAvatarStale(ch, "anime", [])).toBe(false);
+	});
+});

--- a/lib/project/__tests__/avatarInputs.test.ts
+++ b/lib/project/__tests__/avatarInputs.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { MetadataCharacter } from "../types";
-import { avatarInputsSignature, isAvatarStale } from "../avatarInputs";
+import {
+	avatarInputsSignature,
+	backfillAvatarSignatures,
+	isAvatarStale,
+} from "../avatarInputs";
 
 const character = (over: Partial<MetadataCharacter>): MetadataCharacter => ({
 	appearance: "A girl in red",
@@ -71,5 +75,41 @@ describe("isAvatarStale", () => {
 	it("is not stale when there is no avatar yet", () => {
 		const ch = character({ avatarUrl: undefined });
 		expect(isAvatarStale(ch, "anime", [])).toBe(false);
+	});
+});
+
+describe("backfillAvatarSignatures", () => {
+	it("stamps a baseline only for generated avatars missing a signature", () => {
+		const stamped = backfillAvatarSignatures(
+			{
+				Legacy: { appearance: "A girl in red", avatarUrl: "u" },
+				Signed: {
+					appearance: "x",
+					avatarUrl: "u",
+					avatarInputsSignature: "keep",
+				},
+				Uploaded: { appearance: "y", avatarUrl: "u", avatarUploaded: true },
+				NoAvatar: { appearance: "z" },
+				NoAppearance: { appearance: "", avatarUrl: "u" },
+			},
+			"anime",
+			["ref-a"],
+		);
+
+		expect(Object.keys(stamped)).toEqual(["Legacy"]);
+		expect(stamped["Legacy"]).toBe(
+			avatarInputsSignature("A girl in red", "anime", ["ref-a"]),
+		);
+	});
+
+	it("returns nothing to stamp when every avatar is already covered", () => {
+		const stamped = backfillAvatarSignatures(
+			{
+				Signed: { appearance: "x", avatarUrl: "u", avatarInputsSignature: "s" },
+			},
+			undefined,
+			[],
+		);
+		expect(stamped).toEqual({});
 	});
 });

--- a/lib/project/__tests__/ensureCharacterAvatars.test.ts
+++ b/lib/project/__tests__/ensureCharacterAvatars.test.ts
@@ -1,39 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-	GenerationQueue,
-	type ElementSnapshot,
-	type GenerationJob,
-} from "@/lib/generation/queue";
-import { getGenerationInputs } from "@/lib/generation/getGenerationInputs";
+import { GenerationQueue, type GenerationJob } from "@/lib/generation/queue";
 import { clearProjectStore, getProjectStore } from "../store";
 import {
 	buildCharacterAvatarJob,
-	characterAvatarElement,
 	characterAvatarElementId,
 	ensureCharacterAvatars,
 } from "../ensureCharacterAvatars";
-
-// A queue pre-seeded with an avatar snapshot whose result was produced by
-// `seededAppearance` — mimics a project loaded with an already-generated avatar.
-function warmQueue(name: string, seededAppearance: string): GenerationQueue {
-	const metadata = getProjectStore(PROJECT_ID).getState().metadata;
-	const resultInputs = getGenerationInputs(
-		characterAvatarElement(name, seededAppearance),
-		metadata,
-	);
-	const snapshot: ElementSnapshot = {
-		status: "idle",
-		seconds: 0,
-		result: null,
-		error: null,
-		resultInputs,
-		connectorType: "image",
-	};
-	return new GenerationQueue({
-		batchSize: 3,
-		initialState: { [characterAvatarElementId(name)]: snapshot },
-	});
-}
 
 const PROJECT_ID = "test-project";
 
@@ -121,7 +93,7 @@ describe("ensureCharacterAvatars", () => {
 		]);
 	});
 
-	it("skips characters that already have an avatarUrl", () => {
+	it("skips a legacy avatar (has avatarUrl but no recorded source appearance)", () => {
 		getProjectStore(PROJECT_ID)
 			.getState()
 			.updateMetadata({
@@ -148,7 +120,7 @@ describe("ensureCharacterAvatars", () => {
 		expect(lastJobs()).toEqual([]);
 	});
 
-	it("skips an avatar whose appearance is unchanged (warm snapshot, not stale)", () => {
+	it("skips an avatar whose appearance matches its recorded source", () => {
 		getProjectStore(PROJECT_ID)
 			.getState()
 			.updateMetadata({
@@ -156,18 +128,17 @@ describe("ensureCharacterAvatars", () => {
 					Alice: {
 						appearance: "A girl in red",
 						avatarUrl: "https://existing.com/alice.png",
+						avatarSourceAppearance: "A girl in red",
 					},
 				},
 			});
-		const warm = warmQueue("Alice", "A girl in red");
-		const spy = vi.spyOn(warm, "enqueueAll").mockImplementation(() => {});
 
-		ensureCharacterAvatars(warm, PROJECT_ID, registry);
+		ensureCharacterAvatars(queue, PROJECT_ID, registry);
 
-		expect(spy.mock.calls.at(-1)?.[0]).toEqual([]);
+		expect(lastJobs()).toEqual([]);
 	});
 
-	it("regenerates an avatar whose appearance changed since it was generated", () => {
+	it("regenerates an avatar whose appearance changed from its recorded source (survives reload)", () => {
 		getProjectStore(PROJECT_ID)
 			.getState()
 			.updateMetadata({
@@ -175,17 +146,14 @@ describe("ensureCharacterAvatars", () => {
 					Alice: {
 						appearance: "A girl in blue, now with short hair",
 						avatarUrl: "https://existing.com/alice.png",
+						avatarSourceAppearance: "A girl in red",
 					},
 				},
 			});
-		// The seeded snapshot was produced by the OLD appearance.
-		const warm = warmQueue("Alice", "A girl in red");
-		const spy = vi.spyOn(warm, "enqueueAll").mockImplementation(() => {});
 
-		ensureCharacterAvatars(warm, PROJECT_ID, registry);
+		ensureCharacterAvatars(queue, PROJECT_ID, registry);
 
-		const jobs = spy.mock.calls.at(-1)?.[0] as GenerationJob[];
-		expect(jobs.map((j) => j.elementId)).toEqual([
+		expect(lastJobs().map((j) => j.elementId)).toEqual([
 			characterAvatarElementId("Alice"),
 		]);
 	});

--- a/lib/project/__tests__/ensureCharacterAvatars.test.ts
+++ b/lib/project/__tests__/ensureCharacterAvatars.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GenerationQueue, type GenerationJob } from "@/lib/generation/queue";
+import { avatarInputsSignature } from "../avatarInputs";
 import { clearProjectStore, getProjectStore } from "../store";
 import {
 	buildCharacterAvatarJob,
@@ -120,7 +121,7 @@ describe("ensureCharacterAvatars", () => {
 		expect(lastJobs()).toEqual([]);
 	});
 
-	it("skips an avatar whose appearance matches its recorded source", () => {
+	it("skips an avatar whose inputs match its recorded signature", () => {
 		getProjectStore(PROJECT_ID)
 			.getState()
 			.updateMetadata({
@@ -128,7 +129,11 @@ describe("ensureCharacterAvatars", () => {
 					Alice: {
 						appearance: "A girl in red",
 						avatarUrl: "https://existing.com/alice.png",
-						avatarSourceAppearance: "A girl in red",
+						avatarInputsSignature: avatarInputsSignature(
+							"A girl in red",
+							undefined,
+							[],
+						),
 					},
 				},
 			});
@@ -138,7 +143,7 @@ describe("ensureCharacterAvatars", () => {
 		expect(lastJobs()).toEqual([]);
 	});
 
-	it("regenerates an avatar whose appearance changed from its recorded source (survives reload)", () => {
+	it("regenerates an avatar whose appearance changed from its recorded signature (survives reload)", () => {
 		getProjectStore(PROJECT_ID)
 			.getState()
 			.updateMetadata({
@@ -146,7 +151,37 @@ describe("ensureCharacterAvatars", () => {
 					Alice: {
 						appearance: "A girl in blue, now with short hair",
 						avatarUrl: "https://existing.com/alice.png",
-						avatarSourceAppearance: "A girl in red",
+						avatarInputsSignature: avatarInputsSignature(
+							"A girl in red",
+							undefined,
+							[],
+						),
+					},
+				},
+			});
+
+		ensureCharacterAvatars(queue, PROJECT_ID, registry);
+
+		expect(lastJobs().map((j) => j.elementId)).toEqual([
+			characterAvatarElementId("Alice"),
+		]);
+	});
+
+	it("regenerates an avatar when the project art style changed (not just appearance)", () => {
+		getProjectStore(PROJECT_ID)
+			.getState()
+			.updateMetadata({
+				style: "watercolor",
+				characters: {
+					Alice: {
+						appearance: "A girl in red",
+						avatarUrl: "https://existing.com/alice.png",
+						// Signature captured under the old "anime" style.
+						avatarInputsSignature: avatarInputsSignature(
+							"A girl in red",
+							"anime",
+							[],
+						),
 					},
 				},
 			});
@@ -167,7 +202,11 @@ describe("ensureCharacterAvatars", () => {
 						appearance: "A girl in blue",
 						avatarUrl: "https://upload.com/alice.png",
 						avatarUploaded: true,
-						avatarSourceAppearance: "A girl in red",
+						avatarInputsSignature: avatarInputsSignature(
+							"A girl in red",
+							undefined,
+							[],
+						),
 					},
 				},
 			});

--- a/lib/project/__tests__/ensureCharacterAvatars.test.ts
+++ b/lib/project/__tests__/ensureCharacterAvatars.test.ts
@@ -94,7 +94,7 @@ describe("ensureCharacterAvatars", () => {
 		]);
 	});
 
-	it("skips a legacy avatar (has avatarUrl but no recorded source appearance)", () => {
+	it("skips a character that already has an avatarUrl", () => {
 		getProjectStore(PROJECT_ID)
 			.getState()
 			.updateMetadata({
@@ -121,90 +121,20 @@ describe("ensureCharacterAvatars", () => {
 		expect(lastJobs()).toEqual([]);
 	});
 
-	it("skips an avatar whose inputs match its recorded signature", () => {
-		getProjectStore(PROJECT_ID)
-			.getState()
-			.updateMetadata({
-				characters: {
-					Alice: {
-						appearance: "A girl in red",
-						avatarUrl: "https://existing.com/alice.png",
-						avatarInputsSignature: avatarInputsSignature(
-							"A girl in red",
-							undefined,
-							[],
-						),
-					},
-				},
-			});
-
-		ensureCharacterAvatars(queue, PROJECT_ID, registry);
-
-		expect(lastJobs()).toEqual([]);
-	});
-
-	it("regenerates an avatar whose appearance changed from its recorded signature (survives reload)", () => {
-		getProjectStore(PROJECT_ID)
-			.getState()
-			.updateMetadata({
-				characters: {
-					Alice: {
-						appearance: "A girl in blue, now with short hair",
-						avatarUrl: "https://existing.com/alice.png",
-						avatarInputsSignature: avatarInputsSignature(
-							"A girl in red",
-							undefined,
-							[],
-						),
-					},
-				},
-			});
-
-		ensureCharacterAvatars(queue, PROJECT_ID, registry);
-
-		expect(lastJobs().map((j) => j.elementId)).toEqual([
-			characterAvatarElementId("Alice"),
-		]);
-	});
-
-	it("regenerates an avatar when the project art style changed (not just appearance)", () => {
+	it("does not auto-regenerate when inputs change; only backfills missing avatars", () => {
 		getProjectStore(PROJECT_ID)
 			.getState()
 			.updateMetadata({
 				style: "watercolor",
 				characters: {
+					// Appearance and art style both differ from the recorded signature,
+					// but the avatar exists, so it is left alone. Regeneration is manual.
 					Alice: {
-						appearance: "A girl in red",
+						appearance: "A girl in blue",
 						avatarUrl: "https://existing.com/alice.png",
-						// Signature captured under the old "anime" style.
 						avatarInputsSignature: avatarInputsSignature(
 							"A girl in red",
 							"anime",
-							[],
-						),
-					},
-				},
-			});
-
-		ensureCharacterAvatars(queue, PROJECT_ID, registry);
-
-		expect(lastJobs().map((j) => j.elementId)).toEqual([
-			characterAvatarElementId("Alice"),
-		]);
-	});
-
-	it("never auto-regenerates a user-uploaded avatar, even when appearance changed", () => {
-		getProjectStore(PROJECT_ID)
-			.getState()
-			.updateMetadata({
-				characters: {
-					Alice: {
-						appearance: "A girl in blue",
-						avatarUrl: "https://upload.com/alice.png",
-						avatarUploaded: true,
-						avatarInputsSignature: avatarInputsSignature(
-							"A girl in red",
-							undefined,
 							[],
 						),
 					},

--- a/lib/project/__tests__/ensureCharacterAvatars.test.ts
+++ b/lib/project/__tests__/ensureCharacterAvatars.test.ts
@@ -158,6 +158,25 @@ describe("ensureCharacterAvatars", () => {
 		]);
 	});
 
+	it("never auto-regenerates a user-uploaded avatar, even when appearance changed", () => {
+		getProjectStore(PROJECT_ID)
+			.getState()
+			.updateMetadata({
+				characters: {
+					Alice: {
+						appearance: "A girl in blue",
+						avatarUrl: "https://upload.com/alice.png",
+						avatarUploaded: true,
+						avatarSourceAppearance: "A girl in red",
+					},
+				},
+			});
+
+		ensureCharacterAvatars(queue, PROJECT_ID, registry);
+
+		expect(lastJobs()).toEqual([]);
+	});
+
 	it("buildCharacterAvatarJob produces a job for any character (used for regenerate)", () => {
 		getProjectStore(PROJECT_ID)
 			.getState()

--- a/lib/project/__tests__/ensureCharacterAvatars.test.ts
+++ b/lib/project/__tests__/ensureCharacterAvatars.test.ts
@@ -1,11 +1,39 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { GenerationQueue, type GenerationJob } from "@/lib/generation/queue";
+import {
+	GenerationQueue,
+	type ElementSnapshot,
+	type GenerationJob,
+} from "@/lib/generation/queue";
+import { getGenerationInputs } from "@/lib/generation/getGenerationInputs";
 import { clearProjectStore, getProjectStore } from "../store";
 import {
 	buildCharacterAvatarJob,
+	characterAvatarElement,
 	characterAvatarElementId,
 	ensureCharacterAvatars,
 } from "../ensureCharacterAvatars";
+
+// A queue pre-seeded with an avatar snapshot whose result was produced by
+// `seededAppearance` — mimics a project loaded with an already-generated avatar.
+function warmQueue(name: string, seededAppearance: string): GenerationQueue {
+	const metadata = getProjectStore(PROJECT_ID).getState().metadata;
+	const resultInputs = getGenerationInputs(
+		characterAvatarElement(name, seededAppearance),
+		metadata,
+	);
+	const snapshot: ElementSnapshot = {
+		status: "idle",
+		seconds: 0,
+		result: null,
+		error: null,
+		resultInputs,
+		connectorType: "image",
+	};
+	return new GenerationQueue({
+		batchSize: 3,
+		initialState: { [characterAvatarElementId(name)]: snapshot },
+	});
+}
 
 const PROJECT_ID = "test-project";
 
@@ -118,6 +146,48 @@ describe("ensureCharacterAvatars", () => {
 		ensureCharacterAvatars(queue, PROJECT_ID, registry);
 
 		expect(lastJobs()).toEqual([]);
+	});
+
+	it("skips an avatar whose appearance is unchanged (warm snapshot, not stale)", () => {
+		getProjectStore(PROJECT_ID)
+			.getState()
+			.updateMetadata({
+				characters: {
+					Alice: {
+						appearance: "A girl in red",
+						avatarUrl: "https://existing.com/alice.png",
+					},
+				},
+			});
+		const warm = warmQueue("Alice", "A girl in red");
+		const spy = vi.spyOn(warm, "enqueueAll").mockImplementation(() => {});
+
+		ensureCharacterAvatars(warm, PROJECT_ID, registry);
+
+		expect(spy.mock.calls.at(-1)?.[0]).toEqual([]);
+	});
+
+	it("regenerates an avatar whose appearance changed since it was generated", () => {
+		getProjectStore(PROJECT_ID)
+			.getState()
+			.updateMetadata({
+				characters: {
+					Alice: {
+						appearance: "A girl in blue, now with short hair",
+						avatarUrl: "https://existing.com/alice.png",
+					},
+				},
+			});
+		// The seeded snapshot was produced by the OLD appearance.
+		const warm = warmQueue("Alice", "A girl in red");
+		const spy = vi.spyOn(warm, "enqueueAll").mockImplementation(() => {});
+
+		ensureCharacterAvatars(warm, PROJECT_ID, registry);
+
+		const jobs = spy.mock.calls.at(-1)?.[0] as GenerationJob[];
+		expect(jobs.map((j) => j.elementId)).toEqual([
+			characterAvatarElementId("Alice"),
+		]);
 	});
 
 	it("buildCharacterAvatarJob produces a job for any character (used for regenerate)", () => {

--- a/lib/project/__tests__/storeSnapshot.test.ts
+++ b/lib/project/__tests__/storeSnapshot.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { avatarInputsSignature, isAvatarStale } from "../avatarInputs";
 import { getProjectStore, clearProjectStore } from "../store";
 import { applyStoreSnapshot, extractStoreSnapshot } from "../storeSnapshot";
 
@@ -42,6 +43,67 @@ describe("storeSnapshot", () => {
 		expect(after.metadata.style).toBe("noir");
 		expect(after.metadata.narration.age).toBe("adult");
 		expect(after.referenceImages).toEqual(["x", "y"]);
+
+		clearProjectStore(sourceId);
+		clearProjectStore(targetId);
+	});
+
+	it("backfills a baseline signature for a legacy avatar on load", () => {
+		const sourceId = newProjectId();
+		const targetId = newProjectId();
+		const src = getProjectStore(sourceId);
+		src.getState().updateMetadata({
+			style: "anime",
+			characters: {
+				Alice: {
+					appearance: "A girl in red",
+					avatarUrl: "https://img/alice.png",
+				},
+			},
+		});
+		src.getState().setReferenceImages(["ref-a"]);
+
+		const dest = getProjectStore(targetId);
+		applyStoreSnapshot(dest, extractStoreSnapshot(src));
+
+		const alice = dest.getState().metadata.characters["Alice"];
+		// Stamped to the loaded inputs, so it reads as in sync now,
+		expect(alice.avatarInputsSignature).toBe(
+			avatarInputsSignature("A girl in red", "anime", ["ref-a"]),
+		);
+		expect(isAvatarStale(alice, "anime", ["ref-a"])).toBe(false);
+		// but goes stale the moment the appearance changes.
+		expect(
+			isAvatarStale({ ...alice, appearance: "A girl in blue" }, "anime", [
+				"ref-a",
+			]),
+		).toBe(true);
+
+		clearProjectStore(sourceId);
+		clearProjectStore(targetId);
+	});
+
+	it("does not overwrite an existing signature or stamp uploads on load", () => {
+		const sourceId = newProjectId();
+		const targetId = newProjectId();
+		const src = getProjectStore(sourceId);
+		src.getState().updateMetadata({
+			characters: {
+				Signed: {
+					appearance: "x",
+					avatarUrl: "u",
+					avatarInputsSignature: "keep-me",
+				},
+				Uploaded: { appearance: "y", avatarUrl: "up", avatarUploaded: true },
+			},
+		});
+
+		const dest = getProjectStore(targetId);
+		applyStoreSnapshot(dest, extractStoreSnapshot(src));
+
+		const chars = dest.getState().metadata.characters;
+		expect(chars["Signed"].avatarInputsSignature).toBe("keep-me");
+		expect(chars["Uploaded"].avatarInputsSignature).toBeUndefined();
 
 		clearProjectStore(sourceId);
 		clearProjectStore(targetId);

--- a/lib/project/avatarInputs.ts
+++ b/lib/project/avatarInputs.ts
@@ -1,3 +1,5 @@
+import type { MetadataCharacter } from "./types";
+
 /**
  * Serializes everything that actually drives avatar image generation: the
  * character's appearance, the project art style, and the project reference
@@ -16,4 +18,26 @@ export function avatarInputsSignature(
 		style: style?.trim() ?? "",
 		referenceImages: [...referenceImages].sort(),
 	});
+}
+
+/**
+ * Whether a character's generated avatar no longer matches its current inputs.
+ * Compares the persisted signature (recorded when the avatar was generated)
+ * against the current inputs, so it works across reloads — unlike the in-memory
+ * generation-queue snapshot. Uploaded avatars are never stale (the user owns
+ * them), and legacy avatars with no recorded signature read as not-stale since
+ * their inputs are unknown (one manual regenerate stamps a signature and opts
+ * them in).
+ */
+export function isAvatarStale(
+	character: MetadataCharacter,
+	style: string | undefined,
+	referenceImages: readonly string[],
+): boolean {
+	if (character.avatarUploaded || !character.avatarUrl) return false;
+	if (character.avatarInputsSignature === undefined) return false;
+	return (
+		character.avatarInputsSignature !==
+		avatarInputsSignature(character.appearance, style, referenceImages)
+	);
 }

--- a/lib/project/avatarInputs.ts
+++ b/lib/project/avatarInputs.ts
@@ -1,0 +1,19 @@
+/**
+ * Serializes everything that actually drives avatar image generation: the
+ * character's appearance, the project art style, and the project reference
+ * images. Persisted alongside a generated avatar so a change in any of them
+ * (not just the appearance) is detected as stale. Art style and reference
+ * images are injected by plugins at generation time, so they are not part of
+ * the queue's GenerationInputs and have to be captured here.
+ */
+export function avatarInputsSignature(
+	appearance: string,
+	style: string | undefined,
+	referenceImages: readonly string[],
+): string {
+	return JSON.stringify({
+		appearance,
+		style: style?.trim() ?? "",
+		referenceImages: [...referenceImages].sort(),
+	});
+}

--- a/lib/project/avatarInputs.ts
+++ b/lib/project/avatarInputs.ts
@@ -41,3 +41,34 @@ export function isAvatarStale(
 		avatarInputsSignature(character.appearance, style, referenceImages)
 	);
 }
+
+/**
+ * Baseline signatures to stamp on avatars generated before signatures existed,
+ * so staleness detection works for them without a manual regenerate. Treats a
+ * loaded avatar as in sync with its current inputs (true unless it was edited
+ * in an older session and never regenerated, which self-heals on the next
+ * edit/regen). Returns name → signature only for avatars that need one;
+ * signed, uploaded, and avatar-less characters are skipped. Idempotent.
+ */
+export function backfillAvatarSignatures(
+	characters: Record<string, MetadataCharacter>,
+	style: string | undefined,
+	referenceImages: readonly string[],
+): Record<string, string> {
+	const stamped: Record<string, string> = {};
+	for (const [name, ch] of Object.entries(characters)) {
+		if (
+			ch.avatarUrl &&
+			!ch.avatarUploaded &&
+			ch.avatarInputsSignature === undefined &&
+			ch.appearance
+		) {
+			stamped[name] = avatarInputsSignature(
+				ch.appearance,
+				style,
+				referenceImages,
+			);
+		}
+	}
+	return stamped;
+}

--- a/lib/project/ensureCharacterAvatars.ts
+++ b/lib/project/ensureCharacterAvatars.ts
@@ -3,6 +3,7 @@ import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import { buildCharacterAvatarPlugins } from "@/lib/connectors/image/plugins/imageChain";
 import type { GenerationJob, GenerationQueue } from "@/lib/generation/queue";
+import { avatarInputsSignature } from "./avatarInputs";
 import { getProjectStore } from "./store";
 
 export const CHARACTER_AVATAR_ID_PREFIX = "character-avatar:";
@@ -29,16 +30,25 @@ export function buildCharacterAvatarJob(
 	registry: ConnectorRegistry,
 ): GenerationJob {
 	const { provider, config } = getDefaultConnector(registry, "image");
-	const appearance =
-		getProjectStore(projectId).getState().metadata.characters[name]
-			?.appearance ?? "";
+	const { metadata, referenceImages } = getProjectStore(projectId).getState();
+	const appearance = metadata.characters[name]?.appearance ?? "";
+	const signature = avatarInputsSignature(
+		appearance,
+		metadata.style,
+		referenceImages,
+	);
 	return {
 		elementId: characterAvatarElementId(name),
 		connectorType: "image",
 		provider,
 		config: {
 			...config,
-			plugins: buildCharacterAvatarPlugins(projectId, name, appearance),
+			plugins: buildCharacterAvatarPlugins(
+				projectId,
+				name,
+				appearance,
+				signature,
+			),
 		},
 		projectId,
 		element: characterAvatarElement(name, appearance),
@@ -50,17 +60,22 @@ export function ensureCharacterAvatars(
 	projectId: string,
 	registry: ConnectorRegistry,
 ): void {
-	const { metadata } = getProjectStore(projectId).getState();
+	const { metadata, referenceImages } = getProjectStore(projectId).getState();
 	const jobs: GenerationJob[] = Object.entries(metadata.characters)
 		.filter(([, ch]) => {
 			if (!ch.appearance) return false;
 			if (ch.avatarUploaded) return false; // user-owned upload — never auto-regen
 			if (!ch.avatarUrl) return true; // never generated → generate
-			// Regenerate only when the appearance that produced the avatar changed.
-			// Legacy avatars with no recorded source are left alone until a manual
-			// regenerate stamps the source, after which they rejoin this happy path.
-			if (ch.avatarSourceAppearance === undefined) return false;
-			return ch.appearance !== ch.avatarSourceAppearance;
+			// Regenerate when any input that drives avatar generation changed
+			// (appearance, art style, or reference images), compared via the
+			// persisted signature so it survives reloads. Legacy avatars with no
+			// recorded signature are left alone until a manual regenerate stamps
+			// one, after which they rejoin this happy path.
+			if (ch.avatarInputsSignature === undefined) return false;
+			return (
+				ch.avatarInputsSignature !==
+				avatarInputsSignature(ch.appearance, metadata.style, referenceImages)
+			);
 		})
 		.map(([name]) => buildCharacterAvatarJob(projectId, name, registry));
 	queue.enqueueAll(jobs);

--- a/lib/project/ensureCharacterAvatars.ts
+++ b/lib/project/ensureCharacterAvatars.ts
@@ -38,7 +38,7 @@ export function buildCharacterAvatarJob(
 		provider,
 		config: {
 			...config,
-			plugins: buildCharacterAvatarPlugins(projectId, name),
+			plugins: buildCharacterAvatarPlugins(projectId, name, appearance),
 		},
 		projectId,
 		element: characterAvatarElement(name, appearance),
@@ -54,12 +54,11 @@ export function ensureCharacterAvatars(
 	const jobs: GenerationJob[] = Object.entries(metadata.characters)
 		.filter(([, ch]) => {
 			if (!ch.appearance) return false;
+			if (ch.avatarUploaded) return false; // user-owned upload — never auto-regen
 			if (!ch.avatarUrl) return true; // never generated → generate
-			// Regenerate when the appearance that produced the avatar changed. The
-			// source appearance is persisted in metadata, so this works across
-			// reloads (unlike the in-memory queue, which is empty after a load).
-			// Legacy avatars with no recorded source are left alone — don't re-spend
-			// credits on an avatar we can't prove is stale.
+			// Regenerate only when the appearance that produced the avatar changed.
+			// Legacy avatars with no recorded source are left alone until a manual
+			// regenerate stamps the source, after which they rejoin this happy path.
 			if (ch.avatarSourceAppearance === undefined) return false;
 			return ch.appearance !== ch.avatarSourceAppearance;
 		})

--- a/lib/project/ensureCharacterAvatars.ts
+++ b/lib/project/ensureCharacterAvatars.ts
@@ -60,23 +60,13 @@ export function ensureCharacterAvatars(
 	projectId: string,
 	registry: ConnectorRegistry,
 ): void {
-	const { metadata, referenceImages } = getProjectStore(projectId).getState();
+	// Backfill avatars for characters that don't have one yet. Avatars are never
+	// auto-regenerated on an input change — that's a deliberate credit decision.
+	// Staleness is surfaced in the character editor (see isAvatarStale) and the
+	// user pulls the trigger to regenerate.
+	const { metadata } = getProjectStore(projectId).getState();
 	const jobs: GenerationJob[] = Object.entries(metadata.characters)
-		.filter(([, ch]) => {
-			if (!ch.appearance) return false;
-			if (ch.avatarUploaded) return false; // user-owned upload — never auto-regen
-			if (!ch.avatarUrl) return true; // never generated → generate
-			// Regenerate when any input that drives avatar generation changed
-			// (appearance, art style, or reference images), compared via the
-			// persisted signature so it survives reloads. Legacy avatars with no
-			// recorded signature are left alone until a manual regenerate stamps
-			// one, after which they rejoin this happy path.
-			if (ch.avatarInputsSignature === undefined) return false;
-			return (
-				ch.avatarInputsSignature !==
-				avatarInputsSignature(ch.appearance, metadata.style, referenceImages)
-			);
-		})
+		.filter(([, ch]) => !ch.avatarUrl && ch.appearance)
 		.map(([name]) => buildCharacterAvatarJob(projectId, name, registry));
 	queue.enqueueAll(jobs);
 }

--- a/lib/project/ensureCharacterAvatars.ts
+++ b/lib/project/ensureCharacterAvatars.ts
@@ -2,7 +2,12 @@ import type { CanvasContentElement } from "@/lib/canvas/types";
 import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import { buildCharacterAvatarPlugins } from "@/lib/connectors/image/plugins/imageChain";
-import type { GenerationJob, GenerationQueue } from "@/lib/generation/queue";
+import {
+	isStaleResult,
+	type GenerationJob,
+	type GenerationQueue,
+} from "@/lib/generation/queue";
+import { getGenerationInputs } from "@/lib/generation/getGenerationInputs";
 import { getProjectStore } from "./store";
 
 export const CHARACTER_AVATAR_ID_PREFIX = "character-avatar:";
@@ -50,9 +55,23 @@ export function ensureCharacterAvatars(
 	projectId: string,
 	registry: ConnectorRegistry,
 ): void {
-	const { characters } = getProjectStore(projectId).getState().metadata;
-	const jobs: GenerationJob[] = Object.entries(characters)
-		.filter(([, ch]) => !ch.avatarUrl && ch.appearance)
+	const { metadata } = getProjectStore(projectId).getState();
+	const jobs: GenerationJob[] = Object.entries(metadata.characters)
+		.filter(([name, ch]) => {
+			if (!ch.appearance) return false;
+			if (!ch.avatarUrl) return true; // never generated → generate
+			// Regenerate when the appearance that produced the avatar changed.
+			// Guard the cold case: if the queue has no memory of the inputs that
+			// produced this avatar (no resultInputs), keep the existing one rather
+			// than blindly respending credits.
+			const snapshot = queue.getElementSnapshot(characterAvatarElementId(name));
+			if (!snapshot.resultInputs) return false;
+			const inputs = getGenerationInputs(
+				characterAvatarElement(name, ch.appearance),
+				metadata,
+			);
+			return isStaleResult(snapshot, inputs);
+		})
 		.map(([name]) => buildCharacterAvatarJob(projectId, name, registry));
 	queue.enqueueAll(jobs);
 }

--- a/lib/project/ensureCharacterAvatars.ts
+++ b/lib/project/ensureCharacterAvatars.ts
@@ -2,12 +2,7 @@ import type { CanvasContentElement } from "@/lib/canvas/types";
 import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import { buildCharacterAvatarPlugins } from "@/lib/connectors/image/plugins/imageChain";
-import {
-	isStaleResult,
-	type GenerationJob,
-	type GenerationQueue,
-} from "@/lib/generation/queue";
-import { getGenerationInputs } from "@/lib/generation/getGenerationInputs";
+import type { GenerationJob, GenerationQueue } from "@/lib/generation/queue";
 import { getProjectStore } from "./store";
 
 export const CHARACTER_AVATAR_ID_PREFIX = "character-avatar:";
@@ -57,20 +52,16 @@ export function ensureCharacterAvatars(
 ): void {
 	const { metadata } = getProjectStore(projectId).getState();
 	const jobs: GenerationJob[] = Object.entries(metadata.characters)
-		.filter(([name, ch]) => {
+		.filter(([, ch]) => {
 			if (!ch.appearance) return false;
 			if (!ch.avatarUrl) return true; // never generated → generate
-			// Regenerate when the appearance that produced the avatar changed.
-			// Guard the cold case: if the queue has no memory of the inputs that
-			// produced this avatar (no resultInputs), keep the existing one rather
-			// than blindly respending credits.
-			const snapshot = queue.getElementSnapshot(characterAvatarElementId(name));
-			if (!snapshot.resultInputs) return false;
-			const inputs = getGenerationInputs(
-				characterAvatarElement(name, ch.appearance),
-				metadata,
-			);
-			return isStaleResult(snapshot, inputs);
+			// Regenerate when the appearance that produced the avatar changed. The
+			// source appearance is persisted in metadata, so this works across
+			// reloads (unlike the in-memory queue, which is empty after a load).
+			// Legacy avatars with no recorded source are left alone — don't re-spend
+			// credits on an avatar we can't prove is stale.
+			if (ch.avatarSourceAppearance === undefined) return false;
+			return ch.appearance !== ch.avatarSourceAppearance;
 		})
 		.map(([name]) => buildCharacterAvatarJob(projectId, name, registry));
 	queue.enqueueAll(jobs);

--- a/lib/project/storeSnapshot.ts
+++ b/lib/project/storeSnapshot.ts
@@ -1,3 +1,4 @@
+import { backfillAvatarSignatures } from "./avatarInputs";
 import type { ProjectStore } from "./store";
 import type { Metadata } from "./types";
 
@@ -25,5 +26,22 @@ export function applyStoreSnapshot(
 	if (snapshot?.metadata) state.updateMetadata(snapshot.metadata);
 	if (snapshot?.referenceImages)
 		state.setReferenceImages(snapshot.referenceImages);
+
+	// Backfill input signatures for avatars generated before signatures existed,
+	// so staleness detection (and its UI) works for them on the next edit instead
+	// of staying invisible until a manual regenerate.
+	const { metadata, referenceImages } = store.getState();
+	const stamped = backfillAvatarSignatures(
+		metadata.characters,
+		metadata.style,
+		referenceImages,
+	);
+	for (const [name, signature] of Object.entries(stamped)) {
+		state.setCharacter(name, {
+			...metadata.characters[name],
+			avatarInputsSignature: signature,
+		});
+	}
+
 	state.markHydrated();
 }

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -46,9 +46,10 @@ export type MetadataCharacter = MetadataVoice & {
 	appearance: string;
 	avatarUrl?: string;
 	avatarUploaded?: boolean;
-	// The appearance the current avatarUrl was generated from. Used to detect a
-	// stale avatar across reloads (the in-memory generation queue is empty then).
-	avatarSourceAppearance?: string;
+	// Signature of the inputs the current avatarUrl was generated from (see
+	// avatarInputsSignature). Used to detect a stale avatar across reloads, when
+	// the in-memory generation queue is empty.
+	avatarInputsSignature?: string;
 };
 
 export type VideoSettings = {

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -46,6 +46,9 @@ export type MetadataCharacter = MetadataVoice & {
 	appearance: string;
 	avatarUrl?: string;
 	avatarUploaded?: boolean;
+	// The appearance the current avatarUrl was generated from. Used to detect a
+	// stale avatar across reloads (the in-memory generation queue is empty then).
+	avatarSourceAppearance?: string;
 };
 
 export type VideoSettings = {


### PR DESCRIPTION
Editing a character's appearance (or changing the art style / reference images) makes its avatar out of date, but the staleness signal was computed from the in-memory generation queue, so it vanished on reload. A user who edited and came back later got no indication the avatar was stale.

This keeps avatars on the deliberate manual-regen model (no silent credit spend) and makes staleness durable and obvious:

- `isAvatarStale` compares a persisted signature of the avatar's real inputs (appearance, art style, reference images) against the current inputs, so the stale state survives reloads. Art style and reference images are injected by plugins at generation time, so they are not in the queue's GenerationInputs and are captured here.
- The character editor shows an inline "This avatar is out of date" banner with a Regenerate action whenever it is stale, and the editor description spells out that appearance, art style, or reference-image changes all require a regenerate.
- Closing the editor while stale (escape, click-out, or the X) raises an accessible, viewport-centered confirm — a nested radix `AlertDialog` with proper focus trap and labelling — offering Regenerate / Leave stale / Keep editing. Edits already auto-save, so the prompt is only about the avatar.
- `ensureCharacterAvatars` is back to backfilling missing avatars only; it no longer auto-regenerates on input changes.

Tests cover the staleness helper across each input (appearance, style, reference images, uploaded, legacy, no-avatar) and the backfill-only behavior.

Follow-ups (not in this PR):
- A cheap **Revert** to discard a draft appearance edit without spending a regenerate — built in #234 (issue #233), stacked on this branch.
- Scene staleness already works on `master` (a scene's tracked inputs include the referenced avatar URLs, so it restales when an avatar image actually changes), so no propagation was needed. What's left is a dependency-aware generation queue so an image job waits on fresh avatars rather than relying on enqueue order.



<img width="2532" height="1396" alt="image" src="https://github.com/user-attachments/assets/a1fd5fc7-2739-4284-b827-619fe70da625" />
<img width="2532" height="1396" alt="image" src="https://github.com/user-attachments/assets/2cc2ae45-901f-47c8-86f3-2296caef585a" />