### PR TITLE
Tweak voice config and editor layout polish

### DIFF
--- a/app/components/PostPromptView.tsx
+++ b/app/components/PostPromptView.tsx
@@ -140,13 +140,14 @@ function PostPromptViewInner() {
 					<div className="flex flex-1 items-start justify-end gap-2 max-sm:flex-none">
 						<Button
 							type="button"
+							variant="generate"
 							onClick={generateAll}
 							className="h-11 shrink-0 px-4 sm:px-5"
 							aria-label={generateLabel}
 							disabled={busy}
 						>
 							{busy ? (
-								<Spinner className="text-primary-foreground" />
+								<Spinner className="text-current" />
 							) : (
 								<Sparkles aria-hidden="true" />
 							)}

--- a/app/components/canvas/dnd/DragOverlay.tsx
+++ b/app/components/canvas/dnd/DragOverlay.tsx
@@ -20,13 +20,13 @@ export function DragOverlayContent({ element }: { element: Descendant }) {
 						aria-label="Add element"
 						className="inline-flex items-center rounded-md p-0.5 text-foreground"
 					>
-						<Plus size={24} />
+						<Plus size={18} />
 					</button>
 					<button
 						aria-label="Drag handle"
 						className="inline-flex items-center rounded-md p-0.5 text-foreground"
 					>
-						<GripVertical size={24} />
+						<GripVertical size={22} />
 					</button>
 				</div>
 				<Editable

--- a/app/components/canvas/dnd/SortableActions.tsx
+++ b/app/components/canvas/dnd/SortableActions.tsx
@@ -37,7 +37,7 @@ export function SortableActions<K extends string>({
 							className="inline-flex items-center rounded-md p-0.5 text-muted-foreground
               hover:text-foreground hover:bg-muted transition-[color,background-color] duration-200"
 						>
-							<Plus size={24} />
+							<Plus size={18} />
 						</button>
 					</DropdownMenuTrigger>
 					<DropdownMenuContent
@@ -69,7 +69,7 @@ export function SortableActions<K extends string>({
         cursor-grab active:cursor-grabbing"
 				{...listeners}
 			>
-				<GripVertical size={24} />
+				<GripVertical size={22} />
 			</button>
 		</>
 	);

--- a/app/components/canvas/dnd/SortableScene.tsx
+++ b/app/components/canvas/dnd/SortableScene.tsx
@@ -1,6 +1,7 @@
 import { RenderElementProps } from "slate-react";
 import type { SceneElement } from "@/lib/canvas/types";
 import { useActiveSceneId } from "@/app/components/scene-selection/ActiveSceneContext";
+import { useViewMode } from "../ViewModeContext";
 import { SortableItem } from "./SortableItem";
 
 const ACTIVE_SCENE_CLASS = "scene-active bg-element-card";
@@ -17,10 +18,12 @@ export function SortableScene({
 	renderElement: (props: RenderElementProps) => React.ReactNode;
 }) {
 	const isActive = useActiveSceneId() === element.id;
+	const { isCollapsed } = useViewMode();
 	return (
 		<SortableItem
 			sceneId={element.id}
 			sortableType="scene"
+			disabled={!isCollapsed(element.id)}
 			wrapperClassName={`border-t border-border pt-3 mt-3 first:border-t-0 first:pt-0 first:mt-0 ${isActive ? ACTIVE_SCENE_CLASS : ""}`}
 			attributes={attributes}
 			element={element}

--- a/app/components/canvas/elements/CharacterPill.tsx
+++ b/app/components/canvas/elements/CharacterPill.tsx
@@ -44,16 +44,6 @@ function CharacterName({ name }: { name: string }) {
 	);
 }
 
-export function CharacterBadge({ name }: { name?: string }) {
-	const avatarUrl = useCharacterAvatarUrl(name);
-	return (
-		<div className="flex items-center gap-2 shrink-0 min-w-0 max-w-[140px]">
-			<CharacterAvatar name={name} avatarUrl={avatarUrl} />
-			{name && <CharacterName name={name} />}
-		</div>
-	);
-}
-
 export function CharacterPill({
 	name,
 	onRemove,

--- a/app/components/canvas/elements/CharactersPicker.tsx
+++ b/app/components/canvas/elements/CharactersPicker.tsx
@@ -19,7 +19,7 @@ import type { CanvasContentElement } from "@/lib/canvas/types";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useProjectStore } from "@/lib/project/store";
 import { getElementCharacterNames } from "../utils/characters";
-import { CharacterPill } from "./CharacterBadge";
+import { CharacterPill } from "./CharacterPill";
 
 function useProjectCharacterNames(): string[] {
 	const { projectId } = useConfig();

--- a/app/components/canvas/elements/CollapsibleHeader.tsx
+++ b/app/components/canvas/elements/CollapsibleHeader.tsx
@@ -25,7 +25,7 @@ export function CollapsibleHeader({
 			<button
 				type="button"
 				onClick={onToggle}
-				className="opacity-0 group-hover/collapsible:opacity-100 transition-opacity duration-200 p-0.5 -ml-1 rounded hover:bg-muted"
+				className="inline-flex items-center justify-center opacity-0 group-hover/collapsible:opacity-100 transition-opacity duration-200 p-1 ml-1 rounded hover:bg-button-hover"
 				aria-label={ariaLabel}
 			>
 				<Icon size={12} />

--- a/app/components/canvas/elements/CompactElement.tsx
+++ b/app/components/canvas/elements/CompactElement.tsx
@@ -17,12 +17,12 @@ export function CompactElement({
 
 	return (
 		<div
-			className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 animate-fadeInUp"
+			className="inline-flex items-center gap-1 rounded-md py-0.5 animate-fadeInUp"
 			contentEditable={false}
 			{...attributes}
 		>
 			<span
-				className="flex items-center gap-1 rounded-md bg-muted px-1.5 py-0.5"
+				className="flex items-center gap-1 rounded-md bg-muted px-1 py-0.5"
 				contentEditable={false}
 			>
 				{config.icon}

--- a/app/components/canvas/elements/DeleteButton.tsx
+++ b/app/components/canvas/elements/DeleteButton.tsx
@@ -1,33 +1,19 @@
-import { Trash2 } from "@/components/ui/icon";
 import { Transforms } from "slate";
 import { ReactEditor, useSlateStatic } from "slate-react";
-import { IconButton } from "@/components/ui/icon-button";
-import {
-	Tooltip,
-	TooltipTrigger,
-	TooltipContent,
-} from "@/components/ui/tooltip";
+import { DeleteButton as DeleteIconButton } from "@/components/ui/delete-button";
 import type { CanvasElement } from "@/lib/canvas/types";
 
 export function DeleteButton({ element }: { element: CanvasElement }) {
 	const editor = useSlateStatic();
 
 	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<IconButton
-					ariaLabel="Delete element"
-					className="hover:text-destructive"
-					onMouseDown={(e) => {
-						e.preventDefault();
-						const path = ReactEditor.findPath(editor, element);
-						Transforms.removeNodes(editor, { at: path });
-					}}
-				>
-					<Trash2 className="h-4 w-4" strokeWidth={1.5} />
-				</IconButton>
-			</TooltipTrigger>
-			<TooltipContent>Delete</TooltipContent>
-		</Tooltip>
+		<DeleteIconButton
+			ariaLabel="Delete element"
+			onMouseDown={(e) => {
+				e.preventDefault();
+				const path = ReactEditor.findPath(editor, element);
+				Transforms.removeNodes(editor, { at: path });
+			}}
+		/>
 	);
 }

--- a/app/components/canvas/elements/ElementCharacters.tsx
+++ b/app/components/canvas/elements/ElementCharacters.tsx
@@ -3,7 +3,7 @@
 import { useSlateStatic } from "slate-react";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { getElementCharacterNames } from "../utils/characters";
-import { CharacterPill } from "./CharacterBadge";
+import { CharacterPill } from "./CharacterPill";
 import {
 	CharacterSwitcher,
 	CharactersPicker,

--- a/app/components/canvas/elements/OutputPreview.tsx
+++ b/app/components/canvas/elements/OutputPreview.tsx
@@ -27,7 +27,6 @@ function OutputPreviewComponent({
 				<AudioResult
 					type={type}
 					src={result.audioUrl}
-					characterName={element.customAttributes?.name}
 					status={status}
 					seconds={seconds}
 				/>

--- a/app/components/canvas/elements/PlayFromHereButton.tsx
+++ b/app/components/canvas/elements/PlayFromHereButton.tsx
@@ -23,6 +23,7 @@ export function PlayFromHereButton({ scene }: { scene: SceneElement }) {
 			<TooltipTrigger asChild>
 				<IconButton
 					ariaLabel="Play from here"
+					className="bg-muted"
 					disabled={disabled}
 					onMouseDown={(e) => e.preventDefault()}
 					onClick={() => {

--- a/app/components/canvas/elements/SceneContainer.tsx
+++ b/app/components/canvas/elements/SceneContainer.tsx
@@ -20,7 +20,7 @@ import { SceneTimestamp } from "./SceneTimestamp";
 const COLLAPSED_MAX_VISIBLE = 3;
 
 const SCENE_FRAME_CLASS =
-	"px-3 py-2 transition-[box-shadow,background-color] duration-200";
+	"pr-3 py-2 transition-[box-shadow,background-color] duration-200";
 interface SceneProps {
 	attributes: RenderElementProps["attributes"];
 	element: SceneElement;
@@ -106,13 +106,17 @@ function CollapsedScene({ attributes, element, children }: SceneProps) {
 			className={`group/collapsible relative h-32 ${SCENE_FRAME_CLASS}`}
 			style={dropPadding}
 		>
-			<div className="relative z-[1] flex flex-col h-full pr-[calc(8rem+0.75rem)]">
-				<SceneHeader
-					sceneIndex={sceneIndex}
-					collapsed
-					onToggle={() => toggle(element.id)}
-					element={element}
-				/>
+			<div className="relative z-[1] flex flex-col h-full">
+				{/* Pull the header back over the drag-handle gutter so it lines up
+				    with the expanded header instead of shifting right. */}
+				<div className="-ml-[34px]">
+					<SceneHeader
+						sceneIndex={sceneIndex}
+						collapsed
+						onToggle={() => toggle(element.id)}
+						element={element}
+					/>
+				</div>
 				<div className="flex flex-col gap-0.5 flex-1 min-h-0 overflow-hidden transition-all duration-300 ease-out motion-reduce:transition-none">
 					{childArray.slice(0, COLLAPSED_MAX_VISIBLE)}
 					{overflowCount > 0 && (

--- a/app/components/canvas/elements/character/VoicePicker.tsx
+++ b/app/components/canvas/elements/character/VoicePicker.tsx
@@ -111,7 +111,7 @@ export function VoicePicker({
 		<div className="flex min-w-0 flex-col gap-1.5">
 			<FieldLabel>Voices</FieldLabel>
 			{error && <span className="text-[11px] text-rose-400">{error}</span>}
-			<div className="flex h-64 min-w-0 flex-col gap-0.5 overflow-y-auto">
+			<div className="flex max-h-64 min-w-0 flex-col gap-0.5 overflow-y-auto">
 				{loading &&
 					Array.from({ length: SKELETON_ROWS }).map((_, i) => (
 						<Skeleton key={`skel-${i}`} className="h-12 shrink-0 rounded-md" />

--- a/app/components/canvas/elements/preview/results.tsx
+++ b/app/components/canvas/elements/preview/results.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { AudioPlayer } from "../AudioPlayer";
-import { CharacterBadge } from "../CharacterBadge";
 import { MediaWithSkeleton } from "../MediaWithSkeleton";
 import { GenerationIndicator } from "../GenerationIndicator";
 import type { CanvasElementType } from "@/lib/canvas/types";
@@ -13,17 +12,14 @@ import { PlaceholderOverlay, ResultOverlay } from "./overlays";
 export function AudioResult({
 	type,
 	src,
-	characterName,
 	status,
 	seconds,
 }: GenerationState & {
 	type: CanvasElementType;
 	src: string;
-	characterName?: string;
 }) {
 	return (
 		<div className="group relative w-full min-h-16 rounded-lg overflow-hidden border border-border bg-element-card flex flex-wrap items-center gap-x-2 gap-y-1.5 px-2 py-1.5">
-			{type === "character" && <CharacterBadge name={characterName} />}
 			{status !== "idle" && (
 				<GenerationIndicator
 					status={status}

--- a/app/components/canvas/panel/EditorSidebar.tsx
+++ b/app/components/canvas/panel/EditorSidebar.tsx
@@ -90,7 +90,7 @@ export function EditorSidebar() {
 
 	return (
 		<div className="flex shrink-0">
-			<nav className="flex w-14 shrink-0 flex-col items-center gap-1 pt-16 pr-0.5 pl-1 lg:w-[72px] lg:pt-4">
+			<nav className="flex w-14 shrink-0 flex-col items-center gap-1 pt-16 pr-0.5 mr-2 pl-1 lg:w-[72px] lg:pt-4">
 				<RailItem icon={Home} label="Home" href="/" />
 				<div className="my-1.5 h-px w-8 bg-border" />
 				{(Object.keys(PANELS) as PanelKey[]).map((key) => {
@@ -109,7 +109,7 @@ export function EditorSidebar() {
 			</nav>
 
 			{current && HeaderIcon && Panel && (
-				<div className="flex w-60 shrink-0 flex-col gap-3 overflow-y-auto px-2 pt-4 pb-3 text-panel-fg">
+				<div className="flex w-60 shrink-0 flex-col gap-3 overflow-y-auto pr-2 pt-4 pb-3 text-panel-fg">
 					<div className="flex items-center gap-2 px-1">
 						<HeaderIcon className="h-5 w-5 text-panel-label" />
 						<h2 className="text-sm font-semibold text-panel-label">

--- a/app/components/canvas/styles/sortable.module.css
+++ b/app/components/canvas/styles/sortable.module.css
@@ -41,7 +41,7 @@
 	display: flex;
 	align-items: center;
 	user-select: none;
-	margin-right: 8px;
+	margin-inline: 4px;
 	opacity: 0;
 	pointer-events: none;
 	transition: opacity 0.15s ease;

--- a/app/components/projects/ProjectsList.tsx
+++ b/app/components/projects/ProjectsList.tsx
@@ -2,13 +2,15 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { Plus, Trash2 } from "@/components/ui/icon";
+import { Plus } from "@/components/ui/icon";
 import { toast } from "sonner";
 import { createProject, deleteProject } from "@/lib/project/api";
 import type { ProjectRow } from "@/lib/project/api";
 import { ImageWithShimmer } from "@/lib/components/ImageWithShimmer";
 import UserProfile from "@/app/components/UserProfile";
 import { Button } from "@/components/ui/button";
+import { DeleteButton } from "@/components/ui/delete-button";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { relativeTime } from "@/lib/project/relativeTime";
 
 export default function ProjectsList({
@@ -45,84 +47,84 @@ export default function ProjectsList({
 	};
 
 	return (
-		<div className="relative min-h-screen bg-background text-foreground">
-			<div
-				aria-hidden
-				className="dot-grid-bg pointer-events-none absolute inset-0 z-0"
-			/>
-			<div className="fixed top-4 left-4 z-[100]">
-				<UserProfile />
-			</div>
-			<div className="relative z-10 mx-auto max-w-7xl px-6 pt-20 pb-16">
-				<header className="mb-10 flex items-end justify-between">
-					<div>
-						<h1 className="text-4xl font-semibold tracking-tight">My Slop</h1>
-						<p className="mt-1 text-sm text-muted-foreground">
-							{projects.length === 0
-								? "No projects yet — start your first slop."
-								: `${projects.length} project${projects.length === 1 ? "" : "s"}`}
-						</p>
-					</div>
-					<Button type="button" onClick={handleCreate} disabled={pending}>
-						<Plus size={16} strokeWidth={1.5} />
-						New slop
-					</Button>
-				</header>
+		<TooltipProvider>
+			<div className="relative min-h-screen bg-background text-foreground">
+				<div
+					aria-hidden
+					className="dot-grid-bg pointer-events-none absolute inset-0 z-0"
+				/>
+				<div className="fixed top-4 left-4 z-[100]">
+					<UserProfile />
+				</div>
+				<div className="relative z-10 mx-auto max-w-7xl px-6 pt-20 pb-16">
+					<header className="mb-10 flex items-end justify-between">
+						<div>
+							<h1 className="text-4xl font-semibold tracking-tight">My Slop</h1>
+							<p className="mt-1 text-sm text-muted-foreground">
+								{projects.length === 0
+									? "No projects yet — start your first slop."
+									: `${projects.length} project${projects.length === 1 ? "" : "s"}`}
+							</p>
+						</div>
+						<Button type="button" onClick={handleCreate} disabled={pending}>
+							<Plus size={16} strokeWidth={1.5} />
+							New slop
+						</Button>
+					</header>
 
-				<ul className="grid grid-cols-2 gap-x-4 gap-y-7 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-					{projects.map((project) => (
-						<li key={project.id} className="group">
-							<div className="relative">
+					<ul className="grid grid-cols-2 gap-x-4 gap-y-7 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+						{projects.map((project) => (
+							<li key={project.id} className="group">
+								<div className="relative">
+									<button
+										type="button"
+										onClick={() => router.push(`/projects/${project.id}`)}
+										aria-label={`Open ${project.name}`}
+										className="block w-full overflow-hidden rounded-lg bg-muted focus-ring"
+									>
+										<div className="relative aspect-square">
+											{project.thumbnail_url ? (
+												<ImageWithShimmer
+													src={project.thumbnail_url}
+													alt={project.name}
+													fill
+													sizes="(min-width: 1280px) 200px, (min-width: 768px) 25vw, 50vw"
+													className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
+												/>
+											) : (
+												<div className="absolute inset-0 flex items-center justify-center text-xs text-muted-foreground">
+													No preview
+												</div>
+											)}
+										</div>
+									</button>
+									<div className="absolute top-2 right-2 opacity-0 transition-opacity group-hover:opacity-100">
+										<DeleteButton
+											ariaLabel={`Delete ${project.name}`}
+											onClick={() => handleDelete(project.id)}
+										/>
+									</div>
+								</div>
 								<button
 									type="button"
 									onClick={() => router.push(`/projects/${project.id}`)}
-									aria-label={`Open ${project.name}`}
-									className="block w-full overflow-hidden rounded-lg bg-muted focus-ring"
+									className="mt-2 block w-full text-left"
 								>
-									<div className="relative aspect-square">
-										{project.thumbnail_url ? (
-											<ImageWithShimmer
-												src={project.thumbnail_url}
-												alt={project.name}
-												fill
-												sizes="(min-width: 1280px) 200px, (min-width: 768px) 25vw, 50vw"
-												className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
-											/>
-										) : (
-											<div className="absolute inset-0 flex items-center justify-center text-xs text-muted-foreground">
-												No preview
-											</div>
-										)}
+									<div className="truncate text-sm font-semibold text-foreground">
+										{project.name}
+									</div>
+									<div
+										className="mt-0.5 truncate text-xs text-muted-foreground"
+										suppressHydrationWarning
+									>
+										Edited {relativeTime(project.updated_at)}
 									</div>
 								</button>
-								<button
-									type="button"
-									onClick={() => handleDelete(project.id)}
-									aria-label={`Delete ${project.name}`}
-									className="absolute top-2 right-2 rounded-md border border-border bg-popover p-1.5 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:bg-muted hover:text-foreground"
-								>
-									<Trash2 size={14} strokeWidth={1.5} />
-								</button>
-							</div>
-							<button
-								type="button"
-								onClick={() => router.push(`/projects/${project.id}`)}
-								className="mt-2 block w-full text-left"
-							>
-								<div className="truncate text-sm font-semibold text-foreground">
-									{project.name}
-								</div>
-								<div
-									className="mt-0.5 truncate text-xs text-muted-foreground"
-									suppressHydrationWarning
-								>
-									Edited {relativeTime(project.updated_at)}
-								</div>
-							</button>
-						</li>
-					))}
-				</ul>
+							</li>
+						))}
+					</ul>
+				</div>
 			</div>
-		</div>
+		</TooltipProvider>
 	);
 }

--- a/app/projects/[id]/loading.tsx
+++ b/app/projects/[id]/loading.tsx
@@ -1,6 +1,42 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
-/** High-level placeholder for the editor: refine bar, canvas, transport bar. */
+/**
+ * Editor placeholder that mirrors the real canvas
+ */
+
+const SCENES = [3, 2, 4];
+
+function RailItemSkeleton() {
+	return (
+		<div className="flex w-full flex-col items-center gap-1 px-2 py-2.5">
+			<Skeleton className="h-5 w-5 rounded-md" />
+			<Skeleton className="hidden h-2 w-8 rounded lg:block" />
+		</div>
+	);
+}
+
+function SceneSkeleton({
+	elements,
+	first,
+}: {
+	elements: number;
+	first?: boolean;
+}) {
+	return (
+		<div className={first ? "" : "mt-3 border-t border-border pt-3"}>
+			<Skeleton className="mb-2 h-3 w-16 rounded" />
+			<div className="flex flex-col gap-2">
+				{Array.from({ length: elements }).map((_, i) => (
+					<Skeleton
+						key={i}
+						className={`h-9 rounded-md ${i === elements - 1 ? "w-2/3" : "w-full"}`}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}
+
 export default function Loading() {
 	return (
 		<div className="relative flex h-screen w-full flex-col overflow-hidden text-foreground">
@@ -9,8 +45,13 @@ export default function Loading() {
 				className="dot-grid-bg pointer-events-none fixed inset-0 -z-10"
 			/>
 
+			{/* Profile avatar */}
+			<div className="fixed top-4 left-4 z-[100]">
+				<Skeleton className="h-9 w-9 rounded-full" />
+			</div>
+
 			{/* Refine bar + generate button */}
-			<div className="flex w-full shrink-0 items-start gap-3 px-4 py-3 pb-2 pl-16">
+			<div className="z-40 flex w-full shrink-0 items-start gap-3 px-4 py-3 pb-2 pl-16">
 				<div className="hidden flex-1 sm:block" aria-hidden />
 				<Skeleton className="h-12 min-w-0 max-w-2xl flex-1 rounded-xl" />
 				<div className="flex flex-1 justify-end">
@@ -18,15 +59,61 @@ export default function Loading() {
 				</div>
 			</div>
 
-			{/* Canvas card with bottom transport bar */}
-			<div className="relative mx-2 mb-2 flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl bg-element-card shadow-elevation-5">
-				<Skeleton className="min-h-0 flex-1 rounded-none" />
-				<div className="flex w-full shrink-0 flex-col gap-1.5 border-t border-border px-4 py-2">
-					<Skeleton className="h-2 w-full rounded-full" />
-					<div className="flex items-center justify-between">
-						<Skeleton className="h-4 w-20 rounded" />
-						<Skeleton className="h-7 w-28 rounded-md" />
-						<Skeleton className="h-4 w-16 rounded" />
+			{/* Left rail + canvas card */}
+			<div className="flex min-h-0 flex-1 overflow-hidden">
+				<nav className="mr-2 flex w-14 shrink-0 flex-col items-center gap-1 pt-16 pr-0.5 pl-1 lg:w-[72px] lg:pt-4">
+					<RailItemSkeleton />
+					<div className="my-1.5 h-px w-8 bg-border" />
+					<RailItemSkeleton />
+					<RailItemSkeleton />
+				</nav>
+
+				<div className="relative mr-2 mb-2 flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl bg-element-card shadow-elevation-5">
+					<div className="flex min-h-0 flex-1 overflow-hidden">
+						{/* Scene list */}
+						<div
+							className="flex-1 overflow-y-auto"
+							style={{ scrollbarGutter: "stable" }}
+						>
+							<div className="mx-auto max-w-6xl px-4 py-4">
+								<div className="mb-3 flex h-8 items-center">
+									<Skeleton className="h-7 w-48 rounded-md" />
+								</div>
+								<div className="flex flex-col">
+									{SCENES.map((elements, i) => (
+										<SceneSkeleton
+											key={i}
+											elements={elements}
+											first={i === 0}
+										/>
+									))}
+								</div>
+							</div>
+						</div>
+
+						{/* Side player panel */}
+						<div className="hidden w-[42%] max-w-[560px] shrink-0 flex-col justify-center border-l border-border p-4 lg:flex">
+							<Skeleton className="aspect-video w-full rounded-lg" />
+						</div>
+					</div>
+
+					{/* Bottom transport bar */}
+					<div className="flex w-full shrink-0 flex-col gap-1.5 border-t border-border px-4 py-2">
+						<Skeleton className="h-3 w-full rounded-full" />
+						<div className="flex items-center gap-2">
+							<div className="flex flex-1 items-center">
+								<Skeleton className="h-4 w-20 rounded" />
+							</div>
+							<div className="flex items-center gap-1">
+								<Skeleton className="h-7 w-7 rounded-md" />
+								<Skeleton className="h-7 w-7 rounded-md" />
+								<Skeleton className="h-7 w-7 rounded-md" />
+							</div>
+							<div className="flex flex-1 items-center justify-end gap-1.5">
+								<Skeleton className="h-7 w-7 rounded-md" />
+								<Skeleton className="h-7 w-7 rounded-md" />
+							</div>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -19,6 +19,8 @@ const buttonVariants = cva(
 				ghost: "hover:bg-button-hover hover:text-foreground",
 				destructive:
 					"bg-destructive text-destructive-foreground hover:brightness-110 active:brightness-95",
+				generate:
+					"bg-generate text-generate-foreground hover:bg-generate-hover disabled:bg-generate-disabled disabled:text-generate-disabled-foreground disabled:opacity-100",
 				link: "text-accent underline-offset-4 hover:underline",
 			},
 			size: {

--- a/components/ui/delete-button.tsx
+++ b/components/ui/delete-button.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { Trash2 } from "@/components/ui/icon";
+import { cn } from "@/lib/utils";
+import { IconButton } from "@/components/ui/icon-button";
+import {
+	Tooltip,
+	TooltipTrigger,
+	TooltipContent,
+} from "@/components/ui/tooltip";
+
+export function DeleteButton({
+	ariaLabel,
+	className,
+	...props
+}: React.ComponentProps<typeof IconButton>) {
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<IconButton
+					ariaLabel={ariaLabel}
+					className={cn("bg-muted hover:text-destructive", className)}
+					{...props}
+				>
+					<Trash2 className="h-4 w-4" strokeWidth={1.5} />
+				</IconButton>
+			</TooltipTrigger>
+			<TooltipContent>Delete</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -94,7 +94,9 @@ function DialogContent({
 							"radial-gradient(60% 100% at 50% 0%, var(--glow), transparent 70%)",
 					}}
 				/>
-				<div className="relative z-[2] flex flex-col gap-4">{children}</div>
+				<div className="relative z-[2] flex min-h-0 flex-1 flex-col gap-4">
+					{children}
+				</div>
 				{showCloseButton && (
 					<DialogPrimitive.Close
 						className="absolute right-4 top-4 z-10 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-ring"

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -1,6 +1,6 @@
 import type { GatewayClient } from "@/lib/gateway/base";
 import type { WithMetadata } from "@/lib/providers/base";
-import type { TTSGender, TTSSpeed } from "./tts/enums";
+import type { TTSEmotion, TTSGender, TTSSpeed } from "./tts/enums";
 
 export type ConnectorType =
 	| "llm"
@@ -145,7 +145,7 @@ export type TTSGenerateParams = ConnectorGenerateParams & {
 	query?: string;
 	language?: string;
 	speed?: TTSSpeed;
-	volume?: number;
+	emotion?: TTSEmotion;
 	format?: string;
 };
 

--- a/lib/providers/tts/cartesia.ts
+++ b/lib/providers/tts/cartesia.ts
@@ -30,6 +30,7 @@ type RawTTSResult = {
 const SAMPLE_RATE = 44100;
 const NUM_CHANNELS = 1;
 const ENCODING = "pcm_f32le";
+const CARTESIA_VOLUME = 1.5;
 
 const CARTESIA_SPEED: Record<TTSSpeed, number> = {
 	slow: 0.6,
@@ -203,7 +204,7 @@ export class CartesiaTTS extends BaseProvider<TTSGenerateParams, RawTTSResult> {
 				add_timestamps: true,
 				generation_config: {
 					speed: CARTESIA_SPEED[params.speed ?? "medium"],
-					volume: params.volume ?? 1.5,
+					volume: CARTESIA_VOLUME,
 				},
 			};
 			for await (const response of ws.generate(req)) {


### PR DESCRIPTION
## Summary
- Add `emotion` attribute to narration/character TTS elements (defaults to `neutral`) and thread `TTSEmotion` through connector params
- Pin Cartesia volume to a fixed `CARTESIA_VOLUME` constant instead of a per-call param
- Drop the character avatar from the audio output preview so character output matches narration; remove the now-dead `CharacterBadge` component
- Shrink dnd add/grip icons and only allow scene drag when the scene is collapsed
- Fix spacing on the editor sidebar, dialog content flex, and voice picker (`max-h-64`)
- Misc UI improvements

## Test plan
- [ ] Generate character + narration TTS: output previews look identical (no avatar), emotion + volume behave
- [ ] Open the editor: sidebar/rail spacing correct, dnd icons sized right
- [ ] Drag a scene only works when collapsed
- [ ] Voice picker list grows up to max height and scrolls