### PR TITLE
refactor: nightly maintainability 2026-06-19

### DIFF
--- a/app/components/PostPromptView.tsx
+++ b/app/components/PostPromptView.tsx
@@ -5,7 +5,6 @@ import { useScriptInitial } from "@/lib/script/ScriptProvider";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getContentElements, isSceneElement } from "@/lib/canvas/scenes";
 import { getLayoutKey } from "@/lib/video/layoutKey";
-import { useAspectRatio } from "@/lib/video/useAspectRatio";
 import { useTransitionType } from "@/lib/video/useTransitionType";
 import UserProfile from "./UserProfile";
 import { EditorToolbar } from "./EditorToolbar";
@@ -35,7 +34,6 @@ function PostPromptViewInner() {
 	useMetadataSync();
 
 	const transitionType = useTransitionType();
-	const aspectRatio = useAspectRatio();
 	const layoutKey = useMemo(
 		() => getLayoutKey(getContentElements(value), transitionType),
 		[value, transitionType],
@@ -62,8 +60,6 @@ function PostPromptViewInner() {
 			<CanvasProviders
 				editor={editor}
 				layoutKey={layoutKey}
-				transitionType={transitionType}
-				aspectRatio={aspectRatio}
 				sceneIds={sceneIds}
 			>
 				<div className="flex min-h-0 flex-1 overflow-hidden">

--- a/app/components/canvas/CanvasProviders.tsx
+++ b/app/components/canvas/CanvasProviders.tsx
@@ -2,8 +2,6 @@
 
 import type { ReactNode } from "react";
 import type { Editor } from "slate";
-import type { AspectRatio } from "@/lib/video/aspectRatio";
-import type { TransitionType } from "@/lib/video/transitions";
 import { VideoLayoutProvider } from "../video/VideoLayoutContext";
 import { PlayerControlProvider } from "../video/PlayerControlContext";
 import { ActiveSceneProvider } from "../scene-selection/ActiveSceneContext";
@@ -18,25 +16,16 @@ import { ViewModeProvider } from "./ViewModeContext";
 export function CanvasProviders({
 	editor,
 	layoutKey,
-	transitionType,
-	aspectRatio,
 	sceneIds,
 	children,
 }: {
 	editor: Editor;
 	layoutKey: string;
-	transitionType: TransitionType;
-	aspectRatio: AspectRatio;
 	sceneIds: string[];
 	children: ReactNode;
 }) {
 	return (
-		<VideoLayoutProvider
-			editor={editor}
-			layoutKey={layoutKey}
-			transitionType={transitionType}
-			aspectRatio={aspectRatio}
-		>
+		<VideoLayoutProvider editor={editor} layoutKey={layoutKey}>
 			<PlayerControlProvider>
 				<ActiveSceneProvider>
 					<AutoScrollProvider>

--- a/app/components/video/VideoLayoutContext.tsx
+++ b/app/components/video/VideoLayoutContext.tsx
@@ -5,8 +5,6 @@ import type { Editor } from "slate";
 import type { SceneElement } from "@/lib/canvas/types";
 import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
-import type { AspectRatio } from "@/lib/video/aspectRatio";
-import type { TransitionType } from "@/lib/video/transitions";
 import type { VideoLayout } from "@/lib/video/types";
 import { useAssetPrefetch } from "./useAssetPrefetch";
 import { useVideoLayout } from "./useVideoLayout";
@@ -25,22 +23,13 @@ export { useLayout };
 export function VideoLayoutProvider({
 	editor,
 	layoutKey,
-	transitionType,
-	aspectRatio,
 	children,
 }: {
 	editor: Editor;
 	layoutKey: string;
-	transitionType: TransitionType;
-	aspectRatio: AspectRatio;
 	children: ReactNode;
 }) {
-	const { layout, playerKey, scenes } = useVideoLayout(
-		editor,
-		layoutKey,
-		transitionType,
-		aspectRatio,
-	);
+	const { layout, playerKey, scenes } = useVideoLayout(editor, layoutKey);
 	const prefetched = useAssetPrefetch(layout);
 	const busy = useQueueSelector((q) => q.isBusy());
 	const ready = prefetched && !busy;

--- a/app/components/video/useVideoLayout.ts
+++ b/app/components/video/useVideoLayout.ts
@@ -8,15 +8,13 @@ import {
 } from "@/lib/generation/GenerationQueueProvider";
 import { resolveElements } from "@/lib/video/resolve";
 import { buildVideoLayout } from "@/lib/video/scene-builder";
-import type { AspectRatio } from "@/lib/video/aspectRatio";
-import type { TransitionType } from "@/lib/video/transitions";
+import { useAspectRatio } from "@/lib/video/useAspectRatio";
+import { useTransitionType } from "@/lib/video/useTransitionType";
 import type { VideoLayout } from "@/lib/video/types";
 
 export function useVideoLayout(
 	editor: Editor,
 	layoutKey: string,
-	transitionType: TransitionType,
-	aspectRatio: AspectRatio,
 ): {
 	layout: VideoLayout | null;
 	playerKey: string;
@@ -24,6 +22,8 @@ export function useVideoLayout(
 } {
 	const queue = useGenerationQueue();
 	const resultVersion = useQueueSelector((q) => q.getResultVersion());
+	const transitionType = useTransitionType();
+	const aspectRatio = useAspectRatio();
 
 	const { layout, scenes } = useMemo(() => {
 		const elements = editor.children as CanvasElement[];


### PR DESCRIPTION
## Summary
- Removed store-derived video settings from the canvas provider prop chain.
- Let `useVideoLayout` read `transitionType` and `aspectRatio` directly from the existing project-store hooks.
- Kept `layoutKey` as the only lifted layout input because it is derived from editor content.

## Architecture / maintainability changes
- Narrows `CanvasProviders` and `VideoLayoutProvider` to the editor/content boundary they actually need.
- Consolidates video settings access at the layout hook instead of threading the same store values through `PostPromptView` → `CanvasProviders` → `VideoLayoutProvider` → `useVideoLayout`.
- Removes duplicate interface surface and type imports from intermediate provider components.

## Complexity delta
- 4 files changed, 6 insertions / 32 deletions.
- Removed two props from two provider interfaces and one hook signature.
- Reduced prop drilling across three layers without changing layout computation inputs.

## Validation
- `git diff --check` ✅
- Independent no-edit review for semantic drift / hook ordering / import boundaries ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run typecheck` ✅
- `npm run knip` ✅
- `npm test -- --passWithNoTests` ✅ (94 files / 837 tests)
- `npm run build` ✅

## Open PR overlap check
Considered open PRs #312, #309, #305, #304, #303, and #302. This PR touches only:
- `app/components/PostPromptView.tsx`
- `app/components/canvas/CanvasProviders.tsx`
- `app/components/video/VideoLayoutContext.tsx`
- `app/components/video/useVideoLayout.ts`

The change is limited to video-layout setting ownership and does not overlap with the open TTS route validation, dropdown/menu sharing, project rehydrate undo, Playwright/CI, connector architecture, or tooltip-composition PRs.

## Skipped items
- Did not touch `proxy.ts` or third-party `<head>` scripts.
- Did not add docs; the narrowed provider interfaces are self-explanatory and extra prose would be low-signal.
- Avoided open-PR areas and adjacent themes listed above.
