### PR TITLE
fix: nightly bug fixes 2026-06-14

### DIFF
--- a/app/components/video/__tests__/useAssetPrefetch.test.ts
+++ b/app/components/video/__tests__/useAssetPrefetch.test.ts
@@ -1,9 +1,20 @@
 import { describe, expect, it, vi } from "vitest";
 import type { prefetch as PrefetchFn } from "remotion";
 import type { ResolvedElement, Sequence, VideoLayout } from "@/lib/video/types";
-import { collectUrls, reconcilePrefetch } from "../useAssetPrefetch";
+import {
+	awaitPrefetch,
+	collectUrls,
+	reconcilePrefetch,
+} from "../useAssetPrefetch";
 
 type PrefetchHandle = ReturnType<typeof PrefetchFn>;
+
+function handleRejecting(): PrefetchHandle {
+	return {
+		free: vi.fn(),
+		waitUntilDone: () => Promise.reject(new Error("HTTP error, status = 404")),
+	} as unknown as PrefetchHandle;
+}
 
 function el(url: string): ResolvedElement {
 	return {
@@ -120,5 +131,49 @@ describe("reconcilePrefetch", () => {
 		expect(active.has("old")).toBe(false);
 		expect(active.has("new")).toBe(true);
 		expect(added).toBe(true);
+	});
+});
+
+describe("awaitPrefetch", () => {
+	it("resolves once all handles are done", async () => {
+		await expect(
+			awaitPrefetch([fakeHandle(), fakeHandle()]),
+		).resolves.toBeUndefined();
+	});
+
+	it("does not reject when a single asset fails to prefetch", async () => {
+		// A 404/CORS/network failure on one asset must not short-circuit the wait
+		// on the others (Promise.all would reject and reveal the player early).
+		await expect(
+			awaitPrefetch([fakeHandle(), handleRejecting(), fakeHandle()]),
+		).resolves.toBeUndefined();
+	});
+
+	it("waits for every handle to settle before resolving", async () => {
+		const order: string[] = [];
+		const slow = {
+			free: vi.fn(),
+			waitUntilDone: () =>
+				new Promise((res) =>
+					queueMicrotask(() => {
+						order.push("slow");
+						res("done");
+					}),
+				),
+		} as unknown as PrefetchHandle;
+		const failing = {
+			free: vi.fn(),
+			waitUntilDone: () => {
+				order.push("fail");
+				return Promise.reject(new Error("boom"));
+			},
+		} as unknown as PrefetchHandle;
+
+		await awaitPrefetch([failing, slow]);
+		expect(order).toEqual(["fail", "slow"]);
+	});
+
+	it("resolves immediately for an empty handle list", async () => {
+		await expect(awaitPrefetch([])).resolves.toBeUndefined();
 	});
 });

--- a/app/components/video/useAssetPrefetch.ts
+++ b/app/components/video/useAssetPrefetch.ts
@@ -52,6 +52,10 @@ export function reconcilePrefetch(
 	return added;
 }
 
+export async function awaitPrefetch(handles: PrefetchHandle[]): Promise<void> {
+	await Promise.allSettled(handles.map((h) => h.waitUntilDone()));
+}
+
 export function useAssetPrefetch(layout: VideoLayout | null): boolean {
 	const activeRef = useRef(new Map<string, PrefetchHandle>());
 	const [ready, setReady] = useState(false);
@@ -67,7 +71,7 @@ export function useAssetPrefetch(layout: VideoLayout | null): boolean {
 				if (reconcilePrefetch(collectUrls(layout), active, prefetch)) {
 					setReady(false);
 				}
-				await Promise.all([...active.values()].map((h) => h.waitUntilDone()));
+				await awaitPrefetch([...active.values()]);
 				if (!cancelled) setReady(true);
 			})
 			.catch((err) => {


### PR DESCRIPTION
## Summary
- Fixes video asset prefetch readiness when one Remotion prefetch handle rejects (for example 404/CORS/network failures).
- Previously `Promise.all` rejected on the first failed asset and marked the player ready immediately, even while other valid assets were still prefetching.
- Adds an `awaitPrefetch` helper that waits for every active prefetch handle to settle before revealing the player, while preserving the existing behavior that a failed optional prefetch does not block playback forever.

## Bugs fixed
- A single failed asset prefetch could short-circuit waiting for the remaining assets and reveal the video player before successfully-prefetched assets had finished loading.

## Tests added
- Regression coverage for `awaitPrefetch` resolving with all successful handles.
- Regression coverage for one failed handle not rejecting and not short-circuiting other pending handles.
- Empty-handle coverage for immediate readiness.

## Validation
- [x] `npm test -- --run app/components/video/__tests__/useAssetPrefetch.test.ts --passWithNoTests`
- [x] `npm test -- --passWithNoTests`
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run knip`
- [x] `npm run test:coverage`

## Open PR overlap check
- Considered open PRs at the start and before commit: none were open (`gh pr list --state open` returned `[]`).
- Final diff only touches `app/components/video/useAssetPrefetch.ts` and its test file, so there is no open-PR overlap.

## Skipped
- Skipped broader player, Remotion, or render pipeline refactors to keep the change scoped to the correctness bug.
- Skipped style-only cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
