### PR TITLE
refactor: nightly maintainability 2026-06-12

### DIFF
--- a/app/components/GlassDropdown.tsx
+++ b/app/components/GlassDropdown.tsx
@@ -6,6 +6,53 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+/** Glass-chrome dropdown surface; pass sizing/z-index/scroll classes per use. */
+export function GlassDropdownContent({
+	className,
+	...props
+}: React.ComponentProps<typeof DropdownMenuContent>) {
+	return (
+		<DropdownMenuContent
+			className={cn(
+				"rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0.5",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+/**
+ * Menu item for glass dropdowns. Passing `selected` (even false) reserves a
+ * leading check column so option labels stay aligned across the menu.
+ */
+export function GlassDropdownItem({
+	selected,
+	className,
+	children,
+	...props
+}: React.ComponentProps<typeof DropdownMenuItem> & { selected?: boolean }) {
+	return (
+		<DropdownMenuItem
+			className={cn(
+				"cursor-pointer rounded-full px-2 py-1 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10",
+				className,
+			)}
+			{...props}
+		>
+			{selected !== undefined && (
+				<span className="w-3.5 shrink-0 flex items-center justify-center">
+					{selected && (
+						<Check className="w-3 h-3 text-white" aria-hidden="true" />
+					)}
+				</span>
+			)}
+			{children}
+		</DropdownMenuItem>
+	);
+}
 
 export interface GlassDropdownOption<T extends string> {
 	value: T;
@@ -49,27 +96,18 @@ export default function GlassDropdown<T extends string>({
 					<ChevronDown className="w-2.5 h-2.5 text-white/70" />
 				</button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent
-				side={side}
-				align={align}
-				className="min-w-32 rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
-			>
+			<GlassDropdownContent side={side} align={align} className="min-w-32">
 				{options.map((option) => (
-					<DropdownMenuItem
+					<GlassDropdownItem
 						key={option.value}
-						onClick={() => onChange(option.value)}
-						className="cursor-pointer rounded-full px-2 py-1 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10"
+						selected={option.value === value}
+						onSelect={() => onChange(option.value)}
 					>
-						<span className="w-3.5 shrink-0 flex items-center justify-center">
-							{option.value === value && (
-								<Check className="w-3 h-3 text-white" aria-hidden="true" />
-							)}
-						</span>
 						{option.icon}
 						{option.label}
-					</DropdownMenuItem>
+					</GlassDropdownItem>
 				))}
-			</DropdownMenuContent>
+			</GlassDropdownContent>
 		</DropdownMenu>
 	);
 }

--- a/app/components/canvas/dnd/SortableActions.tsx
+++ b/app/components/canvas/dnd/SortableActions.tsx
@@ -2,10 +2,12 @@ import { GripVertical, Plus } from "lucide-react";
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
 import {
 	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+	GlassDropdownContent,
+	GlassDropdownItem,
+} from "@/app/components/GlassDropdown";
 
 export interface InsertOption<K extends string = string> {
 	key: K;
@@ -40,16 +42,16 @@ export function SortableActions<K extends string>({
 							<Plus size={24} />
 						</button>
 					</DropdownMenuTrigger>
-					<DropdownMenuContent
+					<GlassDropdownContent
 						side="bottom"
 						align="start"
-						className="w-40 rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-1"
+						className="w-40 p-1"
 					>
 						{options.map((option) => (
-							<DropdownMenuItem
+							<GlassDropdownItem
 								key={option.key}
-								onClick={() => onInsert(option.key)}
-								className="cursor-pointer rounded-lg py-2 text-white/70 hover:bg-white/10 hover:text-white focus:text-white focus:bg-white/10"
+								onSelect={() => onInsert(option.key)}
+								className="rounded-lg py-2 text-sm hover:bg-white/10"
 							>
 								<span
 									className={`${option.bgColor} inline-flex items-center justify-center rounded p-1 mr-1`}
@@ -57,9 +59,9 @@ export function SortableActions<K extends string>({
 									{option.icon}
 								</span>
 								{option.label}
-							</DropdownMenuItem>
+							</GlassDropdownItem>
 						))}
-					</DropdownMenuContent>
+					</GlassDropdownContent>
 				</DropdownMenu>
 			)}
 			<button

--- a/app/components/canvas/elements/AttributeBadge.tsx
+++ b/app/components/canvas/elements/AttributeBadge.tsx
@@ -1,11 +1,13 @@
-import { Check, ChevronDown } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import { ReactEditor, useSlateStatic } from "slate-react";
 import {
 	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+	GlassDropdownContent,
+	GlassDropdownItem,
+} from "@/app/components/GlassDropdown";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import type { AttributeSpec } from "../config/elementConfigs";
 import { setNodeAttrs } from "../utils/editorOps";
@@ -85,25 +87,20 @@ export function AttributeBadge({
 					<ChevronDown className="w-3 h-3 shrink-0 text-white/80" />
 				</button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent
+			<GlassDropdownContent
 				align="start"
-				className="min-w-24 max-h-64 overflow-y-auto rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+				className="min-w-24 max-h-64 overflow-y-auto"
 			>
 				{spec.edit.options.map((opt) => (
-					<DropdownMenuItem
+					<GlassDropdownItem
 						key={opt}
-						onClick={() => handleSelect(opt)}
-						className="cursor-pointer rounded-full px-2 py-1 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10"
+						selected={opt === value}
+						onSelect={() => handleSelect(opt)}
 					>
-						<span className="w-3.5 shrink-0 flex items-center justify-center">
-							{opt === value && (
-								<Check className="w-3 h-3 text-white" aria-hidden="true" />
-							)}
-						</span>
 						{formatValue(attrKey, opt)}
-					</DropdownMenuItem>
+					</GlassDropdownItem>
 				))}
-			</DropdownMenuContent>
+			</GlassDropdownContent>
 		</DropdownMenu>
 	);
 }

--- a/app/components/canvas/elements/CharactersPicker.tsx
+++ b/app/components/canvas/elements/CharactersPicker.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { Check, UserPlus } from "lucide-react";
+import { UserPlus } from "lucide-react";
 import { Editor } from "slate";
 import { ReactEditor, useSlateStatic } from "slate-react";
 import {
 	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+	GlassDropdownContent,
+	GlassDropdownItem,
+} from "@/app/components/GlassDropdown";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useProjectStore } from "@/lib/project/store";
 import type { CanvasContentElement } from "@/lib/canvas/types";
@@ -75,26 +77,23 @@ function ProjectCharactersMenu({
 }) {
 	const names = useProjectCharacterNames();
 	return (
-		<DropdownMenuContent
+		<GlassDropdownContent
 			align="start"
-			className="min-w-32 max-h-64 overflow-y-auto rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+			className="min-w-32 max-h-64 overflow-y-auto"
 		>
 			{names.map((name) => (
-				<DropdownMenuItem
+				<GlassDropdownItem
 					key={name}
-					onClick={() => onSelect(name)}
-					onSelect={(e) => e.preventDefault()}
-					className="cursor-pointer rounded-full px-2 py-1 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10"
+					selected={selected.has(name)}
+					onSelect={(e) => {
+						e.preventDefault();
+						onSelect(name);
+					}}
 				>
-					<span className="w-3.5 shrink-0 flex items-center justify-center">
-						{selected.has(name) && (
-							<Check className="w-3 h-3 text-white" aria-hidden="true" />
-						)}
-					</span>
 					{name}
-				</DropdownMenuItem>
+				</GlassDropdownItem>
 			))}
-		</DropdownMenuContent>
+		</GlassDropdownContent>
 	);
 }
 

--- a/app/components/canvas/elements/character/fields.tsx
+++ b/app/components/canvas/elements/character/fields.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { type ReactNode } from "react";
-import { Check, ChevronDown } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import {
 	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+	GlassDropdownContent,
+	GlassDropdownItem,
+} from "@/app/components/GlassDropdown";
 
 export const FIELD_CLS =
 	"w-full rounded-md border border-glass-border bg-glass-fill px-2 py-1.5 text-[12px] text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-accent-violet/50";
@@ -72,6 +74,8 @@ export function TextAreaField({
 	);
 }
 
+const ENUM_OPTION_CLS = "gap-1.5 rounded-md text-[12px]";
+
 export function EnumField<T extends string>({
 	label,
 	options,
@@ -96,49 +100,29 @@ export function EnumField<T extends string>({
 					</span>
 					<ChevronDown className="h-3 w-3 shrink-0 text-white/60" />
 				</DropdownMenuTrigger>
-				<DropdownMenuContent
+				<GlassDropdownContent
 					align="start"
-					className="max-h-64 min-w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto rounded-xl border border-glass-border bg-glass-fill p-0.5 shadow-md shadow-black/40 backdrop-blur-xl"
+					className="max-h-64 min-w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto shadow-black/40"
 				>
-					<EnumOption
+					<GlassDropdownItem
 						selected={value === undefined}
 						onSelect={() => onChange(undefined)}
+						className={ENUM_OPTION_CLS}
 					>
 						<span className="text-white/50">—</span>
-					</EnumOption>
+					</GlassDropdownItem>
 					{options.map((option) => (
-						<EnumOption
+						<GlassDropdownItem
 							key={option}
 							selected={option === value}
 							onSelect={() => onChange(option)}
+							className={ENUM_OPTION_CLS}
 						>
 							{option}
-						</EnumOption>
+						</GlassDropdownItem>
 					))}
-				</DropdownMenuContent>
+				</GlassDropdownContent>
 			</DropdownMenu>
 		</div>
-	);
-}
-
-function EnumOption({
-	selected,
-	onSelect,
-	children,
-}: {
-	selected: boolean;
-	onSelect: () => void;
-	children: ReactNode;
-}) {
-	return (
-		<DropdownMenuItem
-			onClick={onSelect}
-			className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-[12px] text-white/70 hover:text-white focus:bg-white/10 focus:text-white"
-		>
-			<span className="flex w-3.5 shrink-0 items-center justify-center">
-				{selected && <Check className="h-3 w-3 text-white" aria-hidden />}
-			</span>
-			{children}
-		</DropdownMenuItem>
 	);
 }

--- a/app/components/canvas/panel/TransitionPanel.tsx
+++ b/app/components/canvas/panel/TransitionPanel.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { Check, ChevronDown } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import {
 	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+	GlassDropdownContent,
+	GlassDropdownItem,
+} from "@/app/components/GlassDropdown";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getProjectStore } from "@/lib/project/store";
 import { TRANSITION_TYPES, type TransitionType } from "@/lib/video/transitions";
@@ -50,25 +52,21 @@ export default function TransitionPanel() {
 						/>
 					</button>
 				</DropdownMenuTrigger>
-				<DropdownMenuContent
+				<GlassDropdownContent
 					align="start"
-					className="z-[90] min-w-[--radix-dropdown-menu-trigger-width] max-h-64 overflow-y-auto rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
+					className="z-[90] min-w-[--radix-dropdown-menu-trigger-width] max-h-64 overflow-y-auto"
 				>
 					{TRANSITION_TYPES.map((value) => (
-						<DropdownMenuItem
+						<GlassDropdownItem
 							key={value}
-							onClick={() => setTransitionType(value)}
-							className="cursor-pointer rounded-md px-2 py-1 text-xs text-white/70 hover:text-white focus:text-white focus:bg-white/10"
+							selected={value === transitionType}
+							onSelect={() => setTransitionType(value)}
+							className="rounded-md text-xs"
 						>
-							<span className="w-3.5 shrink-0 flex items-center justify-center">
-								{value === transitionType && (
-									<Check className="w-3 h-3 text-white" aria-hidden="true" />
-								)}
-							</span>
 							{LABELS[value]}
-						</DropdownMenuItem>
+						</GlassDropdownItem>
 					))}
-				</DropdownMenuContent>
+				</GlassDropdownContent>
 			</DropdownMenu>
 		</div>
 	);

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -13,11 +13,11 @@ import {
 } from "lucide-react";
 import {
 	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import GlassDropdown, {
+	GlassDropdownContent,
+	GlassDropdownItem,
 	type GlassDropdownOption,
 } from "@/app/components/GlassDropdown";
 import { CharacterEditModal } from "@/app/components/canvas/elements/character/CharacterEditModal";
@@ -82,22 +82,18 @@ function AttachMenu({
 					)}
 				</button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent
-				side="bottom"
-				align="start"
-				className="min-w-36 rounded-xl border border-glass-border bg-glass-fill backdrop-blur-xl shadow-md shadow-black/8 p-0.5"
-			>
+			<GlassDropdownContent side="bottom" align="start" className="min-w-36">
 				{items.map(({ icon: Icon, label, onSelect }) => (
-					<DropdownMenuItem
+					<GlassDropdownItem
 						key={label}
 						onSelect={onSelect}
-						className="cursor-pointer rounded-lg px-2 py-1.5 text-[11px] text-white/70 hover:text-white focus:text-white focus:bg-white/10"
+						className="rounded-lg py-1.5"
 					>
 						<Icon className="mr-1.5 h-3.5 text-white w-3.5" strokeWidth={1.5} />
 						{label}
-					</DropdownMenuItem>
+					</GlassDropdownItem>
 				))}
-			</DropdownMenuContent>
+			</GlassDropdownContent>
 		</DropdownMenu>
 	);
 }


### PR DESCRIPTION
## Summary
- Extract shared glass dropdown surface/item helpers with selected-state check column support
- Reuse the helpers across UI dropdowns in the canvas, character fields, transition panel, sortable insert menu, and copilot attach menu
- Switch duplicated dropdown selections to idiomatic Radix `onSelect` handlers while preserving existing prevent-close behavior for multi-select character picks

## Architecture changes
- Centralizes glass menu chrome in `GlassDropdownContent` and `GlassDropdownItem`, giving dropdown call sites a narrower styling/composition interface.
- Keeps per-site sizing, z-index, scrolling, and intentional visual deviations as explicit class overrides.

## Maintainability changes
- Removes duplicate menu-content and selected-check markup from seven UI modules.
- Deletes the local `EnumOption` implementation in favor of the shared glass item component.
- Keeps behavior and visuals unchanged; notably preserves the enum menu's existing `shadow-black/40` override.

## Complexity delta
- 7 files touched.
- 5 duplicate selected-option implementations collapsed into one shared item helper.
- 1 local component removed (`EnumOption`).
- Net diff: 127 insertions / 113 deletions, with duplicated branching/check rendering centralized.

## Validation
- [x] `npm run build`
- [x] `npm test -- --passWithNoTests`
- [x] CI parity: `npm run lint && npm run format:check && npm run typecheck && npm run knip && npm run test:coverage`

## Open PR overlap check
Considered open PRs:
- #262 touches `lib/video/__tests__/elementAttributes.test.ts`, `lib/video/elementAttributes.ts`
- #236 touches `ARCHITECTURE.md`, render/upload/validate API routes, and `lib/api/*`
- #231 touches Cartesia TTS, embeddings, voice similarity, and package files

This PR only changes UI dropdown components under `app/components/*`; it does not overlap those files, modules, or workflows.

## Skipped / notes
- Left `UserProfile`'s account menu alone because it uses separate card-style chrome, not this glass dropdown pattern.
- Did not normalize the enum dropdown `shadow-black/40` to the default `/8`, because that could be a visual behavior change.
