### PR TITLE
fix: nightly bug fixes 2026-06-11

### DIFF
--- a/lib/video/__tests__/elementAttributes.test.ts
+++ b/lib/video/__tests__/elementAttributes.test.ts
@@ -18,8 +18,10 @@ function el(customAttributes?: Record<string, string>): CanvasContentElement {
 }
 
 describe("getVolume", () => {
-	it("defaults to 10 when missing or non-numeric", () => {
+	it("defaults to 10 when missing, blank, or non-numeric", () => {
 		expect(getVolume(el())).toBe(10);
+		expect(getVolume(el({ volume: "" }))).toBe(10);
+		expect(getVolume(el({ volume: "   " }))).toBe(10);
 		expect(getVolume(el({ volume: "not-a-number" }))).toBe(10);
 	});
 

--- a/lib/video/elementAttributes.ts
+++ b/lib/video/elementAttributes.ts
@@ -17,9 +17,13 @@ const VOLUME_MIN = 0;
 const VOLUME_MAX = 10;
 const DEFAULT_VOLUME = VOLUME_MAX;
 
+function parseNumericAttribute(value: string | undefined): number {
+	return value === undefined || value.trim() === "" ? NaN : Number(value);
+}
+
 /** Volume coerced to a finite number clamped to [0, 10], defaulting to 10. */
 export function getVolume(element: CanvasContentElement): number {
-	const raw = Number(element.customAttributes?.volume);
+	const raw = parseNumericAttribute(element.customAttributes?.volume);
 	return Number.isFinite(raw)
 		? Math.max(VOLUME_MIN, Math.min(VOLUME_MAX, raw))
 		: DEFAULT_VOLUME;
@@ -29,7 +33,7 @@ const LOOPS_MAX = 1000;
 
 /** Loop count coerced to an integer in [1, 1000], defaulting to 1. */
 export function getLoops(element: CanvasContentElement): number {
-	const raw = Number(element.customAttributes?.loops);
+	const raw = parseNumericAttribute(element.customAttributes?.loops);
 	if (!Number.isFinite(raw)) return 1;
 	return Math.max(1, Math.min(LOOPS_MAX, Math.floor(raw)));
 }


### PR DESCRIPTION
## Summary
- Treat blank/whitespace video volume attributes as missing instead of coercing them to `0` via `Number("")`.
- Reuse the same numeric attribute parsing path for volume and loop counts so blank numeric layout attributes consistently fall back to their defaults.

## Bugs fixed
- A blank saved `volume` custom attribute muted an element because `Number("")` and `Number("   ")` evaluate to `0`. The volume helper is documented to default missing/non-numeric values to `10`, so blank input should not silently become mute.

## Tests added
- `lib/video/__tests__/elementAttributes.test.ts`: regression coverage for empty-string and whitespace volume attributes defaulting to `10`.

## Open PR overlap check
- Considered open PRs #234, #232, #231, #230, #228, #226, and #225 before implementation and again before commit.
- This PR only touches `lib/video/elementAttributes.ts` and `lib/video/__tests__/elementAttributes.test.ts`; those files/themes are not covered by the open PRs, so the change is non-overlapping.

## Validation
- [x] Regression test first failed as expected: `npm test -- --passWithNoTests lib/video/__tests__/elementAttributes.test.ts --run`
- [x] `npm test -- --passWithNoTests lib/video/__tests__/elementAttributes.test.ts --run`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run knip`
- [x] `npm test -- --passWithNoTests` (93 files / 816 tests)
- [x] `npm run build`
- [x] `npm run test:coverage` (93 files / 816 tests, thresholds met)

## Skipped items / automation notes
- Skipped avatar, background/layout, TTS/embedding, character parsing, refine/editor diff, design token, and avatar staleness themes because they are covered by open PRs.
- The required Claude Code print-mode core pass hung for ~6.5 minutes with no output and no diff; per the runbook fallback pattern, Hermes completed the same correctness/test pass directly and verified the result independently.
