### PR TITLE
refactor: nightly maintainability 2026-06-17

### DIFF
--- a/app/components/EditorToolbar.tsx
+++ b/app/components/EditorToolbar.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import type { Editor } from "slate";
+import { Sparkles, X } from "@/components/ui/icon";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useScriptControl } from "@/lib/script/ScriptProvider";
+import {
+	useGenerationQueue,
+	useQueueSelector,
+} from "@/lib/generation/GenerationQueueProvider";
+import InlineCopilot from "./copilot/InlineCopilot";
+import { useGenerateAll } from "./canvas/hooks/useGenerateAll";
+import { useRefineScript } from "./canvas/hooks/useRefineScript";
+import editorStyles from "./Editor.module.css";
+
+function RefineComposer({
+	editor,
+	loading,
+	onStop,
+}: {
+	editor: Editor;
+	loading: boolean;
+	onStop: () => void;
+}) {
+	const [value, setValue] = useState("");
+	const { refineScript, refineLoading, stopRefine } = useRefineScript(editor);
+	return (
+		<InlineCopilot
+			value={value}
+			onValueChange={setValue}
+			onSubmit={() => {
+				refineScript(value);
+				setValue("");
+			}}
+			onStop={refineLoading ? stopRefine : onStop}
+			loading={loading || refineLoading}
+			placeholder="Refine your script…"
+		/>
+	);
+}
+
+function getGenerateLabel(loading: boolean, generating: boolean): string {
+	if (loading) return "Writing…";
+	if (generating) return "Generating…";
+	return "Generate All";
+}
+
+export function EditorToolbar({ editor }: { editor: Editor }) {
+	const { loading, stopGeneration } = useScriptControl();
+	const { generateAll } = useGenerateAll(editor);
+	const queue = useGenerationQueue();
+	const generating = useQueueSelector((q) => q.isBusy());
+	const busy = loading || generating;
+	const generateLabel = getGenerateLabel(loading, generating);
+
+	return (
+		<div
+			className={`z-40 flex w-full shrink-0 flex-col items-center gap-3 px-4 py-3 pb-2 pl-16 ${editorStyles.copilotEnter}`}
+		>
+			<div className="flex w-full items-start gap-3">
+				<div className="hidden flex-1 sm:block" aria-hidden />
+				<div className="min-w-0 max-w-2xl flex-1">
+					<RefineComposer
+						editor={editor}
+						loading={loading}
+						onStop={stopGeneration}
+					/>
+				</div>
+				<div className="flex flex-1 items-start justify-end gap-2 max-sm:flex-none">
+					<Button
+						type="button"
+						variant="generate"
+						onClick={generateAll}
+						className="h-11 shrink-0 px-4 sm:px-5"
+						aria-label={generateLabel}
+						disabled={busy}
+					>
+						{busy ? (
+							<Spinner className="text-current" />
+						) : (
+							<Sparkles aria-hidden="true" />
+						)}
+						<span className="hidden sm:inline">{generateLabel}</span>
+					</Button>
+					{generating && (
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									onClick={() => queue.cancelAll()}
+									aria-label="Cancel generation"
+									className="relative flex h-7 w-7 shrink-0 items-center justify-center self-center rounded-md bg-muted text-muted-foreground transition-colors hover:bg-button-hover hover:text-foreground"
+								>
+									<X className="h-3 w-3" aria-hidden="true" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent>Cancel generation</TooltipContent>
+						</Tooltip>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/app/components/PostPromptView.tsx
+++ b/app/components/PostPromptView.tsx
@@ -1,92 +1,31 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import type { Editor } from "slate";
-import {
-	useScriptControl,
-	useScriptInitial,
-} from "@/lib/script/ScriptProvider";
-import {
-	useGenerationQueue,
-	useQueueSelector,
-} from "@/lib/generation/GenerationQueueProvider";
+import { useMemo } from "react";
+import { useScriptInitial } from "@/lib/script/ScriptProvider";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getContentElements, isSceneElement } from "@/lib/canvas/scenes";
 import { getLayoutKey } from "@/lib/video/layoutKey";
 import { useAspectRatio } from "@/lib/video/useAspectRatio";
 import { useTransitionType } from "@/lib/video/useTransitionType";
-import InlineCopilot from "./copilot/InlineCopilot";
 import UserProfile from "./UserProfile";
+import { EditorToolbar } from "./EditorToolbar";
 import Canvas from "./canvas/Canvas";
+import { CanvasProviders } from "./canvas/CanvasProviders";
 import { EditorSidebar } from "./canvas/panel/EditorSidebar";
-import { ViewModeProvider } from "./canvas/ViewModeContext";
 import { ProjectTitle } from "./canvas/ProjectTitle";
 import { useEditorSetup } from "./canvas/hooks/useEditorSetup";
 import { useAutosave } from "./canvas/hooks/useAutosave";
-import { useGenerateAll } from "./canvas/hooks/useGenerateAll";
 import { useMetadataSync } from "./canvas/hooks/useMetadataSync";
 import { useProjectRehydrate } from "./canvas/hooks/useProjectRehydrate";
 import { useScriptSync } from "./canvas/hooks/useScriptSync";
-import { useRefineScript } from "./canvas/hooks/useRefineScript";
-import { Sparkles, X } from "@/components/ui/icon";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { TopPlayerPanel, SidePlayerPanel } from "./video/PlayerPanel";
 import { BottomTransportBar } from "./video/BottomTransportBar";
 import {
 	PlayerPositionProvider,
 	usePlayerPosition,
 } from "./video/PlayerPositionContext";
-import { ActiveSceneProvider } from "./scene-selection/ActiveSceneContext";
-import { AutoScrollProvider } from "./scene-selection/AutoScrollContext";
-import { PlayerControlProvider } from "./video/PlayerControlContext";
-import { VideoLayoutProvider } from "./video/VideoLayoutContext";
-import editorStyles from "./Editor.module.css";
-import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
-
-function RefineComposer({
-	editor,
-	loading,
-	onStop,
-}: {
-	editor: Editor;
-	loading: boolean;
-	onStop: () => void;
-}) {
-	const [value, setValue] = useState("");
-	const { refineScript, refineLoading, stopRefine } = useRefineScript(editor);
-	return (
-		<InlineCopilot
-			value={value}
-			onValueChange={setValue}
-			onSubmit={() => {
-				refineScript(value);
-				setValue("");
-			}}
-			onStop={refineLoading ? stopRefine : onStop}
-			loading={loading || refineLoading}
-			placeholder="Refine your script…"
-		/>
-	);
-}
-
-function getGenerateLabel(loading: boolean, generating: boolean): string {
-	switch (true) {
-		case loading:
-			return "Writing…";
-		case generating:
-			return "Generating…";
-		default:
-			return "Generate All";
-	}
-}
 
 function PostPromptViewInner() {
-	const { loading, stopGeneration } = useScriptControl();
 	const { editor, value, setValue } = useEditorSetup();
 	const { projectId } = useConfig();
 	const initialScript = useScriptInitial();
@@ -94,7 +33,6 @@ function PostPromptViewInner() {
 	useAutosave(projectId, value);
 	useScriptSync(editor);
 	useMetadataSync();
-	const { generateAll } = useGenerateAll(editor);
 
 	const transitionType = useTransitionType();
 	const aspectRatio = useAspectRatio();
@@ -102,18 +40,12 @@ function PostPromptViewInner() {
 		() => getLayoutKey(getContentElements(value), transitionType),
 		[value, transitionType],
 	);
-
-	const { position, visible } = usePlayerPosition();
 	const sceneIds = useMemo(
 		() => value.filter(isSceneElement).map((scene) => scene.id),
 		[value],
 	);
 
-	const queue = useGenerationQueue();
-	const generating = useQueueSelector((q) => q.isBusy());
-	const busy = loading || generating;
-	const generateLabel = getGenerateLabel(loading, generating);
-
+	const { position, visible } = usePlayerPosition();
 	const isTop = position === "top";
 
 	return (
@@ -125,96 +57,40 @@ function PostPromptViewInner() {
 			<div className="fixed top-4 left-4 z-[100]">
 				<UserProfile />
 			</div>
-			<div
-				className={`z-40 flex w-full shrink-0 flex-col items-center gap-3 px-4 py-3 pb-2 pl-16 ${editorStyles.copilotEnter}`}
-			>
-				<div className="flex w-full items-start gap-3">
-					<div className="hidden flex-1 sm:block" aria-hidden />
-					<div className="min-w-0 max-w-2xl flex-1">
-						<RefineComposer
-							editor={editor}
-							loading={loading}
-							onStop={stopGeneration}
-						/>
-					</div>
-					<div className="flex flex-1 items-start justify-end gap-2 max-sm:flex-none">
-						<Button
-							type="button"
-							variant="generate"
-							onClick={generateAll}
-							className="h-11 shrink-0 px-4 sm:px-5"
-							aria-label={generateLabel}
-							disabled={busy}
-						>
-							{busy ? (
-								<Spinner className="text-current" />
-							) : (
-								<Sparkles aria-hidden="true" />
-							)}
-							<span className="hidden sm:inline">{generateLabel}</span>
-						</Button>
-						{generating && (
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<button
-										type="button"
-										onClick={() => queue.cancelAll()}
-										aria-label="Cancel generation"
-										className="relative flex h-7 w-7 shrink-0 items-center justify-center self-center rounded-md bg-muted text-muted-foreground transition-colors hover:bg-button-hover hover:text-foreground"
-									>
-										<X className="h-3 w-3" aria-hidden="true" />
-									</button>
-								</TooltipTrigger>
-								<TooltipContent>Cancel generation</TooltipContent>
-							</Tooltip>
-						)}
-					</div>
-				</div>
-			</div>
+			<EditorToolbar editor={editor} />
 
-			<VideoLayoutProvider
+			<CanvasProviders
 				editor={editor}
 				layoutKey={layoutKey}
 				transitionType={transitionType}
 				aspectRatio={aspectRatio}
+				sceneIds={sceneIds}
 			>
-				<PlayerControlProvider>
-					<ActiveSceneProvider>
-						<AutoScrollProvider>
-							<ViewModeProvider sceneIds={sceneIds}>
-								<div className="flex min-h-0 flex-1 overflow-hidden">
-									<EditorSidebar />
-									<div className="grain relative mr-2 mb-2 flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl bg-element-card shadow-elevation-5">
-										<div className="relative z-10 flex min-h-0 flex-1 flex-col overflow-hidden">
-											{visible && isTop && <TopPlayerPanel />}
+				<div className="flex min-h-0 flex-1 overflow-hidden">
+					<EditorSidebar />
+					<div className="grain relative mr-2 mb-2 flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl bg-element-card shadow-elevation-5">
+						<div className="relative z-10 flex min-h-0 flex-1 flex-col overflow-hidden">
+							{visible && isTop && <TopPlayerPanel />}
 
-											<div className="flex min-h-0 flex-1 overflow-hidden">
-												<div
-													className="flex-1 overflow-y-auto"
-													style={{ scrollbarGutter: "stable" }}
-												>
-													<div className="mx-auto max-w-6xl px-4 py-4">
-														<ProjectTitle />
-														<Canvas
-															editor={editor}
-															value={value}
-															setValue={setValue}
-														/>
-													</div>
-												</div>
-
-												{visible && !isTop && <SidePlayerPanel />}
-											</div>
-
-											<BottomTransportBar />
-										</div>
+							<div className="flex min-h-0 flex-1 overflow-hidden">
+								<div
+									className="flex-1 overflow-y-auto"
+									style={{ scrollbarGutter: "stable" }}
+								>
+									<div className="mx-auto max-w-6xl px-4 py-4">
+										<ProjectTitle />
+										<Canvas editor={editor} value={value} setValue={setValue} />
 									</div>
 								</div>
-							</ViewModeProvider>
-						</AutoScrollProvider>
-					</ActiveSceneProvider>
-				</PlayerControlProvider>
-			</VideoLayoutProvider>
+
+								{visible && !isTop && <SidePlayerPanel />}
+							</div>
+
+							<BottomTransportBar />
+						</div>
+					</div>
+				</div>
+			</CanvasProviders>
 		</div>
 	);
 }

--- a/app/components/canvas/CanvasProviders.tsx
+++ b/app/components/canvas/CanvasProviders.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { Editor } from "slate";
+import type { AspectRatio } from "@/lib/video/aspectRatio";
+import type { TransitionType } from "@/lib/video/transitions";
+import { VideoLayoutProvider } from "../video/VideoLayoutContext";
+import { PlayerControlProvider } from "../video/PlayerControlContext";
+import { ActiveSceneProvider } from "../scene-selection/ActiveSceneContext";
+import { AutoScrollProvider } from "../scene-selection/AutoScrollContext";
+import { ViewModeProvider } from "./ViewModeContext";
+
+/**
+ * Composes the editor's canvas-scoped providers (video layout, player control,
+ * scene selection, auto-scroll, collapse state) into a single boundary so the
+ * top-level view stays a flat orchestrator rather than a provider pyramid.
+ */
+export function CanvasProviders({
+	editor,
+	layoutKey,
+	transitionType,
+	aspectRatio,
+	sceneIds,
+	children,
+}: {
+	editor: Editor;
+	layoutKey: string;
+	transitionType: TransitionType;
+	aspectRatio: AspectRatio;
+	sceneIds: string[];
+	children: ReactNode;
+}) {
+	return (
+		<VideoLayoutProvider
+			editor={editor}
+			layoutKey={layoutKey}
+			transitionType={transitionType}
+			aspectRatio={aspectRatio}
+		>
+			<PlayerControlProvider>
+				<ActiveSceneProvider>
+					<AutoScrollProvider>
+						<ViewModeProvider sceneIds={sceneIds}>{children}</ViewModeProvider>
+					</AutoScrollProvider>
+				</ActiveSceneProvider>
+			</PlayerControlProvider>
+		</VideoLayoutProvider>
+	);
+}


### PR DESCRIPTION
## Summary
- Extracts the editor header controls into `EditorToolbar`, keeping generation/refinement queue wiring behind a focused component boundary.
- Extracts the canvas-scoped provider pyramid into `CanvasProviders`, preserving provider order while giving `PostPromptView` a flat orchestration shape.
- Keeps behavior unchanged; moved existing JSX/hook wiring into narrower modules.

## Architecture / maintainability changes
- `PostPromptView` now owns editor setup, sync hooks, layout derivation, and page composition only.
- `EditorToolbar` owns refine/generate/cancel toolbar state and UI.
- `CanvasProviders` owns the video/player/scene/auto-scroll/view-mode provider stack behind a single interface.

## Complexity delta
- `PostPromptView.tsx` reduced from 228 lines to 104 lines.
- Replaced an inline 5-deep provider pyramid and toolbar orchestration with two named composition boundaries.
- Net diff: 3 files changed, 190 insertions, 154 deletions.

## Validation
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run typecheck` ✅
- `npm run knip` ✅
- `npm run build` ✅
- `npm test -- --passWithNoTests` ✅ (94 files / 842 tests)
- Independent review subagent ✅ (no security concerns or logic errors)

## Open PR overlap check
Considered open PRs:
- #291 `fix: nightly bug fixes 2026-06-17` (`lib/canvas/characterNames.ts`, `lib/canvas/__tests__/characterNames.test.ts`; character-name behavior/tests)
- #285 `refactor: unify canvas media-result colors with the design system` (canvas media-result color/theme files)

This PR only touches `PostPromptView`, `EditorToolbar`, and `CanvasProviders`, so it does not overlap those files or themes.

## Skipped
- Did not rename `proxy.ts`.
- Did not touch third-party `<head>` scripts/pixels.
- Did not pursue connector/gateway subclass boilerplate because project invariants mark those layers as intentional extension seams.
- Did not address the ScrubBar keyboard-accessibility follow-up because this run focused on a non-overlapping editor composition refactor.
