### PR TITLE
fix: preserve project after reload undo

### DIFF
--- a/app/components/canvas/hooks/useProjectRehydrate.test.ts
+++ b/app/components/canvas/hooks/useProjectRehydrate.test.ts
@@ -1,0 +1,45 @@
+import { createEditor } from "slate";
+import { withHistory } from "slate-history";
+import { describe, expect, it } from "vitest";
+import { OSMLSerializer } from "@/lib/canvas/osmlSerializer";
+import { SCENE_TYPE, type SceneElement } from "@/lib/canvas/types";
+import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
+import { rehydrateProjectEditor } from "./useProjectRehydrate";
+
+const connector = {
+	openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },
+};
+
+const connectors: ConnectorRegistry = {
+	llm: connector,
+	tts: connector,
+	image: connector,
+	animated_image: connector,
+	video: connector,
+	sfx: connector,
+	music: connector,
+};
+
+const scene: SceneElement = {
+	id: "scene-id",
+	type: SCENE_TYPE,
+	children: [
+		{
+			id: "narration-id",
+			type: "narration",
+			children: [{ id: "text-id", type: "narration", text: "hello" }],
+		},
+	],
+};
+
+describe("rehydrateProjectEditor", () => {
+	it("does not save project load operations to undo history", () => {
+		const editor = withHistory(createEditor());
+		const osml = OSMLSerializer.serializeWithScenes([scene]);
+
+		rehydrateProjectEditor(editor, osml, connectors);
+
+		expect(editor.children).toHaveLength(1);
+		expect(editor.history.undos).toEqual([]);
+	});
+});

--- a/app/components/canvas/hooks/useProjectRehydrate.ts
+++ b/app/components/canvas/hooks/useProjectRehydrate.ts
@@ -1,19 +1,18 @@
 import { useEffect, useRef } from "react";
 import { Editor, Transforms } from "slate";
-import { useConfig } from "@/lib/config/ConfigProvider";
+import { HistoryEditor } from "slate-history";
+import { useConfig, type ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import { deserializeWithScenes } from "@/lib/project/serialize";
 
-export function useProjectRehydrate(editor: Editor, script: string): void {
-	const { connectorConfig } = useConfig();
-	const ranRef = useRef(false);
+export function rehydrateProjectEditor(
+	editor: Editor,
+	script: string,
+	connectorConfig: ConnectorRegistry,
+): void {
+	const scenes = deserializeWithScenes(script, connectorConfig);
+	if (scenes.length === 0) return;
 
-	useEffect(() => {
-		if (ranRef.current) return;
-		ranRef.current = true;
-
-		const scenes = deserializeWithScenes(script, connectorConfig);
-		if (scenes.length === 0) return;
-
+	const replaceChildren = () => {
 		Editor.withoutNormalizing(editor, () => {
 			while (editor.children.length > 0) {
 				Transforms.removeNodes(editor, { at: [0] });
@@ -23,5 +22,24 @@ export function useProjectRehydrate(editor: Editor, script: string): void {
 			});
 		});
 		Editor.normalize(editor, { force: true });
+	};
+
+	if (HistoryEditor.isHistoryEditor(editor)) {
+		HistoryEditor.withoutSaving(editor, replaceChildren);
+		return;
+	}
+
+	replaceChildren();
+}
+
+export function useProjectRehydrate(editor: Editor, script: string): void {
+	const { connectorConfig } = useConfig();
+	const ranRef = useRef(false);
+
+	useEffect(() => {
+		if (ranRef.current) return;
+		ranRef.current = true;
+
+		rehydrateProjectEditor(editor, script, connectorConfig);
 	}, [editor, script, connectorConfig]);
 }


### PR DESCRIPTION
## Summary
- Prevent project rehydration from recording Slate load operations in undo history.
- Extract the rehydrate operation into a focused helper so it can be covered without mounting the editor.
- Add regression coverage that a loaded project keeps the undo stack empty.

## Selected issue
Selected #266 because it is a small, clearly scoped correctness bug: after project reload, Ctrl+Z can undo the initial load and leave an empty project. The relevant code path was isolated to `useProjectRehydrate`, and the fix can be validated with a focused Slate history regression test.

## Validation
- `npm test -- app/components/canvas/hooks/useProjectRehydrate.test.ts --run` — passed (RED first: failed with missing `rehydrateProjectEditor`, then passed after implementation).
- `npm run lint` — passed.
- `npm run format:check` — passed.
- `npm run typecheck` — passed.
- `npm run knip` — passed.
- `npm run build` — passed.
- `npm run test:coverage` — passed, 95 files / 837 tests.
- `npm test -- --passWithNoTests` — passed, 95 files / 837 tests.

## Open PR overlap check
Checked currently open PRs before editing and again before staging:
- #304 touches CI, Playwright e2e setup, package files, and Vitest config — no overlap.
- #303 touches connector/gateway/LLM plugin architecture — no overlap.
- #302 touches tooltip composition in editor/canvas UI components — no overlap.
- #301 touches Cartesia TTS provider/tests — no overlap.
- #300 touches `AppToaster` toast scrolling — no overlap.

This PR only touches `app/components/canvas/hooks/useProjectRehydrate.ts` and its new focused test.

## Skipped issue categories
Skipped broader/product-context-heavy items such as avatar/style generation policy, post-generation upload UX, render lifecycle robustness, video export/upscaling, i18n, and major feature/control requests.

Closes #266
