### PR TITLE
Revert character appearance to the avatar's source while stale

### DIFF
--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -114,6 +114,19 @@ function CharacterEditDialogBody({
 			),
 		);
 
+	// The appearance the current avatar was generated from lives in the queue's
+	// resultInputs (the same record staleness compares against). Offer it as a
+	// cheap "discard my appearance draft" whenever the appearance has diverged
+	// from it. Reverting only discards the draft — if the art style or reference
+	// images also changed, the avatar stays stale afterwards.
+	const sourceAppearance = avatarSnapshot.resultInputs?.attributes?.appearance;
+	const revertTo =
+		isStale &&
+		typeof sourceAppearance === "string" &&
+		sourceAppearance !== character.appearance
+			? sourceAppearance
+			: undefined;
+
 	const requestClose = () => (isStale ? setCloseConfirm(true) : onClose());
 
 	const interceptClose = (e: { preventDefault(): void }) => {
@@ -163,6 +176,18 @@ function CharacterEditDialogBody({
 						value={character.appearance}
 						onChange={(appearance) => update({ appearance })}
 						placeholder="Describe the character's look"
+						action={
+							revertTo !== undefined ? (
+								<button
+									type="button"
+									onClick={() => update({ appearance: revertTo })}
+									title="Restore the appearance the avatar was generated from"
+									className="text-[11px] text-white/50 underline-offset-2 transition-colors hover:text-white hover:underline"
+								>
+									Revert
+								</button>
+							) : undefined
+						}
 					/>
 					<div className="relative">
 						{character.avatarUrl ? (

--- a/app/components/canvas/elements/character/fields.tsx
+++ b/app/components/canvas/elements/character/fields.tsx
@@ -51,16 +51,21 @@ export function TextAreaField({
 	onChange,
 	placeholder,
 	rows = 4,
+	action,
 }: {
 	label: string;
 	value: string;
 	onChange: (value: string) => void;
 	placeholder?: string;
 	rows?: number;
+	action?: ReactNode;
 }) {
 	return (
 		<label className="flex flex-col gap-1">
-			<FieldLabel>{label}</FieldLabel>
+			<div className="flex items-center justify-between gap-2">
+				<FieldLabel>{label}</FieldLabel>
+				{action}
+			</div>
 			<textarea
 				rows={rows}
 				value={value}


### PR DESCRIPTION
Targets `master`. Implements #233.

## What

Adds a **Revert** action to the character edit modal that restores the appearance text to what the current avatar was generated from — a cheap way to **discard a draft appearance edit** without spending a regeneration. Edit = draft, Regenerate = commit, Revert = discard the draft.

Revert is intentionally a destructive discard (no undo), consistent with discarding a draft.

## Approach (no new persistence, uses the existing abstraction)

Reworked onto `master` after #225 closed in favor of #237's queue-based staleness. The appearance the current avatar was generated from is already captured in the avatar element's `resultInputs.attributes.appearance` (`characterAvatarElement` stores it in `customAttributes.appearance`) — the exact record `isStaleResult` compares against for staleness. So Revert reads that directly:

```ts
const sourceAppearance = avatarSnapshot.resultInputs?.attributes?.appearance;
const revertTo =
  isStale && typeof sourceAppearance === "string" && sourceAppearance !== character.appearance
    ? sourceAppearance
    : undefined;
```

No `avatarInputsSignature`, no helper module, no migration. Durable across reloads for free, because the queue snapshot (with `resultInputs`) already persists to Supabase — the same mechanism #237 relies on.

## Behavior

Revert shows whenever the avatar is stale **and the appearance has diverged from its source**. Clicking it discards the appearance draft (`update({ appearance })` only — never a generation path).

It clears staleness only when appearance was the sole change. If the art style or reference images also changed, reverting the appearance won't un-stale the avatar; Revert just discards the appearance draft and disappears, and the stale indicator + Regenerate remain.

## UI

The amber banner was removed in #237, so Revert lives in the Appearance field's label row (a subtle text action), shown only when there's a draft to discard. It's the semantically correct home — it acts on the appearance text.

## Tests

The logic is a 3-line inline derivation off the existing `resultInputs`; there's no new pure helper to unit-test, and the repo has no component-test harness, so the button is manual QA (consistent with #237). Full suite green (818).

Closes #233 on merge.