### PR TITLE
fix: include reference images and all character avatars as style refs

### DIFF
--- a/lib/connectors/__tests__/character-avatar-style.test.ts
+++ b/lib/connectors/__tests__/character-avatar-style.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import { GatewayClient } from "@/lib/gateway/base";
+import { createCharacterAvatarStylePlugin } from "@/lib/connectors/llm/plugins/character-avatar-style";
+import { clearProjectStore, getProjectStore } from "@/lib/project/store";
+import type {
+	LLMGenerateParams,
+	LLMGenerateResult,
+	PluginContext,
+} from "../types";
+
+class MockLLMGateway extends GatewayClient<
+	LLMGenerateParams,
+	LLMGenerateResult
+> {
+	generate = vi.fn(
+		async (_params: LLMGenerateParams): Promise<LLMGenerateResult> => ({
+			text: "A freckled girl with red braids, painterly style.",
+			model: "test",
+		}),
+	);
+}
+
+function setup(projectId: string) {
+	clearProjectStore(projectId);
+	const gateway = new MockLLMGateway();
+	const plugin = createCharacterAvatarStylePlugin(projectId);
+	if (!plugin.transformPrompt)
+		throw new Error(
+			"character-avatar-style plugin must define transformPrompt",
+		);
+	const ctx: PluginContext<LLMGenerateParams, LLMGenerateResult> = { gateway };
+	return { gateway, transformPrompt: plugin.transformPrompt, ctx };
+}
+
+describe("createCharacterAvatarStylePlugin", () => {
+	it("returns the prompt unchanged when no character has an avatar", async () => {
+		const { gateway, transformPrompt, ctx } = setup("c1");
+		getProjectStore("c1")
+			.getState()
+			.setCharacter("Mira", { appearance: "blue hair" });
+
+		const result = await transformPrompt("write a scene", ctx);
+
+		expect(result).toBe("write a scene");
+		expect(gateway.generate).not.toHaveBeenCalled();
+	});
+
+	it("describes uploaded avatars from the image", async () => {
+		const { gateway, transformPrompt, ctx } = setup("c2");
+		getProjectStore("c2").getState().setCharacter("Mira", {
+			appearance: "",
+			avatarUrl: "https://example.com/mira.png",
+			avatarUploaded: true,
+		});
+
+		const result = await transformPrompt("write a scene", ctx);
+
+		expect(gateway.generate).toHaveBeenCalledOnce();
+		expect(gateway.generate.mock.calls[0][0].referenceImages).toEqual([
+			"https://example.com/mira.png",
+		]);
+		expect(result).toContain(
+			"- Mira: A freckled girl with red braids, painterly style.",
+		);
+		expect(result).toContain("write a scene");
+	});
+
+	it("reuses the appearance text for generated avatars without calling the gateway", async () => {
+		const { gateway, transformPrompt, ctx } = setup("c3");
+		getProjectStore("c3").getState().setCharacter("Mira", {
+			appearance: "a tall woman with green hair",
+			avatarUrl: "https://example.com/generated.png",
+			avatarUploaded: false,
+		});
+
+		const result = await transformPrompt("write a scene", ctx);
+
+		expect(gateway.generate).not.toHaveBeenCalled();
+		expect(result).toContain("- Mira: a tall woman with green hair");
+	});
+
+	it("preserves both generated and uploaded character appearances", async () => {
+		const { gateway, transformPrompt, ctx } = setup("c4");
+		const store = getProjectStore("c4").getState();
+		store.setCharacter("Generated", {
+			appearance: "a tall woman with green hair",
+			avatarUrl: "https://example.com/generated.png",
+			avatarUploaded: false,
+		});
+		store.setCharacter("Uploaded", {
+			appearance: "",
+			avatarUrl: "https://example.com/uploaded.png",
+			avatarUploaded: true,
+		});
+
+		const result = await transformPrompt("write a scene", ctx);
+
+		expect(gateway.generate).toHaveBeenCalledOnce();
+		expect(result).toContain("- Generated: a tall woman with green hair");
+		expect(result).toContain(
+			"- Uploaded: A freckled girl with red braids, painterly style.",
+		);
+	});
+
+	it("throws when an uploaded avatar needs description but no gateway is provided", async () => {
+		const { transformPrompt } = setup("c5");
+		getProjectStore("c5").getState().setCharacter("Mira", {
+			appearance: "",
+			avatarUrl: "https://example.com/mira.png",
+			avatarUploaded: true,
+		});
+
+		await expect(transformPrompt("write a scene")).rejects.toThrow(
+			"character-avatar-style plugin requires gateway context",
+		);
+	});
+});

--- a/lib/connectors/__tests__/reference-style.test.ts
+++ b/lib/connectors/__tests__/reference-style.test.ts
@@ -55,6 +55,55 @@ describe("createReferenceStylePlugin", () => {
 		expect(result).toContain("a knight and a dragon");
 	});
 
+	it("combines reference images with all character avatars (uploaded and generated)", async () => {
+		const projectId = "p4";
+		const referenceImage = "https://example.com/reference.jpg";
+		const uploadedAvatar = "https://example.com/uploaded-avatar.jpg";
+		const generatedAvatar = "https://example.com/generated-avatar.jpg";
+		const { gateway, transformPrompt, ctx } = setup(projectId, [
+			referenceImage,
+		]);
+		const store = getProjectStore(projectId);
+		store.getState().setCharacter("Mira", {
+			appearance: "blue hair",
+			avatarUrl: uploadedAvatar,
+			avatarUploaded: true,
+		});
+		store.getState().setCharacter("Generated", {
+			appearance: "green hair",
+			avatarUrl: generatedAvatar,
+			avatarUploaded: false,
+		});
+
+		const result = await transformPrompt("a knight and a dragon", ctx);
+
+		expect(gateway.generate).toHaveBeenCalledOnce();
+		expect(gateway.generate.mock.calls[0][0].referenceImages).toEqual([
+			referenceImage,
+			uploadedAvatar,
+			generatedAvatar,
+		]);
+		expect(result).toMatch(
+			/^Art style reference: Soft watercolor, pastel palette, dreamy lighting\./,
+		);
+	});
+
+	it("uses character avatars as style references when no reference images are present", async () => {
+		const projectId = "p5";
+		const avatar = "https://example.com/avatar.jpg";
+		const { gateway, transformPrompt, ctx } = setup(projectId, []);
+		getProjectStore(projectId).getState().setCharacter("Mira", {
+			appearance: "blue hair",
+			avatarUrl: avatar,
+			avatarUploaded: false,
+		});
+
+		await transformPrompt("a knight and a dragon", ctx);
+
+		expect(gateway.generate).toHaveBeenCalledOnce();
+		expect(gateway.generate.mock.calls[0][0].referenceImages).toEqual([avatar]);
+	});
+
 	it("throws when no gateway is provided", async () => {
 		const { transformPrompt } = setup("p3", ["https://example.com/a.jpg"]);
 		await expect(transformPrompt("hi")).rejects.toThrow(

--- a/lib/connectors/__tests__/reference-style.test.ts
+++ b/lib/connectors/__tests__/reference-style.test.ts
@@ -55,7 +55,7 @@ describe("createReferenceStylePlugin", () => {
 		expect(result).toContain("a knight and a dragon");
 	});
 
-	it("combines reference images with all character avatars (uploaded and generated)", async () => {
+	it("combines reference images with uploaded avatars but excludes generated ones", async () => {
 		const projectId = "p4";
 		const referenceImage = "https://example.com/reference.jpg";
 		const uploadedAvatar = "https://example.com/uploaded-avatar.jpg";
@@ -81,27 +81,41 @@ describe("createReferenceStylePlugin", () => {
 		expect(gateway.generate.mock.calls[0][0].referenceImages).toEqual([
 			referenceImage,
 			uploadedAvatar,
-			generatedAvatar,
 		]);
 		expect(result).toMatch(
 			/^Art style reference: Soft watercolor, pastel palette, dreamy lighting\./,
 		);
 	});
 
-	it("uses character avatars as style references when no reference images are present", async () => {
+	it("uses uploaded character avatars as style references when no reference images are present", async () => {
 		const projectId = "p5";
 		const avatar = "https://example.com/avatar.jpg";
 		const { gateway, transformPrompt, ctx } = setup(projectId, []);
 		getProjectStore(projectId).getState().setCharacter("Mira", {
 			appearance: "blue hair",
 			avatarUrl: avatar,
-			avatarUploaded: false,
+			avatarUploaded: true,
 		});
 
 		await transformPrompt("a knight and a dragon", ctx);
 
 		expect(gateway.generate).toHaveBeenCalledOnce();
 		expect(gateway.generate.mock.calls[0][0].referenceImages).toEqual([avatar]);
+	});
+
+	it("ignores generated avatars to avoid circular style references", async () => {
+		const projectId = "p6";
+		const { gateway, transformPrompt, ctx } = setup(projectId, []);
+		getProjectStore(projectId).getState().setCharacter("Generated", {
+			appearance: "green hair",
+			avatarUrl: "https://example.com/generated-avatar.jpg",
+			avatarUploaded: false,
+		});
+
+		const result = await transformPrompt("a knight and a dragon", ctx);
+
+		expect(result).toBe("a knight and a dragon");
+		expect(gateway.generate).not.toHaveBeenCalled();
 	});
 
 	it("throws when no gateway is provided", async () => {

--- a/lib/connectors/llm/plugins/character-avatar-style.ts
+++ b/lib/connectors/llm/plugins/character-avatar-style.ts
@@ -15,7 +15,7 @@ export function createCharacterAvatarStylePlugin(projectId: string): LLMPlugin {
 			ctx?: PluginContext<LLMGenerateParams, LLMGenerateResult>,
 		) {
 			const characters =
-				getProjectStore(projectId).getState().metadata.characters ?? {};
+				getProjectStore(projectId).getState().metadata.characters;
 			const withAvatar = Object.entries(characters).flatMap(([name, c]) =>
 				c.avatarUrl ? [{ name, character: c, url: c.avatarUrl }] : [],
 			);

--- a/lib/connectors/llm/plugins/character-avatar-style.ts
+++ b/lib/connectors/llm/plugins/character-avatar-style.ts
@@ -27,12 +27,11 @@ export function createCharacterAvatarStylePlugin(projectId: string): LLMPlugin {
 					if (!character.avatarUploaded && character.appearance.trim())
 						return `- ${name}: ${character.appearance.trim()}`;
 
-					const gateway = ctx?.gateway;
-					if (!gateway)
+					if (!ctx?.gateway)
 						throw new Error(
 							"character-avatar-style plugin requires gateway context",
 						);
-					const { text } = await gateway.generate({
+					const { text } = await ctx.gateway.generate({
 						prompt: dedent`Concisely describe the visual appearance of the character in the attached reference image in a short sentence. Focus on gender, ethnicity, face, hair, body type, art style, and any distinctive features. Do not describe the background.`,
 						referenceImages: [url],
 						maxTokens: 4096,

--- a/lib/connectors/llm/plugins/character-avatar-style.ts
+++ b/lib/connectors/llm/plugins/character-avatar-style.ts
@@ -16,18 +16,22 @@ export function createCharacterAvatarStylePlugin(projectId: string): LLMPlugin {
 		) {
 			const characters =
 				getProjectStore(projectId).getState().metadata.characters ?? {};
-			const uploaded = Object.entries(characters).flatMap(([name, c]) =>
-				c.avatarUploaded && c.avatarUrl ? [{ name, url: c.avatarUrl }] : [],
+			const withAvatar = Object.entries(characters).flatMap(([name, c]) =>
+				c.avatarUrl ? [{ name, character: c, url: c.avatarUrl }] : [],
 			);
-			if (uploaded.length === 0) return prompt;
-			const gateway = ctx?.gateway;
-			if (!gateway)
-				throw new Error(
-					"character-avatar-style plugin requires gateway context",
-				);
+			if (withAvatar.length === 0) return prompt;
 
 			const described = await Promise.all(
-				uploaded.map(async ({ name, url }) => {
+				withAvatar.map(async ({ name, character, url }) => {
+					// Reuse appearance text from generated avatars
+					if (!character.avatarUploaded && character.appearance.trim())
+						return `- ${name}: ${character.appearance.trim()}`;
+
+					const gateway = ctx?.gateway;
+					if (!gateway)
+						throw new Error(
+							"character-avatar-style plugin requires gateway context",
+						);
 					const { text } = await gateway.generate({
 						prompt: dedent`Concisely describe the visual appearance of the character in the attached reference image in a short sentence. Focus on gender, ethnicity, face, hair, body type, art style, and any distinctive features. Do not describe the background.`,
 						referenceImages: [url],

--- a/lib/connectors/llm/plugins/reference-style.ts
+++ b/lib/connectors/llm/plugins/reference-style.ts
@@ -19,8 +19,10 @@ export function createReferenceStylePlugin(projectId: string): LLMPlugin {
 				getProjectStore(projectId).getState();
 			const styleReferenceImages = compact([
 				...referenceImages,
-				...Object.values(metadata.characters).map(
-					(character) => character.avatarUrl,
+				...Object.values(metadata.characters).flatMap((character) =>
+					character.avatarUploaded && character.avatarUrl
+						? [character.avatarUrl]
+						: [],
 				),
 			]);
 			if (styleReferenceImages.length === 0) return prompt;

--- a/lib/connectors/llm/plugins/reference-style.ts
+++ b/lib/connectors/llm/plugins/reference-style.ts
@@ -19,10 +19,8 @@ export function createReferenceStylePlugin(projectId: string): LLMPlugin {
 				getProjectStore(projectId).getState();
 			const styleReferenceImages = compact([
 				...referenceImages,
-				...Object.values(metadata.characters).flatMap((character) =>
-					character.avatarUploaded && character.avatarUrl
-						? [character.avatarUrl]
-						: [],
+				...Object.values(metadata.characters).map((character) =>
+					character.avatarUploaded ? character.avatarUrl : undefined,
 				),
 			]);
 			if (styleReferenceImages.length === 0) return prompt;

--- a/lib/connectors/llm/plugins/reference-style.ts
+++ b/lib/connectors/llm/plugins/reference-style.ts
@@ -1,4 +1,5 @@
 import dedent from "dedent";
+import compact from "lodash/compact";
 import { getProjectStore } from "@/lib/project/store";
 import type {
 	LLMGenerateParams,
@@ -14,14 +15,20 @@ export function createReferenceStylePlugin(projectId: string): LLMPlugin {
 			prompt: string,
 			ctx?: PluginContext<LLMGenerateParams, LLMGenerateResult>,
 		) {
-			const referenceImages =
-				getProjectStore(projectId).getState().referenceImages;
-			if (referenceImages.length === 0) return prompt;
+			const { metadata, referenceImages } =
+				getProjectStore(projectId).getState();
+			const styleReferenceImages = compact([
+				...referenceImages,
+				...Object.values(metadata.characters).map(
+					(character) => character.avatarUrl,
+				),
+			]);
+			if (styleReferenceImages.length === 0) return prompt;
 			if (!ctx?.gateway)
 				throw new Error("reference-style plugin requires gateway context");
 			const { text: style } = await ctx.gateway.generate({
 				prompt: dedent`Vividly and concisely describe the visual art style of the attached reference image(s) in 1–2 concise sentences. Include ultra specific detail on character art style and overall art style.`,
-				referenceImages,
+				referenceImages: styleReferenceImages,
 				maxTokens: 4096,
 			});
 			return dedent`Art style reference: ${style}


### PR DESCRIPTION
## Summary
- Feed the LLM reference-style plugin **uploaded** style sources: project reference images **and uploaded** character avatars.
- Previously uploaded character avatars were only a fallback used when no project reference images existed. Now they are always combined with project references into a single style-reference set.
- **Generated** character avatars are excluded: they were themselves produced from the style, so describing style off them feeds the model's own output back as ground truth (circular → style drift). See #298.

## Selected issue and scope
Selected #298 because it is a small, well-scoped correctness bug with clear acceptance criteria and an isolated code path (`lib/connectors/llm/plugins/reference-style.ts`). The fix is limited to style-reference input selection and focused regression tests.

## Behavior
- Style references = `referenceImages` + every uploaded `character.avatarUrl` (`avatarUploaded && avatarUrl`), deduped of empties via `lodash/compact`.
- Uploaded character avatars contribute even when no project-level references exist; generated avatars never do.
- Empty set (no reference images and no uploaded avatars) still short-circuits and returns the prompt unchanged.

## Related fix
- `character-avatar-style.ts` now preserves **all** character avatars (uploaded and generated), not just uploaded ones. A pregenerated avatar would otherwise be ignored by the script LLM, which would invent a new appearance and leave the existing avatar stale. Generated avatars reuse their stored appearance text; uploaded ones are described from the image. (This is the appearance-preservation path, distinct from art-style extraction above, so including generated avatars here is not circular.)

## Tests
- Reference images combine with uploaded avatars but exclude generated ones, in order.
- Uploaded character avatars are used as style references when no project reference images are present (the original #298 path).
- Generated-only avatars short-circuit (no gateway call), guarding against circular references.
- Character-avatar-style coverage: passthrough with no avatars, uploaded described from image, generated avatars reuse appearance text without a gateway call, mixed generated + uploaded, and the gateway-required guard.

## Validation
- `npm test -- lib/connectors --run` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run typecheck` ✅

Closes #298
