### PR TITLE
refactor: rethink openslop architecture 2026-06-13

### DIFF
--- a/lib/config/ConfigProvider.tsx
+++ b/lib/config/ConfigProvider.tsx
@@ -1,13 +1,7 @@
 "use client";
 
-import {
-	createContext,
-	use,
-	useCallback,
-	useMemo,
-	useState,
-	type ReactNode,
-} from "react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import type {
 	ConnectorConfig,
 	ConnectorPlugin,
@@ -91,13 +85,9 @@ type ConfigContextValue = {
 	applyTemplate: (templateId: string) => void;
 };
 
-const ConfigContext = createContext<ConfigContextValue | null>(null);
-
-export function useConfig() {
-	const ctx = use(ConfigContext);
-	if (!ctx) throw new Error("useConfig must be used within ConfigProvider");
-	return ctx;
-}
+const [ConfigContext, useConfig] =
+	createRequiredContext<ConfigContextValue>("ConfigProvider");
+export { useConfig };
 
 export function ConfigProvider({
 	projectId,
@@ -166,7 +156,5 @@ export function ConfigProvider({
 		],
 	);
 
-	return (
-		<ConfigContext.Provider value={value}>{children}</ConfigContext.Provider>
-	);
+	return <ConfigContext value={value}>{children}</ConfigContext>;
 }

--- a/lib/user/UserProvider.tsx
+++ b/lib/user/UserProvider.tsx
@@ -1,15 +1,11 @@
 "use client";
 
-import { createContext, use, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import type { User } from "@supabase/supabase-js";
+import { createRequiredContext } from "@/lib/components/createRequiredContext";
 
-const UserContext = createContext<User | null>(null);
-
-export function useUser() {
-	const ctx = use(UserContext);
-	if (!ctx) throw new Error("useUser must be used within UserProvider");
-	return ctx;
-}
+const [UserContext, useUser] = createRequiredContext<User>("UserProvider");
+export { useUser };
 
 export function UserProvider({
 	user,
@@ -18,5 +14,5 @@ export function UserProvider({
 	user: User;
 	children: ReactNode;
 }) {
-	return <UserContext.Provider value={user}>{children}</UserContext.Provider>;
+	return <UserContext value={user}>{children}</UserContext>;
 }


### PR DESCRIPTION
## App understanding

OpenSlop is an open-source AI video creator. Users compose a script on a Slate-based canvas (scenes of narration/character/image/video/sound/music elements), generate assets per element through pluggable AI providers (Anthropic, Runware, ElevenLabs, Cartesia), refine the script via LLM edit-ops, and render with Remotion. Persistence and auth run on Supabase. Intended layering:

```
UI (app/) → hooks → generation queue → connectors → gateways → API routes (app/api/v1) → providers
```

Main workflows: create project → pick mode/template → edit canvas → generate per element (queued/polled) → preview/render video.

## From-scratch architecture

Rebuilt from scratch, the existing layering survives almost unchanged — it is genuinely good: the generation queue decouples async polling from UI, connectors/gateways are intentionally layered (and per the repo's own note, deliberately not flattened), and validation is centralized in zod route schemas. React context is standardized behind a single `createRequiredContext` helper (`lib/components/createRequiredContext.ts`), already used by 8 contexts and established by merged PR #222 ("make missing context providers fail loudly").

The only divergence from that standard: two required-context providers still hand-rolled their own `createContext` + null-check + throw boilerplate, predating the helper.

## Implemented simplification

Converted the two remaining stragglers to the shared helper:

- `lib/config/ConfigProvider.tsx`
- `lib/user/UserProvider.tsx`

Net −16 lines. This deletes bespoke duplication in favor of the codebase's own standard (not a new abstraction), aligns all 10 required contexts on one pattern, and preserves behavior exactly (missing-provider access still throws). `AutoScrollContext` and `DragTransferContext` were intentionally left alone — they are *optional* contexts with legitimate default values, not required ones. `ScriptProvider` was left untouched because it is owned by open PR #265.

## Validation

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run format:check` — pass
- `npm run knip` — pass
- `npm run test:run` — 828 passing (95 files)
- `npm run build` — pass

## Skipped items / risks

- Connector `OpenSlop*` index boilerplate (5 files) — a factory would be heavier than the explicit classes; skipped as overengineering.
- All substantial domain reshaping (canvas domain model, serialization, video resolve, API auth wrappers) is already in flight across open PRs; deliberately not duplicated.
- Risk: low — mechanical, behavior-preserving, type-checked.

## Open PR overlap check

Considered all 8 open PRs: #275 (TTS emotions/voice traits), #274 (asset-base duration), #273 (My Slop timestamp hydration), #265 (canvas domain move), #264 (PostPromptView perf), #263 (dropdown UI), #262 (video element attributes), #236 (API auth/route wrappers). This PR touches only `lib/config/ConfigProvider.tsx` and `lib/user/UserProvider.tsx`, neither of which appears in any open PR's file list. No file or theme overlap. #265 touches `lib/script/ScriptProvider.tsx` but not these two providers; left it untouched to avoid overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
