### PR TITLE
refactor: rethink openslop architecture 2026-06-19

### DIFF
--- a/app/components/video/ScrubBar.tsx
+++ b/app/components/video/ScrubBar.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import { type PointerEvent, type ReactNode, useRef, useState } from "react";
-import { cn } from "@/lib/utils";
-
-const clamp = (n: number, min: number, max: number) =>
-	Math.max(min, Math.min(max, n));
+import { clamp, cn } from "@/lib/utils";
 
 /** A slice of a segmented track; `basis` is its fraction (0–1) of the whole. */
 export interface ScrubSegment {

--- a/app/components/video/SeekTooltip.tsx
+++ b/app/components/video/SeekTooltip.tsx
@@ -1,13 +1,11 @@
 "use client";
 
+import { clamp } from "@/lib/utils";
 import { formatTime } from "@/lib/video/timestamps";
 
 export type SeekThumbnail = { url: string; kind: "image" | "video" };
 
 const TOOLTIP_WIDTH = 160;
-
-const clamp = (n: number, min: number, max: number) =>
-	Math.max(min, Math.min(max, n));
 
 export function SeekTooltip({
 	x,

--- a/app/components/video/SegmentedSeekBar.tsx
+++ b/app/components/video/SegmentedSeekBar.tsx
@@ -2,14 +2,12 @@
 
 import type { PlayerRef } from "@remotion/player";
 import { useEffect, useRef, useState } from "react";
+import { clamp } from "@/lib/utils";
 import type { VideoLayout } from "@/lib/video/types";
 import { usePlayerFrame } from "./usePlayerState";
 import { SeekTooltip } from "./SeekTooltip";
 import { findSegmentIndexAt, type SceneSegment } from "./useSceneSegments";
 import { ScrubBar, type ScrubHover } from "./ScrubBar";
-
-const clamp = (n: number, min: number, max: number) =>
-	Math.max(min, Math.min(max, n));
 
 const HOVER_SETTLE_MS = 80;
 

--- a/app/components/video/useResize.ts
+++ b/app/components/video/useResize.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { clamp } from "@/lib/utils";
 
 export type ResizeAxis = "vertical" | "horizontal";
 
@@ -14,7 +15,7 @@ export function clampResize(
 ): number {
 	const delta =
 		axis === "vertical" ? currentPos - startPos : startPos - currentPos;
-	return Math.max(minSize, Math.min(startSize + delta, maxSize));
+	return clamp(startSize + delta, minSize, maxSize);
 }
 
 type ResizeListenerHost = {

--- a/lib/components/Waveform.tsx
+++ b/lib/components/Waveform.tsx
@@ -11,7 +11,7 @@ import {
 	useState,
 } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
-import { cn } from "@/lib/utils";
+import { clamp, cn } from "@/lib/utils";
 import { AUDIO_BAR_COUNT, buildSoundwaveMask } from "./soundwave";
 
 export interface WaveformProps {
@@ -67,8 +67,6 @@ export function extractPeaks(data: Float32Array, count: number): number[] {
 	return max > 0 ? peaks.map((p) => p / max) : peaks;
 }
 
-const clamp01 = (p: number) => Math.max(0, Math.min(1, p));
-
 export function Waveform({
 	src,
 	peaksCache,
@@ -99,7 +97,7 @@ export function Waveform({
 	const setProgress = useCallback((progress: number) => {
 		const el = progressRef.current;
 		if (el)
-			el.style.clipPath = `inset(0 ${(1 - clamp01(progress)) * 100}% 0 0)`;
+			el.style.clipPath = `inset(0 ${(1 - clamp(progress, 0, 1)) * 100}% 0 0)`;
 	}, []);
 
 	const paint = useCallback(() => {
@@ -172,7 +170,7 @@ export function Waveform({
 			seek(progress: number) {
 				const a = audioRef.current;
 				if (a?.duration) {
-					a.currentTime = clamp01(progress) * a.duration;
+					a.currentTime = clamp(progress, 0, 1) * a.duration;
 					setProgress(progress);
 				}
 			},
@@ -185,7 +183,7 @@ export function Waveform({
 		if (!a?.duration) return;
 		const rect = e.currentTarget.getBoundingClientRect();
 		const progress = (e.clientX - rect.left) / rect.width;
-		a.currentTime = clamp01(progress) * a.duration;
+		a.currentTime = clamp(progress, 0, 1) * a.duration;
 		setProgress(progress);
 	};
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,8 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
+
+/** Constrain `n` to the inclusive range [min, max]. */
+export function clamp(n: number, min: number, max: number) {
+	return Math.max(min, Math.min(max, n));
+}

--- a/lib/video/elementAttributes.ts
+++ b/lib/video/elementAttributes.ts
@@ -1,4 +1,5 @@
 import type { CanvasContentElement } from "@/lib/canvas/types";
+import { clamp } from "@/lib/utils";
 import {
 	DEFAULT_MOTION,
 	isMotionEffect,
@@ -21,7 +22,7 @@ const DEFAULT_VOLUME = VOLUME_MAX;
 export function getVolume(element: CanvasContentElement): number {
 	const raw = Number(element.customAttributes?.volume);
 	return Number.isFinite(raw)
-		? Math.max(VOLUME_MIN, Math.min(VOLUME_MAX, raw))
+		? clamp(raw, VOLUME_MIN, VOLUME_MAX)
 		: DEFAULT_VOLUME;
 }
 
@@ -31,7 +32,7 @@ const LOOPS_MAX = 1000;
 export function getLoops(element: CanvasContentElement): number {
 	const raw = Number(element.customAttributes?.loops);
 	if (!Number.isFinite(raw)) return 1;
-	return Math.max(1, Math.min(LOOPS_MAX, Math.floor(raw)));
+	return clamp(Math.floor(raw), 1, LOOPS_MAX);
 }
 
 /** Motion effect validated against the known set, defaulting to "none". */


### PR DESCRIPTION
## App understanding

OpenSlop turns a text prompt into a rendered video. A prompt streams OSML from `POST /api/v1/llm` into a SlateJS canvas (`app/components/canvas`); stale elements are queued and generated through the three-layer **connectors → gateways → providers** pipeline hitting `/api/v1/{asset}` routes backed by a Vercel Queue; results land in Vercel Blob and the canvas previews update; project state lives in per-project Zustand stores (`lib/project/store.ts`) and persists to Supabase (`projects`/`jobs` with RLS); `POST /api/render` fans the composition across Remotion Lambdas into an MP4. Auth is the Supabase session refreshed in `proxy.ts` with two API tiers in `lib/api/with-auth.ts`. Domain logic lives in `lib/` (ESLint-enforced never to import from `app/`); the UI lives in `app/` + shared shadcn primitives in `components/ui/`.

**Main workflows:** auth/onboarding → projects gallery → prompt composer (`PrePromptView`) → streamed canvas editor (`PostPromptView`) → per-element generation → video preview/playback → Lambda render/export.

## From-scratch architecture vs. current

A clean rebuild looks very close to what exists: a strict `lib/` domain layer vs. `app/` UI layer, the intentionally-layered connector/gateway/provider seam (kept — multiple providers per type are planned), a shared `createApiRouteHandler`/`bodySchema` factory for routes, Zustand-per-project state, and pure `lib/video` layout math fed into React hooks. Four parallel deep reads (API layer, canvas/state, video player, generation/providers) plus `knip` confirm there is **no dead code** and no major structural drift; remaining gaps are small duplications of low-level primitives.

The highest-leverage *safe, non-overlapping* gap was a duplicated numeric primitive: a `clamp(n, min, max)` was hand-rolled at **six** sites. A from-scratch build would expose this once, next to `cn`.

## Implemented simplifications

Single coherent change — consolidate the clamp primitive (mirrors the `SimpleTooltip` consolidation merged in #294):

- Added `clamp(n, min, max)` to `lib/utils.ts` (the existing shared-util home, alongside `cn`).
- Replaced three identical local `clamp` definitions in `ScrubBar`, `SeekTooltip`, `SegmentedSeekBar`.
- Replaced Waveform's one-off `clamp01(p)` with `clamp(p, 0, 1)`.
- Replaced the inlined `Math.max(min, Math.min(max, …))` pattern in `lib/video/elementAttributes.ts` (`getVolume`, `getLoops`) and `app/components/video/useResize.ts` (`clampResize`).

No behavior change — every site computed exactly `Math.max(min, Math.min(max, n))`. Net −2 lines but, more importantly, one tested primitive instead of six reinventions.

This candidate was **explicitly identified and deferred in #294** ("numeric clamp helper … lower-leverage and/or partially overlapped the open-PR file set") because it overlapped the then-open #293 (video scrub perf). #293 is now merged, so it is unblocked and non-overlapping.

## Validation

All checks from `.github/workflows/ci.yml`, locally:

- `npm run lint` — pass
- `npm run format:check` — pass
- `npm run typecheck` — pass
- `npm run knip` (dead code) — pass
- `npm run test:run` — 94 files / 837 tests pass
- `npm run build` — pass

## Skipped items / risks

- **Connector/gateway/provider consolidation** — deliberately not touched; the layering is intentional (multiple providers per type planned) and is actively being worked in #303.
- **Audio-provider Pinecone cache wrapper dedup** (`lib/providers/music|sfx/elevenlabs.ts`) — a real but separate concern; folding it in would make this PR span two unrelated abstractions. Deferred to keep one coherent reviewable change.
- **API GET-route auth factory**, **character-modal selector hooks**, **`ProjectTitle` store-access hook** — either marginal, against stated "call directly over wrapper hooks" preference, or overlapping open PRs (#302/#309/#312). Skipped.
- Risk is effectively zero: a pure, behavior-identical numeric helper swap covered by existing `elementAttributes`/`Waveform` tests.

## Open PR overlap check

Re-checked the final 7-file diff against every open PR — **zero file overlap**:

- **#313** (video layout ownership: `PostPromptView`, `CanvasProviders`, `VideoLayoutContext`, `useVideoLayout`) — not touched.
- **#312** (TTS voices route validation: `api/v1/__tests__/routes.test.ts`, `tts/voices/route.ts`, `lib/project/types.ts`) — not touched.
- **#309** (shared dropdown/menu primitives: `GlassDropdown`, `PrePromptView`, `SortableActions`, `AttributeBadge`, `ComposerCopilot`, `ui/action-menu`, `ui/select-menu`) — not touched.
- **#305** (`useProjectRehydrate` undo) — not touched.
- **#304** (Playwright/e2e CI config) — not touched.
- **#303** (connector architecture: `lib/connectors/*`) — not touched.
- **#302** (tooltip composition: `EditorToolbar`, `AudioPlayer`, `CharacterEditModal`) — not touched.

Changed files: `lib/utils.ts`, `lib/video/elementAttributes.ts`, `lib/components/Waveform.tsx`, `app/components/video/{ScrubBar,SeekTooltip,SegmentedSeekBar,useResize}.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
