### PR TITLE
Extract parseCharacterNames helper

### DIFF
--- a/app/components/canvas/utils/characters.ts
+++ b/app/components/canvas/utils/characters.ts
@@ -1,12 +1,9 @@
+import { parseCharacterNames } from "@/lib/canvas/characterNames";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 
 const CHARACTER_NAME_EXTRACTORS: Record<string, (value: string) => string[]> = {
 	name: (v) => [v.trim()],
-	characters: (v) =>
-		v
-			.split(",")
-			.map((s) => s.trim())
-			.filter(Boolean),
+	characters: parseCharacterNames,
 };
 
 export function getElementCharacterNames(

--- a/lib/canvas/__tests__/characterNames.test.ts
+++ b/lib/canvas/__tests__/characterNames.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { parseCharacterNames } from "../characterNames";
+
+describe("parseCharacterNames", () => {
+	it("splits, trims, and drops empty names", () => {
+		expect(parseCharacterNames("Alice, Bob ,, Red")).toEqual([
+			"Alice",
+			"Bob",
+			"Red",
+		]);
+	});
+
+	it("returns an empty array for undefined or empty input", () => {
+		expect(parseCharacterNames(undefined)).toEqual([]);
+		expect(parseCharacterNames("")).toEqual([]);
+		expect(parseCharacterNames("  ,  ")).toEqual([]);
+	});
+});

--- a/lib/canvas/characterNames.ts
+++ b/lib/canvas/characterNames.ts
@@ -1,0 +1,11 @@
+/**
+ * Parse the comma-separated `characters` element attribute into trimmed,
+ * non-empty character names. Single source for the format so the delimiter and
+ * trimming can't drift between call sites.
+ */
+export function parseCharacterNames(value: string | undefined): string[] {
+	return (value ?? "")
+		.split(",")
+		.map((name) => name.trim())
+		.filter(Boolean);
+}

--- a/lib/connectors/image/plugins/character-references.ts
+++ b/lib/connectors/image/plugins/character-references.ts
@@ -1,3 +1,4 @@
+import { parseCharacterNames } from "@/lib/canvas/characterNames";
 import type { ConnectorPlugin } from "@/lib/connectors/types";
 import { getProjectStore } from "@/lib/project/store";
 
@@ -14,9 +15,8 @@ export function createCharacterReferencesPlugin(
 
 			const { characters: chars } =
 				getProjectStore(projectId).getState().metadata;
-			const referenceImages = characters
-				.split(",")
-				.map((name) => chars[name.trim()]?.avatarUrl)
+			const referenceImages = parseCharacterNames(characters)
+				.map((name) => chars[name]?.avatarUrl)
 				.filter(Boolean);
 
 			return {

--- a/lib/generation/elementMetadataInputs.ts
+++ b/lib/generation/elementMetadataInputs.ts
@@ -1,4 +1,5 @@
 import { compact } from "lodash";
+import { parseCharacterNames } from "@/lib/canvas/characterNames";
 import type {
 	CanvasContentElement,
 	CanvasElementType,
@@ -18,11 +19,7 @@ const NONE: Record<string, string | number> = {};
 
 const characterAvatars: MetadataAttributes = (element, metadata) => {
 	const urls = compact(
-		compact(
-			(element.customAttributes?.characters ?? "")
-				.split(",")
-				.map((s) => s.trim()),
-		)
+		parseCharacterNames(element.customAttributes?.characters)
 			.sort()
 			.map((name) => metadata.characters[name]?.avatarUrl),
 	);


### PR DESCRIPTION
## What

Pull the comma-separated `characters` element attribute parsing into a single `parseCharacterNames` helper (`lib/canvas/characterNames.ts`). It was duplicated inline across **three** sites, with the delimiter and trim/empty-filter logic free to drift:

- `lib/connectors/image/plugins/character-references.ts`
- `lib/generation/elementMetadataInputs.ts` (the `characterAvatars` metadata input)
- `app/components/canvas/utils/characters.ts` (`getElementCharacterNames`)

All three now route through one definition. No behavior change. Adds a unit test for the helper; the existing `characters.test.ts` already covers the third site.

This is a standalone, behavior-neutral refactor targeting `master` — it has no dependency on the avatar stack (#225), so it can land independently.

## Why this PR shrank

This PR originally propagated avatar staleness to scenes by deriving scene-staleness from a character's appearance/style/reference-image signature. That turned out to be both redundant and incorrect, so it was dropped:

- **The behavior already exists on master.** A scene's tracked generation inputs already include `characterAvatars` (the referenced characters' `avatarUrl`s) via `elementMetadataInputs`, which flows into `isStaleResult`. So a scene already goes stale, with a visible `StaleIndicator`, when a referenced character's avatar **image** actually changes, and clicking it regenerates the scene.
- **It's durable across reload.** The queue snapshot (including `resultInputs`) is persisted as the project `generation` blob via autosave and rehydrated into the queue on load, so the scene stale signal survives a refresh.
- **The dropped approach was keyed on the wrong thing.** Deriving scene-staleness from the character's *description signature* fired while the user was still typing a draft (before any image change) and cleared exactly when the avatar was regenerated (i.e. when the scene genuinely became out of date). The avatar *image* is the scene's real dependency, and master already keys on it.

What remains is the one genuinely useful, behavior-neutral piece: the `parseCharacterNames` dedup.