### PR TITLE
fix: nightly bug fixes 2026-06-12

### DIFF
--- a/lib/video/__tests__/elementAttributes.test.ts
+++ b/lib/video/__tests__/elementAttributes.test.ts
@@ -18,8 +18,10 @@ function el(customAttributes?: Record<string, string>): CanvasContentElement {
 }
 
 describe("getVolume", () => {
-	it("defaults to 10 when missing or non-numeric", () => {
+	it("defaults to 10 when missing, blank, or non-numeric", () => {
 		expect(getVolume(el())).toBe(10);
+		expect(getVolume(el({ volume: "" }))).toBe(10);
+		expect(getVolume(el({ volume: "   " }))).toBe(10);
 		expect(getVolume(el({ volume: "not-a-number" }))).toBe(10);
 	});
 

--- a/lib/video/elementAttributes.ts
+++ b/lib/video/elementAttributes.ts
@@ -19,7 +19,8 @@ const DEFAULT_VOLUME = VOLUME_MAX;
 
 /** Volume coerced to a finite number clamped to [0, 10], defaulting to 10. */
 export function getVolume(element: CanvasContentElement): number {
-	const raw = Number(element.customAttributes?.volume);
+	const value = element.customAttributes?.volume;
+	const raw = value?.trim() ? Number(value) : DEFAULT_VOLUME;
 	return Number.isFinite(raw)
 		? Math.max(VOLUME_MIN, Math.min(VOLUME_MAX, raw))
 		: DEFAULT_VOLUME;


### PR DESCRIPTION
## Summary
- Fixes blank or whitespace-only audio `volume` attributes being coerced by `Number()` to `0`, which muted the element instead of using the default volume.
- Keeps explicit `"0"` behavior unchanged so intentional mute still works.
- Adds regression coverage for blank and whitespace volume values.

## Test Plan
- [x] `npm test -- --run lib/video/__tests__/elementAttributes.test.ts --passWithNoTests`
- [x] `npm test -- --passWithNoTests`
- [x] `npm run build`
- [x] `npm run lint && npm run format:check && npm run typecheck && npm run knip`

## Open PR overlap check
Considered open PRs:
- #236 touches API auth/route-handler/render/upload/validate-code files: non-overlapping.
- #231 touches Cartesia TTS/provider/embed/package files: non-overlapping.

This PR only touches `lib/video/elementAttributes.ts` and `lib/video/__tests__/elementAttributes.test.ts`, so it does not overlap with the open PR file/theme lists.

## Notes
- Claude Code YOLO core pass was attempted first per runbook but timed out without leaving a diff; Hermes completed the scoped bug fix and then used Claude Code for a tiny diff review (`LGTM`).
