### PR TITLE
refactor: nightly maintainability 2026-06-15

### DIFF
--- a/app/components/PostPromptView.tsx
+++ b/app/components/PostPromptView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import type { Editor } from "slate";
 import {
 	useScriptControl,
@@ -52,16 +52,10 @@ function RefineComposer({
 	loading: boolean;
 	onStop: () => void;
 }) {
-	const [value, setValue] = useState("");
 	const { refineScript, refineLoading, stopRefine } = useRefineScript(editor);
 	return (
 		<InlineCopilot
-			value={value}
-			onValueChange={setValue}
-			onSubmit={() => {
-				refineScript(value);
-				setValue("");
-			}}
+			onSubmit={refineScript}
 			onStop={refineLoading ? stopRefine : onStop}
 			loading={loading || refineLoading}
 			placeholder="Refine your script…"

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -32,6 +32,7 @@ import { useAspectRatio } from "@/lib/video/useAspectRatio";
 import { useImageUpload } from "@/lib/upload/useImageUpload";
 import { ActionButton } from "./ActionButton";
 import { ComposerAssets } from "./ComposerAssets";
+import { CopilotShell, splitPlaceholder } from "./CopilotShell";
 
 const MODE_OPTIONS: GlassDropdownOption<Mode>[] = [
 	{ value: "story", label: "Describe a story" },
@@ -167,13 +168,11 @@ export default function ComposerCopilot({
 		if (hasText) onSubmit();
 	};
 
-	const placeholderOverlay =
-		typeof placeholder !== "string" ? placeholder : undefined;
-	const placeholderText =
-		typeof placeholder === "string" ? placeholder : undefined;
+	const { text: placeholderText, overlay: placeholderOverlay } =
+		splitPlaceholder(placeholder);
 
 	return (
-		<div className="w-full rounded-xl border border-accent-violet/30 bg-glass-fill backdrop-blur-xl transition-shadow focus-within:shadow-glow">
+		<CopilotShell>
 			<div className="px-4 py-3">
 				<ComposerAssets
 					uploadingCount={uploadingCount}
@@ -285,6 +284,6 @@ export default function ComposerCopilot({
 				open={editingNarrator}
 				onOpenChange={setEditingNarrator}
 			/>
-		</div>
+		</CopilotShell>
 	);
 }

--- a/app/components/copilot/CopilotShell.tsx
+++ b/app/components/copilot/CopilotShell.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+
+export function CopilotShell({ children }: { children: ReactNode }) {
+	return (
+		<div className="w-full rounded-xl border border-accent-violet/30 bg-glass-fill backdrop-blur-xl transition-shadow focus-within:shadow-glow">
+			{children}
+		</div>
+	);
+}
+
+export function splitPlaceholder(placeholder?: ReactNode): {
+	text?: string;
+	overlay?: ReactNode;
+} {
+	return typeof placeholder === "string"
+		? { text: placeholder }
+		: { overlay: placeholder };
+}

--- a/app/components/copilot/InlineCopilot.tsx
+++ b/app/components/copilot/InlineCopilot.tsx
@@ -4,6 +4,7 @@ import { type ReactNode, useEffect, useState } from "react";
 import { CornerDownLeft, Sparkles, Square } from "lucide-react";
 import OrbLoader from "../OrbLoader";
 import { ActionButton } from "./ActionButton";
+import { CopilotShell, splitPlaceholder } from "./CopilotShell";
 
 const LOADING_MESSAGES = [
 	"Brewing creativity…",
@@ -36,34 +37,32 @@ function LoadingText() {
 }
 
 interface InlineCopilotProps {
-	value: string;
-	onValueChange: (value: string) => void;
-	onSubmit: () => void;
+	onSubmit: (prompt: string) => void;
 	onStop?: () => void;
 	placeholder?: ReactNode;
 	loading?: boolean;
 }
 
 export default function InlineCopilot({
-	value,
-	onValueChange,
 	onSubmit,
 	onStop,
 	placeholder,
 	loading,
 }: InlineCopilotProps) {
+	const [value, setValue] = useState("");
 	const hasText = value.trim().length > 0;
 	const handleSubmit = () => {
-		if (hasText) onSubmit();
+		if (!hasText) return;
+
+		onSubmit(value);
+		setValue("");
 	};
 
-	const placeholderOverlay =
-		typeof placeholder !== "string" ? placeholder : undefined;
-	const placeholderText =
-		typeof placeholder === "string" ? placeholder : undefined;
+	const { text: placeholderText, overlay: placeholderOverlay } =
+		splitPlaceholder(placeholder);
 
 	return (
-		<div className="w-full rounded-xl border border-accent-violet/30 bg-glass-fill backdrop-blur-xl transition-shadow focus-within:shadow-glow">
+		<CopilotShell>
 			<div className="relative flex items-center px-4 py-3">
 				{loading ? (
 					<OrbLoader />
@@ -84,7 +83,7 @@ export default function InlineCopilot({
 								type="text"
 								aria-label="Describe your video"
 								value={value}
-								onChange={(e) => onValueChange(e.target.value)}
+								onChange={(e) => setValue(e.target.value)}
 								onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
 								placeholder={placeholderText}
 								className="font-body w-full bg-transparent text-sm text-white/80 caret-violet-400 placeholder:text-white/30 outline-none focus-visible:ring-2 focus-visible:ring-violet-400/30 focus-visible:rounded-sm"
@@ -107,6 +106,6 @@ export default function InlineCopilot({
 					/>
 				)}
 			</div>
-		</div>
+		</CopilotShell>
 	);
 }


### PR DESCRIPTION
## Summary
- Moves the shared copilot glass input shell into `CopilotShell` so prompt surfaces have one styling boundary.
- Centralizes the dual-mode placeholder split used by both copilot inputs.
- Narrows `InlineCopilot` to an uncontrolled prompt input with `onSubmit(prompt)`, removing value plumbing from `PostPromptView`.

## Architecture changes
- Adds `app/components/copilot/CopilotShell.tsx` as the local copilot presentation boundary.
- Keeps the refine composer orchestration in `PostPromptView`, while `InlineCopilot` owns only its local draft input state.
- Avoids any lib/app dependency inversion; all changes stay in the app-side copilot UI tree.

## Maintainability changes
- Replaces duplicated shell markup and placeholder branching in `ComposerCopilot` and `InlineCopilot` with one helper module.
- Removes the controlled-value API from `InlineCopilot`; its only caller did not need lifted prompt state.
- No docs added: the code change is self-explanatory and a prose doc would add drift risk.

## Complexity delta
- 4 files changed: 37 insertions, 27 deletions.
- `InlineCopilot` public props shrink from `value` + `onValueChange` + `onSubmit()` to `onSubmit(prompt)`.
- `PostPromptView` drops its local refine prompt state and clear-after-submit wrapper.

## Validation
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run knip`
- `npm run build`
- `npm test -- --passWithNoTests` — 95 files / 836 tests passed
- `npm run test:coverage` — 95 files / 836 tests passed
- Independent review passed with no security or logic blockers.
- Claude best-practice review (`/simplify`, `/vercel-composition-patterns`, `/web-design-guidelines`, `/vercel-react-best-practices` lenses) found no blockers.

## Open PR overlap check
Considered open PRs #282, #280, #279, #278, and #277. This PR touches only:
- `app/components/PostPromptView.tsx`
- `app/components/copilot/ComposerCopilot.tsx`
- `app/components/copilot/InlineCopilot.tsx`
- `app/components/copilot/CopilotShell.tsx`

No file overlap with the open PRs. The theme is limited to copilot input composition/state ownership, not story-mode prompts, character generation, dependency security, required context adoption, or video prefetch readiness.

## Skipped
- Did not add component tests because the repo does not currently include React Testing Library-style component tests or dependencies for this component; existing lint/type/build/test/coverage gates cover the refactor.
- Did not touch the open-PR areas listed above.
