### PR TITLE
refactor: rethink openslop architecture 2026-06-17

### DIFF
--- a/app/components/canvas/elements/CharactersPicker.tsx
+++ b/app/components/canvas/elements/CharactersPicker.tsx
@@ -9,11 +9,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { getElementCharacterNames } from "@/lib/canvas/characterNames";
 import { setNodeAttrs } from "@/lib/canvas/editorOps";
 import type { CanvasContentElement } from "@/lib/canvas/types";
@@ -114,22 +110,19 @@ export function CharactersPicker({
 
 	return (
 		<DropdownMenu modal={false}>
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<DropdownMenuTrigger asChild disabled={disabled}>
-						<button
-							type="button"
-							aria-label={label}
-							onMouseDown={(e) => e.preventDefault()}
-							disabled={disabled}
-							className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-button-hover hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-						>
-							<UserPlus className="h-3.5 w-3.5" strokeWidth={1.5} />
-						</button>
-					</DropdownMenuTrigger>
-				</TooltipTrigger>
-				<TooltipContent>{label}</TooltipContent>
-			</Tooltip>
+			<SimpleTooltip label={label}>
+				<DropdownMenuTrigger asChild disabled={disabled}>
+					<button
+						type="button"
+						aria-label={label}
+						onMouseDown={(e) => e.preventDefault()}
+						disabled={disabled}
+						className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-button-hover hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+					>
+						<UserPlus className="h-3.5 w-3.5" strokeWidth={1.5} />
+					</button>
+				</DropdownMenuTrigger>
+			</SimpleTooltip>
 			<ProjectCharactersMenu
 				selected={selected}
 				onSelect={(name) => toggleCharacter(editor, element, name)}

--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -19,11 +19,7 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { SlidersHorizontal } from "@/components/ui/icon";
 import type { ElementConfig } from "@/lib/canvas/elementConfigs";
 
@@ -38,21 +34,18 @@ function ElementSettings({
 	if (entries.length === 0) return null;
 	return (
 		<Popover>
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<PopoverTrigger asChild>
-						<button
-							type="button"
-							aria-label="Settings"
-							onMouseDown={(e) => e.preventDefault()}
-							className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-button-hover hover:text-foreground"
-						>
-							<SlidersHorizontal size={14} strokeWidth={1.5} />
-						</button>
-					</PopoverTrigger>
-				</TooltipTrigger>
-				<TooltipContent>Settings</TooltipContent>
-			</Tooltip>
+			<SimpleTooltip label="Settings">
+				<PopoverTrigger asChild>
+					<button
+						type="button"
+						aria-label="Settings"
+						onMouseDown={(e) => e.preventDefault()}
+						className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-button-hover hover:text-foreground"
+					>
+						<SlidersHorizontal size={14} strokeWidth={1.5} />
+					</button>
+				</PopoverTrigger>
+			</SimpleTooltip>
 			<PopoverContent align="start" className="w-64">
 				<div className="mb-2 text-xs font-semibold text-muted-foreground">
 					Settings

--- a/app/components/canvas/elements/GenerateButton.tsx
+++ b/app/components/canvas/elements/GenerateButton.tsx
@@ -1,26 +1,19 @@
 "use client";
 
 import { AlertCircle, Sparkles } from "@/components/ui/icon";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { cn } from "@/lib/utils";
 import { useGenerate } from "../hooks/useGenerate";
 
 export function StaleIndicator() {
 	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<span className="inline-flex items-center gap-1 rounded-full border border-stale/50 bg-stale/10 px-2 py-0.5 text-[11px] font-medium text-stale">
-					<AlertCircle className="h-3 w-3" />
-					Stale
-				</span>
-			</TooltipTrigger>
-			<TooltipContent>Prompt changed — regenerate to update</TooltipContent>
-		</Tooltip>
+		<SimpleTooltip label="Prompt changed — regenerate to update">
+			<span className="inline-flex items-center gap-1 rounded-full border border-stale/50 bg-stale/10 px-2 py-0.5 text-[11px] font-medium text-stale">
+				<AlertCircle className="h-3 w-3" />
+				Stale
+			</span>
+		</SimpleTooltip>
 	);
 }
 
@@ -34,26 +27,23 @@ export function GenerateButton({
 	onGenerate: () => void;
 }) {
 	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<button
-					type="button"
-					aria-label={label}
-					disabled={disabled}
-					onMouseDown={(e) => e.preventDefault()}
-					onClick={onGenerate}
-					className={cn(
-						"inline-flex h-7 w-7 items-center justify-center rounded-lg transition-colors enabled:hover:bg-generate-hover disabled:cursor-not-allowed",
-						disabled
-							? "bg-generate-disabled text-generate-disabled-foreground"
-							: "bg-generate text-generate-foreground",
-					)}
-				>
-					<Sparkles className="h-3.5 w-3.5" strokeWidth={1.5} />
-				</button>
-			</TooltipTrigger>
-			<TooltipContent>{label}</TooltipContent>
-		</Tooltip>
+		<SimpleTooltip label={label}>
+			<button
+				type="button"
+				aria-label={label}
+				disabled={disabled}
+				onMouseDown={(e) => e.preventDefault()}
+				onClick={onGenerate}
+				className={cn(
+					"inline-flex h-7 w-7 items-center justify-center rounded-lg transition-colors enabled:hover:bg-generate-hover disabled:cursor-not-allowed",
+					disabled
+						? "bg-generate-disabled text-generate-disabled-foreground"
+						: "bg-generate text-generate-foreground",
+				)}
+			>
+				<Sparkles className="h-3.5 w-3.5" strokeWidth={1.5} />
+			</button>
+		</SimpleTooltip>
 	);
 }
 

--- a/app/components/canvas/elements/GenerationIndicator.tsx
+++ b/app/components/canvas/elements/GenerationIndicator.tsx
@@ -4,11 +4,7 @@ import {
 	Wand2,
 	type LucideIcon,
 } from "@/components/ui/icon";
-import {
-	Tooltip,
-	TooltipTrigger,
-	TooltipContent,
-} from "@/components/ui/tooltip";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import type { ElementSnapshot } from "@/lib/generation/queue";
 
@@ -74,22 +70,19 @@ export function GenerationIndicator({
 	);
 
 	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<button
-					type="button"
-					aria-label={label}
-					className={cn(
-						baseWrapper,
-						"transition-[opacity,background-color] disabled:cursor-not-allowed",
-					)}
-					disabled={active || !onClick}
-					onClick={onClick}
-				>
-					{iconEl}
-				</button>
-			</TooltipTrigger>
-			<TooltipContent>{label}</TooltipContent>
-		</Tooltip>
+		<SimpleTooltip label={label}>
+			<button
+				type="button"
+				aria-label={label}
+				className={cn(
+					baseWrapper,
+					"transition-[opacity,background-color] disabled:cursor-not-allowed",
+				)}
+				disabled={active || !onClick}
+				onClick={onClick}
+			>
+				{iconEl}
+			</button>
+		</SimpleTooltip>
 	);
 }

--- a/app/components/canvas/elements/PlayFromHereButton.tsx
+++ b/app/components/canvas/elements/PlayFromHereButton.tsx
@@ -2,11 +2,7 @@
 
 import { Play } from "@/components/ui/icon";
 import { IconButton } from "@/components/ui/icon-button";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { usePlayerControl } from "@/app/components/video/PlayerControlContext";
 import { findSceneSequence } from "@/app/components/video/useSceneSegments";
 import { useLayout } from "@/app/components/video/VideoLayoutContext";
@@ -19,23 +15,20 @@ export function PlayFromHereButton({ scene }: { scene: SceneElement }) {
 	const startFrame = seq && layout ? Math.round(seq.start * layout.fps) : null;
 	const disabled = startFrame == null;
 	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<IconButton
-					ariaLabel="Play from here"
-					className="bg-muted"
-					disabled={disabled}
-					onMouseDown={(e) => e.preventDefault()}
-					onClick={() => {
-						if (startFrame != null) playFromFrame(startFrame);
-					}}
-				>
-					<Play className="h-4 w-4" />
-				</IconButton>
-			</TooltipTrigger>
-			<TooltipContent>
-				{disabled ? "Generate scene to play" : "Play from here"}
-			</TooltipContent>
-		</Tooltip>
+		<SimpleTooltip
+			label={disabled ? "Generate scene to play" : "Play from here"}
+		>
+			<IconButton
+				ariaLabel="Play from here"
+				className="bg-muted"
+				disabled={disabled}
+				onMouseDown={(e) => e.preventDefault()}
+				onClick={() => {
+					if (startFrame != null) playFromFrame(startFrame);
+				}}
+			>
+				<Play className="h-4 w-4" />
+			</IconButton>
+		</SimpleTooltip>
 	);
 }

--- a/app/components/canvas/elements/character/VoicePicker.tsx
+++ b/app/components/canvas/elements/character/VoicePicker.tsx
@@ -4,11 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Check, Pause, Play } from "@/components/ui/icon";
 import { IconButton } from "@/components/ui/icon-button";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import { createConnector } from "@/lib/connectors/factory";
@@ -44,18 +40,15 @@ function PreviewPlayButton({ src }: { src: string }) {
 				onPause={() => setPlaying(false)}
 				onEnded={() => setPlaying(false)}
 			/>
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<IconButton ariaLabel={playing ? "Pause" : "Play"} onClick={toggle}>
-						{playing ? (
-							<Pause className="h-4 w-4" />
-						) : (
-							<Play className="h-4 w-4" />
-						)}
-					</IconButton>
-				</TooltipTrigger>
-				<TooltipContent>{playing ? "Pause" : "Play"}</TooltipContent>
-			</Tooltip>
+			<SimpleTooltip label={playing ? "Pause" : "Play"}>
+				<IconButton ariaLabel={playing ? "Pause" : "Play"} onClick={toggle}>
+					{playing ? (
+						<Pause className="h-4 w-4" />
+					) : (
+						<Play className="h-4 w-4" />
+					)}
+				</IconButton>
+			</SimpleTooltip>
 		</>
 	);
 }

--- a/app/components/canvas/elements/preview/overlays.tsx
+++ b/app/components/canvas/elements/preview/overlays.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { X as XIcon, AlertCircle, Check, Copy } from "@/components/ui/icon";
-import {
-	Tooltip,
-	TooltipTrigger,
-	TooltipContent,
-} from "@/components/ui/tooltip";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { GenerationIndicator } from "../GenerationIndicator";
 import type { GenerationState, PlaceholderProps } from "./status";
 
@@ -20,19 +16,16 @@ function OverlayButton({
 	children: React.ReactNode;
 }) {
 	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<button
-					type="button"
-					aria-label={label}
-					className={`absolute right-2 z-10 w-6 h-6 rounded-full bg-muted hover:bg-muted flex items-center justify-center opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity ${className}`}
-					onClick={onClick}
-				>
-					{children}
-				</button>
-			</TooltipTrigger>
-			<TooltipContent>{label}</TooltipContent>
-		</Tooltip>
+		<SimpleTooltip label={label}>
+			<button
+				type="button"
+				aria-label={label}
+				className={`absolute right-2 z-10 w-6 h-6 rounded-full bg-muted hover:bg-muted flex items-center justify-center opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity ${className}`}
+				onClick={onClick}
+			>
+				{children}
+			</button>
+		</SimpleTooltip>
 	);
 }
 

--- a/app/components/video/BottomTransportBar.tsx
+++ b/app/components/video/BottomTransportBar.tsx
@@ -2,11 +2,7 @@
 
 import { ChevronsLeft, ChevronsRight, Pause, Play } from "@/components/ui/icon";
 import { IconButton } from "@/components/ui/icon-button";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { usePlayerControl } from "./PlayerControlContext";
 import { usePlayerPosition } from "./PlayerPositionContext";
 import { useLayout } from "./VideoLayoutContext";
@@ -36,14 +32,11 @@ function TooltipButton({
 	children: React.ReactNode;
 }) {
 	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<IconButton onClick={onClick} ariaLabel={ariaLabel}>
-					{children}
-				</IconButton>
-			</TooltipTrigger>
-			<TooltipContent>{label}</TooltipContent>
-		</Tooltip>
+		<SimpleTooltip label={label}>
+			<IconButton onClick={onClick} ariaLabel={ariaLabel}>
+				{children}
+			</IconButton>
+		</SimpleTooltip>
 	);
 }
 

--- a/app/components/video/RenderControls.tsx
+++ b/app/components/video/RenderControls.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { Download, Loader2, X } from "@/components/ui/icon";
-import {
-	Tooltip,
-	TooltipTrigger,
-	TooltipContent,
-} from "@/components/ui/tooltip";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import type { VideoLayout } from "@/lib/video/types";
 import { useRendering } from "./useRendering";
 
@@ -23,19 +19,16 @@ export function RenderControls({ layout }: { layout: VideoLayout }) {
 
 	if (state.status === "idle") {
 		return (
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<button
-						type="button"
-						onClick={() => render(layout)}
-						aria-label="Export Video"
-						className="relative rounded-lg bg-secondary p-2 text-accent opacity-0 shadow-md shadow-black/25 transition-[opacity,filter] hover:brightness-[1.3] group-hover:opacity-100"
-					>
-						<Download size={16} />
-					</button>
-				</TooltipTrigger>
-				<TooltipContent>Export Video</TooltipContent>
-			</Tooltip>
+			<SimpleTooltip label="Export Video">
+				<button
+					type="button"
+					onClick={() => render(layout)}
+					aria-label="Export Video"
+					className="relative rounded-lg bg-secondary p-2 text-accent opacity-0 shadow-md shadow-black/25 transition-[opacity,filter] hover:brightness-[1.3] group-hover:opacity-100"
+				>
+					<Download size={16} />
+				</button>
+			</SimpleTooltip>
 		);
 	}
 

--- a/components/ui/delete-button.tsx
+++ b/components/ui/delete-button.tsx
@@ -2,11 +2,7 @@ import * as React from "react";
 import { Trash2 } from "@/components/ui/icon";
 import { cn } from "@/lib/utils";
 import { IconButton } from "@/components/ui/icon-button";
-import {
-	Tooltip,
-	TooltipTrigger,
-	TooltipContent,
-} from "@/components/ui/tooltip";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 
 export function DeleteButton({
 	ariaLabel,
@@ -14,17 +10,14 @@ export function DeleteButton({
 	...props
 }: React.ComponentProps<typeof IconButton>) {
 	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<IconButton
-					ariaLabel={ariaLabel}
-					className={cn("bg-muted hover:text-destructive", className)}
-					{...props}
-				>
-					<Trash2 className="h-4 w-4" strokeWidth={1.5} />
-				</IconButton>
-			</TooltipTrigger>
-			<TooltipContent>Delete</TooltipContent>
-		</Tooltip>
+		<SimpleTooltip label="Delete">
+			<IconButton
+				ariaLabel={ariaLabel}
+				className={cn("bg-muted hover:text-destructive", className)}
+				{...props}
+			>
+				<Trash2 className="h-4 w-4" strokeWidth={1.5} />
+			</IconButton>
+		</SimpleTooltip>
 	);
 }

--- a/components/ui/media-toggle.tsx
+++ b/components/ui/media-toggle.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import type { LucideIcon } from "@/components/ui/icon";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 export interface MediaToggleOption<T extends string> {
@@ -40,25 +36,22 @@ export function MediaToggle<T extends string>({
 			{options.map(({ value: optValue, label, icon: Icon }) => {
 				const active = optValue === value;
 				return (
-					<Tooltip key={optValue}>
-						<TooltipTrigger asChild>
-							<button
-								type="button"
-								onClick={() => onChange(optValue)}
-								aria-label={label}
-								aria-pressed={active}
-								className={cn(
-									"flex h-6 w-6 items-center justify-center rounded-full transition-colors",
-									active
-										? "bg-media-toggle-active-bg text-media-toggle-active-fg"
-										: "text-media-toggle-fg hover:opacity-70",
-								)}
-							>
-								<Icon className="h-3.5 w-3.5" />
-							</button>
-						</TooltipTrigger>
-						<TooltipContent>{label}</TooltipContent>
-					</Tooltip>
+					<SimpleTooltip key={optValue} label={label}>
+						<button
+							type="button"
+							onClick={() => onChange(optValue)}
+							aria-label={label}
+							aria-pressed={active}
+							className={cn(
+								"flex h-6 w-6 items-center justify-center rounded-full transition-colors",
+								active
+									? "bg-media-toggle-active-bg text-media-toggle-active-fg"
+									: "text-media-toggle-fg hover:opacity-70",
+							)}
+						>
+							<Icon className="h-3.5 w-3.5" />
+						</button>
+					</SimpleTooltip>
 				);
 			})}
 		</div>

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -53,4 +53,31 @@ function TooltipContent({
 	);
 }
 
-export { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent };
+/**
+ * Convenience wrapper for the common case: a single trigger element with a
+ * plain text label. Use the primitives directly when the content or trigger
+ * needs customization.
+ */
+function SimpleTooltip({
+	label,
+	children,
+	...props
+}: Omit<React.ComponentProps<typeof TooltipPrimitive.Root>, "children"> & {
+	label: React.ReactNode;
+	children: React.ReactNode;
+}) {
+	return (
+		<Tooltip {...props}>
+			<TooltipTrigger asChild>{children}</TooltipTrigger>
+			<TooltipContent>{label}</TooltipContent>
+		</Tooltip>
+	);
+}
+
+export {
+	TooltipProvider,
+	Tooltip,
+	TooltipTrigger,
+	TooltipContent,
+	SimpleTooltip,
+};


### PR DESCRIPTION
## App understanding

OpenSlop turns a text prompt into a rendered video. The flow: a prompt streams OSML from `POST /api/v1/llm` into a SlateJS canvas; stale elements are queued and generated through a three-layer pipeline (**connectors** → **gateways** → **providers**) hitting `/api/v1/{asset}` routes backed by a Vercel Queue; results land in Vercel Blob and the canvas previews update; project state persists to Supabase (`projects`/`jobs` with RLS); `POST /api/render` fans the composition across Remotion Lambdas into an MP4. Auth is the Supabase session refreshed in `proxy.ts` with two API tiers in `lib/api/with-auth.ts`.

## From-scratch architecture vs. current

The current architecture is already close to what a clean rebuild would look like: a domain layer (`lib/`) strictly separated from the UI layer (`app/`), a connector/gateway/provider seam that lets providers and asset types be swapped independently (intentional layering — kept), a shared `createApiRouteHandler` factory for routes, and Zustand stores per project. The highest-leverage *safe* gap was in the UI layer: a single Radix tooltip idiom — `<Tooltip><TooltipTrigger asChild>{trigger}</TooltipTrigger><TooltipContent>{label}</TooltipContent></Tooltip>` — was hand-rolled at ~12 sites across the editor, canvas, and video components, with the 3-symbol import repeated each time and **two independent local reinventions** of the wrapper (`BottomTransportBar`'s `TooltipButton`, `overlays`' `OverlayButton`). A from-scratch build would expose this as one convenience primitive next to the tooltip parts.

## Implemented simplifications

- Added `SimpleTooltip` to `components/ui/tooltip.tsx`: a thin wrapper taking `label` + a single trigger child, built on the existing primitives. Minimal API — no site customizes `TooltipContent`, so nothing speculative was added; the raw primitives remain exported for the customization cases.
- Adopted it across 11 files, removing the repeated wrapper/imports and reducing JSX nesting with **no behavior change**: `PlayFromHereButton`, `ElementContainer` (nested `PopoverTrigger` preserved), `GenerateButton` (×2), `GenerationIndicator`, `CharactersPicker` (nested `DropdownMenuTrigger` preserved), `BottomTransportBar`, `RenderControls`, `VoicePicker`, `preview/overlays`, plus the shared `components/ui/delete-button` and `components/ui/media-toggle` primitives.
- Net −53 lines; the two ad-hoc local tooltip wrappers now delegate to the shared one.

## Validation

All checks from `.github/workflows/ci.yml`, locally:

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run format:check` — pass
- `npm run knip` (dead code) — pass
- `npm run test:run` — 94 files / 842 tests pass
- `npm run build` — pass

## Skipped items / risks

- **Connector/gateway class-factory consolidation** (collapsing the per-asset `Base*Connector` / `OpenSlop*` / `OpenSlop*Gateway` stubs into generated classes) was deliberately **not** done: it conflicts with the intentionally-preserved connector/gateway layering and the planned BYOK gateway + multiple-providers-per-type work, and would trade explicit, extensible classes for harder-to-extend generics.
- Other candidates (numeric clamp helper, `elementConfigs` spec factories, modal-wrapper HOC) were lower-leverage and/or partially overlapped the open-PR file set; deferred to keep this PR a single coherent, reviewable change.
- Risk is low: every change is a presentational wrapper swap; the trigger elements (native `<button>`, `<span>`, `IconButton`, nested Radix `*Trigger`) were already inside `TooltipTrigger asChild`, so rendering and a11y are identical.

## Open PR overlap check

Re-checked open PRs before and after editing — **zero file overlap**:

- **#293** (video `ScrubBar`/`SegmentedSeekBar` perf) — not touched.
- **#292** (`EditorToolbar`/`PostPromptView`/`CanvasProviders` composition) — not touched. `PostPromptView` left on the tooltip primitives intentionally.
- **#291** (`lib/canvas/characterNames` correctness) — not touched; `CharactersPicker` imports that module but this PR only swaps its tooltip JSX, not the character-name logic.
- **#285** (canvas media-result colors / `useThemeColor`: `AudioPlayer`, `OutputPreview`, `CharacterEditModal`, `AnimatedImagePreview`, `results`, `status`, `useThemeColor`) — all left on the tooltip primitives intentionally; none touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)