### PR TITLE
fix missing PreviewCacheProvider in new-project voice picker

### DIFF
--- a/app/components/Editor.tsx
+++ b/app/components/Editor.tsx
@@ -6,18 +6,21 @@ import {
 } from "@/lib/script/ScriptProvider";
 import PrePromptView from "./PrePromptView";
 import PostPromptView from "./PostPromptView";
+import { PreviewCacheProvider } from "./canvas/PreviewCacheContext";
 
 export default function Editor() {
 	const { loading } = useScriptControl();
 	const hasScript = useScriptHasContent() || loading;
 
 	return (
-		<div
-			className={`flex min-h-screen flex-col items-center text-white transition-[padding] duration-700 ease-out ${
-				hasScript ? "" : "pt-[22vh]"
-			}`}
-		>
-			{hasScript ? <PostPromptView /> : <PrePromptView />}
-		</div>
+		<PreviewCacheProvider>
+			<div
+				className={`flex min-h-screen flex-col items-center text-white transition-[padding] duration-700 ease-out ${
+					hasScript ? "" : "pt-[22vh]"
+				}`}
+			>
+				{hasScript ? <PostPromptView /> : <PrePromptView />}
+			</div>
+		</PreviewCacheProvider>
 	);
 }

--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -18,7 +18,6 @@ import { DragOverlayContent } from "./dnd/DragOverlay";
 import Sidebar from "./panel/Sidebar";
 import { renderCanvasElement } from "./elements/ElementContainer";
 import { AssetsSection } from "./elements/AssetsSection";
-import { PreviewCacheProvider } from "./PreviewCacheContext";
 import { ViewModeProvider } from "./ViewModeContext";
 
 export default function Canvas({
@@ -84,40 +83,36 @@ export default function Canvas({
 
 	return (
 		<ViewModeProvider sceneIds={sceneItems}>
-			<PreviewCacheProvider>
-				<DragTransferContext.Provider value={dragTransfer}>
-					<DndContext
-						sensors={sensors}
-						collisionDetection={pointerWithin}
-						onDragStart={handleDragStart}
-						onDragOver={handleDragOver}
-						onDragEnd={handleDragEnd}
-						onDragCancel={handleDragCancel}
-					>
-						<Sidebar />
+			<DragTransferContext.Provider value={dragTransfer}>
+				<DndContext
+					sensors={sensors}
+					collisionDetection={pointerWithin}
+					onDragStart={handleDragStart}
+					onDragOver={handleDragOver}
+					onDragEnd={handleDragEnd}
+					onDragCancel={handleDragCancel}
+				>
+					<Sidebar />
 
-						<Slate editor={editor} initialValue={value} onChange={setValue}>
-							<AssetsSection />
-							<SortableContext
-								items={sceneItems}
-								strategy={verticalListSortingStrategy}
-							>
-								<Editable
-									placeholder="Start typing your story…"
-									renderElement={renderElement}
-									onKeyDown={handleKeyDown}
-									className="font-body text-sm leading-relaxed outline-none focus-visible:ring-2 focus-visible:ring-ring"
-								/>
-							</SortableContext>
-							<DragOverlay>
-								{activeElement && (
-									<DragOverlayContent element={activeElement} />
-								)}
-							</DragOverlay>
-						</Slate>
-					</DndContext>
-				</DragTransferContext.Provider>
-			</PreviewCacheProvider>
+					<Slate editor={editor} initialValue={value} onChange={setValue}>
+						<AssetsSection />
+						<SortableContext
+							items={sceneItems}
+							strategy={verticalListSortingStrategy}
+						>
+							<Editable
+								placeholder="Start typing your story…"
+								renderElement={renderElement}
+								onKeyDown={handleKeyDown}
+								className="font-body text-sm leading-relaxed outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							/>
+						</SortableContext>
+						<DragOverlay>
+							{activeElement && <DragOverlayContent element={activeElement} />}
+						</DragOverlay>
+					</Slate>
+				</DndContext>
+			</DragTransferContext.Provider>
 		</ViewModeProvider>
 	);
 }


### PR DESCRIPTION
## Summary
- Selecting a narrator voice from the composer in a new project threw `PreviewCacheContext is missing a provider` (fail-loud contexts from #222)
- Hoist `PreviewCacheProvider` from `Canvas` to `Editor` so both pre- and post-prompt views are covered; peaks cache now also persists across the pre→post transition

## Test plan
- [ ] New project → attach menu → "Select narrator voice" → preview a voice: no context error
- [ ] Editor view audio previews still work
- [ ] CI: lint, format, typecheck, knip, tests (816 passing locally)