### PR TITLE
refactor: nightly maintainability 2026-06-11

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,7 +34,7 @@ The generation pipeline is split so providers and asset types can be swapped ind
 
 ## API routes
 
-Every `app/api/v1/<type>/route.ts` is built from a shared `createRouteHandler` factory that handles auth, parsing, model validation, and error mapping. Reusable Zod field schemas live in `lib/api/request-schema-fields.ts`. If a provider's API key isn't set, the route falls back to a mock provider.
+Every `app/api/v1/<type>/route.ts` is built from a shared `createApiRouteHandler` factory that handles auth, parsing, model validation, and error mapping. Internal app routes use the session-tier variants from the same module (see Auth). Reusable Zod field schemas live in `lib/api/request-schema-fields.ts`. If a provider's API key isn't set, the route falls back to a mock provider.
 
 ## Editor state
 
@@ -57,7 +57,9 @@ Generated assets live in Vercel Blob under `assets/{type}/{provider}/{id}/`, ser
 ## Auth
 
 - `proxy.ts` (Next.js 16's renamed middleware, keep this name) refreshes the Supabase session on each request.
-- `/api/v1/*` is same-origin only and authenticates via the Supabase session cookie.
+- API routes have two auth tiers, both defined in `lib/api/with-auth.ts`:
+  - `withApiAccess` (`/api/v1/*`): same-origin Supabase session cookie plus the `api_access` grant in `app_metadata` (403 without it).
+  - `withSession` (`/api/render*`, `/api/upload/*`): any signed-in user.
 
 ## Adding a new asset type
 

--- a/app/api/render/progress/__tests__/progress.test.ts
+++ b/app/api/render/progress/__tests__/progress.test.ts
@@ -95,6 +95,20 @@ describe("POST /api/render/progress", () => {
 		});
 	});
 
+	it("returns 500 when done without an output file", async () => {
+		mockGetRenderProgress.mockResolvedValue({
+			fatalErrorEncountered: false,
+			done: true,
+			outputFile: null,
+			outputSizeInBytes: null,
+		});
+
+		const res = await POST(makeRequest(validBody));
+
+		expect(res.status).toBe(500);
+		expect((await res.json()).error).toContain("output file");
+	});
+
 	it("reports in-flight progress otherwise", async () => {
 		mockGetRenderProgress.mockResolvedValue({
 			fatalErrorEncountered: false,

--- a/app/api/render/progress/route.ts
+++ b/app/api/render/progress/route.ts
@@ -2,11 +2,9 @@ import {
 	getRenderProgress,
 	speculateFunctionName,
 } from "@remotion/lambda/client";
-import { type NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { z } from "zod";
-import { getUser } from "@/lib/api/auth";
-import { parseBody } from "@/lib/api/parse";
-import { unauthorized } from "@/lib/api/response";
+import { createSessionRouteHandler } from "@/lib/api/route-handler";
 import { DISK, RAM, REGION, TIMEOUT } from "@/lib/video/lambda-config";
 
 const ProgressRequest = z.object({
@@ -19,39 +17,40 @@ export type ProgressResponse =
 	| { type: "done"; url: string; size: number }
 	| { type: "error"; message: string };
 
-export async function POST(req: NextRequest) {
-	const user = await getUser();
-	if (!user) return unauthorized();
-
-	const parsed = await parseBody(req, ProgressRequest, "render/progress");
-	if (!parsed.ok) return parsed.response;
-
-	const progress = await getRenderProgress({
-		renderId: parsed.data.renderId,
-		bucketName: parsed.data.bucketName,
-		functionName: speculateFunctionName({
-			diskSizeInMb: DISK,
-			memorySizeInMb: RAM,
-			timeoutInSeconds: TIMEOUT,
-		}),
-		region: REGION,
-	});
-
-	if (progress.fatalErrorEncountered) {
-		return NextResponse.json<ProgressResponse>({
-			type: "error",
-			message: progress.errors[0]?.message ?? "Render failed",
+export const POST = createSessionRouteHandler({
+	schema: ProgressRequest,
+	label: "render/progress",
+	handle: async ({ body }) => {
+		const progress = await getRenderProgress({
+			renderId: body.renderId,
+			bucketName: body.bucketName,
+			functionName: speculateFunctionName({
+				diskSizeInMb: DISK,
+				memorySizeInMb: RAM,
+				timeoutInSeconds: TIMEOUT,
+			}),
+			region: REGION,
 		});
-	}
-	if (progress.done) {
+
+		if (progress.fatalErrorEncountered) {
+			return NextResponse.json<ProgressResponse>({
+				type: "error",
+				message: progress.errors[0]?.message ?? "Render failed",
+			});
+		}
+		if (progress.done) {
+			if (progress.outputFile == null || progress.outputSizeInBytes == null) {
+				throw new Error("Render reported done without an output file");
+			}
+			return NextResponse.json<ProgressResponse>({
+				type: "done",
+				url: progress.outputFile,
+				size: progress.outputSizeInBytes,
+			});
+		}
 		return NextResponse.json<ProgressResponse>({
-			type: "done",
-			url: progress.outputFile as string,
-			size: progress.outputSizeInBytes as number,
+			type: "progress",
+			progress: progress.overallProgress,
 		});
-	}
-	return NextResponse.json<ProgressResponse>({
-		type: "progress",
-		progress: progress.overallProgress,
-	});
-}
+	},
+});

--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -2,11 +2,9 @@ import {
 	renderMediaOnLambda,
 	speculateFunctionName,
 } from "@remotion/lambda/client";
-import { type NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { z } from "zod";
-import { getUser } from "@/lib/api/auth";
-import { parseBody } from "@/lib/api/parse";
-import { unauthorized } from "@/lib/api/response";
+import { createSessionRouteHandler } from "@/lib/api/route-handler";
 import {
 	DISK,
 	getSiteName,
@@ -20,26 +18,24 @@ const RenderRequest = z.object({
 	inputProps: z.record(z.string(), z.unknown()),
 });
 
-export async function POST(req: NextRequest) {
-	const user = await getUser();
-	if (!user) return unauthorized();
+export const POST = createSessionRouteHandler({
+	schema: RenderRequest,
+	label: "render",
+	handle: async ({ body }) => {
+		const { renderId, bucketName } = await renderMediaOnLambda({
+			codec: "h264",
+			region: REGION,
+			serveUrl: getSiteName(),
+			functionName: speculateFunctionName({
+				diskSizeInMb: DISK,
+				memorySizeInMb: RAM,
+				timeoutInSeconds: TIMEOUT,
+			}),
+			composition: COMPOSITION_ID,
+			inputProps: body.inputProps,
+			downloadBehavior: { type: "download", fileName: "video.mp4" },
+		});
 
-	const parsed = await parseBody(req, RenderRequest, "render");
-	if (!parsed.ok) return parsed.response;
-
-	const { renderId, bucketName } = await renderMediaOnLambda({
-		codec: "h264",
-		region: REGION,
-		serveUrl: getSiteName(),
-		functionName: speculateFunctionName({
-			diskSizeInMb: DISK,
-			memorySizeInMb: RAM,
-			timeoutInSeconds: TIMEOUT,
-		}),
-		composition: COMPOSITION_ID,
-		inputProps: parsed.data.inputProps,
-		downloadBehavior: { type: "download", fileName: "video.mp4" },
-	});
-
-	return NextResponse.json({ renderId, bucketName });
-}
+		return NextResponse.json({ renderId, bucketName });
+	},
+});

--- a/app/api/upload/image/route.ts
+++ b/app/api/upload/image/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { AssetBundle } from "@/lib/api/asset-bundle";
-import { getUser } from "@/lib/api/auth";
-import { unauthorized } from "@/lib/api/response";
+import { badRequest } from "@/lib/api/response";
+import { withSession } from "@/lib/api/with-auth";
 
 const MAX_SIZE = 10 * 1024 * 1024; // 10 MB
 
@@ -11,42 +11,34 @@ function sanitizeFilename(name: string): string {
 	return cleaned.slice(0, 200) || "upload";
 }
 
-export async function POST(request: NextRequest) {
-	const user = await getUser();
-	if (!user) return unauthorized();
+export function POST(request: NextRequest) {
+	return withSession("upload/image", async () => {
+		let formData: FormData;
+		try {
+			formData = await request.formData();
+		} catch {
+			return badRequest("Invalid form data");
+		}
+		const file = formData.get("file");
 
-	const formData = await request.formData();
-	const file = formData.get("file");
+		if (!(file instanceof File)) return badRequest("No file provided");
+		if (!file.type.startsWith("image/")) {
+			return badRequest("File must be an image");
+		}
+		if (file.size > MAX_SIZE) return badRequest("File must be under 10 MB");
 
-	if (!(file instanceof File)) {
-		return NextResponse.json({ error: "No file provided" }, { status: 400 });
-	}
+		const filename = sanitizeFilename(file.name);
+		const buffer = Buffer.from(await file.arrayBuffer());
+		const response = await AssetBundle.upload("upload", "user", [
+			{
+				key: "image",
+				filename,
+				data: buffer,
+				contentType: file.type,
+			},
+		]);
 
-	if (!file.type.startsWith("image/")) {
-		return NextResponse.json(
-			{ error: "File must be an image" },
-			{ status: 400 },
-		);
-	}
-
-	if (file.size > MAX_SIZE) {
-		return NextResponse.json(
-			{ error: "File must be under 10 MB" },
-			{ status: 400 },
-		);
-	}
-
-	const filename = sanitizeFilename(file.name);
-	const buffer = Buffer.from(await file.arrayBuffer());
-	const response = await AssetBundle.upload("upload", "user", [
-		{
-			key: "image",
-			filename,
-			data: buffer,
-			contentType: file.type,
-		},
-	]);
-
-	const url = `${AssetBundle.buildUrl("upload", "user", response.id)}/${encodeURIComponent(filename)}`;
-	return NextResponse.json({ url });
+		const url = `${AssetBundle.buildUrl("upload", "user", response.id)}/${encodeURIComponent(filename)}`;
+		return NextResponse.json({ url });
+	});
 }

--- a/app/api/v1/llm/route.ts
+++ b/app/api/v1/llm/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { getLLMProvider } from "@/lib/api/providers";
-import { bodySchema, createRouteHandler } from "@/lib/api/route-handler";
+import { bodySchema, createApiRouteHandler } from "@/lib/api/route-handler";
 import { optionalReferenceImages } from "@/lib/api/request-schema-fields";
 import { createSSEStreamResponse } from "@/lib/api/sse";
 import { LLM_MODELS } from "@/lib/connectors/llm/openslop/models";
@@ -15,7 +15,7 @@ const schema = bodySchema(LLM_MODELS, {
 	stream: z.boolean().optional(),
 });
 
-export const POST = createRouteHandler({
+export const POST = createApiRouteHandler({
 	schema,
 	label: "LLM generation",
 	handle: async ({ body }) => {

--- a/app/api/v1/tts/voices/preview/route.ts
+++ b/app/api/v1/tts/voices/preview/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getTTSProvider } from "@/lib/api/providers";
 import { badRequest } from "@/lib/api/response";
-import { withAuth } from "@/lib/api/with-auth";
+import { withApiAccess } from "@/lib/api/with-auth";
 
 export async function GET(request: NextRequest) {
-	return withAuth("Voice preview fetch", async () => {
+	return withApiAccess("Voice preview fetch", async () => {
 		const url = request.nextUrl.searchParams.get("url");
 		if (!url) return badRequest("Missing url");
 

--- a/app/api/v1/tts/voices/route.ts
+++ b/app/api/v1/tts/voices/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getTTSProvider } from "@/lib/api/providers";
-import { withAuth } from "@/lib/api/with-auth";
+import { withApiAccess } from "@/lib/api/with-auth";
 import { voiceSearchParamsSchema } from "@/lib/project/types";
 
 export async function GET(request: NextRequest) {
-	return withAuth("Voice search", async () => {
+	return withApiAccess("Voice search", async () => {
 		const params = voiceSearchParamsSchema.parse(
 			Object.fromEntries(request.nextUrl.searchParams),
 		);

--- a/app/api/validate-code/route.ts
+++ b/app/api/validate-code/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { parseBody } from "@/lib/api/parse";
 import { createClient } from "@/lib/supabase/server";
 
 const ERROR_MESSAGES: Record<string, string> = {
@@ -7,18 +9,24 @@ const ERROR_MESSAGES: Record<string, string> = {
 	expired: "This code has expired",
 };
 
-export async function POST(request: NextRequest) {
-	const body = await request.json();
-	const { code } = body;
+const INVALID_FORMAT = "Invalid code format";
+const ValidateCodeRequest = z.object(
+	{
+		code: z
+			.string({ error: INVALID_FORMAT })
+			.length(6, { message: INVALID_FORMAT }),
+	},
+	INVALID_FORMAT,
+);
 
-	if (!code || typeof code !== "string" || code.length !== 6) {
-		return NextResponse.json({ error: "Invalid code format" }, { status: 400 });
-	}
+export async function POST(request: NextRequest) {
+	const parsed = await parseBody(request, ValidateCodeRequest, "validate-code");
+	if (!parsed.ok) return parsed.response;
 
 	const supabase = await createClient();
 
 	const { data, error } = await supabase.rpc("validate_access_code", {
-		p_code: code.toUpperCase(),
+		p_code: parsed.data.code.toUpperCase(),
 	});
 
 	if (error || typeof data !== "string") {

--- a/lib/api/__tests__/route-handler.test.ts
+++ b/lib/api/__tests__/route-handler.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
-import { bodySchema, createRouteHandler } from "../route-handler";
+import {
+	bodySchema,
+	createApiRouteHandler,
+	createSessionRouteHandler,
+} from "../route-handler";
 
 vi.mock("../logger", () => ({
 	logger: { warn: vi.fn(), error: vi.fn() },
@@ -30,9 +34,9 @@ const models = { "model-a": "slug-a", "model-b": "slug-b" };
 const schema = bodySchema(models, {});
 
 function makeHandler(
-	handle?: Parameters<typeof createRouteHandler>[0]["handle"],
+	handle?: Parameters<typeof createApiRouteHandler>[0]["handle"],
 ) {
-	return createRouteHandler({
+	return createApiRouteHandler({
 		schema,
 		label: "TestRoute",
 		handle:
@@ -42,13 +46,22 @@ function makeHandler(
 	});
 }
 
-describe("createRouteHandler", () => {
+describe("createApiRouteHandler", () => {
 	it("returns 401 when the user is not authenticated", async () => {
 		mockGetUser.mockResolvedValue(null);
 		const handle = vi.fn(async () => NextResponse.json({}));
 		const handler = makeHandler(handle);
 		const res = await handler(makeRequest({ prompt: "hello" }));
 		expect(res.status).toBe(401);
+		expect(handle).not.toHaveBeenCalled();
+	});
+
+	it("returns 403 when the user lacks api_access", async () => {
+		mockGetUser.mockResolvedValue({ id: "user-1", app_metadata: {} });
+		const handle = vi.fn(async () => NextResponse.json({}));
+		const handler = makeHandler(handle);
+		const res = await handler(makeRequest({ prompt: "hello" }));
+		expect(res.status).toBe(403);
 		expect(handle).not.toHaveBeenCalled();
 	});
 
@@ -138,5 +151,33 @@ describe("createRouteHandler", () => {
 		const json = await res.json();
 		expect(json.error).toContain("TestRoute failed: ");
 		expect(json.error).toContain("raw string failure");
+	});
+});
+
+describe("createSessionRouteHandler", () => {
+	function makeUserHandler() {
+		return createSessionRouteHandler({
+			schema,
+			label: "TestUserRoute",
+			handle: async ({ body }) => NextResponse.json({ prompt: body.prompt }),
+		});
+	}
+
+	it("returns 401 when the user is not authenticated", async () => {
+		mockGetUser.mockResolvedValue(null);
+		const res = await makeUserHandler()(makeRequest({ prompt: "hello" }));
+		expect(res.status).toBe(401);
+	});
+
+	it("allows signed-in users without api_access", async () => {
+		mockGetUser.mockResolvedValue({ id: "user-1", app_metadata: {} });
+		const res = await makeUserHandler()(makeRequest({ prompt: "hello" }));
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ prompt: "hello" });
+	});
+
+	it("returns 400 for an invalid body", async () => {
+		const res = await makeUserHandler()(makeRequest({}));
+		expect(res.status).toBe(400);
 	});
 });

--- a/lib/api/route-handler.ts
+++ b/lib/api/route-handler.ts
@@ -2,28 +2,33 @@ import { NextRequest, NextResponse } from "next/server";
 import type { User } from "@supabase/supabase-js";
 import { z } from "zod";
 import type { ConnectorType } from "@/lib/connectors/types";
-import { withAuth } from "./with-auth";
+import { withApiAccess, withSession } from "./with-auth";
 import { getJobHandler, rowView } from "./job-handlers";
 import { createJob, enqueueJob, getJob } from "./jobs";
 import { parseBody } from "./parse";
 import { badRequest } from "./response";
 
-export function createRouteHandler<TSchema extends z.ZodType>(opts: {
-	schema: TSchema;
-	label: string;
-	handle: (ctx: {
-		user: User;
-		body: z.infer<TSchema>;
-		request: NextRequest;
-	}) => Promise<Response>;
-}) {
-	return async (request: NextRequest) =>
-		withAuth(opts.label, async (user) => {
-			const parsed = await parseBody(request, opts.schema, opts.label);
-			if (!parsed.ok) return parsed.response;
-			return opts.handle({ user, body: parsed.data, request });
-		});
+function jsonRouteHandler(authTier: typeof withApiAccess) {
+	return function createHandler<TSchema extends z.ZodType>(opts: {
+		schema: TSchema;
+		label: string;
+		handle: (ctx: {
+			user: User;
+			body: z.infer<TSchema>;
+			request: NextRequest;
+		}) => Promise<Response>;
+	}) {
+		return async (request: NextRequest) =>
+			authTier(opts.label, async (user) => {
+				const parsed = await parseBody(request, opts.schema, opts.label);
+				if (!parsed.ok) return parsed.response;
+				return opts.handle({ user, body: parsed.data, request });
+			});
+	};
 }
+
+export const createApiRouteHandler = jsonRouteHandler(withApiAccess);
+export const createSessionRouteHandler = jsonRouteHandler(withSession);
 
 export function modelField(models: Record<string, string>) {
 	const names = Object.keys(models);
@@ -41,7 +46,7 @@ type AssetBody = { projectId?: string } & Record<string, unknown>;
 export function createAssetRouteHandlers<
 	TSchema extends z.ZodType<AssetBody>,
 >(opts: { connectorType: ConnectorType; schema: TSchema; label: string }) {
-	const POST = createRouteHandler({
+	const POST = createApiRouteHandler({
 		schema: opts.schema,
 		label: opts.label,
 		handle: async ({ user, body }) => {
@@ -63,7 +68,7 @@ export async function pollJob(
 	_request: NextRequest,
 	context: { params: Promise<{ jobId: string }> },
 ) {
-	return withAuth("Job poll", async (user) => {
+	return withApiAccess("Job poll", async (user) => {
 		const { jobId } = await context.params;
 		if (!jobId) return badRequest("jobId is required");
 		const job = await getJob(jobId, user.id);

--- a/lib/api/with-auth.ts
+++ b/lib/api/with-auth.ts
@@ -4,19 +4,30 @@ import { getUser } from "./auth";
 import { logger } from "./logger";
 import { forbidden, serverError, unauthorized } from "./response";
 
+type RouteBody = (user: User) => Promise<Response>;
+
 // Wraps a route handler with auth + a uniform error envelope. The handler only
-// runs for authenticated users; thrown errors are logged and returned as 500.
-export async function withAuth(
+// runs for authorized users; thrown errors are logged and returned as 500.
+async function guard(
 	label: string,
-	run: (user: User) => Promise<Response>,
+	run: RouteBody,
+	authorize: (user: User) => Response | null = () => null,
 ): Promise<Response> {
 	try {
 		const user = await getUser();
 		if (!user) return unauthorized();
-		if (!user.app_metadata?.api_access) return forbidden();
+		const denied = authorize(user);
+		if (denied) return denied;
 		return await run(user);
 	} catch (error) {
 		logger.error(error, `${label} failed`);
 		return serverError(`${label} failed: ${stringifyError(error)}`);
 	}
 }
+
+export const withApiAccess = (label: string, run: RouteBody) =>
+	guard(label, run, (user) =>
+		user.app_metadata?.api_access ? null : forbidden(),
+	);
+
+export const withSession = (label: string, run: RouteBody) => guard(label, run);


### PR DESCRIPTION
## Summary
- Split API auth into explicit public API (`api_access`) and signed-in app route tiers.
- Reused a shared JSON route-handler boundary for render/progress routes and centralized validation for access-code parsing.
- Documented the two API auth tiers and added regression coverage for app-session routes and render completion invariants.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run knip`
- [x] `npm run build`
- [x] `npm test -- --passWithNoTests`
- [x] `npm run test:coverage`

## Open PR overlap check
Considered open PRs #235, #234, #232, #231, #230, #228, #226, and #225. This PR changes API route auth/validation boundaries and docs only; changed files do not overlap with open PR file lists.
