### PR TITLE
fix: cap toast height and make long messages scrollable

### DIFF
--- a/app/components/AppToaster.tsx
+++ b/app/components/AppToaster.tsx
@@ -10,6 +10,9 @@ export function AppToaster() {
 			theme={resolvedTheme === "dark" ? "dark" : "light"}
 			position="bottom-center"
 			richColors
+			toastOptions={{
+				classNames: { content: "max-h-[40vh] overflow-y-auto" },
+			}}
 		/>
 	);
 }


### PR DESCRIPTION
## What

Top-level toasts now cap their content area at `40vh` and scroll vertically when the message is longer. Previously a long toast message could overflow off-screen and become unreadable.

## How

Applied a `content` class via sonner's `toastOptions` in `AppToaster`. Scoping to the `content` slot (rather than the whole toast) keeps the icon and close button fixed while only the message scrolls.

```tsx
toastOptions={{
  classNames: { content: "max-h-[40vh] overflow-y-auto" },
}}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)