### PR TITLE
refactor: nightly maintainability 2026-06-13

### DIFF
--- a/lib/connectors/llm/plugins/osml.ts
+++ b/lib/connectors/llm/plugins/osml.ts
@@ -6,10 +6,10 @@ import {
 	TTS_ACCENTS,
 	TTS_AGES,
 	TTS_GENDERS,
+	TTS_EMOTIONS,
 	TTS_LANGUAGES,
 	TTS_PITCHES,
 	TTS_SPEEDS,
-	TTSEmotion,
 } from "@/lib/connectors/tts/enums";
 import type { LLMPlugin } from "@/lib/connectors/types";
 
@@ -44,7 +44,7 @@ const OSML_SYSTEM_PROMPT = dedent`
 	- Supported attributes for character tags are name, emotion, and captions
 
 	### Narration and Character XML Tags
-	- For both character and narration tags, the emotion attribute should be appropriately set to one of the following: ${Object.values(TTSEmotion).join(", ")}.
+	- For both character and narration tags, the emotion attribute should be appropriately set to one of the following: ${TTS_EMOTIONS.join(", ")}.
 	- For both character and narration tags, the speed attribute should be appropriately set to one of the following: ${TTS_SPEEDS.join(", ")}.
 	- The optional captions attribute is "on" or "off" (default "on") and controls whether on-screen subtitle text is overlaid during the element's audio.
 

--- a/lib/connectors/tts/enums.ts
+++ b/lib/connectors/tts/enums.ts
@@ -135,3 +135,5 @@ export enum TTSEmotion {
 	Contemplative = "contemplative",
 	Determined = "determined",
 }
+
+export const TTS_EMOTIONS = Object.values(TTSEmotion) as TTSEmotion[];

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -17,23 +17,21 @@ export const ageSchema = z.enum(TTS_AGES).optional().catch(undefined);
 export const pitchSchema = z.enum(TTS_PITCHES).optional().catch(undefined);
 export const accentSchema = z.enum(TTS_ACCENTS).optional().catch(undefined);
 
-const voiceTraits = {
+const voiceTraitsSchema = z.object({
 	gender: genderSchema,
 	age: ageSchema,
 	pitch: pitchSchema,
 	accent: accentSchema,
 	description: optionalString,
 	language: languageSchema,
-};
+});
 
-export const MetadataVoiceSchema = z.object({
-	...voiceTraits,
+export const MetadataVoiceSchema = voiceTraitsSchema.extend({
 	voiceId: optionalString,
 	resolvedVoiceId: optionalString,
 });
 
-export const voiceSearchParamsSchema = z.object({
-	...voiceTraits,
+export const voiceSearchParamsSchema = voiceTraitsSchema.extend({
 	query: optionalString,
 	name: optionalString,
 	limit: z.coerce.number().int().positive().optional().catch(undefined),

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -17,26 +17,25 @@ export const ageSchema = z.enum(TTS_AGES).optional().catch(undefined);
 export const pitchSchema = z.enum(TTS_PITCHES).optional().catch(undefined);
 export const accentSchema = z.enum(TTS_ACCENTS).optional().catch(undefined);
 
-export const MetadataVoiceSchema = z.object({
+const voiceTraits = {
 	gender: genderSchema,
 	age: ageSchema,
 	pitch: pitchSchema,
 	accent: accentSchema,
 	description: optionalString,
 	language: languageSchema,
+};
+
+export const MetadataVoiceSchema = z.object({
+	...voiceTraits,
 	voiceId: optionalString,
 	resolvedVoiceId: optionalString,
 });
 
 export const voiceSearchParamsSchema = z.object({
+	...voiceTraits,
 	query: optionalString,
-	gender: genderSchema,
-	age: ageSchema,
-	pitch: pitchSchema,
-	accent: accentSchema,
-	description: optionalString,
 	name: optionalString,
-	language: languageSchema,
 	limit: z.coerce.number().int().positive().optional().catch(undefined),
 });
 


### PR DESCRIPTION
## Summary
- Centralizes the TTS emotion option list behind `TTS_EMOTIONS`, so OSML prompt generation no longer repeats enum reflection inline.
- Extracts shared voice trait schemas used by project metadata voices and voice search params.
- Keeps behavior unchanged: the emotion list still comes from `TTSEmotion`, and the Zod schema fields/catch behavior remain the same.

## Architecture changes
- Gives TTS emotion consumers a narrow exported data interface (`TTS_EMOTIONS`) instead of each consumer deciding how to derive values from the enum.
- Groups reusable voice trait schema fields in `lib/project/types.ts`, reducing drift risk between metadata and voice search contracts.

## Maintainability changes
- Removes duplicate schema field declarations for gender/age/pitch/accent/description/language.
- Simplifies the OSML prompt template by moving enum-value derivation to the TTS boundary.
- No docs were added; the code change is self-describing and the runbook's high signal-to-noise bar did not justify new prose.

## Complexity delta
- 3 files changed.
- 1 repeated six-field voice schema group consolidated into `voiceTraits`.
- 1 inline `Object.values(TTSEmotion)` prompt expression replaced by a named boundary export.
- Net diff: 10 insertions / 9 deletions.

## Validation
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test -- --passWithNoTests`
- [x] `npm run lint`
- [x] `npm run knip`

## Open PR overlap check
Considered open PRs #274, #273, #265, #264, #263, #262, and #236. The final diff touches only `lib/connectors/llm/plugins/osml.ts`, `lib/connectors/tts/enums.ts`, and `lib/project/types.ts`; none intersect the open PR file lists. I reverted an initial canvas config cleanup because it overlapped the canvas-domain/dropdown themes already covered by #265/#263.

## Skipped
- Skipped broader canvas/domain cleanup because #265 owns that area.
- Skipped API route validation work because #236 owns API route/auth wrappers.
- Skipped UI dropdown/Radix cleanup because #263 owns the dropdown surface area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)