### PR TITLE
Clean avatar staleness: queue-based, no redundant signature field

### DIFF
--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ImagePlus, Loader2, Trash2 } from "lucide-react";
+import { ImagePlus, Loader2, Trash2, X } from "lucide-react";
 import {
 	DialogContent,
 	DialogDescription,
@@ -32,6 +32,7 @@ import type { MetadataCharacter } from "@/lib/project/types";
 import { useImageUpload } from "@/lib/upload/useImageUpload";
 import { MediaPlaceholder, MediaPreview } from "../preview/results";
 import { TextAreaField } from "./fields";
+import { StaleAvatarCloseDialog } from "./StaleAvatarCloseDialog";
 import { VoiceSection } from "./VoiceMetadataFields";
 
 export function CharacterEditModal({
@@ -71,6 +72,7 @@ function CharacterEditDialogBody({
 	const removeCharacter = useProjectStore(projectId, (s) => s.removeCharacter);
 
 	const [confirmDelete, setConfirmDelete] = useState(false);
+	const [closeConfirm, setCloseConfirm] = useState(false);
 
 	const avatarElementId = characterAvatarElementId(name);
 	const avatarSnapshot = useQueueSelector((q) =>
@@ -112,6 +114,15 @@ function CharacterEditDialogBody({
 			),
 		);
 
+	const requestClose = () => (isStale ? setCloseConfirm(true) : onClose());
+
+	const interceptClose = (e: { preventDefault(): void }) => {
+		if (isStale && !closeConfirm) {
+			e.preventDefault();
+			setCloseConfirm(true);
+		}
+	};
+
 	const handleDelete = () => {
 		if (!confirmDelete) {
 			setConfirmDelete(true);
@@ -123,7 +134,20 @@ function CharacterEditDialogBody({
 	};
 
 	return (
-		<DialogContent className="max-w-2xl">
+		<DialogContent
+			className="max-w-2xl"
+			showCloseButton={false}
+			onEscapeKeyDown={interceptClose}
+			onInteractOutside={interceptClose}
+		>
+			<button
+				type="button"
+				onClick={requestClose}
+				aria-label="Close"
+				className="absolute right-3 top-3 z-10 rounded-md p-1 text-white/60 transition-colors hover:bg-white/10 hover:text-white focus:outline-none focus:ring-1 focus:ring-accent-violet/50"
+			>
+				<X className="h-4 w-4" />
+			</button>
 			<DialogHeader className="shrink-0">
 				<DialogTitle>{name}</DialogTitle>
 				<DialogDescription>
@@ -199,6 +223,17 @@ function CharacterEditDialogBody({
 					{confirmDelete ? "Confirm delete" : "Delete"}
 				</button>
 			</DialogFooter>
+
+			<StaleAvatarCloseDialog
+				open={closeConfirm}
+				onOpenChange={setCloseConfirm}
+				characterName={name}
+				onLeaveStale={onClose}
+				onRegenerate={() => {
+					regenerateAvatar();
+					onClose();
+				}}
+			/>
 		</DialogContent>
 	);
 }

--- a/app/components/canvas/elements/character/StaleAvatarCloseDialog.tsx
+++ b/app/components/canvas/elements/character/StaleAvatarCloseDialog.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+export function StaleAvatarCloseDialog({
+	open,
+	onOpenChange,
+	characterName,
+	onLeaveStale,
+	onRegenerate,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	characterName: string;
+	onLeaveStale: () => void;
+	onRegenerate: () => void;
+}) {
+	return (
+		<AlertDialog open={open} onOpenChange={onOpenChange}>
+			<AlertDialogContent>
+				<AlertDialogTitle>Avatar is out of date</AlertDialogTitle>
+				<AlertDialogDescription>
+					{characterName}&apos;s avatar no longer matches its current inputs.
+					Your edits are already saved.
+				</AlertDialogDescription>
+				<AlertDialogFooter>
+					<AlertDialogCancel className="rounded-md px-2.5 py-1 text-[12px] text-white/60 transition-colors hover:text-white">
+						Keep editing
+					</AlertDialogCancel>
+					<AlertDialogAction
+						onClick={onLeaveStale}
+						className="rounded-md border border-white/10 px-2.5 py-1 text-[12px] text-white/70 transition-colors hover:bg-white/10"
+					>
+						Leave stale
+					</AlertDialogAction>
+					<AlertDialogAction
+						onClick={onRegenerate}
+						className="rounded-md bg-accent-violet px-3 py-1 text-[12px] font-medium text-white shadow-glow transition hover:brightness-110"
+					>
+						Regenerate
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import * as React from "react";
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function AlertDialog({
+	...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+	return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogOverlay({
+	className,
+	...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+	return (
+		<AlertDialogPrimitive.Overlay
+			data-slot="alert-dialog-overlay"
+			className={cn(
+				"fixed inset-0 z-[60] bg-black/60 backdrop-blur-sm data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function AlertDialogContent({
+	className,
+	...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+	return (
+		<AlertDialogPrimitive.Portal data-slot="alert-dialog-portal">
+			<AlertDialogOverlay />
+			<AlertDialogPrimitive.Content
+				data-slot="alert-dialog-content"
+				className={cn(
+					"fixed left-[50%] top-[50%] z-[60] flex w-[calc(100vw-2rem)] max-w-sm translate-x-[-50%] translate-y-[-50%] flex-col gap-1 rounded-xl border border-white/10 bg-white/5 p-4 text-white shadow-xl shadow-black/50 backdrop-blur-xl outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+					className,
+				)}
+				{...props}
+			/>
+		</AlertDialogPrimitive.Portal>
+	);
+}
+
+function AlertDialogTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+	return (
+		<AlertDialogPrimitive.Title
+			data-slot="alert-dialog-title"
+			className={cn("text-sm font-medium text-white/90", className)}
+			{...props}
+		/>
+	);
+}
+
+function AlertDialogDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+	return (
+		<AlertDialogPrimitive.Description
+			data-slot="alert-dialog-description"
+			className={cn("text-[12px] text-white/50", className)}
+			{...props}
+		/>
+	);
+}
+
+function AlertDialogFooter({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="alert-dialog-footer"
+			className={cn("mt-4 flex items-center justify-end gap-2", className)}
+			{...props}
+		/>
+	);
+}
+
+function AlertDialogAction({
+	...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+	return (
+		<AlertDialogPrimitive.Action data-slot="alert-dialog-action" {...props} />
+	);
+}
+
+function AlertDialogCancel({
+	...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+	return (
+		<AlertDialogPrimitive.Cancel data-slot="alert-dialog-cancel" {...props} />
+	);
+}
+
+export {
+	AlertDialog,
+	AlertDialogContent,
+	AlertDialogTitle,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogAction,
+	AlertDialogCancel,
+};

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -27,8 +27,9 @@ export function isStaleResult(
 	currentInputs: GenerationInputs,
 ): boolean {
 	return (
-		isNil(snapshot.resultInputs) ||
-		!isEqual(currentInputs, snapshot.resultInputs)
+		!isActive(snapshot.status) &&
+		(isNil(snapshot.resultInputs) ||
+			!isEqual(currentInputs, snapshot.resultInputs))
 	);
 }
 


### PR DESCRIPTION
## Summary

Rework of #225 — same UX intent, cleaner implementation.

- **No new persistence field**: instead of `avatarInputsSignature` on `MetadataCharacter`, style and `referenceImages` are embedded in the avatar element's `customAttributes` so the generation queue's existing `resultInputs` captures all three inputs that drive the image (appearance, art style, reference images). Queue snapshots persist to Supabase across reloads, so staleness detection is durable without a separate signature.
- **`isStaleResult` now guards `isActive`**: callers no longer need to check generating status themselves; `useGenerate` and `useGenerateAll` benefit automatically.
- **Stale-close dialog extracted**: `StaleAvatarCloseDialog` is a focused, well-contained component — no inline AlertDialog sprawl in the modal.
- **DRY close interception**: single `interceptClose` callback covers escape and outside-click instead of duplicated bodies.
- **Amber banner removed**: it caused layout shift and was a net negative UX — the stale indicator on the avatar card + the close-intercept dialog are sufficient.
- **Description text reverted**: the ", art style, or reference images." addition was inaccurate since the dialog only lets you edit character avatars and voices.

## One caveat vs #225

Existing projects whose queue snapshots were saved before this change won't have `style`/`referenceImages` in `resultInputs`. Those avatars will appear stale once when first opened — a single regen stamps the correct inputs permanently. Peter's `backfillAvatarSignatures` addressed this differently (pre-emptive stamp on load); we accept the one-time prompt instead, which avoids a separate persistence layer entirely.

## Test plan

- [ ] Open CharacterEditModal for a character with an existing avatar, change appearance → stale indicator appears on the avatar card
- [ ] Press Escape / click outside → confirm dialog appears with three options
- [ ] "Keep editing" dismisses dialog, "Leave stale" closes modal, "Regenerate" triggers job and closes
- [ ] Change art style or reference images → avatar shows stale on next open (requires a prior regen to have resultInputs with style embedded)
- [ ] Uploaded avatar → never stale
- [ ] Reload page → staleness persists (queue snapshot preserved in Supabase)
- [ ] npm run lint && npm run format:check && npm run typecheck && npm run test — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)