### PR TITLE
fix: compact editor sidebar and clear profile overlap on small screens

### DIFF
--- a/app/components/canvas/panel/EditorSidebar.tsx
+++ b/app/components/canvas/panel/EditorSidebar.tsx
@@ -60,7 +60,7 @@ function RailItem({
 	const body = (
 		<>
 			<Icon className="h-5 w-5" />
-			<span className="leading-tight">{label}</span>
+			<span className="hidden leading-tight lg:block">{label}</span>
 		</>
 	);
 	return href ? (
@@ -68,7 +68,12 @@ function RailItem({
 			{body}
 		</Link>
 	) : (
-		<button type="button" onClick={onClick} className={className}>
+		<button
+			type="button"
+			onClick={onClick}
+			className={className}
+			aria-label={label}
+		>
 			{body}
 		</button>
 	);
@@ -85,7 +90,7 @@ export function EditorSidebar() {
 
 	return (
 		<div className="flex shrink-0">
-			<nav className="flex w-[72px] shrink-0 flex-col items-center gap-1 pt-4 pr-0.5 pl-1">
+			<nav className="flex w-14 shrink-0 flex-col items-center gap-1 pt-16 pr-0.5 pl-1 lg:w-[72px] lg:pt-4">
 				<RailItem icon={Home} label="Home" href="/" />
 				<div className="my-1.5 h-px w-8 bg-border" />
 				{(Object.keys(PANELS) as PanelKey[]).map((key) => {


### PR DESCRIPTION
## Context

The recent css changes gave the editor view a left rail (`EditorSidebar`) whose top item is a **Home** icon, while the account **profile** avatar floats independently via `fixed top-4 left-4` in the same top-left column. On narrow screens the two crowd/collide. Separately, the rail always rendered text labels under each icon, wasting horizontal space where canvas room is scarce.

## Changes

All in `app/components/canvas/panel/EditorSidebar.tsx`:

- **Compact rail below `lg` (1024px):** icons only, narrower width — `nav` is `w-14 lg:w-[72px]` and labels are `hidden ... lg:block`. Full icon+label rail returns at `lg`+.
- **Profile/Home separation below `lg`:** kept the avatar floating and pushed the rail's first item clear of it (`pt-16 lg:pt-4`), giving the avatar its own clean slot at the top of the narrow mobile rail.
- **Accessibility:** added `aria-label` to the Layout/Properties buttons, which otherwise lose their accessible name once labels are hidden.

Scope is the editor view only. `ProjectsList` (My Slop) also floats the profile but has no Home icon / rail, so it needs no change.

## Verification

The editor route is auth-gated (magic-link only), so it isn't reachable headlessly. Verified by rendering the **real `EditorSidebar`** inside a faithful copy of the editor's outer layout on a throwaway route and measuring/screenshotting at 375 / 768 / 1023 / 1024 / 1280px:

- ✅ Rail width switches 56px → 72px at `lg`
- ✅ Labels hidden below `lg`, shown at `lg`+
- ✅ Home icon clearly separated from the avatar on mobile; desktop spacing unchanged
- ✅ lint, format, typecheck, knip, and the test suite (836 tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)