### PR TITLE
fix: nightly bug fixes 2026-06-15

### DIFF
--- a/lib/connectors/__tests__/story-kernel.test.ts
+++ b/lib/connectors/__tests__/story-kernel.test.ts
@@ -43,4 +43,26 @@ describe("storyModePlugin", () => {
 			"story mode plugin requires gateway context",
 		);
 	});
+
+	describe("beforeGenerate", () => {
+		const { beforeGenerate } = storyModePlugin;
+		if (!beforeGenerate)
+			throw new Error("storyModePlugin.beforeGenerate is required");
+
+		it("does not leak the literal string 'undefined' when no upstream systemPrompt is set", async () => {
+			const result = await beforeGenerate({ prompt: "a knight" });
+			expect(result.systemPrompt).toBeDefined();
+			expect(result.systemPrompt).not.toContain("undefined");
+			expect(result.systemPrompt).toContain("Storywriting guidelines");
+		});
+
+		it("appends an upstream systemPrompt after the storytelling guidelines", async () => {
+			const result = await beforeGenerate({
+				prompt: "a knight",
+				systemPrompt: "PROJECT METADATA PREAMBLE",
+			});
+			expect(result.systemPrompt).toContain("Storywriting guidelines");
+			expect(result.systemPrompt).toContain("PROJECT METADATA PREAMBLE");
+		});
+	});
 });

--- a/lib/connectors/llm/plugins/story-mode.ts
+++ b/lib/connectors/llm/plugins/story-mode.ts
@@ -6,18 +6,20 @@ import type {
 	PluginContext,
 } from "@/lib/connectors/types";
 
+const STORY_MODE_SYSTEM_PROMPT = dedent`You are a highly engaging storyteller who expertly narrates video stories.
+
+	Storywriting guidelines:
+	- The story must be mostly told through character dialogue and action.
+	- When introducing a character, the narration should mention who they are and what they are doing in the scene.`;
+
 export const storyModePlugin: LLMPlugin = {
 	name: "storyMode",
 	beforeGenerate(params) {
 		return {
 			...params,
-			systemPrompt: dedent`You are a highly engaging storyteller who expertly narrates video stories.
-			
-			Storywriting guidelines:
-			- The story must be mostly told through character dialogue and action.
-			- When introducing a character, the narration should mention who they are and what they are doing in the scene.
-	
-			${params.systemPrompt}`,
+			systemPrompt: params.systemPrompt
+				? `${STORY_MODE_SYSTEM_PROMPT}\n\n${params.systemPrompt}`
+				: STORY_MODE_SYSTEM_PROMPT,
 		};
 	},
 	async transformPrompt(


### PR DESCRIPTION
## Summary
- Fixes the story-mode LLM prompt builder so fresh/default projects no longer send the literal string `undefined` in the system prompt.
- Mirrors the existing script-mode behavior: story-mode guidelines are always present, and an upstream system prompt is appended only when one exists.
- Keeps behavior unchanged when project metadata or another upstream preamble is already present.

## Bugs fixed
- `storyModePlugin.beforeGenerate` unconditionally interpolated `${params.systemPrompt}`. When the upstream `projectMetadata` plugin returned no preamble for an empty/default project, story mode polluted the LLM system prompt with a literal `undefined` line.

## Tests added / areas covered
- Added regression coverage in `lib/connectors/__tests__/story-kernel.test.ts` for no-upstream-prompt story mode output.
- Added coverage proving an upstream system prompt is still appended after the story-mode guidelines.

## Validation
- `npm test -- --run lib/connectors/__tests__/story-kernel.test.ts --passWithNoTests` ✅
- `npm test -- --passWithNoTests` ✅ (95 files / 838 tests)
- `npm run build` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run typecheck` ✅
- `npm run knip` ✅
- `npm run test:coverage` ✅ (95 files / 838 tests)

Note: the first full test attempt exposed a local missing dependency (`lucide-react` absent from `node_modules`); after `npm install` restored the installed package from the existing lockfile, the full suite passed. No package files changed.

## Open PR overlap check
Considered current open PRs before and after implementation:
- #280 touches canvas helper relocation files under `app/components/canvas/**`, `lib/canvas/**`, and `lib/generation/**`.
- #279 touches `package.json` and `package-lock.json` for security dependencies.
- #278 touches React context consolidation files.
- #277 touches video prefetch readiness files.

This PR only touches `lib/connectors/llm/plugins/story-mode.ts` and `lib/connectors/__tests__/story-kernel.test.ts`, with a distinct story-mode LLM prompt correctness theme, so it is non-overlapping.

## Skipped
- Skipped broader LLM prompt/plugin refactors to keep the fix small and avoid overengineering.
- Skipped dependency/security changes because #279 already covers that area.
