### PR TITLE
perf: nightly performance optimizations 2026-06-15

### DIFF
--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -50,6 +50,15 @@ export default function Canvas({
 		[editor],
 	);
 
+	const handleChange = useCallback(
+		(next: Descendant[]) => {
+			if (editor.operations.some((op) => op.type !== "set_selection")) {
+				setValue(next);
+			}
+		},
+		[editor, setValue],
+	);
+
 	const renderElement = useCallback((props: RenderElementProps) => {
 		const { element } = props;
 		if (isSceneElement(element)) {
@@ -94,7 +103,7 @@ export default function Canvas({
 				>
 					<Sidebar />
 
-					<Slate editor={editor} initialValue={value} onChange={setValue}>
+					<Slate editor={editor} initialValue={value} onChange={handleChange}>
 						<AssetsSection />
 						<SortableContext
 							items={sceneItems}


### PR DESCRIPTION
## Summary
- Skips Slate `set_selection`-only operations in the canvas `onChange` handler.
- Keeps React's mirrored document value focused on AST/content edits instead of cursor movement.
- Reduces editor-side rerenders/effect churn during clicks, arrow-key movement, and selection changes without changing document behavior.

## Why this matters
Slate stores selection on the editor; pure selection operations do not change the document tree. Before this pass, cursor movement still called `setValue(next)`, causing the canvas tree and document-dependent effects to churn for non-content changes. This applies Slate's recommended performance pattern so autosave/script sync/video layout consumers only see actual AST changes.

## Open PR overlap check
Considered current open PRs:
- #283 copilot input composition/state ownership (`PostPromptView`, copilot components)
- #282 story-mode LLM prompt correctness
- #280 canvas/generation helper relocation and character-name helpers
- #279 dependency security (`package.json`, `package-lock.json`)
- #278 required context consolidation
- #277 video asset prefetch readiness

This PR touches only `app/components/canvas/Canvas.tsx`, so it has no file overlap and a distinct Slate runtime-performance theme.

## Skipped
- Remotion `MotionLayer` transform memoization: skipped because frame changes every render frame, so caching would add indirection without a material win.
- Captions arithmetic memoization: skipped as marginal; the existing calculations are trivial and already behind stable inputs where meaningful.
- Bundle/dynamic-import churn: skipped because the runbook prioritizes runtime interaction responsiveness over initial-load micro-optimizations.

## Validation
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run knip`
- `npm run build`
- `npm test -- --passWithNoTests` — 95 files / 836 tests passed
- `npm run test:coverage` — 95 files / 836 tests passed
- Claude best-practice review (`/simplify`, `/vercel-composition-patterns`, `/web-design-guidelines`, `/vercel-react-best-practices` lenses): PASS, no blockers
