### PR TITLE
refactor: nightly maintainability 2026-06-18

### DIFF
--- a/app/components/EditorToolbar.tsx
+++ b/app/components/EditorToolbar.tsx
@@ -5,11 +5,7 @@ import type { Editor } from "slate";
 import { Sparkles, X } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { useScriptControl } from "@/lib/script/ScriptProvider";
 import {
 	useGenerationQueue,
@@ -90,19 +86,16 @@ export function EditorToolbar({ editor }: { editor: Editor }) {
 						<span className="hidden sm:inline">{generateLabel}</span>
 					</Button>
 					{generating && (
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<button
-									type="button"
-									onClick={() => queue.cancelAll()}
-									aria-label="Cancel generation"
-									className="relative flex h-7 w-7 shrink-0 items-center justify-center self-center rounded-md bg-muted text-muted-foreground transition-colors hover:bg-button-hover hover:text-foreground"
-								>
-									<X className="h-3 w-3" aria-hidden="true" />
-								</button>
-							</TooltipTrigger>
-							<TooltipContent>Cancel generation</TooltipContent>
-						</Tooltip>
+						<SimpleTooltip label="Cancel generation">
+							<button
+								type="button"
+								onClick={() => queue.cancelAll()}
+								aria-label="Cancel generation"
+								className="relative flex h-7 w-7 shrink-0 items-center justify-center self-center rounded-md bg-muted text-muted-foreground transition-colors hover:bg-button-hover hover:text-foreground"
+							>
+								<X className="h-3 w-3" aria-hidden="true" />
+							</button>
+						</SimpleTooltip>
 					)}
 				</div>
 			</div>

--- a/app/components/canvas/elements/AudioPlayer.tsx
+++ b/app/components/canvas/elements/AudioPlayer.tsx
@@ -3,11 +3,7 @@
 import { useRef, useState } from "react";
 import { Play, Pause } from "@/components/ui/icon";
 import { IconButton } from "@/components/ui/icon-button";
-import {
-	Tooltip,
-	TooltipTrigger,
-	TooltipContent,
-} from "@/components/ui/tooltip";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Waveform, type WaveformHandle } from "@/lib/components/Waveform";
 import { formatTime } from "@/lib/video/timestamps";
 import { usePreviewCache } from "../PreviewCacheContext";
@@ -21,22 +17,19 @@ export function AudioPlayer({ src }: { src: string }) {
 
 	return (
 		<>
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<IconButton
-						ariaLabel={playing ? "Pause" : "Play"}
-						onClick={() => waveformRef.current?.toggle()}
-						disabled={duration === 0}
-					>
-						{playing ? (
-							<Pause className="h-4 w-4" />
-						) : (
-							<Play className="h-4 w-4" />
-						)}
-					</IconButton>
-				</TooltipTrigger>
-				<TooltipContent>{playing ? "Pause" : "Play"}</TooltipContent>
-			</Tooltip>
+			<SimpleTooltip label={playing ? "Pause" : "Play"}>
+				<IconButton
+					ariaLabel={playing ? "Pause" : "Play"}
+					onClick={() => waveformRef.current?.toggle()}
+					disabled={duration === 0}
+				>
+					{playing ? (
+						<Pause className="h-4 w-4" />
+					) : (
+						<Play className="h-4 w-4" />
+					)}
+				</IconButton>
+			</SimpleTooltip>
 			<Waveform
 				ref={waveformRef}
 				src={src}

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -12,11 +12,7 @@ import {
 	DialogTitle,
 	MountedDialog,
 } from "@/components/ui/dialog";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import {
 	useGenerationQueue,
@@ -213,23 +209,20 @@ function CharacterEditDialogBody({
 							/>
 						)}
 						{inputElement}
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<IconButton
-									ariaLabel="Upload image"
-									onClick={openPicker}
-									disabled={uploading}
-									className="absolute left-2 top-2 z-10 rounded-full bg-card shadow-sm ring-1 ring-border"
-								>
-									{uploading ? (
-										<Loader2 className="h-3.5 w-3.5 animate-spin" />
-									) : (
-										<ImagePlus className="h-3.5 w-3.5" />
-									)}
-								</IconButton>
-							</TooltipTrigger>
-							<TooltipContent>Upload image</TooltipContent>
-						</Tooltip>
+						<SimpleTooltip label="Upload image">
+							<IconButton
+								ariaLabel="Upload image"
+								onClick={openPicker}
+								disabled={uploading}
+								className="absolute left-2 top-2 z-10 rounded-full bg-card shadow-sm ring-1 ring-border"
+							>
+								{uploading ? (
+									<Loader2 className="h-3.5 w-3.5 animate-spin" />
+								) : (
+									<ImagePlus className="h-3.5 w-3.5" />
+								)}
+							</IconButton>
+						</SimpleTooltip>
 					</div>
 				</div>
 				<VoiceSection voice={character} onChange={update} />


### PR DESCRIPTION
## Summary
- Finished the `SimpleTooltip` migration for the remaining exact simple tooltip call sites.
- Replaced repeated raw `Tooltip` / `TooltipTrigger asChild` / `TooltipContent` boilerplate in editor and canvas controls with the existing wrapper.
- Preserved trigger elements, labels, disabled states, click handlers, and tooltip text.

## Architecture / maintainability changes
- Consolidates simple tooltip usage behind the narrow `SimpleTooltip` interface.
- Removes the remaining duplicate raw primitive pattern where no custom tooltip behavior was needed.
- Keeps raw tooltip primitives available only for provider/root wiring and future customized tooltip cases.

## Complexity delta
- 3 files changed.
- 21 net lines removed: 40 insertions / 61 deletions.
- Simplified three UI control render paths by replacing repeated wrapper structure with a single composition boundary.

## Validation
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run typecheck` ✅
- `npm run knip` ✅
- `npm run build` ✅
- `npm test -- --passWithNoTests` ✅ (94 files / 836 tests)
- `npm run test:coverage` ✅ (94 files / 836 tests; all files 77.04% statements)
- Independent review: passed; no behavior, accessibility, provider-ordering, or import-boundary issues found.

## Open PR overlap check
Considered open PRs:
- #301 `fix: forward Cartesia TTS emotion` touches Cartesia TTS provider/tests.
- #300 `fix: cap toast height and make long messages scrollable` touches `AppToaster` and toast scrolling.

This PR touches only `EditorToolbar`, `AudioPlayer`, and `CharacterEditModal` tooltip composition, so it does not overlap by file or theme.

## Skipped items
- Did not touch `proxy.ts` or third-party `<head>` scripts.
- Did not modify open-PR areas: Cartesia TTS emotion forwarding or toast height/scrolling.
- Did not add docs because the change is self-explanatory and docs would be low-signal.
