### PR TITLE
fix: nightly bug fixes 2026-06-13

### DIFF
--- a/lib/connectors/__tests__/asset-base.test.ts
+++ b/lib/connectors/__tests__/asset-base.test.ts
@@ -119,6 +119,44 @@ describe("BaseAssetConnector", () => {
 			const result = await connector.resolveBundle(bundle);
 			expect(result.durationSec).toBe(0);
 		});
+
+		it("parses numeric duration metadata strings", async () => {
+			const connector = new TestAssetConnector(config);
+			const bundle = new AssetBundle(
+				"https://blob.example.com/assets/image/mock/xyz",
+				{
+					version: 1,
+					type: "image",
+					createdAt: "",
+					result: { image: "output.jpg" },
+					metadata: { durationSec: "2.5" },
+				},
+			);
+
+			const result = await connector.resolveBundle(bundle);
+			expect(result.durationSec).toBe(2.5);
+		});
+
+		it.each(["", "   ", "not-a-number", -1, null, false, [], {}])(
+			"throws when durationSec metadata is invalid: %s",
+			async (durationSec) => {
+				const connector = new TestAssetConnector(config);
+				const bundle = new AssetBundle(
+					"https://blob.example.com/assets/image/mock/xyz",
+					{
+						version: 1,
+						type: "image",
+						createdAt: "",
+						result: { image: "output.jpg" },
+						metadata: { durationSec },
+					},
+				);
+
+				await expect(connector.resolveBundle(bundle)).rejects.toThrow(
+					"Asset bundle durationSec metadata must be a finite number",
+				);
+			},
+		);
 	});
 
 	describe("_generate (via generate)", () => {

--- a/lib/connectors/asset-base.ts
+++ b/lib/connectors/asset-base.ts
@@ -14,6 +14,27 @@ const ASSET_KEY_TO_URL_FIELD: Record<
 	video: "videoUrl",
 };
 
+function parseDurationSec(value: unknown): number {
+	if (value === undefined) return 0;
+	if (typeof value !== "number" && typeof value !== "string") {
+		throw new Error(
+			"Asset bundle durationSec metadata must be a finite number",
+		);
+	}
+	if (typeof value === "string" && value.trim() === "") {
+		throw new Error(
+			"Asset bundle durationSec metadata must be a finite number",
+		);
+	}
+	const durationSec = Number(value);
+	if (!Number.isFinite(durationSec) || durationSec < 0) {
+		throw new Error(
+			"Asset bundle durationSec metadata must be a finite number",
+		);
+	}
+	return durationSec;
+}
+
 export abstract class BaseAssetConnector<
 	TParams extends { prompt: string },
 	TResult,
@@ -25,7 +46,7 @@ export abstract class BaseAssetConnector<
 	async resolveBundle(bundle: AssetBundle): Promise<TResult> {
 		return {
 			[ASSET_KEY_TO_URL_FIELD[this.assetKey]]: bundle.resolve(this.assetKey),
-			durationSec: Number(bundle.manifest.metadata?.durationSec ?? 0),
+			durationSec: parseDurationSec(bundle.manifest.metadata?.durationSec),
 		} as TResult;
 	}
 


### PR DESCRIPTION
## Summary
- Validates asset bundle `durationSec` metadata before connector results hand it to generation/rendering paths.
- Preserves the existing default of `0` when metadata is absent and numeric-string support for serialized manifests.
- Fails loudly for malformed present metadata instead of silently propagating `NaN`, negative, or JavaScript-coerced durations.

## Bugs fixed
- `BaseAssetConnector.resolveBundle` previously used `Number(metadata?.durationSec ?? 0)`, so malformed present values like `"not-a-number"` became `NaN`, negative values stayed negative, and non-number shapes like `false`/`[]` could coerce to `0`. Those invalid durations could flow into generated asset results and downstream rendering.

## Tests added
- Added `BaseAssetConnector` regression coverage for numeric duration strings.
- Added invalid metadata cases for blank/whitespace strings, non-numeric strings, negative numbers, `null`, booleans, arrays, and objects.

## Validation
- [x] `npm test -- --run lib/connectors/__tests__/asset-base.test.ts --passWithNoTests`
- [x] `npm test -- --passWithNoTests`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run knip`
- [x] `npm run build`
- [x] `npm run test:coverage`
- [x] Independent review pass after the first review flagged overly broad `Number()` coercion; tightened accepted metadata types and re-reviewed cleanly.

## Open PR overlap check
Considered open PRs #273, #265, #264, #263, #262, and #236. This PR only touches `lib/connectors/asset-base.ts` and `lib/connectors/__tests__/asset-base.test.ts`, which are not in those PR file lists and do not overlap their themes (timestamp hydration, canvas domain move, refine composer perf, dropdown UI, video element attributes, or API auth/route wrappers).

## Skipped / notes
- Claude Code YOLO core pass was attempted per runbook, but after ~15 minutes it produced no output and left no diff; Hermes completed the scoped non-overlapping bug fix directly and used an independent reviewer for the diff.
- No UI/visual files changed.
