### PR TITLE
fix: nightly bug fixes 2026-06-19

### DIFF
--- a/app/api/v1/__tests__/routes.test.ts
+++ b/app/api/v1/__tests__/routes.test.ts
@@ -465,7 +465,7 @@ describe("API routes", () => {
 			]);
 
 			const req = makeRequest(
-				"/api/v1/tts/voices?query=english",
+				"/api/v1/tts/voices?query=english&limit=1",
 				undefined,
 				"GET",
 			);
@@ -475,6 +475,20 @@ describe("API routes", () => {
 			expect(res.status).toBe(200);
 			expect(json.voices).toHaveLength(1);
 			expect(json.voices[0].name).toBe("Voice 1");
+			expect(mockTTSSearch).toHaveBeenCalledWith(
+				expect.objectContaining({ query: "english", limit: 1 }),
+			);
+		});
+
+		it("returns 400 for invalid voice search parameters", async () => {
+			const { GET } = await import("@/app/api/v1/tts/voices/route");
+			const res = await GET(
+				makeRequest("/api/v1/tts/voices?limit=abc", undefined, "GET"),
+			);
+
+			expect(res.status).toBe(400);
+			expect((await res.json()).error).toContain("limit");
+			expect(mockTTSSearch).not.toHaveBeenCalled();
 		});
 
 		it("returns 500 on error", async () => {

--- a/app/api/v1/tts/voices/route.ts
+++ b/app/api/v1/tts/voices/route.ts
@@ -1,14 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getTTSProvider } from "@/lib/api/providers";
+import { badRequest } from "@/lib/api/response";
 import { withApiAccess } from "@/lib/api/with-auth";
-import { voiceSearchParamsSchema } from "@/lib/project/types";
+import { voiceSearchRequestSchema } from "@/lib/project/types";
 
 export async function GET(request: NextRequest) {
 	return withApiAccess("Voice search", async () => {
-		const params = voiceSearchParamsSchema.parse(
+		const parsed = voiceSearchRequestSchema.safeParse(
 			Object.fromEntries(request.nextUrl.searchParams),
 		);
-		const voices = await getTTSProvider().search(params);
+		if (!parsed.success) {
+			return badRequest(
+				parsed.error.issues[0]?.message ?? "Invalid voice search",
+			);
+		}
+
+		const voices = await getTTSProvider().search(parsed.data);
 		return NextResponse.json({ voices });
 	});
 }

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -10,6 +10,12 @@ import type { AspectRatio } from "@/lib/video/aspectRatio";
 import type { TransitionType } from "@/lib/video/transitions";
 
 const optionalString = z.string().min(1).optional().catch(undefined);
+const voiceSearchString = z.string().min(1).optional();
+const voiceSearchLimitSchema = z
+	.string()
+	.regex(/^[1-9]\d*$/, "limit must be a positive integer")
+	.transform(Number)
+	.optional();
 
 export const genderSchema = z.enum(TTS_GENDERS).optional().catch(undefined);
 export const languageSchema = z.enum(TTS_LANGUAGES).optional().catch(undefined);
@@ -31,10 +37,19 @@ export const MetadataVoiceSchema = voiceTraitsSchema.extend({
 	resolvedVoiceId: optionalString,
 });
 
-export const voiceSearchParamsSchema = voiceTraitsSchema.extend({
-	query: optionalString,
-	name: optionalString,
-	limit: z.coerce.number().int().positive().optional().catch(undefined),
+const voiceSearchTraitsSchema = z.object({
+	gender: z.enum(TTS_GENDERS).optional(),
+	age: z.enum(TTS_AGES).optional(),
+	pitch: z.enum(TTS_PITCHES).optional(),
+	accent: z.enum(TTS_ACCENTS).optional(),
+	description: voiceSearchString,
+	language: z.enum(TTS_LANGUAGES).optional(),
+});
+
+export const voiceSearchRequestSchema = voiceSearchTraitsSchema.extend({
+	query: voiceSearchString,
+	name: voiceSearchString,
+	limit: voiceSearchLimitSchema,
 });
 
 export type MetadataVoice = z.infer<typeof MetadataVoiceSchema>;


### PR DESCRIPTION
## Summary
- Add strict route-boundary validation for `/api/v1/tts/voices` search parameters.
- Reject malformed voice search query values before calling the TTS provider instead of silently dropping invalid filters.
- Keep permissive metadata parsing separate from API request validation.

## Bugs fixed
- `limit=abc` (and other malformed positive-integer limits) previously parsed to `undefined`, causing the route to return an unbounded/default voice search instead of a client error.
- Invalid voice search trait values now fail request validation at the route boundary rather than being silently ignored.

## Tests
- Updated `GET /api/v1/tts/voices` coverage to assert valid `limit` values are parsed and forwarded as numbers.
- Added regression coverage that invalid voice search parameters return `400` and do not call the provider.

## Validation
- `npm test -- app/api/v1/__tests__/routes.test.ts` ✅
- `npm test -- --passWithNoTests` ✅
- `npm run build` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run typecheck` ✅
- `npm run knip` ✅
- `npm run test:coverage` ✅

## Open PR overlap check
Considered open PRs #309, #305, #304, #303, and #302. This PR changes only:
- `app/api/v1/__tests__/routes.test.ts`
- `app/api/v1/tts/voices/route.ts`
- `lib/project/types.ts`

These files and the voice-search route-boundary validation theme do not overlap with the open dropdown, project rehydrate, Playwright smoke, connector architecture, or tooltip-maintainability PRs.

## Notes
- Claude Code was invoked in the required YOLO print-mode style for the core pass, but it timed out without leaving a diff; Hermes completed the focused fallback fix and independently validated it.
