### PR TITLE
chore: apply quality-skill principles (a11y, composition, perf, DRY)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@
 - Never use non-null assertions (!). Use type guards, default values, or validated helpers instead
 - Fail loudly: never catch-and-log errors on critical paths to "keep things going" — propagate the error or surface it explicitly
 - Use the `@/*` path alias for imports that traverse 2+ directory levels (e.g. `@/lib/connectors/types`); keep single-level relative imports (`../`) as-is
+- Keep concerns separated. Favor small, composable, reusable components over feature-packed ones.
+- Understand the root problem behind each change, then solve that whole class of problem with a clean abstraction rather than special-casing the instance.
 
 ## Package manager
 

--- a/app/components/AuthForm.tsx
+++ b/app/components/AuthForm.tsx
@@ -90,6 +90,7 @@ export default function AuthForm({
 					type="email"
 					name="email"
 					autoComplete="email"
+					aria-label="Email"
 					placeholder="Email"
 					value={email}
 					onChange={(e) => setEmail(e.target.value)}

--- a/app/components/UserProfile.tsx
+++ b/app/components/UserProfile.tsx
@@ -34,6 +34,7 @@ export default function UserProfile() {
 					<button
 						type="button"
 						suppressHydrationWarning
+						aria-label="Account menu"
 						className="relative z-[91] rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring"
 					>
 						<Avatar className="h-9 w-9 cursor-pointer">

--- a/app/components/canvas/dnd/DragTransferContext.tsx
+++ b/app/components/canvas/dnd/DragTransferContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react";
+import { createContext, use } from "react";
 
 export type DragTransfer = {
 	itemId: string;
@@ -10,5 +10,5 @@ export type DragTransfer = {
 export const DragTransferContext = createContext<DragTransfer>(null);
 
 export function useDragTransfer(): DragTransfer {
-	return useContext(DragTransferContext);
+	return use(DragTransferContext);
 }

--- a/app/components/canvas/elements/attributes/TextAttributePopover.tsx
+++ b/app/components/canvas/elements/attributes/TextAttributePopover.tsx
@@ -88,6 +88,7 @@ export function TextAttributePopover({
 					autoFocus
 					rows={rows}
 					value={draft}
+					aria-label={label}
 					placeholder={placeholder}
 					onChange={(e) => setDraft(e.target.value)}
 					onKeyDown={(e) => {

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -61,9 +61,9 @@ function AttachMenu({
 	onSelectNarrator: () => void;
 }) {
 	const items = [
-		{ icon: ImagePlus, label: "Upload Reference Images", onClick: openPicker },
-		{ icon: User, label: "Create character", onClick: onCreateCharacter },
-		{ icon: Mic, label: "Select narrator voice", onClick: onSelectNarrator },
+		{ icon: ImagePlus, label: "Upload reference images", onSelect: openPicker },
+		{ icon: User, label: "Create character", onSelect: onCreateCharacter },
+		{ icon: Mic, label: "Select narrator voice", onSelect: onSelectNarrator },
 	];
 
 	return (
@@ -87,10 +87,10 @@ function AttachMenu({
 				align="start"
 				className="min-w-36 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
 			>
-				{items.map(({ icon: Icon, label, onClick }) => (
+				{items.map(({ icon: Icon, label, onSelect }) => (
 					<DropdownMenuItem
 						key={label}
-						onClick={onClick}
+						onSelect={onSelect}
 						className="cursor-pointer rounded-lg px-2 py-1.5 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10"
 					>
 						<Icon className="mr-1.5 h-3.5 text-white w-3.5" strokeWidth={1.5} />

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -60,6 +60,12 @@ function AttachMenu({
 	onCreateCharacter: () => void;
 	onSelectNarrator: () => void;
 }) {
+	const items = [
+		{ icon: ImagePlus, label: "Upload Reference Images", onClick: openPicker },
+		{ icon: User, label: "Create character", onClick: onCreateCharacter },
+		{ icon: Mic, label: "Select narrator voice", onClick: onSelectNarrator },
+	];
+
 	return (
 		<DropdownMenu modal={false}>
 			<DropdownMenuTrigger asChild>
@@ -81,30 +87,16 @@ function AttachMenu({
 				align="start"
 				className="min-w-36 rounded-xl border border-white/10 bg-white/5 backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
 			>
-				<DropdownMenuItem
-					onClick={openPicker}
-					className="cursor-pointer rounded-lg px-2 py-1.5 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10"
-				>
-					<ImagePlus
-						className="mr-1.5 h-3.5 text-white w-3.5"
-						strokeWidth={1.5}
-					/>
-					Upload Reference Images
-				</DropdownMenuItem>
-				<DropdownMenuItem
-					onClick={onCreateCharacter}
-					className="cursor-pointer rounded-lg px-2 py-1.5 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10"
-				>
-					<User className="mr-1.5 h-3.5 text-white w-3.5" strokeWidth={1.5} />
-					Create character
-				</DropdownMenuItem>
-				<DropdownMenuItem
-					onClick={onSelectNarrator}
-					className="cursor-pointer rounded-lg px-2 py-1.5 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10"
-				>
-					<Mic className="mr-1.5 h-3.5 text-white w-3.5" strokeWidth={1.5} />
-					Select narrator voice
-				</DropdownMenuItem>
+				{items.map(({ icon: Icon, label, onClick }) => (
+					<DropdownMenuItem
+						key={label}
+						onClick={onClick}
+						className="cursor-pointer rounded-lg px-2 py-1.5 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10"
+					>
+						<Icon className="mr-1.5 h-3.5 text-white w-3.5" strokeWidth={1.5} />
+						{label}
+					</DropdownMenuItem>
+				))}
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/app/components/video/RenderControls.tsx
+++ b/app/components/video/RenderControls.tsx
@@ -79,6 +79,7 @@ export function RenderControls({ layout }: { layout: VideoLayout }) {
 				<button
 					type="button"
 					onClick={reset}
+					aria-label="Dismiss"
 					className="rounded-md p-1 text-white/40 hover:text-white/80"
 				>
 					<X size={14} />

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -31,6 +31,7 @@ export default function SignupPage() {
 				type="text"
 				name="fullName"
 				autoComplete="name"
+				aria-label="Full name"
 				placeholder="Full Name"
 				value={fullName}
 				onChange={(e) => setFullName(e.target.value)}

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -1,13 +1,10 @@
-import { cache } from "react";
 import type { User } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/server";
 
-// Deduplicate the auth lookup per request: multiple handlers/components asking
-// for the current user share a single Supabase round-trip.
-export const getUser = cache(async (): Promise<User | null> => {
+export async function getUser(): Promise<User | null> {
 	const supabase = await createClient();
 	const {
 		data: { user },
 	} = await supabase.auth.getUser();
 	return user;
-});
+}

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -1,10 +1,13 @@
+import { cache } from "react";
 import type { User } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/server";
 
-export async function getUser(): Promise<User | null> {
+// Deduplicate the auth lookup per request: multiple handlers/components asking
+// for the current user share a single Supabase round-trip.
+export const getUser = cache(async (): Promise<User | null> => {
 	const supabase = await createClient();
 	const {
 		data: { user },
 	} = await supabase.auth.getUser();
 	return user;
-}
+});


### PR DESCRIPTION
## What

A thorough pass of the codebase against the four quality skills — `/simplify`, `/vercel-composition-patterns`, `/web-design-guidelines`, `/vercel-react-best-practices`. The codebase already followed most principles, so this lands the genuine gaps and intentionally skips mechanical churn.

## Changes

**Accessibility** (5 unlabeled controls now have accessible names)
- `AuthForm` email input, `signup` full-name input, `TextAttributePopover` textarea → `aria-label`
- `UserProfile` account-menu trigger, `RenderControls` dismiss button → `aria-label`

**Composition (React 19)**
- `DragTransferContext`: `useContext` → `use()`

**Simplify (DRY)**
- `ComposerCopilot` `AttachMenu`: data-driven items (removed 3× duplicated classNames), using the idiomatic Radix `onSelect` and consistent sentence-case labels

**Docs**
- `CLAUDE.md`: note the small/composable-components and root-cause-abstraction principles

## Audited & already compliant (no change)

Zero `forwardRef`; Remotion Player already code-split via `next/dynamic` + `Promise.all`; static I/O module-hoisted; `prefers-reduced-motion` handled in CSS; all dialogs titled; no `onClick` on non-interactive elements; context providers already use `use()` + memoized values.

## Deliberately skipped (would be churn / over-abstraction)

Consolidating the ~14 varied "glass icon buttons" into one component (would introduce variant-prop proliferation), and decomposing large-but-cohesive files purely for line count.

> Note: an earlier revision wrapped `getUser` in `React.cache()` for per-request auth dedup; that was reverted in 9cd7db5 and is **not** part of this PR.

## Verification

CI checks all green locally: `lint`, `format:check`, `typecheck`, `knip`, `build`, and 818 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
