### PR TITLE
test: add playwright smoke tests 2026-06-18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,17 @@ jobs:
       - name: Tests
         run: npm run test:coverage
 
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(npm ls @playwright/test --json | jq -r '.dependencies["@playwright/test"].version')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 
@@ -52,6 +63,16 @@ jobs:
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+
+      - name: Upload Playwright report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7
 
       - name: Bundle size report
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,15 @@ jobs:
       - name: Tests
         run: npm run test:coverage
 
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Smoke tests
+        run: npm run test:e2e
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+
       - name: Bundle size report
         run: |
           echo "## Bundle Size Report" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,17 +44,6 @@ jobs:
       - name: Tests
         run: npm run test:coverage
 
-      - name: Resolve Playwright version
-        id: playwright-version
-        run: echo "version=$(npm ls @playwright/test --json | jq -r '.dependencies["@playwright/test"].version')" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
-
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@
 # testing
 /coverage
 
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+
 # next.js
 /.next/
 /out/

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("public onboarding", () => {
+	test("home shows the beta welcome and links to login", async ({ page }) => {
+		await page.goto("/");
+
+		await expect(
+			page.getByRole("heading", { name: "Welcome to the OpenSlop Beta" }),
+		).toBeVisible();
+		await expect(
+			page.getByRole("button", { name: "Get Started" }),
+		).toBeVisible();
+
+		await page.getByRole("link", { name: "Login" }).click();
+		await expect(page).toHaveURL(/\/login$/);
+		await expect(page.getByRole("heading", { name: "Login" })).toBeVisible();
+	});
+
+	test("login page renders the magic-link form", async ({ page }) => {
+		await page.goto("/login");
+
+		await expect(page.getByRole("heading", { name: "Login" })).toBeVisible();
+		await expect(page.getByLabel("Email")).toBeVisible();
+		await expect(
+			page.getByRole("button", { name: "Send login link" }),
+		).toBeVisible();
+	});
+
+	test("signup page collects name and email", async ({ page }) => {
+		await page.goto("/signup");
+
+		await expect(page.getByRole("heading", { name: "Sign up" })).toBeVisible();
+		await expect(page.getByLabel("Full name")).toBeVisible();
+		await expect(page.getByLabel("Email")).toBeVisible();
+		await expect(
+			page.getByRole("button", { name: "Send signup link" }),
+		).toBeVisible();
+	});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
 			},
 			"devDependencies": {
 				"@next/bundle-analyzer": "^16.2.4",
+				"@playwright/test": "^1.61.0",
 				"@tailwindcss/postcss": "^4",
 				"@types/bun": "^1.3.11",
 				"@types/lodash": "^4.17.24",
@@ -4643,6 +4644,22 @@
 			"resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
 			"integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
 			"license": "MIT"
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+			"integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+			"devOptional": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.61.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/@polka/url": {
 			"version": "1.0.0-next.29",
@@ -16236,6 +16253,53 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+			"integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+			"devOptional": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.61.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+			"integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+			"devOptional": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"db:reset": "supabase db reset",
 		"test": "vitest",
 		"test:run": "vitest run",
+		"test:e2e": "playwright test",
 		"test:coverage": "vitest run --coverage",
 		"typecheck": "tsc --noEmit",
 		"knip": "knip",
@@ -75,6 +76,7 @@
 	},
 	"devDependencies": {
 		"@next/bundle-analyzer": "^16.2.4",
+		"@playwright/test": "^1.61.0",
 		"@tailwindcss/postcss": "^4",
 		"@types/bun": "^1.3.11",
 		"@types/lodash": "^4.17.24",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const PORT = process.env.PLAYWRIGHT_PORT ?? "3000";
+const PORT = process.env.PORT ?? process.env.PLAYWRIGHT_PORT ?? "3000";
 const baseURL = `http://localhost:${PORT}`;
 
 export default defineConfig({
@@ -15,11 +15,10 @@ export default defineConfig({
 	},
 	projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
 	webServer: {
-		command: process.env.CI
-			? `npm run start -- -p ${PORT}`
-			: `npm run dev -- -p ${PORT}`,
+		command: process.env.CI ? "npm run start" : "npm run dev",
 		url: baseURL,
 		reuseExistingServer: !process.env.CI,
 		timeout: 120_000,
+		env: { PORT },
 	},
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = process.env.PLAYWRIGHT_PORT ?? "3000";
+const baseURL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+	testDir: "./e2e",
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 1 : 0,
+	reporter: "list",
+	use: {
+		baseURL,
+		trace: "on-first-retry",
+	},
+	projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+	webServer: {
+		command: process.env.CI
+			? `npm run start -- -p ${PORT}`
+			: `npm run dev -- -p ${PORT}`,
+		url: baseURL,
+		reuseExistingServer: !process.env.CI,
+		timeout: 120_000,
+	},
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 import path from "path";
 
 export default defineConfig({
@@ -9,6 +9,7 @@ export default defineConfig({
 	},
 	test: {
 		setupFiles: ["./vitest.setup.ts"],
+		exclude: [...configDefaults.exclude, "e2e/**"],
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "json-summary"],


### PR DESCRIPTION
## Summary
- Add a minimal Chromium-only Playwright smoke-test setup for the public unauthenticated onboarding surface.
- Add `npm run test:e2e`, Playwright artifact ignores, and a Vitest exclude so unit coverage does not pick up e2e specs.
- Wire smoke tests into CI after build/test with Chromium browser installation.

## Smoke flows covered
- `/` renders the public beta onboarding page and links to `/login`.
- `/login` renders the email magic-link login form.
- `/signup` renders the signup form with name and email fields.

## CI wiring
- CI installs the Chromium Playwright browser via `npx playwright install --with-deps chromium`.
- CI runs `npm run test:e2e` after the existing build and coverage steps, with the same public Supabase env used by build.
- Playwright starts the built Next app in CI via `npm run start -- -p <port>` and reuses a local server outside CI.

## Validation
- `npx playwright install chromium` — passed (browser already/fallback installed locally; host reports unsupported-OS fallback warning).
- `PLAYWRIGHT_PORT=3001 npm run test:e2e` — passed, 3/3 smoke tests. Used 3001 locally because port 3000 is occupied by this machine's Hermes WhatsApp bridge; CI/default remains 3000.
- `npm run lint` — passed.
- `npm run format:check` — passed.
- `npm run typecheck` — passed.
- `npm run knip` — passed.
- `npm run build` — passed.
- `npm run test:coverage` — passed, 94 files / 836 tests.
- `npm test -- --passWithNoTests` — passed, 94 files / 836 tests.

## Logged-in-route skip rationale
- Logged-in/editor/project smoke tests are intentionally skipped because auth currently uses email-link/Gmail flows, not user/password auth, and the runbook explicitly scoped authenticated smoke tests out.

## Open PR overlap check
Considered currently open PRs and confirmed no file/theme overlap:
- #303 architecture/connectors/LLM prompt helper files — not touched.
- #302 tooltip composition in `EditorToolbar`, `AudioPlayer`, `CharacterEditModal` — not touched.
- #301 Cartesia TTS provider/tests — not touched.
- #300 toast scrolling in `AppToaster` — not touched.

## Follow-up risks / skipped items
- Kept smoke scope intentionally light and public-only; no screenshots, visual snapshots, sleeps, third-party service workflows, or logged-in routes.
- The `/` page includes server-side Supabase auth lookup before rendering unauthenticated onboarding; CI already provides the public Supabase env used by build, but that route remains the one smoke path most sensitive to Supabase availability.
