### PR TITLE
Add generic stale-revert control to preview overlay

### DIFF
--- a/app/components/canvas/elements/OutputPreview.tsx
+++ b/app/components/canvas/elements/OutputPreview.tsx
@@ -52,6 +52,7 @@ function OutputPreviewComponent({
 	if (type === "animated_image") {
 		return (
 			<AnimatedImagePreview
+				elementId={element.id}
 				imageUrl={result?.imageUrl}
 				videoUrl={result?.videoUrl}
 				borderColor={borderColor}
@@ -71,6 +72,7 @@ function OutputPreviewComponent({
 		return (
 			<MediaPreview
 				key={url}
+				elementId={element.id}
 				url={url}
 				outputKind={outputKind}
 				borderColor={borderColor}

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -168,6 +168,7 @@ function CharacterEditDialogBody({
 						{character.avatarUrl ? (
 							<MediaPreview
 								key={character.avatarUrl}
+								elementId={avatarElementId}
 								url={character.avatarUrl}
 								outputKind="image"
 								borderColor="border-white/20"
@@ -175,6 +176,9 @@ function CharacterEditDialogBody({
 								seconds={avatarSnapshot.seconds}
 								stale={isStale}
 								onRegenerate={regenerateAvatar}
+								onRevert={({ attributes }) =>
+									update({ appearance: String(attributes.appearance) })
+								}
 							/>
 						) : (
 							<MediaPlaceholder

--- a/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
+++ b/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
@@ -5,6 +5,7 @@ import { MediaPreview, MediaPlaceholder } from "./results";
 import type { PlaceholderProps } from "./status";
 
 type AnimatedImagePreviewProps = PlaceholderProps & {
+	elementId: string;
 	imageUrl?: string;
 	videoUrl?: string;
 	borderColor: string;
@@ -13,6 +14,7 @@ type AnimatedImagePreviewProps = PlaceholderProps & {
 };
 
 export function AnimatedImagePreview({
+	elementId,
 	imageUrl,
 	videoUrl,
 	borderColor,
@@ -32,6 +34,7 @@ export function AnimatedImagePreview({
 			{url ? (
 				<MediaPreview
 					key={url}
+					elementId={elementId}
 					url={url}
 					outputKind={mode === "animated" ? "video" : "image"}
 					borderColor={borderColor}

--- a/app/components/canvas/elements/preview/overlays.tsx
+++ b/app/components/canvas/elements/preview/overlays.tsx
@@ -6,6 +6,8 @@ import {
 	TooltipContent,
 } from "@/components/ui/tooltip";
 import { GenerationIndicator } from "../GenerationIndicator";
+import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
+import type { GenerationInputs } from "@/lib/generation/generationInputs";
 import type { GenerationState, PlaceholderProps } from "./status";
 
 function OverlayButton({
@@ -54,13 +56,13 @@ function CancelButton({
 	);
 }
 
-export function StaleIndicator({ onClick }: { onClick: () => void }) {
+function StaleBadge({ onClick }: { onClick: () => void }) {
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>
 				<button
 					type="button"
-					className="absolute bottom-2 right-2 z-10 flex items-center gap-1 rounded-full bg-amber-500/80 px-2 py-1 text-[10px] font-medium text-white transition-opacity hover:bg-amber-500"
+					className="flex items-center gap-1 rounded-full bg-amber-500/80 px-2 py-1 text-[10px] font-medium text-white transition-opacity hover:bg-amber-500"
 					onClick={onClick}
 				>
 					<AlertCircle className="w-3 h-3" />
@@ -69,6 +71,49 @@ export function StaleIndicator({ onClick }: { onClick: () => void }) {
 			</TooltipTrigger>
 			<TooltipContent>Prompt changed — click to regenerate</TooltipContent>
 		</Tooltip>
+	);
+}
+
+export function StaleIndicator({ onClick }: { onClick: () => void }) {
+	return (
+		<div className="absolute bottom-2 right-2 z-10">
+			<StaleBadge onClick={onClick} />
+		</div>
+	);
+}
+
+export function StaleControls({
+	elementId,
+	onRegenerate,
+	onRevert,
+}: {
+	elementId: string;
+	onRegenerate: () => void;
+	onRevert?: (resultInputs: GenerationInputs) => void;
+}) {
+	const resultInputs = useQueueSelector(
+		(q) => q.getElementSnapshot(elementId).resultInputs,
+	);
+	return (
+		<div className="absolute bottom-2 right-2 z-10 flex items-center gap-1.5">
+			{onRevert && resultInputs && (
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<button
+							type="button"
+							onClick={() => onRevert(resultInputs)}
+							className="rounded-full bg-black/55 px-2 py-1 text-[10px] font-medium text-white/80 ring-1 ring-inset ring-white/10 backdrop-blur-xl transition-colors hover:bg-black/70 hover:text-white"
+						>
+							Revert
+						</button>
+					</TooltipTrigger>
+					<TooltipContent>
+						Discard edits — restore what this was generated from
+					</TooltipContent>
+				</Tooltip>
+			)}
+			<StaleBadge onClick={onRegenerate} />
+		</div>
 	);
 }
 

--- a/app/components/canvas/elements/preview/results.tsx
+++ b/app/components/canvas/elements/preview/results.tsx
@@ -8,7 +8,13 @@ import type { GenerationState, PlaceholderProps } from "./status";
 import { WAVE_COLORS } from "./status";
 import { PlaceholderBallsLoader } from "./placeholderBalls";
 import { AUDIO_BAR_COUNT, buildSoundwaveMask } from "./soundwave";
-import { PlaceholderOverlay, ResultOverlay, StaleIndicator } from "./overlays";
+import {
+	PlaceholderOverlay,
+	ResultOverlay,
+	StaleControls,
+	StaleIndicator,
+} from "./overlays";
+import type { GenerationInputs } from "@/lib/generation/generationInputs";
 
 export function AudioResult({
 	type,
@@ -91,13 +97,17 @@ export function MediaPreview({
 	status,
 	seconds,
 	stale,
+	elementId,
 	onRegenerate,
+	onRevert,
 }: GenerationState & {
 	url: string;
 	outputKind: "image" | "video";
 	borderColor: string;
 	stale: boolean;
+	elementId: string;
 	onRegenerate: () => void;
+	onRevert?: (resultInputs: GenerationInputs) => void;
 }) {
 	return (
 		<div
@@ -115,7 +125,13 @@ export function MediaPreview({
 				seconds={seconds}
 				onRegenerate={onRegenerate}
 			/>
-			{stale && <StaleIndicator onClick={onRegenerate} />}
+			{stale && (
+				<StaleControls
+					elementId={elementId}
+					onRegenerate={onRegenerate}
+					onRevert={onRevert}
+				/>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
## What

Adds a **Revert** affordance next to the stale indicator in the output preview — a cheap way to discard local edits and restore the inputs the current result was generated from, without spending a regeneration.

Reworks the special-cased revert from #234 (a `revertTo` derivation + a button injected via an `action` prop on the character form field) into a general, id-driven overlay component.

## How

`StaleControls({ elementId, onRegenerate, onRevert? })`:
- Reads `resultInputs` straight from the element's queue snapshot by `elementId` — the same record `isStaleResult` compares against. No new persisted state, no migration.
- When `onRevert` and `resultInputs` are present, renders a subtle **Revert** pill beside the stale badge that calls `onRevert(resultInputs)`.

Any node opts in by passing `onRevert` and mapping the generic `resultInputs` back to its own editable state — nothing is special-cased inside the component. The character avatar wires it as:

```tsx
onRevert={({ attributes }) => update({ appearance: String(attributes.appearance) })}
```

`elementId` is threaded through `MediaPreview` / `AnimatedImagePreview`. A shared `StaleBadge` is extracted so the existing `StaleIndicator` (used by `AudioResult`) stays visually unchanged and the previous `right-[4.25rem]` magic-number positioning is gone.

## Behavior

Revert shows whenever the result is **stale**. Clicking it discards local edits and restores the generated-from inputs. For the avatar, if the art style or reference images also changed, reverting appearance won't un-stale it — the draft is discarded and the stale badge + Regenerate remain.

## Tests

The revert is a thin, generic derivation off the existing queue snapshot with no new pure helper to unit-test; the button is manual QA (consistent with the existing stale flow). Full suite green (818).

🤖 Generated with [Claude Code](https://claude.com/claude-code)