### PR TITLE
feat(design): dark-studio design system (tokens, fonts, adoption)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,3 +25,7 @@
 
 - `next/dynamic` with `ssr: false` is a **Client Component API only**. Never use it in Server Components. If you need to lazy-load a client-only component from a Server Component, create a thin Client Component wrapper that does the dynamic import, then use that wrapper in the Server Component.
 - `proxy.ts` is the correct file name (Next.js 16 migrated from `middleware.ts` to `proxy.ts`). Do NOT rename it.
+
+## Design System
+
+Always read `DESIGN.md` before making any visual or UI decisions. Font choices, colors, spacing, the disciplined-violet rule, and the media-type palette are defined there. Do not deviate without explicit user approval. Flag any UI code that doesn't match `DESIGN.md`.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,69 @@
+# Design System — openslop
+
+## Product Context
+
+- **What this is:** An AI faceless-video generator. Users describe or paste a script, openslop builds a storyboard of scenes (image, narration, character dialogue, music, sound), and renders a finished video.
+- **Who it's for:** Creators producing faceless video at volume who want control over the result and to feel in charge of the process.
+- **Space/industry:** AI video tooling. Peers: Runway, Sora, Luma (pro/dark camp); Pika, Captions (consumer/playful camp). openslop belongs in the pro camp.
+- **Project type:** Web app (editor) + auth/marketing surfaces.
+- **Memorable thing:** "A serious creative studio." Every decision below serves this.
+
+## Aesthetic Direction
+
+- **Direction:** Dark glassmorphism — "a creative studio at night."
+- **Decoration level:** Intentional. Film-grain texture, restrained glow, shimmer loaders. Not flat, not maximalist.
+- **Mood:** Premium, calm, confident. Pro tooling, not a toy.
+- **Core rule (the discipline):** Near-black + glass + grain carry the weight. Violet marks only what is **alive or actionable** (active Generate, focus rings, playhead, the one primary action). The purple glow is a rare earned moment, never an ambient wash. This is what separates "serious studio" from "generic AI-purple wrapper."
+
+## Typography
+
+- **Display/Titles:** Instrument Serif (weight 400) — `.font-title`. Used sparingly for titles only, so it stays special and never turns precious. A serif title is the deliberate departure from the category's neutral grotesks.
+- **Body/UI:** Satoshi — `.font-body`. All narration, dialogue, labels, controls.
+- **Data/Timestamps:** a monospace (JetBrains Mono or Geist Mono) with tabular-nums for scene times and durations.
+- **Cleanup owed:** today four families float (Geist, Satoshi, Instrument Serif, Google Sans Flex). Consolidate to the three above. Drop "Google Sans Flex"; reduce Geist to mono-or-remove.
+- **Loading:** Instrument Serif via Google Fonts; Satoshi via Fontshare; mono via Google Fonts. Self-host for production.
+
+## Color
+
+- **Approach:** Restrained. One accent + neutrals; color is rare and meaningful.
+- **Canvas:** `#0a0a0a` (near-black).
+- **Surfaces (glass):** fill `rgba(255,255,255,0.05)`, border `rgba(255,255,255,0.10)`, `backdrop-blur`.
+- **Accent (violet):** `#8b5cf6` (primary), `#a78bfa` (soft) — active Generate, focus rings, playhead, primary action only.
+- **Glow:** `#371e64` / `rgba(55,30,100,0.55)` — rare earned highlight (e.g. the live Generate state), never ambient.
+- **Text:** `rgba(255,255,255,0.80)` body, `0.40` muted, `0.30` placeholder.
+- **Media-type palette (signature — every element type reads at a glance):** character `#fbbf24`, image `#22d3ee`, animated `#e879f9`, clip `#818cf8`, music `#a78bfa`, sound `#34d399`, narration `#9ca3af`. Use as small tags/borders on storyboard scene rows. Keep disciplined so it reads, not confetti.
+- **Dark mode:** Dark is the only mode. The stock light `:root` palette in `globals.css` is unreachable (html forces `#0a0a0a`); remove it or commit to dark-only.
+
+## Spacing
+
+- **Base unit:** 4px (Tailwind default).
+- **Density:** Compact-to-comfortable. The editor runs dense (`text-[11px]`, tight gaps); reading surfaces (narration) get more room.
+- **Scale:** 2xs(2) xs(4) sm(8) md(16) lg(24) xl(32) 2xl(48) 3xl(64).
+
+## Layout
+
+- **Approach:** Hybrid. Editor/canvas is grid-disciplined; composer and player are focal surfaces.
+- **Editor shell:** top "Refine your script" copilot bar + violet Generate to its right; vertical scrollable storyboard of scene rows; player panel docked (top or side).
+- **Max content width:** ~1100px for the storyboard column.
+- **Border radius:** `--radius: 0.625rem` (10px) base; scale to 4xl. Panels `rounded-xl`; pills `rounded-full`.
+
+## Motion
+
+- **Approach:** Intentional. Entrance `fadeInUp` (0.3s ease-out), shimmer loaders, OrbLoader for generation. `prefers-reduced-motion` already honored — keep it.
+- **Easing:** enter(ease-out) exit(ease-in) move(ease-in-out).
+- **Duration:** micro(50-100ms) short(150-250ms) medium(250-400ms) long(400-700ms).
+
+## Implementation Notes (sharpen backlog)
+
+These are the gaps between the shipped look and a real system. None block; all reduce drift.
+
+1. Tokenize the accent + glass: add `--accent-violet`, `--glow-violet`, `--glass-fill`, `--glass-border` instead of hardcoding `violet-500/30`, `bg-white/5`, `shadow-[0_0_40px_rgba(55,30,100,0.5)]` per component.
+2. Tokenize the media-type palette so storyboard surfaces (and the new conversational refine thread) reference tokens, not literals from `status.ts`.
+3. Resolve the four-font sprawl (see Typography).
+4. Remove the dead light `:root` palette.
+
+## Decisions Log
+
+| Date       | Decision                         | Rationale                                                                                                                                 |
+| ---------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-09 | Initial design system documented | Codified the existing dark-glass-violet look via /design-consultation; sharpened per "serious creative studio" + disciplined-violet rule. |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -25,13 +25,15 @@
 
 ## Color
 
+> Token values are canonical in `app/globals.css` (the `@theme` block). This section is the usage rules — when and where each color is allowed — not a second source for the literal values. If a value changes, change it in `@theme`; this doc names tokens, not hex.
+
 - **Approach:** Restrained. One accent + neutrals; color is rare and meaningful.
-- **Canvas:** `#0a0a0a` (near-black).
-- **Surfaces (glass):** fill `rgba(255,255,255,0.05)`, border `rgba(255,255,255,0.10)`, `backdrop-blur`.
-- **Accent (violet):** `#8b5cf6` (primary), `#a78bfa` (soft) — active Generate, focus rings, playhead, primary action only.
-- **Glow:** `#371e64` / `rgba(55,30,100,0.55)` — rare earned highlight (e.g. the live Generate state), never ambient.
-- **Text:** `rgba(255,255,255,0.80)` body, `0.40` muted, `0.30` placeholder.
-- **Media-type palette (signature — every element type reads at a glance):** character `#fbbf24`, image `#22d3ee`, animated `#e879f9`, clip `#818cf8`, music `#a78bfa`, sound `#34d399`, narration `#9ca3af`. Use as small tags/borders on storyboard scene rows. Keep disciplined so it reads, not confetti.
+- **Canvas:** `--color-canvas` (near-black).
+- **Surfaces (glass):** `--color-glass-fill`, `--color-glass-border`, `backdrop-blur`.
+- **Accent (violet):** `--color-accent-violet` (primary), `--color-accent-violet-soft` (soft) — active Generate, focus rings, playhead, primary action only.
+- **Glow:** `--color-glow-violet` / `--shadow-glow` — rare earned highlight (e.g. the live Generate state), never ambient.
+- **Text:** white at `0.80` body, `0.40` muted, `0.30` placeholder.
+- **Media-type palette (signature — every element type reads at a glance):** `--color-media-character`, `--color-media-image`, `--color-media-animated`, `--color-media-clip`, `--color-media-music`, `--color-media-sound`, `--color-media-narration`. Use as small tags/borders on storyboard scene rows. Keep disciplined so it reads, not confetti.
 - **Dark mode:** Dark is the only mode. The stock light `:root` palette in `globals.css` is unreachable (html forces `#0a0a0a`); remove it or commit to dark-only.
 
 ## Spacing

--- a/app/components/BackgroundGradientAnimation.tsx
+++ b/app/components/BackgroundGradientAnimation.tsx
@@ -2,121 +2,74 @@
 
 import { useEffect, useRef } from "react";
 
-export default function BackgroundGradientAnimation() {
-	const interactiveRef = useRef<HTMLDivElement>(null);
-
+// Smoothly translates a glow element toward the pointer. Honors reduced-motion
+// by centering the glow instead of animating it.
+function useCursorFollow() {
+	const ref = useRef<HTMLDivElement>(null);
 	useEffect(() => {
-		const el = interactiveRef.current;
+		const el = ref.current;
 		if (!el) return;
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+			el.style.transform = "translate(calc(50vw - 50%), calc(50vh - 50%))";
+			return;
+		}
 
-		const prefersReduced = window.matchMedia(
-			"(prefers-reduced-motion: reduce)",
-		).matches;
-		if (prefersReduced) return;
-
-		let currentX = window.innerWidth / 2;
-		let currentY = window.innerHeight / 2;
-		let targetX = currentX;
-		let targetY = currentY;
+		let curX = window.innerWidth / 2;
+		let curY = window.innerHeight / 3;
+		let tx = curX;
+		let ty = curY;
 		let frame = 0;
-
-		const handleMove = (e: MouseEvent) => {
-			targetX = e.clientX;
-			targetY = e.clientY;
+		const onMove = (e: MouseEvent) => {
+			tx = e.clientX;
+			ty = e.clientY;
 		};
-
 		const animate = () => {
-			currentX += (targetX - currentX) / 12;
-			currentY += (targetY - currentY) / 12;
-
-			el.style.transform = `translate(calc(${currentX}px - 50%), calc(${currentY}px - 50%))`;
-
+			curX += (tx - curX) / 16;
+			curY += (ty - curY) / 16;
+			el.style.transform = `translate(calc(${curX}px - 50%), calc(${curY}px - 50%))`;
 			frame = requestAnimationFrame(animate);
 		};
-
-		window.addEventListener("mousemove", handleMove, { passive: true });
+		window.addEventListener("mousemove", onMove, { passive: true });
 		frame = requestAnimationFrame(animate);
-
 		return () => {
-			window.removeEventListener("mousemove", handleMove);
+			window.removeEventListener("mousemove", onMove);
 			cancelAnimationFrame(frame);
 		};
 	}, []);
+	return ref;
+}
 
+/**
+ * Dark "studio at night" background (DESIGN.md): near-black with two restrained
+ * violet corner glows, a faint cursor-following violet glow, and grain.
+ */
+export default function BackgroundGradientAnimation() {
+	const glowRef = useCursorFollow();
 	return (
-		<div className="fixed inset-0 z-0 overflow-hidden">
-			{/* Base gradient background */}
+		<div className="pointer-events-none fixed inset-0 z-0 overflow-hidden bg-[#0a0a0a]">
 			<div
 				className="absolute inset-0"
 				style={{
-					background:
-						"linear-gradient(135deg, rgb(108, 0, 162) 0%, rgb(0, 17, 82) 100%)",
+					backgroundImage:
+						"radial-gradient(900px 520px at 82% -8%, rgba(139,92,246,0.12), transparent 60%), radial-gradient(760px 520px at -8% 108%, rgba(55,30,100,0.22), transparent 60%)",
 				}}
 			/>
-
-			{/* SVG blur filter */}
-			<svg className="hidden" aria-hidden="true">
-				<filter id="blurMe">
-					<feGaussianBlur in="SourceGraphic" stdDeviation="10" result="blur" />
-					<feColorMatrix
-						in="blur"
-						mode="matrix"
-						values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 18 -8"
-						result="goo"
-					/>
-					<feBlend in="SourceGraphic" in2="goo" />
-				</filter>
-			</svg>
-
-			{/* Animated gradient blobs */}
 			<div
-				className="absolute inset-0"
-				style={{ filter: "url(#blurMe) blur(40px)" }}
-			>
-				{/* Blob 1 — blue, vertical motion */}
-				<div
-					className="absolute w-[80%] h-[80%] top-[calc(50%-40%)] left-[calc(50%-40%)] animate-first opacity-70"
-					style={{
-						background:
-							"radial-gradient(circle at center, rgb(75, 134, 206) 0%, transparent 50%)",
-						mixBlendMode: "hard-light",
-					}}
-				/>
-
-				{/* Blob 2 — magenta, circular reverse */}
-				<div
-					className="absolute w-[90%] h-[90%] top-[calc(50%-45%)] left-[calc(50%-45%)] opacity-70"
-					style={{
-						background:
-							"radial-gradient(circle at center, rgb(178, 74, 230) 0%, transparent 50%)",
-						mixBlendMode: "hard-light",
-					}}
-				/>
-
-				{/* Blob 4 — red, horizontal */}
-				<div
-					className="absolute w-[80%] h-[80%] top-[calc(50%-40%)] left-[calc(50%-40%)] animate-fourth opacity-70"
-					style={{
-						background:
-							"radial-gradient(circle at center, rgb(155, 48, 128) 0%, transparent 50%)",
-						mixBlendMode: "hard-light",
-					}}
-				/>
-
-				{/* Interactive pointer blob */}
-				<div
-					ref={interactiveRef}
-					className="pointer-events-none absolute z-30 w-[100vmin] h-[100vmin] rounded-full opacity-50 blur-[60px]"
-					style={{
-						left: 0,
-						top: 0,
-						willChange: "transform",
-						background:
-							"radial-gradient(circle at center, rgba(40,152,244,0.9) 0%, transparent 75%)",
-						mixBlendMode: "hard-light",
-					}}
-				/>
-			</div>
+				ref={glowRef}
+				className="absolute left-0 top-0 h-[40rem] w-[40rem] rounded-full opacity-40 blur-3xl"
+				style={{
+					willChange: "transform",
+					background:
+						"radial-gradient(circle, rgba(139,92,246,0.10) 0%, transparent 60%)",
+				}}
+			/>
+			<div
+				className="absolute inset-0 opacity-[0.15]"
+				style={{
+					backgroundImage: "url(/grain.png)",
+					backgroundSize: "50px 50px",
+				}}
+			/>
 		</div>
 	);
 }

--- a/app/components/BackgroundGradientAnimation.tsx
+++ b/app/components/BackgroundGradientAnimation.tsx
@@ -46,12 +46,12 @@ function useCursorFollow() {
 export default function BackgroundGradientAnimation() {
 	const glowRef = useCursorFollow();
 	return (
-		<div className="pointer-events-none fixed inset-0 z-0 overflow-hidden bg-[#0a0a0a]">
+		<div className="pointer-events-none fixed inset-0 z-0 overflow-hidden bg-canvas">
 			<div
 				className="absolute inset-0"
 				style={{
 					backgroundImage:
-						"radial-gradient(900px 520px at 82% -8%, rgba(139,92,246,0.12), transparent 60%), radial-gradient(760px 520px at -8% 108%, rgba(55,30,100,0.22), transparent 60%)",
+						"radial-gradient(900px 520px at 82% -8%, color-mix(in srgb, var(--color-accent-violet) 12%, transparent), transparent 60%), radial-gradient(760px 520px at -8% 108%, color-mix(in srgb, var(--color-glow-violet) 22%, transparent), transparent 60%)",
 				}}
 			/>
 			<div
@@ -60,7 +60,7 @@ export default function BackgroundGradientAnimation() {
 				style={{
 					willChange: "transform",
 					background:
-						"radial-gradient(circle, rgba(139,92,246,0.10) 0%, transparent 60%)",
+						"radial-gradient(circle, color-mix(in srgb, var(--color-accent-violet) 10%, transparent) 0%, transparent 60%)",
 				}}
 			/>
 			<div

--- a/app/components/GlassDropdown.tsx
+++ b/app/components/GlassDropdown.tsx
@@ -52,7 +52,7 @@ export default function GlassDropdown<T extends string>({
 			<DropdownMenuContent
 				side={side}
 				align={align}
-				className="min-w-32 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+				className="min-w-32 rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
 			>
 				{options.map((option) => (
 					<DropdownMenuItem

--- a/app/components/GoogleOAuthButton.tsx
+++ b/app/components/GoogleOAuthButton.tsx
@@ -13,7 +13,7 @@ export default function GoogleOAuthButton({
 		<button
 			type="button"
 			onClick={onClick}
-			className="relative grain grain-12 w-full flex items-center justify-center gap-2.5 py-2.5 rounded-2xl bg-[#1e1e1e]/60 text-white text-sm font-medium font-display transition-[filter,transform] hover:brightness-[1.3] active:scale-[0.98]"
+			className="relative grain grain-12 w-full flex items-center justify-center gap-2.5 py-2.5 rounded-2xl bg-[#1e1e1e]/60 text-white text-sm font-medium font-body transition-[filter,transform] hover:brightness-[1.3] active:scale-[0.98]"
 		>
 			<GoogleIcon />
 			{children ?? "Continue with Google"}

--- a/app/components/GradientButton.tsx
+++ b/app/components/GradientButton.tsx
@@ -11,7 +11,7 @@ export default function GradientButton({
 }: GradientButtonProps) {
 	return (
 		<button
-			className={`relative grain w-full py-2.5 rounded-2xl text-white font-semibold text-sm font-display transition-[filter,transform] hover:brightness-[1.15] active:scale-[0.98] disabled:opacity-50 ${gradientStyles.gradient} ${className}`}
+			className={`relative grain w-full py-2.5 rounded-2xl text-white font-semibold text-sm font-body transition-[filter,transform] hover:brightness-[1.15] active:scale-[0.98] disabled:opacity-50 ${gradientStyles.gradient} ${className}`}
 			{...props}
 		>
 			{children}

--- a/app/components/OnboardingCard.tsx
+++ b/app/components/OnboardingCard.tsx
@@ -33,7 +33,7 @@ export default function OnboardingCard({
 				{icon ?? <OpenSlopLogo className="w-14 h-auto text-white" />}
 
 				{/* Heading */}
-				<h1 className="text-2xl sm:text-3xl font-light text-white text-center font-display text-wrap-balance">
+				<h1 className="text-2xl sm:text-3xl font-light text-white text-center font-body text-wrap-balance">
 					{heading}
 				</h1>
 
@@ -41,16 +41,14 @@ export default function OnboardingCard({
 				{extra}
 
 				{/* Subtitle */}
-				<p className="text-white/50 text-center text-xs sm:text-sm font-light leading-relaxed font-display">
+				<p className="text-white/50 text-center text-xs sm:text-sm font-light leading-relaxed font-body">
 					{subtitle}
 				</p>
 
 				{children}
 
 				{/* Footer */}
-				<p className="text-white/40 text-xs sm:text-sm font-display">
-					{footer}
-				</p>
+				<p className="text-white/40 text-xs sm:text-sm font-body">{footer}</p>
 			</div>
 		</div>
 	);

--- a/app/components/OrDivider.tsx
+++ b/app/components/OrDivider.tsx
@@ -2,7 +2,7 @@ export default function OrDivider() {
 	return (
 		<div className="w-full flex items-center gap-3">
 			<div className="flex-1 h-px bg-white/10" />
-			<span className="text-white/30 text-xs font-display">OR</span>
+			<span className="text-white/30 text-xs font-body">OR</span>
 			<div className="flex-1 h-px bg-white/10" />
 		</div>
 	);

--- a/app/components/TemplateGallery.tsx
+++ b/app/components/TemplateGallery.tsx
@@ -44,7 +44,7 @@ export default function TemplateGallery({
 						onClick={() =>
 							onSelect(template.id, template.showcase.examplePrompt)
 						}
-						className="group flex w-full flex-row overflow-hidden rounded-xl border border-white/10 bg-white/5 text-left transition-all hover:border-violet-500/30 hover:shadow-[0_0_20px_rgba(55,30,100,0.3)] sm:w-[calc(50%-0.375rem)]"
+						className="group flex w-full flex-row overflow-hidden rounded-xl border border-glass-border bg-glass-fill text-left transition-all hover:border-accent-violet/30 hover:shadow-[0_0_20px_rgba(55,30,100,0.3)] sm:w-[calc(50%-0.375rem)]"
 					>
 						<CardImage
 							src={template.showcase.image}

--- a/app/components/TemplateGallery.tsx
+++ b/app/components/TemplateGallery.tsx
@@ -44,7 +44,7 @@ export default function TemplateGallery({
 						onClick={() =>
 							onSelect(template.id, template.showcase.examplePrompt)
 						}
-						className="group flex w-full flex-row overflow-hidden rounded-xl border border-glass-border bg-glass-fill text-left transition-all hover:border-accent-violet/30 hover:shadow-[0_0_20px_rgba(55,30,100,0.3)] sm:w-[calc(50%-0.375rem)]"
+						className="group flex w-full flex-row overflow-hidden rounded-xl border border-glass-border bg-glass-fill text-left transition-all hover:border-accent-violet/30 hover:shadow-glow sm:w-[calc(50%-0.375rem)]"
 					>
 						<CardImage
 							src={template.showcase.image}

--- a/app/components/canvas/dnd/SortableActions.tsx
+++ b/app/components/canvas/dnd/SortableActions.tsx
@@ -43,7 +43,7 @@ export function SortableActions<K extends string>({
 					<DropdownMenuContent
 						side="bottom"
 						align="start"
-						className="w-40 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-1"
+						className="w-40 rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-1"
 					>
 						{options.map((option) => (
 							<DropdownMenuItem

--- a/app/components/canvas/elements/AssetTile.tsx
+++ b/app/components/canvas/elements/AssetTile.tsx
@@ -30,7 +30,7 @@ export function AssetTile({
 		fallback === "icon" || !initial ? <Icon className="h-4 w-4" /> : initial;
 	return (
 		<div className="group/tile flex w-16 flex-col gap-1 sm:w-20">
-			<div className="relative aspect-square overflow-hidden rounded-md border border-white/10 bg-white/5">
+			<div className="relative aspect-square overflow-hidden rounded-md border border-glass-border bg-glass-fill">
 				{previewUrl ? (
 					<ImageWithShimmer
 						key={previewUrl}

--- a/app/components/canvas/elements/AttributeBadge.tsx
+++ b/app/components/canvas/elements/AttributeBadge.tsx
@@ -87,7 +87,7 @@ export function AttributeBadge({
 			</DropdownMenuTrigger>
 			<DropdownMenuContent
 				align="start"
-				className="min-w-24 max-h-64 overflow-y-auto rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+				className="min-w-24 max-h-64 overflow-y-auto rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
 			>
 				{spec.edit.options.map((opt) => (
 					<DropdownMenuItem

--- a/app/components/canvas/elements/CharactersPicker.tsx
+++ b/app/components/canvas/elements/CharactersPicker.tsx
@@ -77,7 +77,7 @@ function ProjectCharactersMenu({
 	return (
 		<DropdownMenuContent
 			align="start"
-			className="min-w-32 max-h-64 overflow-y-auto rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+			className="min-w-32 max-h-64 overflow-y-auto rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
 		>
 			{names.map((name) => (
 				<DropdownMenuItem

--- a/app/components/canvas/elements/attributes/TextAttributePopover.tsx
+++ b/app/components/canvas/elements/attributes/TextAttributePopover.tsx
@@ -82,7 +82,7 @@ export function TextAttributePopover({
 				onEscapeKeyDown={() => {
 					cancelRef.current = true;
 				}}
-				className="w-72 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-1.5"
+				className="w-72 rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-1.5"
 			>
 				<textarea
 					autoFocus
@@ -96,7 +96,7 @@ export function TextAttributePopover({
 							setOpen(false);
 						}
 					}}
-					className="w-full resize-none rounded-lg border border-white/10 bg-white/5 px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
+					className="w-full resize-none rounded-lg border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
 				/>
 				<div className="mt-1 px-1 text-[10px] text-white/40">
 					⌘↵ to save · esc to cancel

--- a/app/components/canvas/elements/attributes/TextAttributePopover.tsx
+++ b/app/components/canvas/elements/attributes/TextAttributePopover.tsx
@@ -96,7 +96,7 @@ export function TextAttributePopover({
 							setOpen(false);
 						}
 					}}
-					className="w-full resize-none rounded-lg border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
+					className="w-full resize-none rounded-lg border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-accent-violet/50"
 				/>
 				<div className="mt-1 px-1 text-[10px] text-white/40">
 					⌘↵ to save · esc to cancel

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -192,7 +192,7 @@ function CharacterEditDialogBody({
 					className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[12px] transition-colors ${
 						confirmDelete
 							? "border-rose-500/60 bg-rose-500/20 text-rose-200 hover:bg-rose-500/30"
-							: "border-white/10 bg-white/5 text-white/70 hover:bg-white/10"
+							: "border-glass-border bg-glass-fill text-white/70 hover:bg-white/10"
 					}`}
 				>
 					<Trash2 className="h-3 w-3" />

--- a/app/components/canvas/elements/character/NewCharacterDialog.tsx
+++ b/app/components/canvas/elements/character/NewCharacterDialog.tsx
@@ -67,7 +67,7 @@ function NewCharacterDialogBody({
 					onChange={(e) => setName(e.target.value)}
 					placeholder="Character name"
 					aria-label="Character name"
-					className="w-full rounded-md border border-white/10 bg-white/5 px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
+					className="w-full rounded-md border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
 				/>
 
 				{collision && (

--- a/app/components/canvas/elements/character/NewCharacterDialog.tsx
+++ b/app/components/canvas/elements/character/NewCharacterDialog.tsx
@@ -67,7 +67,7 @@ function NewCharacterDialogBody({
 					onChange={(e) => setName(e.target.value)}
 					placeholder="Character name"
 					aria-label="Character name"
-					className="w-full rounded-md border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
+					className="w-full rounded-md border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-accent-violet/50"
 				/>
 
 				{collision && (

--- a/app/components/canvas/elements/character/VoiceMetadataFields.tsx
+++ b/app/components/canvas/elements/character/VoiceMetadataFields.tsx
@@ -20,7 +20,7 @@ export function VoiceSection({
 	onChange: (partial: Partial<MetadataVoice>) => void;
 }) {
 	return (
-		<section className="flex flex-col gap-2 rounded-lg border border-white/10 p-3">
+		<section className="flex flex-col gap-2 rounded-lg border border-glass-border p-3">
 			<div className="flex flex-col gap-0.5">
 				<FieldLabel>Voice</FieldLabel>
 				<p className="text-[11px] text-white/40">Filter the voice list</p>

--- a/app/components/canvas/elements/character/VoicePicker.tsx
+++ b/app/components/canvas/elements/character/VoicePicker.tsx
@@ -63,7 +63,7 @@ export function VoicePicker({
 		<div className="flex min-w-0 flex-col gap-1.5">
 			<FieldLabel>Voices</FieldLabel>
 			{error && <span className="text-[11px] text-rose-400">{error}</span>}
-			<div className="flex h-64 min-w-0 flex-col gap-1.5 overflow-y-auto rounded-lg border border-white/10 bg-black/20 p-1.5">
+			<div className="flex h-64 min-w-0 flex-col gap-1.5 overflow-y-auto rounded-lg border border-glass-border bg-black/20 p-1.5">
 				{loading &&
 					Array.from({ length: SKELETON_ROWS }).map((_, i) => (
 						<Skeleton

--- a/app/components/canvas/elements/character/fields.tsx
+++ b/app/components/canvas/elements/character/fields.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 export const FIELD_CLS =
-	"w-full rounded-md border border-white/10 bg-white/5 px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30";
+	"w-full rounded-md border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30";
 
 export function FieldLabel({ children }: { children: ReactNode }) {
 	return (
@@ -98,7 +98,7 @@ export function EnumField<T extends string>({
 				</DropdownMenuTrigger>
 				<DropdownMenuContent
 					align="start"
-					className="max-h-64 min-w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto rounded-xl border border-white/10 bg-white/5 p-0.5 shadow-md shadow-black/40 backdrop-blur-xl"
+					className="max-h-64 min-w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto rounded-xl border border-glass-border bg-glass-fill p-0.5 shadow-md shadow-black/40 backdrop-blur-xl"
 				>
 					<EnumOption
 						selected={value === undefined}

--- a/app/components/canvas/elements/character/fields.tsx
+++ b/app/components/canvas/elements/character/fields.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 export const FIELD_CLS =
-	"w-full rounded-md border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30";
+	"w-full rounded-md border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-accent-violet/50";
 
 export function FieldLabel({ children }: { children: ReactNode }) {
 	return (

--- a/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
+++ b/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
@@ -49,7 +49,7 @@ export function AnimatedImagePreview({
 					onDiscard={onDiscard}
 				/>
 			)}
-			<div className="absolute top-2 right-2 z-10 flex items-center rounded-full border border-white/10 bg-black/55 backdrop-blur-xl shadow-md shadow-black/40 p-0.5">
+			<div className="absolute top-2 right-2 z-10 flex items-center rounded-full border border-glass-border bg-black/55 backdrop-blur-xl shadow-md shadow-black/40 p-0.5">
 				<ToggleButton
 					active={mode === "animated"}
 					label="Video"

--- a/app/components/canvas/elements/preview/results.tsx
+++ b/app/components/canvas/elements/preview/results.tsx
@@ -26,7 +26,7 @@ export function AudioResult({
 	onRegenerate: () => void;
 }) {
 	return (
-		<div className="group relative w-full min-h-16 rounded-lg overflow-hidden border border-white/10 bg-white/[0.03] flex flex-wrap items-center gap-x-2 gap-y-1.5 px-2 py-1.5">
+		<div className="group relative w-full min-h-16 rounded-lg overflow-hidden border border-glass-border bg-white/[0.03] flex flex-wrap items-center gap-x-2 gap-y-1.5 px-2 py-1.5">
 			{type === "character" && <CharacterBadge name={characterName} />}
 			<GenerationIndicator
 				status={status}

--- a/app/components/canvas/panel/AutoScrollPanel.tsx
+++ b/app/components/canvas/panel/AutoScrollPanel.tsx
@@ -6,7 +6,7 @@ import { useAutoScroll } from "@/app/components/scene-selection/AutoScrollContex
 export default function AutoScrollPanel() {
 	const { enabled, setEnabled } = useAutoScroll();
 	const activeClass =
-		"relative grain bg-[#2d2040]/60 border border-violet-500/30 text-violet-300";
+		"relative grain bg-[#2d2040]/60 border border-accent-violet/30 text-violet-300";
 	return (
 		<div className="flex flex-col gap-2">
 			<h2 className="text-xs font-semibold uppercase tracking-wider text-white/50">

--- a/app/components/canvas/panel/AutoScrollPanel.tsx
+++ b/app/components/canvas/panel/AutoScrollPanel.tsx
@@ -6,7 +6,7 @@ import { useAutoScroll } from "@/app/components/scene-selection/AutoScrollContex
 export default function AutoScrollPanel() {
 	const { enabled, setEnabled } = useAutoScroll();
 	const activeClass =
-		"relative grain bg-[#2d2040]/60 border border-accent-violet/30 text-violet-300";
+		"relative grain bg-panel-violet/60 border border-accent-violet/30 text-violet-300";
 	return (
 		<div className="flex flex-col gap-2">
 			<h2 className="text-xs font-semibold uppercase tracking-wider text-white/50">

--- a/app/components/canvas/panel/PlayerPositionPanel.tsx
+++ b/app/components/canvas/panel/PlayerPositionPanel.tsx
@@ -20,7 +20,7 @@ export default function PlayerPositionPanel() {
 		usePlayerPosition();
 
 	const activeClass =
-		"relative grain bg-[#2d2040]/60 border border-violet-500/30 text-violet-300";
+		"relative grain bg-[#2d2040]/60 border border-accent-violet/30 text-violet-300";
 
 	return (
 		<div className="flex flex-col gap-2">

--- a/app/components/canvas/panel/PlayerPositionPanel.tsx
+++ b/app/components/canvas/panel/PlayerPositionPanel.tsx
@@ -20,7 +20,7 @@ export default function PlayerPositionPanel() {
 		usePlayerPosition();
 
 	const activeClass =
-		"relative grain bg-[#2d2040]/60 border border-accent-violet/30 text-violet-300";
+		"relative grain bg-panel-violet/60 border border-accent-violet/30 text-violet-300";
 
 	return (
 		<div className="flex flex-col gap-2">

--- a/app/components/canvas/panel/Sidebar.tsx
+++ b/app/components/canvas/panel/Sidebar.tsx
@@ -25,7 +25,7 @@ export default function Sidebar() {
 				}`}
 			>
 				<div
-					className={`absolute inset-0 bg-white/5 backdrop-blur-xl shadow-[2px_0_50px_rgba(0,0,0,0.25)] border-r border-white/10 transition-opacity duration-300 motion-reduce:transition-none ${
+					className={`absolute inset-0 bg-glass-fill backdrop-blur-xl shadow-[2px_0_50px_rgba(0,0,0,0.25)] border-r border-glass-border transition-opacity duration-300 motion-reduce:transition-none ${
 						open ? "opacity-100" : "opacity-0"
 					}`}
 				/>

--- a/app/components/canvas/panel/TransitionPanel.tsx
+++ b/app/components/canvas/panel/TransitionPanel.tsx
@@ -41,7 +41,7 @@ export default function TransitionPanel() {
 					<button
 						type="button"
 						aria-label={`Transition: ${LABELS[transitionType]}`}
-						className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm text-white/70 hover:text-white bg-white/5 hover:bg-white/10 ring-1 ring-inset ring-white/10 hover:ring-white/20 transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+						className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm text-white/70 hover:text-white bg-glass-fill hover:bg-white/10 ring-1 ring-inset ring-white/10 hover:ring-white/20 transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
 					>
 						<span className="truncate">{LABELS[transitionType]}</span>
 						<ChevronDown
@@ -52,7 +52,7 @@ export default function TransitionPanel() {
 				</DropdownMenuTrigger>
 				<DropdownMenuContent
 					align="start"
-					className="z-[90] min-w-[--radix-dropdown-menu-trigger-width] max-h-64 overflow-y-auto rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+					className="z-[90] min-w-[--radix-dropdown-menu-trigger-width] max-h-64 overflow-y-auto rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
 				>
 					{TRANSITION_TYPES.map((value) => (
 						<DropdownMenuItem

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -79,7 +79,7 @@ function AttachMenu({
 			<DropdownMenuContent
 				side="bottom"
 				align="start"
-				className="min-w-36 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+				className="min-w-36 rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
 			>
 				<DropdownMenuItem
 					onClick={openPicker}
@@ -181,7 +181,7 @@ export default function ComposerCopilot({
 		typeof placeholder === "string" ? placeholder : undefined;
 
 	return (
-		<div className="w-full rounded-xl border border-violet-500/30 bg-white/5 shadow-[0_0_40px_rgba(55,30,100,0.5)]">
+		<div className="w-full rounded-xl border border-accent-violet/30 bg-glass-fill backdrop-blur-xl transition-shadow focus-within:shadow-glow">
 			<div className="px-4 py-3">
 				<ComposerAssets
 					uploadingCount={uploadingCount}

--- a/app/components/copilot/InlineCopilot.tsx
+++ b/app/components/copilot/InlineCopilot.tsx
@@ -63,7 +63,7 @@ export default function InlineCopilot({
 		typeof placeholder === "string" ? placeholder : undefined;
 
 	return (
-		<div className="w-full rounded-xl border border-violet-500/30 bg-white/5 shadow-[0_0_40px_rgba(55,30,100,0.5)]">
+		<div className="w-full rounded-xl border border-accent-violet/30 bg-glass-fill backdrop-blur-xl transition-shadow focus-within:shadow-glow">
 			<div className="relative flex items-center px-4 py-3">
 				{loading ? (
 					<OrbLoader />

--- a/app/components/projects/ProjectsList.tsx
+++ b/app/components/projects/ProjectsList.tsx
@@ -62,7 +62,7 @@ export default function ProjectsList({
 			<div className="max-w-5xl mx-auto px-6 pt-20 pb-16">
 				<header className="flex items-end justify-between mb-10">
 					<div>
-						<h1 className="font-display text-4xl tracking-tight">My Slop</h1>
+						<h1 className="font-body text-4xl tracking-tight">My Slop</h1>
 						<p className="text-white/60 text-sm mt-1">
 							{projects.length === 0
 								? "No projects yet — start your first slop."

--- a/app/components/projects/ProjectsList.tsx
+++ b/app/components/projects/ProjectsList.tsx
@@ -83,7 +83,7 @@ export default function ProjectsList({
 				<ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
 					{projects.map((project) => (
 						<li key={project.id}>
-							<div className="group relative rounded-xl border border-white/10 bg-white/[0.03] hover:bg-white/[0.06] transition-colors overflow-hidden">
+							<div className="group relative rounded-xl border border-glass-border bg-white/[0.03] hover:bg-white/[0.06] transition-colors overflow-hidden">
 								<button
 									type="button"
 									onClick={() => router.push(`/projects/${project.id}`)}

--- a/app/components/video/RenderControls.tsx
+++ b/app/components/video/RenderControls.tsx
@@ -16,7 +16,7 @@ function formatBytes(bytes: number): string {
 }
 
 const pillClass =
-	"flex items-center gap-2 rounded-lg border border-white/10 bg-card/90 px-3 py-2 backdrop-blur-xl shadow-md shadow-black/20 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12)]";
+	"flex items-center gap-2 rounded-lg border border-glass-border bg-card/90 px-3 py-2 backdrop-blur-xl shadow-md shadow-black/20 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12)]";
 
 export function RenderControls({ layout }: { layout: VideoLayout }) {
 	const { state, render, reset } = useRendering();

--- a/app/components/video/VideoPanel.tsx
+++ b/app/components/video/VideoPanel.tsx
@@ -35,7 +35,7 @@ export function VideoPanel() {
 	const showControls = !scriptLoading && !!layout?.series.length && ready;
 
 	return (
-		<div className="group relative h-full w-full overflow-hidden rounded-lg border border-white/10 bg-white/5 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12)]">
+		<div className="group relative h-full w-full overflow-hidden rounded-lg border border-glass-border bg-glass-fill shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12)]">
 			<div className="grain grain-light absolute inset-0" aria-hidden="true" />
 			<div className="relative z-[2] h-full w-full">
 				<VideoPanelBody />

--- a/app/globals.css
+++ b/app/globals.css
@@ -53,6 +53,7 @@
 	--color-canvas: #0a0a0a;
 	--color-accent-violet: #8b5cf6;
 	--color-accent-violet-soft: #a78bfa;
+	--color-glow-violet: rgba(55, 30, 100, 0.55);
 	--color-glass-fill: rgba(255, 255, 255, 0.05);
 	--color-glass-border: rgba(255, 255, 255, 0.1);
 
@@ -66,7 +67,7 @@
 	--color-media-narration: #9ca3af;
 
 	/* The earned violet glow. Used rarely, only on the live/primary action. */
-	--shadow-glow: 0 0 40px rgba(55, 30, 100, 0.55);
+	--shadow-glow: 0 0 40px var(--color-glow-violet);
 }
 
 @keyframes moveHorizontal {

--- a/app/globals.css
+++ b/app/globals.css
@@ -54,6 +54,7 @@
 	--color-accent-violet: #8b5cf6;
 	--color-accent-violet-soft: #a78bfa;
 	--color-glow-violet: rgba(55, 30, 100, 0.55);
+	--color-panel-violet: #2d2040;
 	--color-glass-fill: rgba(255, 255, 255, 0.05);
 	--color-glass-border: rgba(255, 255, 255, 0.1);
 
@@ -163,11 +164,6 @@
 html {
 	background-color: #0a0a0a;
 	color-scheme: dark;
-}
-
-/* Display utility — consolidated onto Satoshi (Google Sans Flex dropped per DESIGN.md). */
-.font-display {
-	font-family: "Satoshi", sans-serif;
 }
 
 .font-title {

--- a/app/globals.css
+++ b/app/globals.css
@@ -46,6 +46,29 @@
 	--radius-4xl: calc(var(--radius) + 16px);
 }
 
+/* openslop design tokens — see DESIGN.md. Non-inline so the raw CSS vars are
+   available everywhere (module CSS, arbitrary values) and utilities are generated
+   (bg-glass-fill, border-glass-border, text-media-character, shadow-glow, ...). */
+@theme {
+	--color-canvas: #0a0a0a;
+	--color-accent-violet: #8b5cf6;
+	--color-accent-violet-soft: #a78bfa;
+	--color-glass-fill: rgba(255, 255, 255, 0.05);
+	--color-glass-border: rgba(255, 255, 255, 0.1);
+
+	/* Media-type palette — every storyboard element type reads at a glance. */
+	--color-media-character: #fbbf24;
+	--color-media-image: #22d3ee;
+	--color-media-animated: #e879f9;
+	--color-media-clip: #818cf8;
+	--color-media-music: #a78bfa;
+	--color-media-sound: #34d399;
+	--color-media-narration: #9ca3af;
+
+	/* The earned violet glow. Used rarely, only on the live/primary action. */
+	--shadow-glow: 0 0 40px rgba(55, 30, 100, 0.55);
+}
+
 @keyframes moveHorizontal {
 	0% {
 		transform: translateX(-20%) translateY(-10%);
@@ -141,9 +164,9 @@ html {
 	color-scheme: dark;
 }
 
-/* Reusable font-family utility for Google Sans Flex */
+/* Display utility — consolidated onto Satoshi (Google Sans Flex dropped per DESIGN.md). */
 .font-display {
-	font-family: "Google Sans Flex", sans-serif;
+	font-family: "Satoshi", sans-serif;
 }
 
 .font-title {

--- a/app/globals.css
+++ b/app/globals.css
@@ -71,37 +71,6 @@
 	--shadow-glow: 0 0 40px var(--color-glow-violet);
 }
 
-@keyframes moveHorizontal {
-	0% {
-		transform: translateX(-20%) translateY(-10%);
-	}
-	50% {
-		transform: translateX(20%) translateY(-5%);
-	}
-	100% {
-		transform: translateX(-20%) translateY(-10%);
-	}
-}
-
-@keyframes moveVertical {
-	0% {
-		transform: translateY(-25%);
-	}
-	50% {
-		transform: translateY(25%);
-	}
-	100% {
-		transform: translateY(-25%);
-	}
-}
-
-.animate-first {
-	animation: moveVertical 25s ease infinite;
-}
-.animate-fourth {
-	animation: moveHorizontal 20s ease infinite;
-}
-
 @keyframes fadeInUp {
 	from {
 		opacity: 0;
@@ -153,8 +122,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.animate-first,
-	.animate-fourth,
 	.animate-fadeInUp,
 	.shimmer-surface {
 		animation: none;

--- a/app/globals.css
+++ b/app/globals.css
@@ -53,7 +53,7 @@
 	--color-canvas: #0a0a0a;
 	--color-accent-violet: #8b5cf6;
 	--color-accent-violet-soft: #a78bfa;
-	--color-glow-violet: rgba(55, 30, 100, 0.55);
+	--color-glow-violet: #371e64;
 	--color-panel-violet: #2d2040;
 	--color-glass-fill: rgba(255, 255, 255, 0.05);
 	--color-glass-border: rgba(255, 255, 255, 0.1);
@@ -68,7 +68,8 @@
 	--color-media-narration: #9ca3af;
 
 	/* The earned violet glow. Used rarely, only on the live/primary action. */
-	--shadow-glow: 0 0 40px var(--color-glow-violet);
+	--shadow-glow: 0 0 40px
+		color-mix(in srgb, var(--color-glow-violet) 55%, transparent);
 }
 
 @keyframes fadeInUp {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -43,10 +43,6 @@ export default function RootLayout({
 					href="https://api.fontshare.com/v2/css?f[]=sentient@400&f[]=satoshi@400,500,700&display=swap"
 					rel="stylesheet"
 				/>
-				<link
-					href="https://fonts.googleapis.com/css2?family=Google+Sans+Flex:wght@300;400;500;600;700&display=swap"
-					rel="stylesheet"
-				/>
 			</head>
 			<body
 				className={`${geistSans.variable} ${instrumentSerif.variable} antialiased bg-[#0a0a0a]`}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -15,7 +15,7 @@ export default function Loading() {
 					{Array.from({ length: 6 }).map((_, i) => (
 						<div
 							key={i}
-							className="rounded-xl border border-white/10 overflow-hidden"
+							className="rounded-xl border border-glass-border overflow-hidden"
 						>
 							<Skeleton className="aspect-video rounded-none" />
 							<div className="p-4 space-y-2">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -62,7 +62,7 @@ export default async function Home() {
 				</>
 			}
 		>
-			<p className="text-white/70 text-sm font-medium font-display">
+			<p className="text-white/70 text-sm font-medium font-body">
 				Have an access code?
 			</p>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,7 +37,7 @@ export default async function Home() {
 			heading="Welcome to the OpenSlop Beta"
 			subtitle="OpenSlop is your free, open-source video creator that brings together all your favorite AI tools, helping you get more done with less effort."
 			extra={
-				<div className="w-full flex items-center justify-center gap-3 sm:gap-5 rounded-full border border-white/10 bg-white/5 px-4 sm:px-6 py-2.5 sm:py-3">
+				<div className="w-full flex items-center justify-center gap-3 sm:gap-5 rounded-full border border-glass-border bg-glass-fill px-4 sm:px-6 py-2.5 sm:py-3">
 					{icons.map((icon) => (
 						<Image
 							key={icon}

--- a/app/styles/auth.module.css
+++ b/app/styles/auth.module.css
@@ -11,7 +11,7 @@
 	transition:
 		border-color 0.15s,
 		box-shadow 0.15s;
-	font-family: "Google Sans Flex", sans-serif;
+	font-family: "Satoshi", sans-serif;
 }
 
 .input::placeholder {


### PR DESCRIPTION
Codifies the existing dark-glass-violet look as a real system.

- **DESIGN.md** + a pointer to it from the project's agent guide (source of truth).
- **@theme tokens** in `globals.css`: `accent-violet`, glass fill/border, the media-type palette, `shadow-glow`.
- **Token adoption** across ~24 components — value-identical sweep (`bg-white/5`→`bg-glass-fill`, etc.), so no pixels move.
- **Font consolidation**: drop Google Sans Flex (→ Satoshi).
- **Disciplined violet**: the composer/refine input glow is now earned on focus, not ambient.

Foundation for #228 (refine). Mostly mechanical; should review fast.