### PR TITLE
fix: extend generation timeouts for animated images

### DIFF
--- a/lib/providers/poll.ts
+++ b/lib/providers/poll.ts
@@ -3,7 +3,7 @@ export async function awaitCompletion<T>(
 	jobId: string,
 	isDone: (result: T) => boolean,
 	intervalMs = 1000,
-	timeoutMs = 300_000,
+	timeoutMs = 600_000,
 ): Promise<T> {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {

--- a/lib/providers/runware.ts
+++ b/lib/providers/runware.ts
@@ -6,7 +6,7 @@ export async function withRunware<T>(
 ): Promise<T> {
 	const runware = new Runware({
 		apiKey,
-		timeoutDuration: 180_000,
+		timeoutDuration: 600_000,
 		shouldReconnect: true,
 		globalMaxRetries: 3,
 	});


### PR DESCRIPTION
## Summary

Animated image jobs combine a still-image generation followed by downstream video synthesis on a single job. They regularly exceed the hardcoded 5-minute poll budget, surfacing to users as `Job <id> timed out after 300000ms`.

This aligns both timeout layers to 10 minutes:
- `lib/providers/poll.ts` — `awaitCompletion` default `timeoutMs`: 300s → 600s (the user-visible job timeout)
- `lib/providers/runware.ts` — Runware SDK `timeoutDuration`: 180s → 600s (per-request timeout that, combined with `globalMaxRetries: 3`, could run past the poll window)

## Scope

Partially addresses #310 — this covers the **timeout** portion only.

Still outstanding (tracked in the issue):
- Partial-result delivery: returning the already-generated still image when video generation fails/times out, instead of discarding it (`base.ts`, `asset-base.ts`, `animated-image-chain.ts`, `queue.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)