### PR TITLE
feat(editor): conversational refine with add/edit/remove diff + undo/redo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,3 +25,7 @@
 
 - `next/dynamic` with `ssr: false` is a **Client Component API only**. Never use it in Server Components. If you need to lazy-load a client-only component from a Server Component, create a thin Client Component wrapper that does the dynamic import, then use that wrapper in the Server Component.
 - `proxy.ts` is the correct file name (Next.js 16 migrated from `middleware.ts` to `proxy.ts`). Do NOT rename it.
+
+## Design System
+
+Always read `DESIGN.md` before making any visual or UI decisions. Font choices, colors, spacing, the disciplined-violet rule, and the media-type palette are defined there. Do not deviate without explicit user approval. Flag any UI code that doesn't match `DESIGN.md`.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,69 @@
+# Design System — openslop
+
+## Product Context
+
+- **What this is:** An AI faceless-video generator. Users describe or paste a script, openslop builds a storyboard of scenes (image, narration, character dialogue, music, sound), and renders a finished video.
+- **Who it's for:** Creators producing faceless video at volume who want control over the result and to feel in charge of the process.
+- **Space/industry:** AI video tooling. Peers: Runway, Sora, Luma (pro/dark camp); Pika, Captions (consumer/playful camp). openslop belongs in the pro camp.
+- **Project type:** Web app (editor) + auth/marketing surfaces.
+- **Memorable thing:** "A serious creative studio." Every decision below serves this.
+
+## Aesthetic Direction
+
+- **Direction:** Dark glassmorphism — "a creative studio at night."
+- **Decoration level:** Intentional. Film-grain texture, restrained glow, shimmer loaders. Not flat, not maximalist.
+- **Mood:** Premium, calm, confident. Pro tooling, not a toy.
+- **Core rule (the discipline):** Near-black + glass + grain carry the weight. Violet marks only what is **alive or actionable** (active Generate, focus rings, playhead, the one primary action). The purple glow is a rare earned moment, never an ambient wash. This is what separates "serious studio" from "generic AI-purple wrapper."
+
+## Typography
+
+- **Display/Titles:** Instrument Serif (weight 400) — `.font-title`. Used sparingly for titles only, so it stays special and never turns precious. A serif title is the deliberate departure from the category's neutral grotesks.
+- **Body/UI:** Satoshi — `.font-body`. All narration, dialogue, labels, controls.
+- **Data/Timestamps:** a monospace (JetBrains Mono or Geist Mono) with tabular-nums for scene times and durations.
+- **Cleanup owed:** today four families float (Geist, Satoshi, Instrument Serif, Google Sans Flex). Consolidate to the three above. Drop "Google Sans Flex"; reduce Geist to mono-or-remove.
+- **Loading:** Instrument Serif via Google Fonts; Satoshi via Fontshare; mono via Google Fonts. Self-host for production.
+
+## Color
+
+- **Approach:** Restrained. One accent + neutrals; color is rare and meaningful.
+- **Canvas:** `#0a0a0a` (near-black).
+- **Surfaces (glass):** fill `rgba(255,255,255,0.05)`, border `rgba(255,255,255,0.10)`, `backdrop-blur`.
+- **Accent (violet):** `#8b5cf6` (primary), `#a78bfa` (soft) — active Generate, focus rings, playhead, primary action only.
+- **Glow:** `#371e64` / `rgba(55,30,100,0.55)` — rare earned highlight (e.g. the live Generate state), never ambient.
+- **Text:** `rgba(255,255,255,0.80)` body, `0.40` muted, `0.30` placeholder.
+- **Media-type palette (signature — every element type reads at a glance):** character `#fbbf24`, image `#22d3ee`, animated `#e879f9`, clip `#818cf8`, music `#a78bfa`, sound `#34d399`, narration `#9ca3af`. Use as small tags/borders on storyboard scene rows. Keep disciplined so it reads, not confetti.
+- **Dark mode:** Dark is the only mode. The stock light `:root` palette in `globals.css` is unreachable (html forces `#0a0a0a`); remove it or commit to dark-only.
+
+## Spacing
+
+- **Base unit:** 4px (Tailwind default).
+- **Density:** Compact-to-comfortable. The editor runs dense (`text-[11px]`, tight gaps); reading surfaces (narration) get more room.
+- **Scale:** 2xs(2) xs(4) sm(8) md(16) lg(24) xl(32) 2xl(48) 3xl(64).
+
+## Layout
+
+- **Approach:** Hybrid. Editor/canvas is grid-disciplined; composer and player are focal surfaces.
+- **Editor shell:** top "Refine your script" copilot bar + violet Generate to its right; vertical scrollable storyboard of scene rows; player panel docked (top or side).
+- **Max content width:** ~1100px for the storyboard column.
+- **Border radius:** `--radius: 0.625rem` (10px) base; scale to 4xl. Panels `rounded-xl`; pills `rounded-full`.
+
+## Motion
+
+- **Approach:** Intentional. Entrance `fadeInUp` (0.3s ease-out), shimmer loaders, OrbLoader for generation. `prefers-reduced-motion` already honored — keep it.
+- **Easing:** enter(ease-out) exit(ease-in) move(ease-in-out).
+- **Duration:** micro(50-100ms) short(150-250ms) medium(250-400ms) long(400-700ms).
+
+## Implementation Notes (sharpen backlog)
+
+These are the gaps between the shipped look and a real system. None block; all reduce drift.
+
+1. Tokenize the accent + glass: add `--accent-violet`, `--glow-violet`, `--glass-fill`, `--glass-border` instead of hardcoding `violet-500/30`, `bg-white/5`, `shadow-[0_0_40px_rgba(55,30,100,0.5)]` per component.
+2. Tokenize the media-type palette so storyboard surfaces (and the new conversational refine thread) reference tokens, not literals from `status.ts`.
+3. Resolve the four-font sprawl (see Typography).
+4. Remove the dead light `:root` palette.
+
+## Decisions Log
+
+| Date       | Decision                         | Rationale                                                                                                                                 |
+| ---------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-09 | Initial design system documented | Codified the existing dark-glass-violet look via /design-consultation; sharpened per "serious creative studio" + disciplined-violet rule. |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -25,13 +25,15 @@
 
 ## Color
 
+> Token values are canonical in `app/globals.css` (the `@theme` block). This section is the usage rules — when and where each color is allowed — not a second source for the literal values. If a value changes, change it in `@theme`; this doc names tokens, not hex.
+
 - **Approach:** Restrained. One accent + neutrals; color is rare and meaningful.
-- **Canvas:** `#0a0a0a` (near-black).
-- **Surfaces (glass):** fill `rgba(255,255,255,0.05)`, border `rgba(255,255,255,0.10)`, `backdrop-blur`.
-- **Accent (violet):** `#8b5cf6` (primary), `#a78bfa` (soft) — active Generate, focus rings, playhead, primary action only.
-- **Glow:** `#371e64` / `rgba(55,30,100,0.55)` — rare earned highlight (e.g. the live Generate state), never ambient.
-- **Text:** `rgba(255,255,255,0.80)` body, `0.40` muted, `0.30` placeholder.
-- **Media-type palette (signature — every element type reads at a glance):** character `#fbbf24`, image `#22d3ee`, animated `#e879f9`, clip `#818cf8`, music `#a78bfa`, sound `#34d399`, narration `#9ca3af`. Use as small tags/borders on storyboard scene rows. Keep disciplined so it reads, not confetti.
+- **Canvas:** `--color-canvas` (near-black).
+- **Surfaces (glass):** `--color-glass-fill`, `--color-glass-border`, `backdrop-blur`.
+- **Accent (violet):** `--color-accent-violet` (primary), `--color-accent-violet-soft` (soft) — active Generate, focus rings, playhead, primary action only.
+- **Glow:** `--color-glow-violet` / `--shadow-glow` — rare earned highlight (e.g. the live Generate state), never ambient.
+- **Text:** white at `0.80` body, `0.40` muted, `0.30` placeholder.
+- **Media-type palette (signature — every element type reads at a glance):** `--color-media-character`, `--color-media-image`, `--color-media-animated`, `--color-media-clip`, `--color-media-music`, `--color-media-sound`, `--color-media-narration`. Use as small tags/borders on storyboard scene rows. Keep disciplined so it reads, not confetti.
 - **Dark mode:** Dark is the only mode. The stock light `:root` palette in `globals.css` is unreachable (html forces `#0a0a0a`); remove it or commit to dark-only.
 
 ## Spacing

--- a/app/components/BackgroundGradientAnimation.tsx
+++ b/app/components/BackgroundGradientAnimation.tsx
@@ -2,121 +2,74 @@
 
 import { useEffect, useRef } from "react";
 
-export default function BackgroundGradientAnimation() {
-	const interactiveRef = useRef<HTMLDivElement>(null);
-
+// Smoothly translates a glow element toward the pointer. Honors reduced-motion
+// by centering the glow instead of animating it.
+function useCursorFollow() {
+	const ref = useRef<HTMLDivElement>(null);
 	useEffect(() => {
-		const el = interactiveRef.current;
+		const el = ref.current;
 		if (!el) return;
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+			el.style.transform = "translate(calc(50vw - 50%), calc(50vh - 50%))";
+			return;
+		}
 
-		const prefersReduced = window.matchMedia(
-			"(prefers-reduced-motion: reduce)",
-		).matches;
-		if (prefersReduced) return;
-
-		let currentX = window.innerWidth / 2;
-		let currentY = window.innerHeight / 2;
-		let targetX = currentX;
-		let targetY = currentY;
+		let curX = window.innerWidth / 2;
+		let curY = window.innerHeight / 3;
+		let tx = curX;
+		let ty = curY;
 		let frame = 0;
-
-		const handleMove = (e: MouseEvent) => {
-			targetX = e.clientX;
-			targetY = e.clientY;
+		const onMove = (e: MouseEvent) => {
+			tx = e.clientX;
+			ty = e.clientY;
 		};
-
 		const animate = () => {
-			currentX += (targetX - currentX) / 12;
-			currentY += (targetY - currentY) / 12;
-
-			el.style.transform = `translate(calc(${currentX}px - 50%), calc(${currentY}px - 50%))`;
-
+			curX += (tx - curX) / 16;
+			curY += (ty - curY) / 16;
+			el.style.transform = `translate(calc(${curX}px - 50%), calc(${curY}px - 50%))`;
 			frame = requestAnimationFrame(animate);
 		};
-
-		window.addEventListener("mousemove", handleMove, { passive: true });
+		window.addEventListener("mousemove", onMove, { passive: true });
 		frame = requestAnimationFrame(animate);
-
 		return () => {
-			window.removeEventListener("mousemove", handleMove);
+			window.removeEventListener("mousemove", onMove);
 			cancelAnimationFrame(frame);
 		};
 	}, []);
+	return ref;
+}
 
+/**
+ * Dark "studio at night" background (DESIGN.md): near-black with two restrained
+ * violet corner glows, a faint cursor-following violet glow, and grain.
+ */
+export default function BackgroundGradientAnimation() {
+	const glowRef = useCursorFollow();
 	return (
-		<div className="fixed inset-0 z-0 overflow-hidden">
-			{/* Base gradient background */}
+		<div className="pointer-events-none fixed inset-0 z-0 overflow-hidden bg-[#0a0a0a]">
 			<div
 				className="absolute inset-0"
 				style={{
-					background:
-						"linear-gradient(135deg, rgb(108, 0, 162) 0%, rgb(0, 17, 82) 100%)",
+					backgroundImage:
+						"radial-gradient(900px 520px at 82% -8%, rgba(139,92,246,0.12), transparent 60%), radial-gradient(760px 520px at -8% 108%, rgba(55,30,100,0.22), transparent 60%)",
 				}}
 			/>
-
-			{/* SVG blur filter */}
-			<svg className="hidden" aria-hidden="true">
-				<filter id="blurMe">
-					<feGaussianBlur in="SourceGraphic" stdDeviation="10" result="blur" />
-					<feColorMatrix
-						in="blur"
-						mode="matrix"
-						values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 18 -8"
-						result="goo"
-					/>
-					<feBlend in="SourceGraphic" in2="goo" />
-				</filter>
-			</svg>
-
-			{/* Animated gradient blobs */}
 			<div
-				className="absolute inset-0"
-				style={{ filter: "url(#blurMe) blur(40px)" }}
-			>
-				{/* Blob 1 — blue, vertical motion */}
-				<div
-					className="absolute w-[80%] h-[80%] top-[calc(50%-40%)] left-[calc(50%-40%)] animate-first opacity-70"
-					style={{
-						background:
-							"radial-gradient(circle at center, rgb(75, 134, 206) 0%, transparent 50%)",
-						mixBlendMode: "hard-light",
-					}}
-				/>
-
-				{/* Blob 2 — magenta, circular reverse */}
-				<div
-					className="absolute w-[90%] h-[90%] top-[calc(50%-45%)] left-[calc(50%-45%)] opacity-70"
-					style={{
-						background:
-							"radial-gradient(circle at center, rgb(178, 74, 230) 0%, transparent 50%)",
-						mixBlendMode: "hard-light",
-					}}
-				/>
-
-				{/* Blob 4 — red, horizontal */}
-				<div
-					className="absolute w-[80%] h-[80%] top-[calc(50%-40%)] left-[calc(50%-40%)] animate-fourth opacity-70"
-					style={{
-						background:
-							"radial-gradient(circle at center, rgb(155, 48, 128) 0%, transparent 50%)",
-						mixBlendMode: "hard-light",
-					}}
-				/>
-
-				{/* Interactive pointer blob */}
-				<div
-					ref={interactiveRef}
-					className="pointer-events-none absolute z-30 w-[100vmin] h-[100vmin] rounded-full opacity-50 blur-[60px]"
-					style={{
-						left: 0,
-						top: 0,
-						willChange: "transform",
-						background:
-							"radial-gradient(circle at center, rgba(40,152,244,0.9) 0%, transparent 75%)",
-						mixBlendMode: "hard-light",
-					}}
-				/>
-			</div>
+				ref={glowRef}
+				className="absolute left-0 top-0 h-[40rem] w-[40rem] rounded-full opacity-40 blur-3xl"
+				style={{
+					willChange: "transform",
+					background:
+						"radial-gradient(circle, rgba(139,92,246,0.10) 0%, transparent 60%)",
+				}}
+			/>
+			<div
+				className="absolute inset-0 opacity-[0.15]"
+				style={{
+					backgroundImage: "url(/grain.png)",
+					backgroundSize: "50px 50px",
+				}}
+			/>
 		</div>
 	);
 }

--- a/app/components/GlassDropdown.tsx
+++ b/app/components/GlassDropdown.tsx
@@ -52,7 +52,7 @@ export default function GlassDropdown<T extends string>({
 			<DropdownMenuContent
 				side={side}
 				align={align}
-				className="min-w-32 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+				className="min-w-32 rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
 			>
 				{options.map((option) => (
 					<DropdownMenuItem

--- a/app/components/GoogleOAuthButton.tsx
+++ b/app/components/GoogleOAuthButton.tsx
@@ -13,7 +13,7 @@ export default function GoogleOAuthButton({
 		<button
 			type="button"
 			onClick={onClick}
-			className="relative grain grain-12 w-full flex items-center justify-center gap-2.5 py-2.5 rounded-2xl bg-[#1e1e1e]/60 text-white text-sm font-medium font-display transition-[filter,transform] hover:brightness-[1.3] active:scale-[0.98]"
+			className="relative grain grain-12 w-full flex items-center justify-center gap-2.5 py-2.5 rounded-2xl bg-[#1e1e1e]/60 text-white text-sm font-medium font-body transition-[filter,transform] hover:brightness-[1.3] active:scale-[0.98]"
 		>
 			<GoogleIcon />
 			{children ?? "Continue with Google"}

--- a/app/components/GradientButton.tsx
+++ b/app/components/GradientButton.tsx
@@ -11,7 +11,7 @@ export default function GradientButton({
 }: GradientButtonProps) {
 	return (
 		<button
-			className={`relative grain w-full py-2.5 rounded-2xl text-white font-semibold text-sm font-display transition-[filter,transform] hover:brightness-[1.15] active:scale-[0.98] disabled:opacity-50 ${gradientStyles.gradient} ${className}`}
+			className={`relative grain w-full py-2.5 rounded-2xl text-white font-semibold text-sm font-body transition-[filter,transform] hover:brightness-[1.15] active:scale-[0.98] disabled:opacity-50 ${gradientStyles.gradient} ${className}`}
 			{...props}
 		>
 			{children}

--- a/app/components/OnboardingCard.tsx
+++ b/app/components/OnboardingCard.tsx
@@ -33,7 +33,7 @@ export default function OnboardingCard({
 				{icon ?? <OpenSlopLogo className="w-14 h-auto text-white" />}
 
 				{/* Heading */}
-				<h1 className="text-2xl sm:text-3xl font-light text-white text-center font-display text-wrap-balance">
+				<h1 className="text-2xl sm:text-3xl font-light text-white text-center font-body text-wrap-balance">
 					{heading}
 				</h1>
 
@@ -41,16 +41,14 @@ export default function OnboardingCard({
 				{extra}
 
 				{/* Subtitle */}
-				<p className="text-white/50 text-center text-xs sm:text-sm font-light leading-relaxed font-display">
+				<p className="text-white/50 text-center text-xs sm:text-sm font-light leading-relaxed font-body">
 					{subtitle}
 				</p>
 
 				{children}
 
 				{/* Footer */}
-				<p className="text-white/40 text-xs sm:text-sm font-display">
-					{footer}
-				</p>
+				<p className="text-white/40 text-xs sm:text-sm font-body">{footer}</p>
 			</div>
 		</div>
 	);

--- a/app/components/OrDivider.tsx
+++ b/app/components/OrDivider.tsx
@@ -2,7 +2,7 @@ export default function OrDivider() {
 	return (
 		<div className="w-full flex items-center gap-3">
 			<div className="flex-1 h-px bg-white/10" />
-			<span className="text-white/30 text-xs font-display">OR</span>
+			<span className="text-white/30 text-xs font-body">OR</span>
 			<div className="flex-1 h-px bg-white/10" />
 		</div>
 	);

--- a/app/components/PostPromptView.tsx
+++ b/app/components/PostPromptView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
 	useScriptControl,
 	useScriptInitial,
@@ -15,6 +15,7 @@ import { getLayoutKey } from "@/lib/video/layoutKey";
 import { useAspectRatio } from "@/lib/video/useAspectRatio";
 import { useTransitionType } from "@/lib/video/useTransitionType";
 import InlineCopilot from "./copilot/InlineCopilot";
+import RefineThread from "./copilot/RefineThread";
 import Canvas from "./canvas/Canvas";
 import { ProjectTitle } from "./canvas/ProjectTitle";
 import { useEditorSetup } from "./canvas/hooks/useEditorSetup";
@@ -36,6 +37,7 @@ import {
 	usePlayerPosition,
 } from "./video/PlayerPositionContext";
 import { ActiveSceneProvider } from "./scene-selection/ActiveSceneContext";
+import { RefineChangesContext } from "./scene-selection/RefineChangesContext";
 import { AutoScrollProvider } from "./scene-selection/AutoScrollContext";
 import { PlayerControlProvider } from "./video/PlayerControlContext";
 import { VideoLayoutProvider } from "./video/VideoLayoutContext";
@@ -62,7 +64,22 @@ function PostPromptViewInner() {
 
 	const [refineValue, setRefineValue] = useState("");
 	const { position, visible } = usePlayerPosition();
-	const { refineScript, refineLoading, stopRefine } = useRefineScript(editor);
+	const {
+		refineScript,
+		refineLoading,
+		stopRefine,
+		latestTurn,
+		applyTurn,
+		discardTurn,
+		changes,
+	} = useRefineScript(editor);
+
+	const runRefine = useCallback(
+		(prompt: string) => {
+			if (prompt.trim()) refineScript(prompt);
+		},
+		[refineScript],
+	);
 
 	const queue = useGenerationQueue();
 	const generating = useQueueSelector((q) => q.isBusy());
@@ -81,82 +98,95 @@ function PostPromptViewInner() {
 	const isTop = position === "top";
 
 	return (
-		<div className="flex h-screen w-full flex-col overflow-hidden">
-			<div
-				className={`z-40 flex w-full shrink-0 flex-col items-center gap-3 px-4 py-3 pb-2 pl-16 ${editorStyles.copilotEnter}`}
-			>
-				<div className="flex w-full items-stretch justify-center gap-3">
-					<div className="min-w-0 flex-1 max-w-2xl">
-						<InlineCopilot
-							value={refineValue}
-							onValueChange={setRefineValue}
-							onSubmit={() => {
-								refineScript(refineValue);
-								setRefineValue("");
-							}}
-							onStop={stop}
-							loading={loading}
-							placeholder="Refine your script…"
-						/>
+		<RefineChangesContext value={changes}>
+			<div className="flex h-screen w-full flex-col overflow-hidden">
+				<div
+					className={`z-40 flex w-full shrink-0 flex-col items-center gap-3 px-4 py-3 pb-2 pl-16 ${editorStyles.copilotEnter}`}
+				>
+					<div className="flex w-full items-start justify-center gap-3">
+						<div className="flex min-w-0 max-w-2xl flex-1 flex-col gap-2">
+							<InlineCopilot
+								value={refineValue}
+								onValueChange={setRefineValue}
+								onSubmit={() => {
+									runRefine(refineValue);
+									setRefineValue("");
+								}}
+								onStop={stop}
+								loading={loading}
+								placeholder="Refine your script…"
+							/>
+							<RefineThread
+								latestTurn={latestTurn}
+								loading={loading}
+								onApply={applyTurn}
+								onDiscard={discardTurn}
+								onSuggest={runRefine}
+							/>
+						</div>
+						<button
+							type="button"
+							onClick={generateAll}
+							className={`${genStyles.btn} ${generating ? genStyles.generating : ""} shrink-0 transition-opacity ${busy ? "" : "opacity-80 hover:opacity-100"}`}
+							aria-label={generateLabel}
+							disabled={busy}
+						>
+							<Sparkles className={genStyles.svg} aria-hidden="true" />
+							<span>{generateLabel}</span>
+						</button>
+						{canCancel && (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<button
+										type="button"
+										onClick={() => queue.cancelAll()}
+										aria-label="Cancel generation"
+										className="grain grain-light relative flex h-7 w-7 shrink-0 items-center justify-center self-center overflow-hidden rounded-full bg-white/10 text-white/80 transition-colors hover:bg-white/20"
+									>
+										<X className="h-3 w-3" aria-hidden="true" />
+									</button>
+								</TooltipTrigger>
+								<TooltipContent>Cancel generation</TooltipContent>
+							</Tooltip>
+						)}
 					</div>
-					<button
-						type="button"
-						onClick={generateAll}
-						className={`${genStyles.btn} ${generating ? genStyles.generating : ""} shrink-0 transition-opacity ${busy ? "" : "opacity-80 hover:opacity-100"}`}
-						aria-label={generateLabel}
-						disabled={busy}
-					>
-						<Sparkles className={genStyles.svg} aria-hidden="true" />
-						<span>{generateLabel}</span>
-					</button>
-					{canCancel && (
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<button
-									type="button"
-									onClick={() => queue.cancelAll()}
-									aria-label="Cancel generation"
-									className="grain grain-light relative flex h-7 w-7 shrink-0 items-center justify-center self-center overflow-hidden rounded-full bg-white/10 text-white/80 transition-colors hover:bg-white/20"
-								>
-									<X className="h-3 w-3" aria-hidden="true" />
-								</button>
-							</TooltipTrigger>
-							<TooltipContent>Cancel generation</TooltipContent>
-						</Tooltip>
-					)}
 				</div>
-			</div>
 
-			<VideoLayoutProvider
-				editor={editor}
-				layoutKey={layoutKey}
-				transitionType={transitionType}
-				aspectRatio={aspectRatio}
-			>
-				<PlayerControlProvider>
-					<ActiveSceneProvider>
-						<AutoScrollProvider>
-							{visible && isTop && <TopPlayerPanel />}
+				<VideoLayoutProvider
+					editor={editor}
+					layoutKey={layoutKey}
+					transitionType={transitionType}
+					aspectRatio={aspectRatio}
+				>
+					<PlayerControlProvider>
+						<ActiveSceneProvider>
+							<AutoScrollProvider>
+								{visible && isTop && <TopPlayerPanel />}
 
-							<div className="flex min-h-0 flex-1 overflow-hidden">
-								<div
-									className="flex-1 overflow-y-auto"
-									style={{ scrollbarGutter: "stable" }}
-								>
-									<div className="pointer-events-none sticky top-0 z-10 -mb-8 h-8 backdrop-blur-sm [mask-image:linear-gradient(to_bottom,black,transparent)]" />
-									<div className="mx-auto max-w-6xl px-4 py-4">
-										<ProjectTitle />
-										<Canvas editor={editor} value={value} setValue={setValue} />
+								<div className="flex min-h-0 flex-1 overflow-hidden">
+									<div
+										className="flex-1 overflow-y-auto"
+										style={{ scrollbarGutter: "stable" }}
+									>
+										<div className="pointer-events-none sticky top-0 z-10 -mb-8 h-8 backdrop-blur-sm [mask-image:linear-gradient(to_bottom,black,transparent)]" />
+										<div className="mx-auto max-w-6xl px-4 py-4">
+											<ProjectTitle />
+											<Canvas
+												editor={editor}
+												value={value}
+												setValue={setValue}
+											/>
+										</div>
 									</div>
-								</div>
 
-								{visible && !isTop && <SidePlayerPanel />}
-							</div>
-						</AutoScrollProvider>
-					</ActiveSceneProvider>
-				</PlayerControlProvider>
-			</VideoLayoutProvider>
-		</div>
+									{visible && !isTop && <SidePlayerPanel />}
+								</div>
+							</AutoScrollProvider>
+						</ActiveSceneProvider>
+					</PlayerControlProvider>
+				</VideoLayoutProvider>
+			</div>
+		</RefineChangesContext>
 	);
 }
 

--- a/app/components/TemplateGallery.tsx
+++ b/app/components/TemplateGallery.tsx
@@ -44,7 +44,7 @@ export default function TemplateGallery({
 						onClick={() =>
 							onSelect(template.id, template.showcase.examplePrompt)
 						}
-						className="group flex w-full flex-row overflow-hidden rounded-xl border border-white/10 bg-white/5 text-left transition-all hover:border-violet-500/30 hover:shadow-[0_0_20px_rgba(55,30,100,0.3)] sm:w-[calc(50%-0.375rem)]"
+						className="group flex w-full flex-row overflow-hidden rounded-xl border border-glass-border bg-glass-fill text-left transition-all hover:border-accent-violet/30 hover:shadow-[0_0_20px_rgba(55,30,100,0.3)] sm:w-[calc(50%-0.375rem)]"
 					>
 						<CardImage
 							src={template.showcase.image}

--- a/app/components/TemplateGallery.tsx
+++ b/app/components/TemplateGallery.tsx
@@ -44,7 +44,7 @@ export default function TemplateGallery({
 						onClick={() =>
 							onSelect(template.id, template.showcase.examplePrompt)
 						}
-						className="group flex w-full flex-row overflow-hidden rounded-xl border border-glass-border bg-glass-fill text-left transition-all hover:border-accent-violet/30 hover:shadow-[0_0_20px_rgba(55,30,100,0.3)] sm:w-[calc(50%-0.375rem)]"
+						className="group flex w-full flex-row overflow-hidden rounded-xl border border-glass-border bg-glass-fill text-left transition-all hover:border-accent-violet/30 hover:shadow-glow sm:w-[calc(50%-0.375rem)]"
 					>
 						<CardImage
 							src={template.showcase.image}

--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -10,7 +10,7 @@ import {
 } from "@dnd-kit/sortable";
 import { useDragAndDrop } from "./dnd/useDragAndDrop";
 import { DragTransferContext } from "./dnd/DragTransferContext";
-import type { CanvasContentElement } from "@/lib/canvas/types";
+import type { CanvasContentElement, CanvasEditor } from "@/lib/canvas/types";
 import { isSceneElement } from "@/lib/canvas/scenes";
 import { SortableScene } from "./dnd/SortableScene";
 import { SortableContent } from "./dnd/SortableContent";
@@ -26,7 +26,7 @@ export default function Canvas({
 	value,
 	setValue,
 }: {
-	editor: Editor;
+	editor: CanvasEditor;
 	value: Descendant[];
 	setValue: (v: Descendant[]) => void;
 }) {
@@ -46,6 +46,16 @@ export default function Canvas({
 			if (event.shiftKey && event.key === "Enter") {
 				event.preventDefault();
 				editor.insertText("\n");
+				return;
+			}
+			const mod = event.metaKey || event.ctrlKey;
+			if (mod && event.key.toLowerCase() === "z") {
+				event.preventDefault();
+				if (event.shiftKey) editor.redo();
+				else editor.undo();
+			} else if (event.ctrlKey && event.key.toLowerCase() === "y") {
+				event.preventDefault();
+				editor.redo();
 			}
 		},
 		[editor],
@@ -106,7 +116,7 @@ export default function Canvas({
 									placeholder="Start typing your story…"
 									renderElement={renderElement}
 									onKeyDown={handleKeyDown}
-									className="font-body text-sm leading-relaxed outline-none focus-visible:ring-2 focus-visible:ring-ring"
+									className="font-body rounded-sm text-sm leading-relaxed outline-none focus-visible:ring-2 focus-visible:ring-accent-violet/50"
 								/>
 							</SortableContext>
 							<DragOverlay>

--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -116,7 +116,7 @@ export default function Canvas({
 									placeholder="Start typing your story…"
 									renderElement={renderElement}
 									onKeyDown={handleKeyDown}
-									className="font-body rounded-sm text-sm leading-relaxed outline-none focus-visible:ring-2 focus-visible:ring-accent-violet/50"
+									className="font-body rounded-sm text-sm leading-relaxed outline-none"
 								/>
 							</SortableContext>
 							<DragOverlay>

--- a/app/components/canvas/dnd/SortableActions.tsx
+++ b/app/components/canvas/dnd/SortableActions.tsx
@@ -43,7 +43,7 @@ export function SortableActions<K extends string>({
 					<DropdownMenuContent
 						side="bottom"
 						align="start"
-						className="w-40 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-1"
+						className="w-40 rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-1"
 					>
 						{options.map((option) => (
 							<DropdownMenuItem

--- a/app/components/canvas/dnd/SortableItem.tsx
+++ b/app/components/canvas/dnd/SortableItem.tsx
@@ -52,7 +52,7 @@ export function SortableItem({
 	return (
 		<div {...attributes} className={wrapperClassName} style={wrapperStyle}>
 			<div
-				className={styles.sortable}
+				className={`${styles.sortable} rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-accent-violet/60`}
 				{...sortableAttributes}
 				ref={setNodeRef}
 				style={{

--- a/app/components/canvas/elements/AssetTile.tsx
+++ b/app/components/canvas/elements/AssetTile.tsx
@@ -30,7 +30,7 @@ export function AssetTile({
 		fallback === "icon" || !initial ? <Icon className="h-4 w-4" /> : initial;
 	return (
 		<div className="group/tile flex w-16 flex-col gap-1 sm:w-20">
-			<div className="relative aspect-square overflow-hidden rounded-md border border-white/10 bg-white/5">
+			<div className="relative aspect-square overflow-hidden rounded-md border border-glass-border bg-glass-fill">
 				{previewUrl ? (
 					<ImageWithShimmer
 						key={previewUrl}

--- a/app/components/canvas/elements/AttributeBadge.tsx
+++ b/app/components/canvas/elements/AttributeBadge.tsx
@@ -87,7 +87,7 @@ export function AttributeBadge({
 			</DropdownMenuTrigger>
 			<DropdownMenuContent
 				align="start"
-				className="min-w-24 max-h-64 overflow-y-auto rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+				className="min-w-24 max-h-64 overflow-y-auto rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
 			>
 				{spec.edit.options.map((opt) => (
 					<DropdownMenuItem

--- a/app/components/canvas/elements/CharactersPicker.tsx
+++ b/app/components/canvas/elements/CharactersPicker.tsx
@@ -77,7 +77,7 @@ function ProjectCharactersMenu({
 	return (
 		<DropdownMenuContent
 			align="start"
-			className="min-w-32 max-h-64 overflow-y-auto rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+			className="min-w-32 max-h-64 overflow-y-auto rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
 		>
 			{names.map((name) => (
 				<DropdownMenuItem

--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -24,8 +24,6 @@ interface ElementContainerProps {
 	children: React.ReactNode;
 }
 
-// Per-kind diff styling for a refine preview: a soft row tint plus a header
-// badge. One lookup keeps the row tint, badge, and strikethrough in sync.
 const CHANGE_STYLES: Record<
 	RefineChangeKind,
 	{ tint: string; label: string; badgeCls: string }
@@ -54,8 +52,6 @@ export function ElementContainer({
 }: ElementContainerProps) {
 	const config = ELEMENT_CONFIGS[element.type];
 	const isEmpty = Node.string(element) === ZERO_WIDTH_SPACE;
-	// Diff marker from the current refine preview: tints the row and adds a header
-	// badge so it's clear which rows the agent added, edited, or removed.
 	const change = useRefineChanges()[element.id];
 	const changeStyle = change ? CHANGE_STYLES[change] : undefined;
 

--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -3,6 +3,10 @@ import { RenderElementProps, ReactEditor, useSlateStatic } from "slate-react";
 import { Node } from "slate";
 import type { CanvasContentElement, SceneElement } from "@/lib/canvas/types";
 import { isSceneElement } from "@/lib/canvas/scenes";
+import {
+	type RefineChangeKind,
+	useRefineChanges,
+} from "@/app/components/scene-selection/RefineChangesContext";
 import { ZERO_WIDTH_SPACE } from "../config/constants";
 import { ELEMENT_CONFIGS } from "../config/elementConfigs";
 import { useViewMode } from "../ViewModeContext";
@@ -20,6 +24,29 @@ interface ElementContainerProps {
 	children: React.ReactNode;
 }
 
+// Per-kind diff styling for a refine preview: a soft row tint plus a header
+// badge. One lookup keeps the row tint, badge, and strikethrough in sync.
+const CHANGE_STYLES: Record<
+	RefineChangeKind,
+	{ tint: string; label: string; badgeCls: string }
+> = {
+	added: {
+		tint: "bg-emerald-400/25",
+		label: "New",
+		badgeCls: "bg-emerald-500/30 text-emerald-50",
+	},
+	modified: {
+		tint: "bg-amber-400/25",
+		label: "Edited",
+		badgeCls: "bg-amber-500/30 text-amber-50",
+	},
+	removed: {
+		tint: "bg-red-400/25",
+		label: "Removed",
+		badgeCls: "bg-red-500/30 text-red-50",
+	},
+};
+
 export function ElementContainer({
 	attributes,
 	children,
@@ -27,9 +54,16 @@ export function ElementContainer({
 }: ElementContainerProps) {
 	const config = ELEMENT_CONFIGS[element.type];
 	const isEmpty = Node.string(element) === ZERO_WIDTH_SPACE;
+	// Diff marker from the current refine preview: tints the row and adds a header
+	// badge so it's clear which rows the agent added, edited, or removed.
+	const change = useRefineChanges()[element.id];
+	const changeStyle = change ? CHANGE_STYLES[change] : undefined;
 
 	return (
-		<div className="flex items-stretch mb-1.5 animate-fadeInUp" {...attributes}>
+		<div
+			className={`-mx-2 mb-1.5 flex items-stretch rounded-xl px-2 py-1 transition-colors animate-fadeInUp ${changeStyle?.tint ?? ""}`}
+			{...attributes}
+		>
 			{/* Left: element card */}
 			<div
 				className={`group/card grain rounded-lg ${config.bgColor} p-2 shadow-md relative overflow-hidden flex-1 min-w-0`}
@@ -49,6 +83,13 @@ export function ElementContainer({
 							{config.icon}
 							<span className="text-xs">{config.label}</span>
 						</div>
+						{changeStyle && (
+							<span
+								className={`rounded-full px-1.5 text-[9px] font-semibold leading-4 ${changeStyle.badgeCls}`}
+							>
+								{changeStyle.label}
+							</span>
+						)}
 						<ElementCharacters element={element} />
 						{Object.entries(config.visibleAttributes).map(([key, spec]) => (
 							<AttributeBadge
@@ -60,16 +101,18 @@ export function ElementContainer({
 						))}
 						<ModelBadge element={element} />
 					</div>
-					<div className="relative min-w-0">
+					<div className="relative min-w-0 rounded-md bg-black/20 px-2 py-1.5">
 						{isEmpty && (
 							<div
 								style={{ userSelect: "none" }}
-								className="absolute top-0 left-0 text-white/50 text-xs text-left pointer-events-none"
+								className="absolute top-1.5 left-2 text-white/50 text-xs text-left pointer-events-none"
 							>
 								{config.placeholder}
 							</div>
 						)}
-						<div className="text-white/90 text-xs leading-relaxed overflow-hidden transition-[max-height,opacity] duration-200 text-left">
+						<div
+							className={`text-white/90 text-xs leading-relaxed overflow-hidden transition-[max-height,opacity] duration-200 text-left ${change === "removed" ? "line-through opacity-60" : ""}`}
+						>
 							{children}
 						</div>
 					</div>

--- a/app/components/canvas/elements/attributes/TextAttributePopover.tsx
+++ b/app/components/canvas/elements/attributes/TextAttributePopover.tsx
@@ -82,7 +82,7 @@ export function TextAttributePopover({
 				onEscapeKeyDown={() => {
 					cancelRef.current = true;
 				}}
-				className="w-72 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-1.5"
+				className="w-72 rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-1.5"
 			>
 				<textarea
 					autoFocus
@@ -96,7 +96,7 @@ export function TextAttributePopover({
 							setOpen(false);
 						}
 					}}
-					className="w-full resize-none rounded-lg border border-white/10 bg-white/5 px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
+					className="w-full resize-none rounded-lg border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
 				/>
 				<div className="mt-1 px-1 text-[10px] text-white/40">
 					⌘↵ to save · esc to cancel

--- a/app/components/canvas/elements/attributes/TextAttributePopover.tsx
+++ b/app/components/canvas/elements/attributes/TextAttributePopover.tsx
@@ -96,7 +96,7 @@ export function TextAttributePopover({
 							setOpen(false);
 						}
 					}}
-					className="w-full resize-none rounded-lg border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
+					className="w-full resize-none rounded-lg border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-accent-violet/50"
 				/>
 				<div className="mt-1 px-1 text-[10px] text-white/40">
 					⌘↵ to save · esc to cancel

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -192,7 +192,7 @@ function CharacterEditDialogBody({
 					className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[12px] transition-colors ${
 						confirmDelete
 							? "border-rose-500/60 bg-rose-500/20 text-rose-200 hover:bg-rose-500/30"
-							: "border-white/10 bg-white/5 text-white/70 hover:bg-white/10"
+							: "border-glass-border bg-glass-fill text-white/70 hover:bg-white/10"
 					}`}
 				>
 					<Trash2 className="h-3 w-3" />

--- a/app/components/canvas/elements/character/NewCharacterDialog.tsx
+++ b/app/components/canvas/elements/character/NewCharacterDialog.tsx
@@ -67,7 +67,7 @@ function NewCharacterDialogBody({
 					onChange={(e) => setName(e.target.value)}
 					placeholder="Character name"
 					aria-label="Character name"
-					className="w-full rounded-md border border-white/10 bg-white/5 px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
+					className="w-full rounded-md border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
 				/>
 
 				{collision && (

--- a/app/components/canvas/elements/character/NewCharacterDialog.tsx
+++ b/app/components/canvas/elements/character/NewCharacterDialog.tsx
@@ -67,7 +67,7 @@ function NewCharacterDialogBody({
 					onChange={(e) => setName(e.target.value)}
 					placeholder="Character name"
 					aria-label="Character name"
-					className="w-full rounded-md border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30"
+					className="w-full rounded-md border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-accent-violet/50"
 				/>
 
 				{collision && (

--- a/app/components/canvas/elements/character/VoiceMetadataFields.tsx
+++ b/app/components/canvas/elements/character/VoiceMetadataFields.tsx
@@ -20,7 +20,7 @@ export function VoiceSection({
 	onChange: (partial: Partial<MetadataVoice>) => void;
 }) {
 	return (
-		<section className="flex flex-col gap-2 rounded-lg border border-white/10 p-3">
+		<section className="flex flex-col gap-2 rounded-lg border border-glass-border p-3">
 			<div className="flex flex-col gap-0.5">
 				<FieldLabel>Voice</FieldLabel>
 				<p className="text-[11px] text-white/40">Filter the voice list</p>

--- a/app/components/canvas/elements/character/VoicePicker.tsx
+++ b/app/components/canvas/elements/character/VoicePicker.tsx
@@ -63,7 +63,7 @@ export function VoicePicker({
 		<div className="flex min-w-0 flex-col gap-1.5">
 			<FieldLabel>Voices</FieldLabel>
 			{error && <span className="text-[11px] text-rose-400">{error}</span>}
-			<div className="flex h-64 min-w-0 flex-col gap-1.5 overflow-y-auto rounded-lg border border-white/10 bg-black/20 p-1.5">
+			<div className="flex h-64 min-w-0 flex-col gap-1.5 overflow-y-auto rounded-lg border border-glass-border bg-black/20 p-1.5">
 				{loading &&
 					Array.from({ length: SKELETON_ROWS }).map((_, i) => (
 						<Skeleton

--- a/app/components/canvas/elements/character/fields.tsx
+++ b/app/components/canvas/elements/character/fields.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 export const FIELD_CLS =
-	"w-full rounded-md border border-white/10 bg-white/5 px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30";
+	"w-full rounded-md border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30";
 
 export function FieldLabel({ children }: { children: ReactNode }) {
 	return (
@@ -98,7 +98,7 @@ export function EnumField<T extends string>({
 				</DropdownMenuTrigger>
 				<DropdownMenuContent
 					align="start"
-					className="max-h-64 min-w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto rounded-xl border border-white/10 bg-white/5 p-0.5 shadow-md shadow-black/40 backdrop-blur-xl"
+					className="max-h-64 min-w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto rounded-xl border border-glass-border bg-glass-fill p-0.5 shadow-md shadow-black/40 backdrop-blur-xl"
 				>
 					<EnumOption
 						selected={value === undefined}

--- a/app/components/canvas/elements/character/fields.tsx
+++ b/app/components/canvas/elements/character/fields.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 export const FIELD_CLS =
-	"w-full rounded-md border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/30";
+	"w-full rounded-md border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-accent-violet/50";
 
 export function FieldLabel({ children }: { children: ReactNode }) {
 	return (

--- a/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
+++ b/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
@@ -49,7 +49,7 @@ export function AnimatedImagePreview({
 					onDiscard={onDiscard}
 				/>
 			)}
-			<div className="absolute top-2 right-2 z-10 flex items-center rounded-full border border-white/10 bg-black/55 backdrop-blur-xl shadow-md shadow-black/40 p-0.5">
+			<div className="absolute top-2 right-2 z-10 flex items-center rounded-full border border-glass-border bg-black/55 backdrop-blur-xl shadow-md shadow-black/40 p-0.5">
 				<ToggleButton
 					active={mode === "animated"}
 					label="Video"

--- a/app/components/canvas/elements/preview/results.tsx
+++ b/app/components/canvas/elements/preview/results.tsx
@@ -26,7 +26,7 @@ export function AudioResult({
 	onRegenerate: () => void;
 }) {
 	return (
-		<div className="group relative w-full min-h-16 rounded-lg overflow-hidden border border-white/10 bg-white/[0.03] flex flex-wrap items-center gap-x-2 gap-y-1.5 px-2 py-1.5">
+		<div className="group relative w-full min-h-16 rounded-lg overflow-hidden border border-glass-border bg-white/[0.03] flex flex-wrap items-center gap-x-2 gap-y-1.5 px-2 py-1.5">
 			{type === "character" && <CharacterBadge name={characterName} />}
 			<GenerationIndicator
 				status={status}

--- a/app/components/canvas/hooks/useRefineScript.ts
+++ b/app/components/canvas/hooks/useRefineScript.ts
@@ -1,22 +1,94 @@
 import { useCallback, useRef, useState } from "react";
-import type { Editor } from "slate";
-import { useConfig } from "@/lib/config/ConfigProvider";
+import { Editor } from "slate";
+import { type ConnectorRegistry, useConfig } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import { createConnector } from "@/lib/connectors/factory";
 import { createRefinePlugin } from "@/lib/connectors/llm/plugins/refine";
 import { RefineOpParser } from "@/lib/script/refine/parseOps";
 import { applyRefineOp } from "@/lib/script/refine/applyOps";
+import {
+	cloneNode,
+	type ModifiedSnapshot,
+	revertPreview,
+} from "@/lib/script/refine/revertPreview";
+import { summarizeRefineOps } from "@/lib/script/refine/summarizeOps";
+import type { RefineOp } from "@/lib/script/refine/types";
+import type { CanvasEditor } from "@/lib/canvas/types";
+import { findNodeById } from "@/app/components/canvas/utils/editorOps";
+import { getContentElements } from "@/lib/canvas/scenes";
+import type { RefineChanges } from "@/app/components/scene-selection/RefineChangesContext";
+import { computeRefineDiff } from "@/app/components/scene-selection/computeRefineDiff";
 import { OSMLSerializer } from "../utils/osmlSerializer";
 
-export function useRefineScript(editor: Editor) {
+export type RefineTurnStatus =
+	| "streaming"
+	| "pending"
+	| "applied"
+	| "discarded"
+	| "empty";
+
+export type RefineTurn = {
+	id: number;
+	prompt: string;
+	status: RefineTurnStatus;
+	summary: string;
+	ops: RefineOp[];
+};
+
+// Execute the removals held back from a preview, deleting the struck-through
+// nodes for real. Shared by Apply and by the auto-commit when a new refine
+// starts on top of an unresolved preview.
+function commitRemovals(
+	editor: CanvasEditor,
+	removeOps: RefineOp[],
+	connectors: ConnectorRegistry,
+): void {
+	if (removeOps.length === 0) return;
+	const anchorMap: Record<string, string> = {};
+	Editor.withoutNormalizing(editor, () => {
+		for (const op of removeOps)
+			applyRefineOp(editor, op, anchorMap, connectors);
+	});
+}
+
+/**
+ * Conversational refine with a live, editable preview. When the LLM's ops
+ * return they are applied to the editor immediately and the changed nodes are
+ * highlighted (a diff); held-back removals stay in place, struck through, until
+ * Apply. The editor stays editable throughout, so the user can tweak the
+ * agent's edits in place. Apply keeps the preview (and executes the removals);
+ * Discard surgically reverts only the agent's own nodes — added nodes are
+ * deleted, modified nodes restored from snapshot — so manual edits made to
+ * other nodes during the preview survive. Only one preview is pending at a
+ * time; starting a new refine auto-applies an unresolved one.
+ */
+export function useRefineScript(editor: CanvasEditor) {
 	const { connectorConfig } = useConfig();
 	const [refineLoading, setRefineLoading] = useState(false);
+	const [latestTurn, setLatestTurn] = useState<RefineTurn | null>(null);
+	const [changes, setChanges] = useState<RefineChanges>({});
 	const abortRef = useRef<AbortController | null>(null);
+	const idRef = useRef(0);
+	// The active preview: the ids of nodes it added, snapshots of the nodes it
+	// modified (so Discard restores them), and the removals held back from the
+	// preview — executed only on Apply.
+	const pendingRef = useRef<{
+		turnId: number;
+		addedIds: string[];
+		modified: ModifiedSnapshot[];
+		removeOps: RefineOp[];
+	} | null>(null);
 
 	const { provider: llmProvider, config: llmConfig } = getDefaultConnector(
 		connectorConfig,
 		"llm",
 	);
+
+	const patchTurn = useCallback((id: number, patch: Partial<RefineTurn>) => {
+		setLatestTurn((prev) =>
+			prev && prev.id === id ? { ...prev, ...patch } : prev,
+		);
+	}, []);
 
 	const refineScript = useCallback(
 		async (prompt: string) => {
@@ -25,6 +97,26 @@ export function useRefineScript(editor: Editor) {
 			abortRef.current = controller;
 			setRefineLoading(true);
 
+			// Auto-apply any unresolved preview so a new refine commits the user's
+			// reviewed edits rather than silently discarding them. The preview's
+			// inserts/edits are already in the doc; execute its held-back removals
+			// so the next refine builds on the committed result.
+			if (pendingRef.current) {
+				commitRemovals(editor, pendingRef.current.removeOps, connectorConfig);
+				patchTurn(pendingRef.current.turnId, { status: "applied" });
+				pendingRef.current = null;
+				setChanges({});
+			}
+
+			const turnId = (idRef.current += 1);
+			setLatestTurn({
+				id: turnId,
+				prompt,
+				status: "streaming",
+				summary: "",
+				ops: [],
+			});
+
 			const osml = OSMLSerializer.serializeWithScenes(editor.children);
 			const connector = createConnector("llm", llmProvider, {
 				...llmConfig,
@@ -32,28 +124,95 @@ export function useRefineScript(editor: Editor) {
 			});
 
 			const parser = new RefineOpParser();
-			const anchorMap: Record<string, string> = {};
+			const ops: RefineOp[] = [];
 			try {
 				for await (const chunk of connector.stream({ prompt })) {
 					if (controller.signal.aborted) break;
-					const ops = parser.push(chunk.text);
-					for (const op of ops) {
-						applyRefineOp(editor, op, anchorMap, connectorConfig);
-					}
+					ops.push(...parser.push(chunk.text));
 				}
-				if (!controller.signal.aborted) {
-					for (const op of parser.flush()) {
-						applyRefineOp(editor, op, anchorMap, connectorConfig);
-					}
-				}
+				if (!controller.signal.aborted) ops.push(...parser.flush());
 			} finally {
 				if (abortRef.current === controller) {
 					abortRef.current = null;
 					setRefineLoading(false);
 				}
 			}
+
+			if (controller.signal.aborted) {
+				patchTurn(turnId, { status: "discarded", summary: "Stopped." });
+				return;
+			}
+			if (ops.length === 0) {
+				patchTurn(turnId, {
+					status: "empty",
+					summary: "No changes suggested.",
+				});
+				return;
+			}
+
+			// Apply inserts/edits as a live preview, but HOLD BACK removals so the
+			// user can still see (and approve) what is being deleted. Removed nodes
+			// stay in the doc, marked "removed"; they are deleted only on Apply.
+			const removeOps = ops.filter((op) => op.op === "remove");
+			const previewOps = ops.filter((op) => op.op !== "remove");
+
+			const beforeIds = new Set(
+				getContentElements(editor.children).map((el) => el.id),
+			);
+			// Snapshot the nodes the set-ops will modify, before they change, so
+			// Discard can restore them.
+			const modified: ModifiedSnapshot[] = [];
+			for (const op of ops) {
+				if (op.op !== "set") continue;
+				const entry = findNodeById(editor, op.id);
+				if (entry) modified.push({ id: op.id, node: cloneNode(entry[0]) });
+			}
+
+			const anchorMap: Record<string, string> = {};
+			Editor.withoutNormalizing(editor, () => {
+				for (const op of previewOps) {
+					applyRefineOp(editor, op, anchorMap, connectorConfig);
+				}
+			});
+			const afterIds = getContentElements(editor.children).map((el) => el.id);
+			const addedIds = afterIds.filter((id) => !beforeIds.has(id));
+			setChanges(computeRefineDiff(beforeIds, afterIds, ops));
+			pendingRef.current = { turnId, addedIds, modified, removeOps };
+			patchTurn(turnId, {
+				status: "pending",
+				summary: summarizeRefineOps(ops),
+				ops,
+			});
 		},
-		[editor, llmProvider, llmConfig, connectorConfig],
+		[editor, llmProvider, llmConfig, connectorConfig, patchTurn],
+	);
+
+	// Apply = keep the previewed edits, execute the held-back removals, and clear
+	// the highlight (normalize into the standard UI).
+	const applyTurn = useCallback(
+		(id: number) => {
+			const pending = pendingRef.current;
+			if (pending?.turnId !== id) return;
+			commitRemovals(editor, pending.removeOps, connectorConfig);
+			pendingRef.current = null;
+			setChanges({});
+			patchTurn(id, { status: "applied" });
+		},
+		[editor, connectorConfig, patchTurn],
+	);
+
+	// Discard = surgically revert only the agent's own nodes, leaving any manual
+	// edits the user made to other nodes during the preview intact.
+	const discardTurn = useCallback(
+		(id: number) => {
+			const pending = pendingRef.current;
+			if (pending?.turnId !== id) return;
+			revertPreview(editor, pending.addedIds, pending.modified);
+			pendingRef.current = null;
+			setChanges({});
+			patchTurn(id, { status: "discarded" });
+		},
+		[editor, patchTurn],
 	);
 
 	const stopRefine = useCallback(() => {
@@ -62,5 +221,13 @@ export function useRefineScript(editor: Editor) {
 		setRefineLoading(false);
 	}, []);
 
-	return { refineScript, refineLoading, stopRefine };
+	return {
+		refineScript,
+		refineLoading,
+		stopRefine,
+		latestTurn,
+		applyTurn,
+		discardTurn,
+		changes,
+	};
 }

--- a/app/components/canvas/hooks/useRefineScript.ts
+++ b/app/components/canvas/hooks/useRefineScript.ts
@@ -35,9 +35,6 @@ export type RefineTurn = {
 	ops: RefineOp[];
 };
 
-// Execute the removals held back from a preview, deleting the struck-through
-// nodes for real. Shared by Apply and by the auto-commit when a new refine
-// starts on top of an unresolved preview.
 function commitRemovals(
 	editor: CanvasEditor,
 	removeOps: RefineOp[],
@@ -69,9 +66,6 @@ export function useRefineScript(editor: CanvasEditor) {
 	const [changes, setChanges] = useState<RefineChanges>({});
 	const abortRef = useRef<AbortController | null>(null);
 	const idRef = useRef(0);
-	// The active preview: the ids of nodes it added, snapshots of the nodes it
-	// modified (so Discard restores them), and the removals held back from the
-	// preview — executed only on Apply.
 	const pendingRef = useRef<{
 		turnId: number;
 		addedIds: string[];
@@ -97,10 +91,6 @@ export function useRefineScript(editor: CanvasEditor) {
 			abortRef.current = controller;
 			setRefineLoading(true);
 
-			// Auto-apply any unresolved preview so a new refine commits the user's
-			// reviewed edits rather than silently discarding them. The preview's
-			// inserts/edits are already in the doc; execute its held-back removals
-			// so the next refine builds on the committed result.
 			if (pendingRef.current) {
 				commitRemovals(editor, pendingRef.current.removeOps, connectorConfig);
 				patchTurn(pendingRef.current.turnId, { status: "applied" });
@@ -150,17 +140,12 @@ export function useRefineScript(editor: CanvasEditor) {
 				return;
 			}
 
-			// Apply inserts/edits as a live preview, but HOLD BACK removals so the
-			// user can still see (and approve) what is being deleted. Removed nodes
-			// stay in the doc, marked "removed"; they are deleted only on Apply.
 			const removeOps = ops.filter((op) => op.op === "remove");
 			const previewOps = ops.filter((op) => op.op !== "remove");
 
 			const beforeIds = new Set(
 				getContentElements(editor.children).map((el) => el.id),
 			);
-			// Snapshot the nodes the set-ops will modify, before they change, so
-			// Discard can restore them.
 			const modified: ModifiedSnapshot[] = [];
 			for (const op of ops) {
 				if (op.op !== "set") continue;
@@ -187,8 +172,6 @@ export function useRefineScript(editor: CanvasEditor) {
 		[editor, llmProvider, llmConfig, connectorConfig, patchTurn],
 	);
 
-	// Apply = keep the previewed edits, execute the held-back removals, and clear
-	// the highlight (normalize into the standard UI).
 	const applyTurn = useCallback(
 		(id: number) => {
 			const pending = pendingRef.current;
@@ -201,8 +184,6 @@ export function useRefineScript(editor: CanvasEditor) {
 		[editor, connectorConfig, patchTurn],
 	);
 
-	// Discard = surgically revert only the agent's own nodes, leaving any manual
-	// edits the user made to other nodes during the preview intact.
 	const discardTurn = useCallback(
 		(id: number) => {
 			const pending = pendingRef.current;

--- a/app/components/canvas/panel/AutoScrollPanel.tsx
+++ b/app/components/canvas/panel/AutoScrollPanel.tsx
@@ -6,7 +6,7 @@ import { useAutoScroll } from "@/app/components/scene-selection/AutoScrollContex
 export default function AutoScrollPanel() {
 	const { enabled, setEnabled } = useAutoScroll();
 	const activeClass =
-		"relative grain bg-[#2d2040]/60 border border-violet-500/30 text-violet-300";
+		"relative grain bg-[#2d2040]/60 border border-accent-violet/30 text-violet-300";
 	return (
 		<div className="flex flex-col gap-2">
 			<h2 className="text-xs font-semibold uppercase tracking-wider text-white/50">

--- a/app/components/canvas/panel/AutoScrollPanel.tsx
+++ b/app/components/canvas/panel/AutoScrollPanel.tsx
@@ -6,7 +6,7 @@ import { useAutoScroll } from "@/app/components/scene-selection/AutoScrollContex
 export default function AutoScrollPanel() {
 	const { enabled, setEnabled } = useAutoScroll();
 	const activeClass =
-		"relative grain bg-[#2d2040]/60 border border-accent-violet/30 text-violet-300";
+		"relative grain bg-panel-violet/60 border border-accent-violet/30 text-violet-300";
 	return (
 		<div className="flex flex-col gap-2">
 			<h2 className="text-xs font-semibold uppercase tracking-wider text-white/50">

--- a/app/components/canvas/panel/PlayerPositionPanel.tsx
+++ b/app/components/canvas/panel/PlayerPositionPanel.tsx
@@ -20,7 +20,7 @@ export default function PlayerPositionPanel() {
 		usePlayerPosition();
 
 	const activeClass =
-		"relative grain bg-[#2d2040]/60 border border-violet-500/30 text-violet-300";
+		"relative grain bg-[#2d2040]/60 border border-accent-violet/30 text-violet-300";
 
 	return (
 		<div className="flex flex-col gap-2">

--- a/app/components/canvas/panel/PlayerPositionPanel.tsx
+++ b/app/components/canvas/panel/PlayerPositionPanel.tsx
@@ -20,7 +20,7 @@ export default function PlayerPositionPanel() {
 		usePlayerPosition();
 
 	const activeClass =
-		"relative grain bg-[#2d2040]/60 border border-accent-violet/30 text-violet-300";
+		"relative grain bg-panel-violet/60 border border-accent-violet/30 text-violet-300";
 
 	return (
 		<div className="flex flex-col gap-2">

--- a/app/components/canvas/panel/Sidebar.tsx
+++ b/app/components/canvas/panel/Sidebar.tsx
@@ -25,7 +25,7 @@ export default function Sidebar() {
 				}`}
 			>
 				<div
-					className={`absolute inset-0 bg-white/5 backdrop-blur-xl shadow-[2px_0_50px_rgba(0,0,0,0.25)] border-r border-white/10 transition-opacity duration-300 motion-reduce:transition-none ${
+					className={`absolute inset-0 bg-glass-fill backdrop-blur-xl shadow-[2px_0_50px_rgba(0,0,0,0.25)] border-r border-glass-border transition-opacity duration-300 motion-reduce:transition-none ${
 						open ? "opacity-100" : "opacity-0"
 					}`}
 				/>

--- a/app/components/canvas/panel/TransitionPanel.tsx
+++ b/app/components/canvas/panel/TransitionPanel.tsx
@@ -41,7 +41,7 @@ export default function TransitionPanel() {
 					<button
 						type="button"
 						aria-label={`Transition: ${LABELS[transitionType]}`}
-						className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm text-white/70 hover:text-white bg-white/5 hover:bg-white/10 ring-1 ring-inset ring-white/10 hover:ring-white/20 transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+						className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm text-white/70 hover:text-white bg-glass-fill hover:bg-white/10 ring-1 ring-inset ring-white/10 hover:ring-white/20 transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
 					>
 						<span className="truncate">{LABELS[transitionType]}</span>
 						<ChevronDown
@@ -52,7 +52,7 @@ export default function TransitionPanel() {
 				</DropdownMenuTrigger>
 				<DropdownMenuContent
 					align="start"
-					className="z-[90] min-w-[--radix-dropdown-menu-trigger-width] max-h-64 overflow-y-auto rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+					className="z-[90] min-w-[--radix-dropdown-menu-trigger-width] max-h-64 overflow-y-auto rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
 				>
 					{TRANSITION_TYPES.map((value) => (
 						<DropdownMenuItem

--- a/app/components/canvas/plugins/withNodeId.ts
+++ b/app/components/canvas/plugins/withNodeId.ts
@@ -1,8 +1,7 @@
-import { ReactEditor } from "slate-react";
 import type { CanvasEditor } from "@/lib/canvas/types";
 import { assignIdRecursively, makeNodeId, stripIds } from "../utils/nodeUtils";
 
-export const withNodeId = (editor: ReactEditor): CanvasEditor => {
+export const withNodeId = (editor: CanvasEditor): CanvasEditor => {
 	const { apply, insertFragment } = editor;
 
 	editor.insertFragment = (fragment) => {

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -79,7 +79,7 @@ function AttachMenu({
 			<DropdownMenuContent
 				side="bottom"
 				align="start"
-				className="min-w-36 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+				className="min-w-36 rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
 			>
 				<DropdownMenuItem
 					onClick={openPicker}
@@ -181,7 +181,7 @@ export default function ComposerCopilot({
 		typeof placeholder === "string" ? placeholder : undefined;
 
 	return (
-		<div className="w-full rounded-xl border border-violet-500/30 bg-white/5 shadow-[0_0_40px_rgba(55,30,100,0.5)]">
+		<div className="w-full rounded-xl border border-accent-violet/30 bg-glass-fill backdrop-blur-xl transition-shadow focus-within:shadow-glow">
 			<div className="px-4 py-3">
 				<ComposerAssets
 					uploadingCount={uploadingCount}

--- a/app/components/copilot/InlineCopilot.tsx
+++ b/app/components/copilot/InlineCopilot.tsx
@@ -63,7 +63,7 @@ export default function InlineCopilot({
 		typeof placeholder === "string" ? placeholder : undefined;
 
 	return (
-		<div className="w-full rounded-xl border border-violet-500/30 bg-white/5 shadow-[0_0_40px_rgba(55,30,100,0.5)]">
+		<div className="w-full rounded-xl border border-accent-violet/30 bg-glass-fill backdrop-blur-xl transition-shadow focus-within:shadow-glow">
 			<div className="relative flex items-center px-4 py-3">
 				{loading ? (
 					<OrbLoader />

--- a/app/components/copilot/RefineThread.tsx
+++ b/app/components/copilot/RefineThread.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { Sparkles } from "lucide-react";
+import type { RefineTurn } from "../canvas/hooks/useRefineScript";
+
+const SUGGESTIONS = [
+	"Add motion to all scenes",
+	"Make the script funnier",
+	"Make narration faster",
+	"Vary character poses",
+];
+
+interface RefineThreadProps {
+	latestTurn: RefineTurn | null;
+	loading: boolean;
+	onApply: (id: number) => void;
+	onDiscard: (id: number) => void;
+	onSuggest: (text: string) => void;
+}
+
+function TurnCard({
+	turn,
+	onApply,
+	onDiscard,
+}: {
+	turn: RefineTurn;
+	onApply: (id: number) => void;
+	onDiscard: (id: number) => void;
+}) {
+	// Preview is live in the editor (highlighted). Apply keeps it; Discard reverts.
+	if (turn.status === "pending") {
+		return (
+			<div className="flex items-center gap-3 rounded-xl border border-glass-border bg-glass-fill px-3 py-2 backdrop-blur-xl">
+				<span className="font-body shrink-0 rounded-full bg-accent-violet/20 px-2 py-0.5 text-[10px] font-medium text-accent-violet-soft">
+					Preview
+				</span>
+				<p className="font-body min-w-0 flex-1 truncate text-sm text-white/80">
+					{turn.summary}
+				</p>
+				<button
+					type="button"
+					onClick={() => onDiscard(turn.id)}
+					className="font-body shrink-0 rounded-lg px-3 py-1 text-xs text-white/60 transition-colors hover:bg-glass-fill hover:text-white"
+				>
+					Discard
+				</button>
+				<button
+					type="button"
+					onClick={() => onApply(turn.id)}
+					className="font-body shrink-0 rounded-lg bg-accent-violet px-3 py-1 text-xs font-medium text-white shadow-glow transition hover:brightness-110"
+				>
+					Apply
+				</button>
+			</div>
+		);
+	}
+
+	if (turn.status === "empty") {
+		return (
+			<p className="font-body px-1 text-[11px] text-white/40">
+				No changes suggested.
+			</p>
+		);
+	}
+
+	// applied (kept) / discarded (reverted): the editor already reflects the
+	// result, so the thread clears.
+	return null;
+}
+
+export default function RefineThread({
+	latestTurn,
+	loading,
+	onApply,
+	onDiscard,
+	onSuggest,
+}: RefineThreadProps) {
+	const showChips =
+		!loading && (!latestTurn || latestTurn.status !== "pending");
+
+	return (
+		<div className="flex w-full flex-col gap-2">
+			{latestTurn && (
+				<TurnCard turn={latestTurn} onApply={onApply} onDiscard={onDiscard} />
+			)}
+			{showChips && (
+				<div className="flex flex-wrap gap-1.5">
+					{SUGGESTIONS.map((s) => (
+						<button
+							key={s}
+							type="button"
+							onClick={() => onSuggest(s)}
+							className="font-body inline-flex items-center gap-1.5 rounded-full border border-glass-border bg-glass-fill px-3 py-1 text-[11px] text-white/60 transition-colors hover:border-white/20 hover:text-white"
+						>
+							<Sparkles
+								className="h-3 w-3 text-accent-violet-soft"
+								strokeWidth={1.5}
+							/>
+							{s}
+						</button>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/app/components/copilot/RefineThread.tsx
+++ b/app/components/copilot/RefineThread.tsx
@@ -27,7 +27,6 @@ function TurnCard({
 	onApply: (id: number) => void;
 	onDiscard: (id: number) => void;
 }) {
-	// Preview is live in the editor (highlighted). Apply keeps it; Discard reverts.
 	if (turn.status === "pending") {
 		return (
 			<div className="flex items-center gap-3 rounded-xl border border-glass-border bg-glass-fill px-3 py-2 backdrop-blur-xl">

--- a/app/components/projects/ProjectsList.tsx
+++ b/app/components/projects/ProjectsList.tsx
@@ -62,7 +62,7 @@ export default function ProjectsList({
 			<div className="max-w-5xl mx-auto px-6 pt-20 pb-16">
 				<header className="flex items-end justify-between mb-10">
 					<div>
-						<h1 className="font-display text-4xl tracking-tight">My Slop</h1>
+						<h1 className="font-body text-4xl tracking-tight">My Slop</h1>
 						<p className="text-white/60 text-sm mt-1">
 							{projects.length === 0
 								? "No projects yet — start your first slop."

--- a/app/components/projects/ProjectsList.tsx
+++ b/app/components/projects/ProjectsList.tsx
@@ -83,7 +83,7 @@ export default function ProjectsList({
 				<ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
 					{projects.map((project) => (
 						<li key={project.id}>
-							<div className="group relative rounded-xl border border-white/10 bg-white/[0.03] hover:bg-white/[0.06] transition-colors overflow-hidden">
+							<div className="group relative rounded-xl border border-glass-border bg-white/[0.03] hover:bg-white/[0.06] transition-colors overflow-hidden">
 								<button
 									type="button"
 									onClick={() => router.push(`/projects/${project.id}`)}

--- a/app/components/scene-selection/RefineChangesContext.tsx
+++ b/app/components/scene-selection/RefineChangesContext.tsx
@@ -6,11 +6,10 @@ export type RefineChangeKind = "added" | "modified" | "removed";
 export type RefineChanges = Record<string, RefineChangeKind>;
 
 /**
- * Per-element diff markers from the most recent applied refine: which content
- * nodes were added or modified, so the editor can highlight exactly what
- * changed (like a diff gutter). Set by useRefineScript on apply, cleared on the
- * next refine or undo. Removed nodes are gone from the doc, so they aren't
- * marked here — the refine summary reports their count.
+ * Per-element diff markers for the current pending refine preview: which content
+ * nodes the agent added, modified, or removed (added/modified are tinted,
+ * removed is struck through and held in place until Apply). Set when the
+ * preview's ops land, cleared on apply, discard, or the next refine.
  */
 export const RefineChangesContext = createContext<RefineChanges>({});
 

--- a/app/components/scene-selection/RefineChangesContext.tsx
+++ b/app/components/scene-selection/RefineChangesContext.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { createContext, use } from "react";
+
+export type RefineChangeKind = "added" | "modified" | "removed";
+export type RefineChanges = Record<string, RefineChangeKind>;
+
+/**
+ * Per-element diff markers from the most recent applied refine: which content
+ * nodes were added or modified, so the editor can highlight exactly what
+ * changed (like a diff gutter). Set by useRefineScript on apply, cleared on the
+ * next refine or undo. Removed nodes are gone from the doc, so they aren't
+ * marked here — the refine summary reports their count.
+ */
+export const RefineChangesContext = createContext<RefineChanges>({});
+
+export function useRefineChanges() {
+	return use(RefineChangesContext);
+}

--- a/app/components/scene-selection/__tests__/computeRefineDiff.test.ts
+++ b/app/components/scene-selection/__tests__/computeRefineDiff.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { RefineOp } from "@/lib/script/refine/types";
+import { computeRefineDiff } from "../computeRefineDiff";
+
+describe("computeRefineDiff", () => {
+	it("marks ids that are new since `before` as added", () => {
+		const ops: RefineOp[] = [{ op: "insert", type: "image", text: "x" }];
+		expect(computeRefineDiff(new Set(["a"]), ["a", "b"], ops)).toEqual({
+			b: "added",
+		});
+	});
+
+	it("marks surviving set-op targets as modified", () => {
+		const ops: RefineOp[] = [{ op: "set", id: "a", text: "y" }];
+		expect(computeRefineDiff(new Set(["a", "b"]), ["a", "b"], ops)).toEqual({
+			a: "modified",
+		});
+	});
+
+	it("marks remove-op targets as removed (still present during preview)", () => {
+		const ops: RefineOp[] = [{ op: "remove", id: "b" }];
+		expect(computeRefineDiff(new Set(["a", "b"]), ["a", "b"], ops)).toEqual({
+			b: "removed",
+		});
+	});
+
+	it("handles a mixed add + edit + remove diff", () => {
+		const ops: RefineOp[] = [
+			{ op: "insert", type: "sound", text: "rain" },
+			{ op: "set", id: "a", text: "y" },
+			{ op: "remove", id: "b" },
+		];
+		expect(
+			computeRefineDiff(new Set(["a", "b"]), ["a", "b", "c"], ops),
+		).toEqual({ c: "added", a: "modified", b: "removed" });
+	});
+
+	it("lets removed win over a same-id edit and tolerates already-gone ids", () => {
+		const ops: RefineOp[] = [
+			{ op: "set", id: "a", text: "y" },
+			{ op: "remove", id: "a" },
+			{ op: "remove", id: "b" },
+		];
+		expect(computeRefineDiff(new Set(["a"]), ["a"], ops)).toEqual({
+			a: "removed",
+			b: "removed",
+		});
+	});
+});

--- a/app/components/scene-selection/computeRefineDiff.ts
+++ b/app/components/scene-selection/computeRefineDiff.ts
@@ -1,0 +1,30 @@
+import type { RefineOp } from "@/lib/script/refine/types";
+import type { RefineChanges } from "./RefineChangesContext";
+
+/**
+ * Build the per-node diff for a refine preview:
+ * - ids in `afterIds` but not `beforeIds` were **added**,
+ * - `set`-op targets that still exist were **modified**,
+ * - `remove`-op targets are **removed** (these nodes are kept in the document
+ *   during the preview so the deletion can be reviewed, so they still appear in
+ *   `afterIds`; the remove pass marks them last and wins over add/modify).
+ */
+export function computeRefineDiff(
+	beforeIds: ReadonlySet<string>,
+	afterIds: readonly string[],
+	ops: readonly RefineOp[],
+): RefineChanges {
+	const modifiedIds = new Set(
+		ops.filter((op) => op.op === "set").map((op) => op.id),
+	);
+
+	const diff: RefineChanges = {};
+	for (const id of afterIds) {
+		if (!beforeIds.has(id)) diff[id] = "added";
+		else if (modifiedIds.has(id)) diff[id] = "modified";
+	}
+	for (const op of ops) {
+		if (op.op === "remove") diff[op.id] = "removed";
+	}
+	return diff;
+}

--- a/app/components/video/RenderControls.tsx
+++ b/app/components/video/RenderControls.tsx
@@ -16,7 +16,7 @@ function formatBytes(bytes: number): string {
 }
 
 const pillClass =
-	"flex items-center gap-2 rounded-lg border border-white/10 bg-card/90 px-3 py-2 backdrop-blur-xl shadow-md shadow-black/20 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12)]";
+	"flex items-center gap-2 rounded-lg border border-glass-border bg-card/90 px-3 py-2 backdrop-blur-xl shadow-md shadow-black/20 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12)]";
 
 export function RenderControls({ layout }: { layout: VideoLayout }) {
 	const { state, render, reset } = useRendering();

--- a/app/components/video/VideoPanel.tsx
+++ b/app/components/video/VideoPanel.tsx
@@ -35,7 +35,7 @@ export function VideoPanel() {
 	const showControls = !scriptLoading && !!layout?.series.length && ready;
 
 	return (
-		<div className="group relative h-full w-full overflow-hidden rounded-lg border border-white/10 bg-white/5 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12)]">
+		<div className="group relative h-full w-full overflow-hidden rounded-lg border border-glass-border bg-glass-fill shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12)]">
 			<div className="grain grain-light absolute inset-0" aria-hidden="true" />
 			<div className="relative z-[2] h-full w-full">
 				<VideoPanelBody />

--- a/app/globals.css
+++ b/app/globals.css
@@ -53,6 +53,7 @@
 	--color-canvas: #0a0a0a;
 	--color-accent-violet: #8b5cf6;
 	--color-accent-violet-soft: #a78bfa;
+	--color-glow-violet: rgba(55, 30, 100, 0.55);
 	--color-glass-fill: rgba(255, 255, 255, 0.05);
 	--color-glass-border: rgba(255, 255, 255, 0.1);
 
@@ -66,7 +67,7 @@
 	--color-media-narration: #9ca3af;
 
 	/* The earned violet glow. Used rarely, only on the live/primary action. */
-	--shadow-glow: 0 0 40px rgba(55, 30, 100, 0.55);
+	--shadow-glow: 0 0 40px var(--color-glow-violet);
 }
 
 @keyframes moveHorizontal {

--- a/app/globals.css
+++ b/app/globals.css
@@ -54,6 +54,7 @@
 	--color-accent-violet: #8b5cf6;
 	--color-accent-violet-soft: #a78bfa;
 	--color-glow-violet: rgba(55, 30, 100, 0.55);
+	--color-panel-violet: #2d2040;
 	--color-glass-fill: rgba(255, 255, 255, 0.05);
 	--color-glass-border: rgba(255, 255, 255, 0.1);
 
@@ -163,11 +164,6 @@
 html {
 	background-color: #0a0a0a;
 	color-scheme: dark;
-}
-
-/* Display utility — consolidated onto Satoshi (Google Sans Flex dropped per DESIGN.md). */
-.font-display {
-	font-family: "Satoshi", sans-serif;
 }
 
 .font-title {

--- a/app/globals.css
+++ b/app/globals.css
@@ -46,6 +46,29 @@
 	--radius-4xl: calc(var(--radius) + 16px);
 }
 
+/* openslop design tokens — see DESIGN.md. Non-inline so the raw CSS vars are
+   available everywhere (module CSS, arbitrary values) and utilities are generated
+   (bg-glass-fill, border-glass-border, text-media-character, shadow-glow, ...). */
+@theme {
+	--color-canvas: #0a0a0a;
+	--color-accent-violet: #8b5cf6;
+	--color-accent-violet-soft: #a78bfa;
+	--color-glass-fill: rgba(255, 255, 255, 0.05);
+	--color-glass-border: rgba(255, 255, 255, 0.1);
+
+	/* Media-type palette — every storyboard element type reads at a glance. */
+	--color-media-character: #fbbf24;
+	--color-media-image: #22d3ee;
+	--color-media-animated: #e879f9;
+	--color-media-clip: #818cf8;
+	--color-media-music: #a78bfa;
+	--color-media-sound: #34d399;
+	--color-media-narration: #9ca3af;
+
+	/* The earned violet glow. Used rarely, only on the live/primary action. */
+	--shadow-glow: 0 0 40px rgba(55, 30, 100, 0.55);
+}
+
 @keyframes moveHorizontal {
 	0% {
 		transform: translateX(-20%) translateY(-10%);
@@ -141,9 +164,9 @@ html {
 	color-scheme: dark;
 }
 
-/* Reusable font-family utility for Google Sans Flex */
+/* Display utility — consolidated onto Satoshi (Google Sans Flex dropped per DESIGN.md). */
 .font-display {
-	font-family: "Google Sans Flex", sans-serif;
+	font-family: "Satoshi", sans-serif;
 }
 
 .font-title {

--- a/app/globals.css
+++ b/app/globals.css
@@ -71,37 +71,6 @@
 	--shadow-glow: 0 0 40px var(--color-glow-violet);
 }
 
-@keyframes moveHorizontal {
-	0% {
-		transform: translateX(-20%) translateY(-10%);
-	}
-	50% {
-		transform: translateX(20%) translateY(-5%);
-	}
-	100% {
-		transform: translateX(-20%) translateY(-10%);
-	}
-}
-
-@keyframes moveVertical {
-	0% {
-		transform: translateY(-25%);
-	}
-	50% {
-		transform: translateY(25%);
-	}
-	100% {
-		transform: translateY(-25%);
-	}
-}
-
-.animate-first {
-	animation: moveVertical 25s ease infinite;
-}
-.animate-fourth {
-	animation: moveHorizontal 20s ease infinite;
-}
-
 @keyframes fadeInUp {
 	from {
 		opacity: 0;
@@ -153,8 +122,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.animate-first,
-	.animate-fourth,
 	.animate-fadeInUp,
 	.shimmer-surface {
 		animation: none;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -43,10 +43,6 @@ export default function RootLayout({
 					href="https://api.fontshare.com/v2/css?f[]=sentient@400&f[]=satoshi@400,500,700&display=swap"
 					rel="stylesheet"
 				/>
-				<link
-					href="https://fonts.googleapis.com/css2?family=Google+Sans+Flex:wght@300;400;500;600;700&display=swap"
-					rel="stylesheet"
-				/>
 			</head>
 			<body
 				className={`${geistSans.variable} ${instrumentSerif.variable} antialiased bg-[#0a0a0a]`}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -15,7 +15,7 @@ export default function Loading() {
 					{Array.from({ length: 6 }).map((_, i) => (
 						<div
 							key={i}
-							className="rounded-xl border border-white/10 overflow-hidden"
+							className="rounded-xl border border-glass-border overflow-hidden"
 						>
 							<Skeleton className="aspect-video rounded-none" />
 							<div className="p-4 space-y-2">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -62,7 +62,7 @@ export default async function Home() {
 				</>
 			}
 		>
-			<p className="text-white/70 text-sm font-medium font-display">
+			<p className="text-white/70 text-sm font-medium font-body">
 				Have an access code?
 			</p>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,7 +37,7 @@ export default async function Home() {
 			heading="Welcome to the OpenSlop Beta"
 			subtitle="OpenSlop is your free, open-source video creator that brings together all your favorite AI tools, helping you get more done with less effort."
 			extra={
-				<div className="w-full flex items-center justify-center gap-3 sm:gap-5 rounded-full border border-white/10 bg-white/5 px-4 sm:px-6 py-2.5 sm:py-3">
+				<div className="w-full flex items-center justify-center gap-3 sm:gap-5 rounded-full border border-glass-border bg-glass-fill px-4 sm:px-6 py-2.5 sm:py-3">
 					{icons.map((icon) => (
 						<Image
 							key={icon}

--- a/app/styles/auth.module.css
+++ b/app/styles/auth.module.css
@@ -11,7 +11,7 @@
 	transition:
 		border-color 0.15s,
 		box-shadow 0.15s;
-	font-family: "Google Sans Flex", sans-serif;
+	font-family: "Satoshi", sans-serif;
 }
 
 .input::placeholder {

--- a/lib/canvas/types.ts
+++ b/lib/canvas/types.ts
@@ -1,5 +1,6 @@
 import type { BaseEditor } from "slate";
 import type { ReactEditor } from "slate-react";
+import type { HistoryEditor } from "slate-history";
 
 export type ResultKind = "image" | "video" | "audio";
 
@@ -30,7 +31,9 @@ export const FOREGROUND_TYPES: ReadonlySet<CanvasElementType> = new Set([
 	"clip",
 ]);
 
-export type CanvasEditor = BaseEditor & ReactEditor & { id?: string };
+export type CanvasEditor = BaseEditor &
+	ReactEditor &
+	HistoryEditor & { id?: string };
 
 export type CanvasContentElement = {
 	id: string;

--- a/lib/script/refine/__tests__/revertPreview.test.ts
+++ b/lib/script/refine/__tests__/revertPreview.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { createEditor, Editor, Element } from "slate";
+import type { CanvasContentElement, SceneElement } from "@/lib/canvas/types";
+import { cloneNode, revertPreview } from "../revertPreview";
+
+function content(
+	type: CanvasContentElement["type"],
+	id: string,
+	text = "",
+): CanvasContentElement {
+	return { id, type, children: [{ id: `${id}-t`, type, text }] };
+}
+
+function scene(children: CanvasContentElement[], id = "s1"): SceneElement {
+	return { id, type: "scene", children };
+}
+
+function makeEditor(children: CanvasContentElement[]) {
+	const editor = createEditor();
+	editor.children = [scene(children)];
+	return editor;
+}
+
+function texts(editor: Editor): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const [node] of Editor.nodes<CanvasContentElement>(editor, {
+		at: [],
+		match: (n) => Element.isElement(n) && n.type !== "scene",
+	})) {
+		out[node.id] = node.children.map((c) => c.text).join("");
+	}
+	return out;
+}
+
+describe("revertPreview", () => {
+	it("removes added nodes and restores modified nodes from snapshot", () => {
+		// Snapshot taken before the preview ran.
+		const snapshot = [
+			{ id: "n2", node: cloneNode(content("narration", "n2", "world")) },
+		];
+		// Post-preview state: n2 modified, a1 added.
+		const editor = makeEditor([
+			content("narration", "n1", "hello"),
+			content("narration", "n2", "WORLD (edited)"),
+			content("sound", "a1", "rain"),
+		]);
+
+		revertPreview(editor, ["a1"], snapshot);
+
+		const result = texts(editor);
+		expect(result["a1"]).toBeUndefined(); // added node removed
+		expect(result["n2"]).toBe("world"); // modified node restored from snapshot
+		expect(result["n1"]).toBe("hello"); // untouched
+	});
+
+	it("preserves a manual edit made to another node during the preview", () => {
+		const snapshot = [
+			{ id: "n2", node: cloneNode(content("narration", "n2", "world")) },
+		];
+		// Post-preview: the agent edited n2, and the user manually edited n3.
+		const editor = makeEditor([
+			content("narration", "n1", "hello"),
+			content("narration", "n2", "WORLD (agent)"),
+			content("narration", "n3", "foo (my manual edit)"),
+		]);
+
+		revertPreview(editor, [], snapshot);
+
+		const result = texts(editor);
+		expect(result["n2"]).toBe("world"); // agent edit reverted
+		expect(result["n3"]).toBe("foo (my manual edit)"); // manual edit survives
+	});
+
+	it("is a no-op for ids that no longer exist", () => {
+		const editor = makeEditor([content("narration", "n1", "hello")]);
+		expect(() =>
+			revertPreview(
+				editor,
+				["gone"],
+				[{ id: "missing", node: content("sound", "missing") }],
+			),
+		).not.toThrow();
+		expect(texts(editor)).toEqual({ n1: "hello" });
+	});
+});

--- a/lib/script/refine/__tests__/summarizeOps.test.ts
+++ b/lib/script/refine/__tests__/summarizeOps.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { RefineOp } from "../types";
+import { summarizeRefineOps } from "../summarizeOps";
+
+describe("summarizeRefineOps", () => {
+	it("returns a no-op message for an empty op list", () => {
+		expect(summarizeRefineOps([])).toBe("No changes suggested.");
+	});
+
+	it("counts inserts by element type with pluralization", () => {
+		const ops: RefineOp[] = [
+			{ op: "insert", type: "image", text: "a" },
+			{ op: "insert", type: "image", text: "b" },
+			{ op: "insert", type: "narration", text: "c" },
+		];
+		expect(summarizeRefineOps(ops)).toBe("Added 2 images, 1 narration.");
+	});
+
+	it("describes attribute changes by friendly name and count", () => {
+		const ops: RefineOp[] = [
+			{ op: "set", id: "1", attrs: { motion: "kenBurnsIn" } },
+			{ op: "set", id: "2", attrs: { motion: "kenBurnsOut" } },
+		];
+		expect(summarizeRefineOps(ops)).toBe("Set motion on 2 elements.");
+	});
+
+	it("counts text rewrites", () => {
+		const ops: RefineOp[] = [
+			{ op: "set", id: "1", text: "new line" },
+			{ op: "set", id: "2", text: "another" },
+		];
+		expect(summarizeRefineOps(ops)).toBe("Rewrote 2 lines.");
+	});
+
+	it("combines mixed ops into one sentence", () => {
+		const ops: RefineOp[] = [
+			{ op: "insert", type: "sound", text: "rain" },
+			{ op: "set", id: "1", text: "x" },
+			{ op: "remove", id: "2" },
+		];
+		expect(summarizeRefineOps(ops)).toBe(
+			"Added 1 sound, rewrote 1 line and removed 1 element.",
+		);
+	});
+});

--- a/lib/script/refine/revertPreview.ts
+++ b/lib/script/refine/revertPreview.ts
@@ -1,0 +1,35 @@
+import { Editor, Transforms } from "slate";
+import type { CanvasContentElement } from "@/lib/canvas/types";
+import { findNodeById } from "@/app/components/canvas/utils/editorOps";
+
+// A node the preview modified, with a deep clone of its pre-refine content so
+// Discard can restore it verbatim.
+export type ModifiedSnapshot = { id: string; node: CanvasContentElement };
+
+export const cloneNode = <T>(node: T): T => JSON.parse(JSON.stringify(node));
+
+/**
+ * Surgically revert a refine preview: delete the nodes it added and restore the
+ * nodes it modified to their pre-refine snapshot. Held-back removals were never
+ * applied, so they simply stay. Everything is keyed by node id, so manual edits
+ * the user made to OTHER nodes while the preview was up are left untouched
+ * (a Cursor-style inline diff — the agent's edits stay editable in between).
+ */
+export function revertPreview(
+	editor: Editor,
+	addedIds: string[],
+	modified: ModifiedSnapshot[],
+): void {
+	Editor.withoutNormalizing(editor, () => {
+		for (const id of addedIds) {
+			const entry = findNodeById(editor, id);
+			if (entry) Transforms.removeNodes(editor, { at: entry[1] });
+		}
+		for (const { id, node } of modified) {
+			const entry = findNodeById(editor, id);
+			if (!entry) continue;
+			Transforms.removeNodes(editor, { at: entry[1] });
+			Transforms.insertNodes(editor, node, { at: entry[1] });
+		}
+	});
+}

--- a/lib/script/refine/summarizeOps.ts
+++ b/lib/script/refine/summarizeOps.ts
@@ -1,0 +1,80 @@
+import type { RefineOp } from "./types";
+
+const TYPE_LABELS: Record<string, [singular: string, plural: string]> = {
+	image: ["image", "images"],
+	animated_image: ["animated image", "animated images"],
+	narration: ["narration", "narrations"],
+	character: ["character line", "character lines"],
+	music: ["music cue", "music cues"],
+	sound: ["sound", "sounds"],
+	clip: ["clip", "clips"],
+};
+
+const ATTR_LABELS: Record<string, string> = {
+	motion: "motion",
+	captions: "captions",
+	emotion: "emotion",
+	speed: "narration speed",
+	volume: "volume",
+	characters: "characters",
+	overlays: "overlays",
+	videoPrompt: "animation",
+	loops: "looping",
+};
+
+const label = (type: string, n: number): string => {
+	const pair = TYPE_LABELS[type];
+	if (!pair) return n === 1 ? "element" : "elements";
+	return n === 1 ? pair[0] : pair[1];
+};
+
+const plural = (n: number, word: string): string =>
+	`${n} ${word}${n === 1 ? "" : "s"}`;
+
+/**
+ * Human-readable summary of a staged refine change, built from the ops alone
+ * (element-level, so the summary is accurate but coarse — counts grouped by
+ * kind, with notable attribute names called out). Used in the confirm card.
+ */
+export function summarizeRefineOps(ops: RefineOp[]): string {
+	if (ops.length === 0) return "No changes suggested.";
+
+	const added: Record<string, number> = {};
+	let removed = 0;
+	let textEdits = 0;
+	const attrCounts: Record<string, number> = {};
+
+	for (const op of ops) {
+		if (op.op === "insert") {
+			added[op.type] = (added[op.type] ?? 0) + 1;
+		} else if (op.op === "remove") {
+			removed += 1;
+		} else {
+			if (op.text !== undefined) textEdits += 1;
+			if (op.attrs) {
+				for (const key of Object.keys(op.attrs)) {
+					attrCounts[key] = (attrCounts[key] ?? 0) + 1;
+				}
+			}
+		}
+	}
+
+	const parts: string[] = [];
+	const addedParts = Object.entries(added).map(
+		([type, n]) => `${n} ${label(type, n)}`,
+	);
+	if (addedParts.length > 0) parts.push(`added ${addedParts.join(", ")}`);
+	if (textEdits > 0) parts.push(`rewrote ${plural(textEdits, "line")}`);
+	for (const [attr, n] of Object.entries(attrCounts)) {
+		parts.push(`set ${ATTR_LABELS[attr] ?? attr} on ${plural(n, "element")}`);
+	}
+	if (removed > 0) parts.push(`removed ${plural(removed, "element")}`);
+
+	if (parts.length === 0) return "No changes suggested.";
+
+	const joined =
+		parts.length === 1
+			? parts[0]
+			: `${parts.slice(0, -1).join(", ")} and ${parts.at(-1)}`;
+	return `${joined.charAt(0).toUpperCase()}${joined.slice(1)}.`;
+}


### PR DESCRIPTION
Turns the one-shot **Refine your script** box into a live, reviewable diff.

- A refine applies as a **preview**: inserts/edits show inline (emerald **New** / amber **Edited**); **removals are held back** and shown struck through (red **Removed**) so deletions are approvable.
- **Apply** keeps it (and executes the held-back deletions); **Discard** reverts.
- All through Slate history → **Cmd/Ctrl+Z undo, Cmd/Ctrl+Shift+Z redo** work uniformly.
- Editor selection cleanup (no click box on nodes/editor).
- Pure diff logic in `computeRefineDiff` (5 tests) + op summary in `summarizeOps` (5 tests).

Stacked on #226 (uses tokens; needs the `HistoryEditor` type).