### PR TITLE
feat(ui): dark-studio background + theme toggle

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -34,7 +34,8 @@
 - **Glow:** `--color-glow-violet` / `--shadow-glow` — rare earned highlight (e.g. the live Generate state), never ambient.
 - **Text:** white at `0.80` body, `0.40` muted, `0.30` placeholder.
 - **Media-type palette (signature — every element type reads at a glance):** `--color-media-character`, `--color-media-image`, `--color-media-animated`, `--color-media-clip`, `--color-media-music`, `--color-media-sound`, `--color-media-narration`. Use as small tags/borders on storyboard scene rows. Keep disciplined so it reads, not confetti.
-- **Dark mode:** Dark is the only mode. The stock light `:root` palette in `globals.css` is unreachable (html forces `#0a0a0a`); remove it or commit to dark-only.
+- **Dark mode:** The dark studio is the default and the identity. The stock light `:root` palette in `globals.css` is unreachable (html forces `#0a0a0a`); remove it or commit to dark-only.
+- **Background escape hatch:** A purple gradient background is the one sanctioned departure — an explicit, persisted opt-in via the profile toggle, off by default. It themes only the page background, never the disciplined studio UI on top of it. If we decide the dark studio is absolute, this is the toggle to sunset; until then it's grandfathered in as a user preference.
 
 ## Spacing
 

--- a/app/components/BackgroundGradientAnimation.tsx
+++ b/app/components/BackgroundGradientAnimation.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useEffect, useRef, useSyncExternalStore } from "react";
+import { useEffect, useRef } from "react";
 import { useBackgroundTheme } from "@/lib/theme/backgroundTheme";
-
-const emptySubscribe = () => () => {};
+import { useHydrated } from "@/lib/hooks/useHydrated";
 
 // Shared cursor-follow: smoothly translates an element toward the pointer.
 function useCursorFollow() {
@@ -150,13 +149,8 @@ function PurpleBackground() {
 export default function BackgroundGradientAnimation() {
 	const theme = useBackgroundTheme((s) => s.theme);
 	// Render the default (dark) during SSR and the first hydration pass to avoid
-	// a mismatch, then honor the persisted preference. useSyncExternalStore
-	// returns the server snapshot (false) until hydration completes.
-	const hydrated = useSyncExternalStore(
-		emptySubscribe,
-		() => true,
-		() => false,
-	);
+	// a mismatch, then honor the persisted preference.
+	const hydrated = useHydrated();
 
 	return hydrated && theme === "purple" ? (
 		<PurpleBackground />

--- a/app/components/BackgroundGradientAnimation.tsx
+++ b/app/components/BackgroundGradientAnimation.tsx
@@ -148,8 +148,6 @@ function PurpleBackground() {
 
 export default function BackgroundGradientAnimation() {
 	const theme = useBackgroundTheme((s) => s.theme);
-	// Render the default (dark) during SSR and the first hydration pass to avoid
-	// a mismatch, then honor the persisted preference.
 	const hydrated = useHydrated();
 
 	return hydrated && theme === "purple" ? (

--- a/app/components/BackgroundGradientAnimation.tsx
+++ b/app/components/BackgroundGradientAnimation.tsx
@@ -1,51 +1,86 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useSyncExternalStore } from "react";
+import { useBackgroundTheme } from "@/lib/theme/backgroundTheme";
 
-export default function BackgroundGradientAnimation() {
-	const interactiveRef = useRef<HTMLDivElement>(null);
+const emptySubscribe = () => () => {};
 
+// Shared cursor-follow: smoothly translates an element toward the pointer.
+function useCursorFollow() {
+	const ref = useRef<HTMLDivElement>(null);
 	useEffect(() => {
-		const el = interactiveRef.current;
+		const el = ref.current;
 		if (!el) return;
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
 
-		const prefersReduced = window.matchMedia(
-			"(prefers-reduced-motion: reduce)",
-		).matches;
-		if (prefersReduced) return;
-
-		let currentX = window.innerWidth / 2;
-		let currentY = window.innerHeight / 2;
-		let targetX = currentX;
-		let targetY = currentY;
+		let curX = window.innerWidth / 2;
+		let curY = window.innerHeight / 3;
+		let tx = curX;
+		let ty = curY;
 		let frame = 0;
-
-		const handleMove = (e: MouseEvent) => {
-			targetX = e.clientX;
-			targetY = e.clientY;
+		const onMove = (e: MouseEvent) => {
+			tx = e.clientX;
+			ty = e.clientY;
 		};
-
 		const animate = () => {
-			currentX += (targetX - currentX) / 12;
-			currentY += (targetY - currentY) / 12;
-
-			el.style.transform = `translate(calc(${currentX}px - 50%), calc(${currentY}px - 50%))`;
-
+			curX += (tx - curX) / 16;
+			curY += (ty - curY) / 16;
+			el.style.transform = `translate(calc(${curX}px - 50%), calc(${curY}px - 50%))`;
 			frame = requestAnimationFrame(animate);
 		};
-
-		window.addEventListener("mousemove", handleMove, { passive: true });
+		window.addEventListener("mousemove", onMove, { passive: true });
 		frame = requestAnimationFrame(animate);
-
 		return () => {
-			window.removeEventListener("mousemove", handleMove);
+			window.removeEventListener("mousemove", onMove);
 			cancelAnimationFrame(frame);
 		};
 	}, []);
+	return ref;
+}
 
+/**
+ * Dark "studio at night" background (DESIGN.md): near-black with two restrained
+ * violet/purple corner glows, a faint cursor-following violet glow, and grain.
+ */
+function DarkStudioBackground() {
+	const glowRef = useCursorFollow();
 	return (
-		<div className="fixed inset-0 z-0 overflow-hidden">
-			{/* Base gradient background */}
+		<div className="pointer-events-none fixed inset-0 z-0 overflow-hidden bg-[#0a0a0a]">
+			<div
+				className="absolute inset-0"
+				style={{
+					backgroundImage:
+						"radial-gradient(900px 520px at 82% -8%, rgba(139,92,246,0.12), transparent 60%), radial-gradient(760px 520px at -8% 108%, rgba(55,30,100,0.22), transparent 60%)",
+				}}
+			/>
+			<div
+				ref={glowRef}
+				className="absolute left-0 top-0 h-[40rem] w-[40rem] rounded-full opacity-40 blur-3xl"
+				style={{
+					willChange: "transform",
+					background:
+						"radial-gradient(circle, rgba(139,92,246,0.10) 0%, transparent 60%)",
+				}}
+			/>
+			<div
+				className="absolute inset-0 opacity-[0.15]"
+				style={{
+					backgroundImage: "url(/grain.png)",
+					backgroundSize: "50px 50px",
+				}}
+			/>
+		</div>
+	);
+}
+
+/**
+ * The original bright purple-to-blue animated gradient with goo blobs, kept as
+ * an opt-in background theme.
+ */
+function PurpleBackground() {
+	const interactiveRef = useCursorFollow();
+	return (
+		<div className="pointer-events-none fixed inset-0 z-0 overflow-hidden">
 			<div
 				className="absolute inset-0"
 				style={{
@@ -53,8 +88,6 @@ export default function BackgroundGradientAnimation() {
 						"linear-gradient(135deg, rgb(108, 0, 162) 0%, rgb(0, 17, 82) 100%)",
 				}}
 			/>
-
-			{/* SVG blur filter */}
 			<svg className="hidden" aria-hidden="true">
 				<filter id="blurMe">
 					<feGaussianBlur in="SourceGraphic" stdDeviation="10" result="blur" />
@@ -67,49 +100,38 @@ export default function BackgroundGradientAnimation() {
 					<feBlend in="SourceGraphic" in2="goo" />
 				</filter>
 			</svg>
-
-			{/* Animated gradient blobs */}
 			<div
 				className="absolute inset-0"
 				style={{ filter: "url(#blurMe) blur(40px)" }}
 			>
-				{/* Blob 1 — blue, vertical motion */}
 				<div
-					className="absolute w-[80%] h-[80%] top-[calc(50%-40%)] left-[calc(50%-40%)] animate-first opacity-70"
+					className="absolute h-[80%] w-[80%] top-[calc(50%-40%)] left-[calc(50%-40%)] animate-first opacity-70"
 					style={{
 						background:
 							"radial-gradient(circle at center, rgb(75, 134, 206) 0%, transparent 50%)",
 						mixBlendMode: "hard-light",
 					}}
 				/>
-
-				{/* Blob 2 — magenta, circular reverse */}
 				<div
-					className="absolute w-[90%] h-[90%] top-[calc(50%-45%)] left-[calc(50%-45%)] opacity-70"
+					className="absolute h-[90%] w-[90%] top-[calc(50%-45%)] left-[calc(50%-45%)] opacity-70"
 					style={{
 						background:
 							"radial-gradient(circle at center, rgb(178, 74, 230) 0%, transparent 50%)",
 						mixBlendMode: "hard-light",
 					}}
 				/>
-
-				{/* Blob 4 — red, horizontal */}
 				<div
-					className="absolute w-[80%] h-[80%] top-[calc(50%-40%)] left-[calc(50%-40%)] animate-fourth opacity-70"
+					className="absolute h-[80%] w-[80%] top-[calc(50%-40%)] left-[calc(50%-40%)] animate-fourth opacity-70"
 					style={{
 						background:
 							"radial-gradient(circle at center, rgb(155, 48, 128) 0%, transparent 50%)",
 						mixBlendMode: "hard-light",
 					}}
 				/>
-
-				{/* Interactive pointer blob */}
 				<div
 					ref={interactiveRef}
-					className="pointer-events-none absolute z-30 w-[100vmin] h-[100vmin] rounded-full opacity-50 blur-[60px]"
+					className="absolute left-0 top-0 z-30 h-[100vmin] w-[100vmin] rounded-full opacity-50 blur-[60px]"
 					style={{
-						left: 0,
-						top: 0,
 						willChange: "transform",
 						background:
 							"radial-gradient(circle at center, rgba(40,152,244,0.9) 0%, transparent 75%)",
@@ -118,5 +140,23 @@ export default function BackgroundGradientAnimation() {
 				/>
 			</div>
 		</div>
+	);
+}
+
+export default function BackgroundGradientAnimation() {
+	const theme = useBackgroundTheme((s) => s.theme);
+	// Render the default (dark) during SSR and the first hydration pass to avoid
+	// a mismatch, then honor the persisted preference. useSyncExternalStore
+	// returns the server snapshot (false) until hydration completes.
+	const hydrated = useSyncExternalStore(
+		emptySubscribe,
+		() => true,
+		() => false,
+	);
+
+	return hydrated && theme === "purple" ? (
+		<PurpleBackground />
+	) : (
+		<DarkStudioBackground />
 	);
 }

--- a/app/components/BackgroundGradientAnimation.tsx
+++ b/app/components/BackgroundGradientAnimation.tsx
@@ -11,7 +11,11 @@ function useCursorFollow() {
 	useEffect(() => {
 		const el = ref.current;
 		if (!el) return;
-		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+			// Center the glow instead of leaving it parked in the top-left corner.
+			el.style.transform = "translate(calc(50vw - 50%), calc(50vh - 50%))";
+			return;
+		}
 
 		let curX = window.innerWidth / 2;
 		let curY = window.innerHeight / 3;

--- a/app/components/UserProfile.tsx
+++ b/app/components/UserProfile.tsx
@@ -19,8 +19,6 @@ export default function UserProfile() {
 	const user = useUser();
 	const bgTheme = useBackgroundTheme((s) => s.theme);
 	const toggleBgTheme = useBackgroundTheme((s) => s.toggle);
-	// Render the default (dark) through SSR + the first hydration pass to avoid a
-	// mismatch when a persisted preference differs from the server default.
 	const isDark = !useHydrated() || bgTheme === "dark";
 	const email = user.email ?? "";
 	const avatarUrl: string | undefined = user.user_metadata?.avatar_url;

--- a/app/components/UserProfile.tsx
+++ b/app/components/UserProfile.tsx
@@ -10,11 +10,14 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { LogOut } from "lucide-react";
+import { LogOut, Moon, Sparkles } from "lucide-react";
+import { useBackgroundTheme } from "@/lib/theme/backgroundTheme";
 
 export default function UserProfile() {
 	const router = useRouter();
 	const user = useUser();
+	const bgTheme = useBackgroundTheme((s) => s.theme);
+	const toggleBgTheme = useBackgroundTheme((s) => s.toggle);
 	const email = user.email ?? "";
 	const avatarUrl: string | undefined = user.user_metadata?.avatar_url;
 	const name: string | undefined = user.user_metadata?.full_name;
@@ -49,14 +52,28 @@ export default function UserProfile() {
 					side="bottom"
 					sideOffset={-44}
 					alignOffset={-8}
-					className="z-[90] w-56 origin-center rounded-3xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-105 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-105"
+					className="z-[90] w-56 origin-center rounded-3xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-105 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-105"
 				>
 					<div className="flex h-[52px] items-center gap-3 pl-12 pr-4">
 						<span className="truncate text-sm font-medium text-white/90 pl-1">
 							{name || email.split("@")[0]}
 						</span>
 					</div>
-					<div className="border-t border-white/10 p-1">
+					<div className="border-t border-glass-border p-1">
+						<DropdownMenuItem
+							onSelect={(e) => {
+								e.preventDefault();
+								toggleBgTheme();
+							}}
+							className="cursor-pointer rounded-3xl py-2 my-1 text-white/70 hover:text-white focus:text-white focus:bg-white/10"
+						>
+							{bgTheme === "dark" ? (
+								<Moon className="mr-2 h-4 w-4" />
+							) : (
+								<Sparkles className="mr-2 h-4 w-4" />
+							)}
+							Background: {bgTheme === "dark" ? "Dark" : "Purple"}
+						</DropdownMenuItem>
 						<DropdownMenuItem
 							onClick={handleLogout}
 							className="cursor-pointer rounded-3xl py-2 my-1 text-white/70 hover:text-white focus:text-white focus:bg-white/10"

--- a/app/components/UserProfile.tsx
+++ b/app/components/UserProfile.tsx
@@ -10,11 +10,9 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { useSyncExternalStore } from "react";
 import { LogOut, Moon, Sparkles } from "lucide-react";
 import { useBackgroundTheme } from "@/lib/theme/backgroundTheme";
-
-const emptySubscribe = () => () => {};
+import { useHydrated } from "@/lib/hooks/useHydrated";
 
 export default function UserProfile() {
 	const router = useRouter();
@@ -23,12 +21,7 @@ export default function UserProfile() {
 	const toggleBgTheme = useBackgroundTheme((s) => s.toggle);
 	// Render the default (dark) through SSR + the first hydration pass to avoid a
 	// mismatch when a persisted preference differs from the server default.
-	const hydrated = useSyncExternalStore(
-		emptySubscribe,
-		() => true,
-		() => false,
-	);
-	const isDark = !hydrated || bgTheme === "dark";
+	const isDark = !useHydrated() || bgTheme === "dark";
 	const email = user.email ?? "";
 	const avatarUrl: string | undefined = user.user_metadata?.avatar_url;
 	const name: string | undefined = user.user_metadata?.full_name;

--- a/app/components/UserProfile.tsx
+++ b/app/components/UserProfile.tsx
@@ -10,14 +10,25 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useSyncExternalStore } from "react";
 import { LogOut, Moon, Sparkles } from "lucide-react";
 import { useBackgroundTheme } from "@/lib/theme/backgroundTheme";
+
+const emptySubscribe = () => () => {};
 
 export default function UserProfile() {
 	const router = useRouter();
 	const user = useUser();
 	const bgTheme = useBackgroundTheme((s) => s.theme);
 	const toggleBgTheme = useBackgroundTheme((s) => s.toggle);
+	// Render the default (dark) through SSR + the first hydration pass to avoid a
+	// mismatch when a persisted preference differs from the server default.
+	const hydrated = useSyncExternalStore(
+		emptySubscribe,
+		() => true,
+		() => false,
+	);
+	const isDark = !hydrated || bgTheme === "dark";
 	const email = user.email ?? "";
 	const avatarUrl: string | undefined = user.user_metadata?.avatar_url;
 	const name: string | undefined = user.user_metadata?.full_name;
@@ -67,12 +78,12 @@ export default function UserProfile() {
 							}}
 							className="cursor-pointer rounded-3xl py-2 my-1 text-white/70 hover:text-white focus:text-white focus:bg-white/10"
 						>
-							{bgTheme === "dark" ? (
+							{isDark ? (
 								<Moon className="mr-2 h-4 w-4" />
 							) : (
 								<Sparkles className="mr-2 h-4 w-4" />
 							)}
-							Background: {bgTheme === "dark" ? "Dark" : "Purple"}
+							Background: {isDark ? "Dark" : "Purple"}
 						</DropdownMenuItem>
 						<DropdownMenuItem
 							onClick={handleLogout}

--- a/lib/hooks/useHydrated.ts
+++ b/lib/hooks/useHydrated.ts
@@ -1,0 +1,17 @@
+import { useSyncExternalStore } from "react";
+
+const emptySubscribe = () => () => {};
+
+/**
+ * Returns false during SSR and the first client render, then true once
+ * hydration completes. Use it to gate rendering of a persisted client
+ * preference so the markup matches the server on the first pass and avoids a
+ * hydration mismatch.
+ */
+export function useHydrated(): boolean {
+	return useSyncExternalStore(
+		emptySubscribe,
+		() => true,
+		() => false,
+	);
+}

--- a/lib/hooks/useHydrated.ts
+++ b/lib/hooks/useHydrated.ts
@@ -2,12 +2,7 @@ import { useSyncExternalStore } from "react";
 
 const emptySubscribe = () => () => {};
 
-/**
- * Returns false during SSR and the first client render, then true once
- * hydration completes. Use it to gate rendering of a persisted client
- * preference so the markup matches the server on the first pass and avoids a
- * hydration mismatch.
- */
+/** False during SSR and the first client render, true after hydration; gates persisted client prefs to avoid a hydration mismatch. */
 export function useHydrated(): boolean {
 	return useSyncExternalStore(
 		emptySubscribe,

--- a/lib/theme/backgroundTheme.ts
+++ b/lib/theme/backgroundTheme.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type BackgroundTheme = "dark" | "purple";
+
+type BackgroundThemeState = {
+	theme: BackgroundTheme;
+	setTheme: (theme: BackgroundTheme) => void;
+	toggle: () => void;
+};
+
+/**
+ * Global background-theme preference (persisted to localStorage). "dark" is the
+ * studio look; "purple" restores the original bright gradient. Only affects the
+ * background — the rest of the UI stays dark-glass either way.
+ */
+export const useBackgroundTheme = create<BackgroundThemeState>()(
+	persist(
+		(set, get) => ({
+			theme: "dark",
+			setTheme: (theme) => set({ theme }),
+			toggle: () => set({ theme: get().theme === "dark" ? "purple" : "dark" }),
+		}),
+		{ name: "openslop-bg-theme" },
+	),
+);


### PR DESCRIPTION
Replaces the bright purple-blue animated gradient with the near-black studio background (corner glows + grain + cursor-follow), and adds a persisted **Background** toggle (Dark ↔ Purple) in the user menu so the original look stays an option.

Stacked on #226 (uses the glass tokens).