### PR TITLE
Overlay polish + typography token & prop-driven sizing sweep

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -28,6 +28,8 @@ One clean grotesque for UI and body: **Inter** (`--font-sans`). **IBM Plex Mono*
 
 The scale lives as `@theme` tokens in `app/globals.css`: use the `text-badge-xs` / `text-badge` / `text-label-xs` / `text-label` / `text-body` / `text-body-lg` / `text-heading-sm` / `text-heading` / `text-heading-lg` / `text-display` utilities — named font-sizes only (leading inherits; pair with `leading-*` / `font-medium` where a tighter line or heavier weight is wanted) — rather than hand-picking raw `text-xs` / `text-sm` or `text-[Npx]` arbitraries.
 
+In a dense row, a primary label and its secondary description share one size and weight (e.g. both `text-label`), differentiated by color alone — `text-foreground` for the label, `text-muted-foreground` for the description. Don't shrink or bold the label to set it apart.
+
 ## Spacing, radius, elevation
 
 4px base spacing. Radius via `--radius` (`0.625rem`); cards `rounded-xl`, overlays (modals, popovers, dropdowns, selects) and form controls (inputs, textareas, select triggers) `rounded-md`, pills `rounded-full`. Depth comes from token elevations `shadow-elevation-1/3/5/10`, not glow — popovers and menus sit at `shadow-elevation-3`.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,7 +24,7 @@ Use semantic tokens (`bg-background`, `text-foreground`, `border-border`, `bg-ca
 
 ## Typography
 
-One clean grotesque for UI and body: **Inter** (`--font-sans`). **IBM Plex Mono** (`--font-mono`) for timecodes and durations. Scales are as follows: label 11–12px, body 14–16px, headings 18/24/36/48px. `.font-title` = Inter 600 with tight tracking; `.font-body` = Inter 400.
+UI and titles use **Sloptastic** (`--font-sans`, `.font-title`), a clean grotesque; long-form body text uses **Inter** (`--font-body`). **IBM Plex Mono** (`--font-mono`) for timecodes and durations. Two display faces for marketing surfaces only: **Instrument Serif** (`--font-serif`, hero headlines) and **Sentient** (`--font-sentient`, the onboarding wordmark). Scales are as follows: label 11–12px, body 14–16px, headings 18/24/36/48px. `.font-title` = Sloptastic 575 with tight tracking; `.font-body` = Inter 425.
 
 The scale lives as `@theme` tokens in `app/globals.css`: use the `text-badge-xs` / `text-badge` / `text-label-xs` / `text-label` / `text-body` / `text-body-lg` / `text-heading-sm` / `text-heading` / `text-heading-lg` / `text-display` utilities — named font-sizes only (leading inherits; pair with `leading-*` / `font-medium` where a tighter line or heavier weight is wanted) — rather than hand-picking raw `text-xs` / `text-sm` or `text-[Npx]` arbitraries.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -28,7 +28,7 @@ One clean grotesque for UI and body: **Inter** (`--font-sans`). **IBM Plex Mono*
 
 ## Spacing, radius, elevation
 
-4px base spacing. Radius via `--radius` (`0.625rem`); cards `rounded-xl`, modals `rounded-3xl`, pills `rounded-full`. Depth comes from token elevations `shadow-elevation-1/3/5/10`, not glow.
+4px base spacing. Radius via `--radius` (`0.625rem`); cards `rounded-xl`, overlays (modals, popovers, dropdowns, selects) and form controls (inputs, textareas, select triggers) `rounded-md`, pills `rounded-full`. Depth comes from token elevations `shadow-elevation-1/3/5/10`, not glow — popovers and menus sit at `shadow-elevation-3`.
 
 ## Motion
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -26,6 +26,8 @@ Use semantic tokens (`bg-background`, `text-foreground`, `border-border`, `bg-ca
 
 One clean grotesque for UI and body: **Inter** (`--font-sans`). **IBM Plex Mono** (`--font-mono`) for timecodes and durations. Scales are as follows: label 11–12px, body 14–16px, headings 18/24/36/48px. `.font-title` = Inter 600 with tight tracking; `.font-body` = Inter 400.
 
+The scale lives as `@theme` tokens in `app/globals.css`: use the `text-badge-xs` / `text-badge` / `text-label-xs` / `text-label` / `text-body` / `text-body-lg` / `text-heading-sm` / `text-heading` / `text-heading-lg` / `text-display` utilities — named font-sizes only (leading inherits; pair with `leading-*` / `font-medium` where a tighter line or heavier weight is wanted) — rather than hand-picking raw `text-xs` / `text-sm` or `text-[Npx]` arbitraries.
+
 ## Spacing, radius, elevation
 
 4px base spacing. Radius via `--radius` (`0.625rem`); cards `rounded-xl`, overlays (modals, popovers, dropdowns, selects) and form controls (inputs, textareas, select triggers) `rounded-md`, pills `rounded-full`. Depth comes from token elevations `shadow-elevation-1/3/5/10`, not glow — popovers and menus sit at `shadow-elevation-3`.
@@ -41,3 +43,5 @@ One opt-in treatment: subtle film grain (`.grain`, theme-tuned `--grain-opacity`
 ## Components
 
 Idiomatic, shadcn-consistent primitives in `components/ui/` built with `class-variance-authority`, tokens only. Buttons: `default` (near-black inverse, for in-tool actions), `accent` (blurple, for hero/auth CTAs), plus `secondary`/`outline`/`ghost`/`icon`/`destructive`. Icons: `lucide-react`, thin (`strokeWidth` ≈1.5).
+
+Button **dimensions** come from the `size` prop (`sm`/`default`/`lg`/`icon`) defined in `buttonVariants` — never hand-size a button with `h-*`/`px-*`/`text-*` in `className`. Add a named `size` to the variant if you need a new one.

--- a/app/components/EditorToolbar.tsx
+++ b/app/components/EditorToolbar.tsx
@@ -59,9 +59,9 @@ export function EditorToolbar({ editor }: { editor: Editor }) {
 
 	return (
 		<div
-			className={`z-40 flex w-full shrink-0 flex-col items-center gap-3 px-4 py-3 pb-2 pl-16 ${editorStyles.copilotEnter}`}
+			className={`z-40 flex w-full shrink-0 flex-col items-center gap-3 px-4 py-1.5 pl-16 ${editorStyles.copilotEnter}`}
 		>
-			<div className="flex w-full items-start gap-3">
+			<div className="flex w-full items-center gap-3">
 				<div className="hidden flex-1 sm:block" aria-hidden />
 				<div className="min-w-0 max-w-2xl flex-1">
 					<RefineComposer
@@ -70,12 +70,13 @@ export function EditorToolbar({ editor }: { editor: Editor }) {
 						onStop={stopGeneration}
 					/>
 				</div>
-				<div className="flex flex-1 items-start justify-end gap-2 max-sm:flex-none">
+				<div className="flex flex-1 items-center justify-end gap-2 max-sm:flex-none">
 					<Button
 						type="button"
 						variant="generate"
+						size="sm"
 						onClick={generateAll}
-						className="h-11 shrink-0 px-4 sm:px-5"
+						className="shrink-0 sm:px-4"
 						aria-label={generateLabel}
 						disabled={busy}
 					>

--- a/app/components/PostPromptView.tsx
+++ b/app/components/PostPromptView.tsx
@@ -52,9 +52,7 @@ function PostPromptViewInner() {
 				aria-hidden
 				className="dot-grid-bg pointer-events-none fixed inset-0 -z-10"
 			/>
-			<div className="fixed top-4 left-4 z-[100]">
-				<UserProfile />
-			</div>
+			<UserProfile />
 
 			<CanvasProviders
 				editor={editor}

--- a/app/components/PrePromptView.tsx
+++ b/app/components/PrePromptView.tsx
@@ -10,9 +10,7 @@ export default function PrePromptView() {
 				aria-hidden
 				className="dot-grid-bg pointer-events-none fixed inset-0 -z-10"
 			/>
-			<div className="fixed left-4 top-4 z-[100]">
-				<UserProfile />
-			</div>
+			<UserProfile />
 			<ComposerHero />
 		</>
 	);

--- a/app/components/TemplateGallery.tsx
+++ b/app/components/TemplateGallery.tsx
@@ -61,7 +61,7 @@ export default function TemplateGallery({
 								{template.showcase.description}
 							</span>
 							<span
-								className="relative mt-1.5 inline-block self-start overflow-hidden rounded-full px-1.5 py-0.5 text-[10px] font-medium text-white"
+								className="relative mt-1.5 inline-block self-start overflow-hidden rounded-full px-1.5 py-0.5 text-badge font-medium text-white"
 								style={{ backgroundColor: template.color }}
 							>
 								{template.name}

--- a/app/components/UserProfile.tsx
+++ b/app/components/UserProfile.tsx
@@ -40,7 +40,7 @@ export default function UserProfile() {
 	const initials = email.split("@")[0].slice(0, 2).toUpperCase();
 
 	return (
-		<div className="animate-in fade-in duration-300 motion-reduce:transition-none">
+		<div className="fixed left-5 top-4 z-[100] animate-in fade-in duration-300 motion-reduce:transition-none">
 			<DropdownMenu modal={false}>
 				<DropdownMenuTrigger asChild>
 					<button

--- a/app/components/canvas/ProjectTitle.tsx
+++ b/app/components/canvas/ProjectTitle.tsx
@@ -47,7 +47,7 @@ export function ProjectTitle() {
 					if (e.key === "Enter") commit();
 					else if (e.key === "Escape") setEditing(false);
 				}}
-				className="mb-3 w-full bg-transparent font-body text-2xl font-semibold text-foreground outline-none"
+				className="mb-3 w-full bg-transparent font-body text-heading font-semibold text-foreground outline-none"
 				aria-label="Project title"
 			/>
 		);
@@ -55,7 +55,7 @@ export function ProjectTitle() {
 
 	return (
 		<div className="group mb-3 flex items-center gap-2">
-			<h1 className="font-body text-2xl font-semibold text-foreground">
+			<h1 className="font-body text-heading font-semibold text-foreground">
 				{title}
 			</h1>
 			<button

--- a/app/components/canvas/ProjectTitle.tsx
+++ b/app/components/canvas/ProjectTitle.tsx
@@ -47,7 +47,7 @@ export function ProjectTitle() {
 					if (e.key === "Enter") commit();
 					else if (e.key === "Escape") setEditing(false);
 				}}
-				className="mb-3 w-full bg-transparent text-2xl font-semibold text-foreground outline-none"
+				className="mb-3 w-full bg-transparent font-body text-2xl font-semibold text-foreground outline-none"
 				aria-label="Project title"
 			/>
 		);
@@ -55,7 +55,9 @@ export function ProjectTitle() {
 
 	return (
 		<div className="group mb-3 flex items-center gap-2">
-			<h1 className="text-2xl font-semibold text-foreground">{title}</h1>
+			<h1 className="font-body text-2xl font-semibold text-foreground">
+				{title}
+			</h1>
 			<button
 				type="button"
 				onClick={startEditing}

--- a/app/components/canvas/elements/AssetTile.tsx
+++ b/app/components/canvas/elements/AssetTile.tsx
@@ -86,7 +86,7 @@ export function AssetTile({
 			</div>
 			{name && (
 				<span
-					className="truncate text-[10px] text-muted-foreground"
+					className="truncate text-badge text-muted-foreground"
 					title={name}
 				>
 					{name}

--- a/app/components/canvas/elements/AssetsSection.tsx
+++ b/app/components/canvas/elements/AssetsSection.tsx
@@ -52,7 +52,7 @@ export function AssetsSection() {
 						<div className="flex aspect-square items-center justify-center rounded-md border border-dashed border-border bg-muted text-muted-foreground transition-colors hover:border-border hover:bg-muted hover:text-foreground">
 							<Plus className="h-4 w-4" />
 						</div>
-						<span className="truncate text-[10px] text-muted-foreground">
+						<span className="truncate text-badge text-muted-foreground">
 							New
 						</span>
 					</button>

--- a/app/components/canvas/elements/AttributeBadge.tsx
+++ b/app/components/canvas/elements/AttributeBadge.tsx
@@ -14,7 +14,7 @@ function formatValue(key: string, value: string): string {
 }
 
 const PILL =
-	"bg-secondary text-secondary-foreground text-[12px] px-1.5 py-0.5 rounded-md max-w-[140px] truncate";
+	"bg-secondary text-secondary-foreground text-label px-1.5 py-0.5 rounded-md max-w-[140px] truncate";
 
 interface AttributeBadgeProps {
 	element: CanvasContentElement;
@@ -94,7 +94,7 @@ export function AttributeBadge({
 			<button
 				aria-label={tooltip}
 				onMouseDown={(e) => e.preventDefault()}
-				className="inline-flex max-w-[140px] cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-[12px] text-muted-foreground transition-colors hover:bg-button-hover hover:text-foreground"
+				className="inline-flex max-w-[140px] cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-label text-muted-foreground transition-colors hover:bg-button-hover hover:text-foreground"
 			>
 				<span className="min-w-0 truncate">{labeled}</span>
 				<ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />

--- a/app/components/canvas/elements/AudioPlayer.tsx
+++ b/app/components/canvas/elements/AudioPlayer.tsx
@@ -43,7 +43,7 @@ export function AudioPlayer({ src }: { src: string }) {
 				}}
 				onFinish={() => setPlaying(false)}
 			/>
-			<span className="shrink-0 ml-auto text-[10px] tabular-nums text-muted-foreground">
+			<span className="shrink-0 ml-auto text-badge tabular-nums text-muted-foreground">
 				{formatTime(currentTime)}/{formatTime(duration)}
 			</span>
 		</>

--- a/app/components/canvas/elements/CharactersPicker.tsx
+++ b/app/components/canvas/elements/CharactersPicker.tsx
@@ -82,7 +82,7 @@ function ProjectCharactersMenu({
 					key={name}
 					onClick={() => onSelect(name)}
 					onSelect={(e) => e.preventDefault()}
-					className="cursor-pointer py-1 text-[11px] text-muted-foreground"
+					className="cursor-pointer py-1 text-label text-muted-foreground"
 				>
 					<span className="w-3.5 shrink-0 flex items-center justify-center">
 						{selected.has(name) && (

--- a/app/components/canvas/elements/CollapsibleHeader.tsx
+++ b/app/components/canvas/elements/CollapsibleHeader.tsx
@@ -19,7 +19,7 @@ export function CollapsibleHeader({
 	const Icon = collapsed ? ChevronRight : ChevronDown;
 	return (
 		<div
-			className="flex items-center gap-1 select-none text-[10px] text-muted-foreground font-medium mb-2 h-5"
+			className="flex items-center gap-1 select-none text-badge text-muted-foreground font-medium mb-2 h-5"
 			contentEditable={false}
 		>
 			<button

--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -46,7 +46,7 @@ function ElementSettings({
 					</button>
 				</PopoverTrigger>
 			</SimpleTooltip>
-			<PopoverContent align="start" className="w-64">
+			<PopoverContent align="start" className="w-64 border border-border">
 				<div className="mb-2 text-xs font-semibold text-muted-foreground">
 					Settings
 				</div>

--- a/app/components/canvas/elements/GenerateButton.tsx
+++ b/app/components/canvas/elements/GenerateButton.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { AlertCircle, Sparkles } from "@/components/ui/icon";
+import { AlertCircle, Hourglass, Sparkles } from "@/components/ui/icon";
 import { SimpleTooltip } from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import type { CanvasContentElement } from "@/lib/canvas/types";
-import { cn } from "@/lib/utils";
+import type { GenerationStatus } from "@/lib/generation/queue";
 import { useGenerate } from "../hooks/useGenerate";
 
 export function StaleIndicator() {
 	return (
 		<SimpleTooltip label="Prompt changed — regenerate to update">
-			<span className="inline-flex items-center gap-1 rounded-full border border-tertiary/50 bg-tertiary/10 px-2 py-0.5 text-[11px] font-medium text-tertiary">
+			<span className="inline-flex items-center gap-1 rounded-full border border-tertiary/50 bg-tertiary/10 px-2 py-0.5 text-label-xs font-medium text-tertiary">
 				<AlertCircle className="h-3 w-3" />
 				Stale
 			</span>
@@ -17,33 +19,44 @@ export function StaleIndicator() {
 	);
 }
 
+function generateLabel(status: GenerationStatus, hasResult: boolean) {
+	if (status === "generating") return "Generating…";
+	if (status === "queued") return "Queued";
+	return hasResult ? "Regenerate" : "Generate";
+}
+
 export function GenerateButton({
-	label,
+	status,
+	hasResult,
 	disabled,
 	onGenerate,
 }: {
-	label: string;
+	status: GenerationStatus;
+	hasResult: boolean;
 	disabled: boolean;
 	onGenerate: () => void;
 }) {
+	const label = generateLabel(status, hasResult);
 	return (
-		<SimpleTooltip label={label}>
-			<button
-				type="button"
-				aria-label={label}
-				disabled={disabled}
-				onMouseDown={(e) => e.preventDefault()}
-				onClick={onGenerate}
-				className={cn(
-					"inline-flex h-7 w-7 items-center justify-center rounded-lg transition-colors enabled:hover:bg-generate-hover disabled:cursor-not-allowed",
-					disabled
-						? "bg-generate-disabled text-generate-disabled-foreground"
-						: "bg-generate text-generate-foreground",
-				)}
-			>
-				<Sparkles className="h-3.5 w-3.5" strokeWidth={1.5} />
-			</button>
-		</SimpleTooltip>
+		<Button
+			type="button"
+			variant="generate"
+			size="sm"
+			className="shrink-0"
+			disabled={disabled}
+			onMouseDown={(e) => e.preventDefault()}
+			onClick={onGenerate}
+			aria-label={label}
+		>
+			{status === "generating" ? (
+				<Spinner className="text-current" />
+			) : status === "queued" ? (
+				<Hourglass aria-hidden="true" />
+			) : (
+				<Sparkles aria-hidden="true" />
+			)}
+			{label}
+		</Button>
 	);
 }
 
@@ -58,7 +71,8 @@ export function ElementGenerateButton({
 		<div className="flex items-center gap-2">
 			{stale && hasResult && <StaleIndicator />}
 			<GenerateButton
-				label="Generate"
+				status={status}
+				hasResult={hasResult}
 				disabled={!hasPrompt || status !== "idle"}
 				onGenerate={generate}
 			/>

--- a/app/components/canvas/elements/SceneContainer.tsx
+++ b/app/components/canvas/elements/SceneContainer.tsx
@@ -127,7 +127,7 @@ function CollapsedScene({ attributes, element, children }: SceneProps) {
 				</div>
 				{overflowCount > 0 && (
 					<span
-						className="text-[10px] text-muted-foreground pl-1 select-none shrink-0 text-left"
+						className="text-badge text-muted-foreground pl-1 select-none shrink-0 text-left"
 						contentEditable={false}
 					>
 						+{overflowCount} more

--- a/app/components/canvas/elements/attributes/TextAttributePopover.tsx
+++ b/app/components/canvas/elements/attributes/TextAttributePopover.tsx
@@ -67,7 +67,7 @@ export function TextAttributePopover({
 					type="button"
 					aria-label={tooltip}
 					title={tooltip}
-					className={`${color} text-foreground text-[12px] px-2 py-1 rounded-md max-w-[140px] inline-flex items-center gap-1.5 cursor-pointer ring-1 ring-inset ring-border hover:ring-border hover:brightness-110 transition-all`}
+					className={`${color} text-foreground text-label px-2 py-1 rounded-md max-w-[140px] inline-flex items-center gap-1.5 cursor-pointer ring-1 ring-inset ring-border hover:ring-border hover:brightness-110 transition-all`}
 				>
 					<span className="truncate min-w-0">
 						{!hideLabel && (
@@ -101,9 +101,9 @@ export function TextAttributePopover({
 							setOpen(false);
 						}
 					}}
-					className="w-full resize-none rounded-lg border border-border bg-card px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-accent/50"
+					className="w-full resize-none rounded-lg border border-border bg-card px-2 py-1.5 font-body text-label text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-accent/50"
 				/>
-				<div className="mt-1 px-1 text-[10px] text-muted-foreground">
+				<div className="mt-1 px-1 text-badge text-muted-foreground">
 					⌘↵ to save · esc to cancel
 				</div>
 			</PopoverContent>

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -185,7 +185,8 @@ function CharacterEditDialogBody({
 							)}
 							{isStale && <StaleIndicator />}
 							<GenerateButton
-								label="Generate"
+								status={avatarSnapshot.status}
+								hasResult={Boolean(character.avatarUrl)}
 								disabled={generateDisabled}
 								onGenerate={regenerateAvatar}
 							/>
@@ -232,7 +233,7 @@ function CharacterEditDialogBody({
 				<button
 					type="button"
 					onClick={handleDelete}
-					className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[12px] transition-colors ${
+					className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-label transition-colors ${
 						confirmDelete
 							? "border-rose-500/60 bg-rose-500/20 text-rose-200 hover:bg-rose-500/30"
 							: "border-border bg-card text-muted-foreground hover:bg-muted"

--- a/app/components/canvas/elements/character/NewCharacterDialog.tsx
+++ b/app/components/canvas/elements/character/NewCharacterDialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { normalizeCharacterName } from "@/lib/project/characterName";
+import { FIELD_CLS } from "./fields";
 import { useProjectStore } from "@/lib/project/store";
 
 export function NewCharacterDialog({
@@ -67,11 +68,11 @@ function NewCharacterDialogBody({
 					onChange={(e) => setName(e.target.value)}
 					placeholder="Character name"
 					aria-label="Character name"
-					className="w-full rounded-md border border-border bg-card px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-accent/50"
+					className={FIELD_CLS}
 				/>
 
 				{collision && (
-					<span className="text-[11px] text-rose-400" role="alert">
+					<span className="text-label-xs text-rose-400" role="alert">
 						A character named &quot;{normalized}&quot; already exists.
 					</span>
 				)}
@@ -80,7 +81,7 @@ function NewCharacterDialogBody({
 					<button
 						type="submit"
 						disabled={!canSubmit}
-						className="rounded-md border border-border bg-muted px-3 py-1 text-[12px] font-medium text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-muted"
+						className="rounded-md border border-border bg-muted px-3 py-1 text-label font-medium text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-muted"
 					>
 						Create
 					</button>

--- a/app/components/canvas/elements/character/StaleAvatarCloseDialog.tsx
+++ b/app/components/canvas/elements/character/StaleAvatarCloseDialog.tsx
@@ -32,18 +32,18 @@ export function StaleAvatarCloseDialog({
 					Your edits are already saved.
 				</AlertDialogDescription>
 				<AlertDialogFooter>
-					<AlertDialogCancel className="rounded-md px-2.5 py-1 text-[12px] text-muted-foreground transition-colors hover:text-foreground">
+					<AlertDialogCancel className="rounded-md px-2.5 py-1 text-label text-muted-foreground transition-colors hover:text-foreground">
 						Keep editing
 					</AlertDialogCancel>
 					<AlertDialogAction
 						onClick={onLeaveStale}
-						className="rounded-md border border-border px-2.5 py-1 text-[12px] text-muted-foreground transition-colors hover:bg-muted"
+						className="rounded-md border border-border px-2.5 py-1 text-label text-muted-foreground transition-colors hover:bg-muted"
 					>
 						Leave stale
 					</AlertDialogAction>
 					<AlertDialogAction
 						onClick={onRegenerate}
-						className="rounded-md bg-accent px-3 py-1 text-[12px] font-medium text-foreground shadow-elevation-5 transition hover:brightness-110"
+						className="rounded-md bg-accent px-3 py-1 text-label font-medium text-foreground shadow-elevation-5 transition hover:brightness-110"
 					>
 						Regenerate
 					</AlertDialogAction>

--- a/app/components/canvas/elements/character/VoiceMetadataFields.tsx
+++ b/app/components/canvas/elements/character/VoiceMetadataFields.tsx
@@ -23,7 +23,7 @@ export function VoiceSection({
 		<section className="flex flex-col gap-2 rounded-lg border border-border p-3">
 			<div className="flex flex-col gap-0.5">
 				<FieldLabel>Voice</FieldLabel>
-				<p className="text-[11px] text-muted-foreground">
+				<p className="text-label-xs text-muted-foreground">
 					Filter the voice list
 				</p>
 			</div>

--- a/app/components/canvas/elements/character/VoicePicker.tsx
+++ b/app/components/canvas/elements/character/VoicePicker.tsx
@@ -55,7 +55,7 @@ function PreviewPlayButton({ src }: { src: string }) {
 
 const DEBOUNCE_MS = 300;
 const SKELETON_ROWS = 5;
-const VOICE_LIMIT = 10;
+const VOICE_LIMIT = 50;
 
 export function VoicePicker({
 	filters,
@@ -135,7 +135,7 @@ export function VoicePicker({
 								}`}
 							>
 								<div className="flex min-w-0 items-center gap-1.5">
-									<span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+									<span className="min-w-0 flex-1 truncate text-label text-foreground">
 										{voice.name}
 									</span>
 									{voice.language && (
@@ -154,7 +154,7 @@ export function VoicePicker({
 								</div>
 								{(voice.description || voice.previewUrl) && (
 									<div className="flex min-w-0 items-center justify-between gap-2">
-										<span className="min-w-0 flex-1 truncate text-badge leading-tight text-muted-foreground">
+										<span className="min-w-0 flex-1 truncate text-label text-muted-foreground">
 											{voice.description}
 										</span>
 										{voice.previewUrl && (

--- a/app/components/canvas/elements/character/VoicePicker.tsx
+++ b/app/components/canvas/elements/character/VoicePicker.tsx
@@ -103,14 +103,14 @@ export function VoicePicker({
 	return (
 		<div className="flex min-w-0 flex-col gap-1.5">
 			<FieldLabel>Voices</FieldLabel>
-			{error && <span className="text-[11px] text-rose-400">{error}</span>}
+			{error && <span className="text-label-xs text-rose-400">{error}</span>}
 			<div className="flex max-h-64 min-w-0 flex-col gap-0.5 overflow-y-auto">
 				{loading &&
 					Array.from({ length: SKELETON_ROWS }).map((_, i) => (
 						<Skeleton key={`skel-${i}`} className="h-12 shrink-0 rounded-md" />
 					))}
 				{!loading && voices.length === 0 && !error && (
-					<span className="px-2 py-3 text-center text-[11px] text-muted-foreground">
+					<span className="px-2 py-3 text-center text-label-xs text-muted-foreground">
 						No voices match these filters.
 					</span>
 				)}
@@ -139,12 +139,12 @@ export function VoicePicker({
 										{voice.name}
 									</span>
 									{voice.language && (
-										<span className="shrink-0 rounded border border-border px-1 py-px text-[9px] uppercase text-muted-foreground">
+										<span className="shrink-0 rounded border border-border px-1 py-px text-badge-xs uppercase text-muted-foreground">
 											{voice.language}
 										</span>
 									)}
 									{voice.gender && (
-										<span className="shrink-0 rounded border border-border px-1 py-px text-[9px] uppercase text-muted-foreground">
+										<span className="shrink-0 rounded border border-border px-1 py-px text-badge-xs uppercase text-muted-foreground">
 											{voice.gender}
 										</span>
 									)}
@@ -154,7 +154,7 @@ export function VoicePicker({
 								</div>
 								{(voice.description || voice.previewUrl) && (
 									<div className="flex min-w-0 items-center justify-between gap-2">
-										<span className="min-w-0 flex-1 truncate text-[10px] leading-tight text-muted-foreground">
+										<span className="min-w-0 flex-1 truncate text-badge leading-tight text-muted-foreground">
 											{voice.description}
 										</span>
 										{voice.previewUrl && (

--- a/app/components/canvas/elements/character/fields.tsx
+++ b/app/components/canvas/elements/character/fields.tsx
@@ -10,11 +10,11 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 export const FIELD_CLS =
-	"w-full rounded-md border border-border bg-card px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-accent/50";
+	"w-full rounded-md border border-border bg-card px-2 py-1.5 font-body text-label text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-accent/50";
 
 export function FieldLabel({ children }: { children: ReactNode }) {
 	return (
-		<span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+		<span className="text-label-xs uppercase tracking-wide text-muted-foreground">
 			{children}
 		</span>
 	);
@@ -135,7 +135,7 @@ function EnumOption({
 	return (
 		<DropdownMenuItem
 			onClick={onSelect}
-			className="flex cursor-pointer items-center gap-1.5 py-1 text-[12px] text-muted-foreground"
+			className="flex cursor-pointer items-center gap-1.5 py-1 text-label text-muted-foreground"
 		>
 			<span className="flex w-3.5 shrink-0 items-center justify-center">
 				{selected && <Check className="h-3 w-3 text-foreground" aria-hidden />}

--- a/app/components/canvas/panel/EditorSidebar.tsx
+++ b/app/components/canvas/panel/EditorSidebar.tsx
@@ -52,7 +52,7 @@ function RailItem({
 	onClick?: () => void;
 }) {
 	const className = cn(
-		"flex w-full flex-col items-center gap-1 rounded-xl px-2 py-2.5 text-center text-[11px] font-medium transition-colors",
+		"flex w-full flex-col items-center gap-1 rounded-xl px-2 py-2.5 text-center text-label-xs font-medium transition-colors",
 		selected
 			? "bg-secondary font-semibold text-panel-label"
 			: "text-muted-foreground hover:bg-secondary/60 hover:text-foreground",
@@ -90,9 +90,9 @@ export function EditorSidebar() {
 
 	return (
 		<div className="flex shrink-0">
-			<nav className="flex w-14 shrink-0 flex-col items-center gap-1 pt-16 pr-0.5 mr-2 pl-1 lg:w-[72px] lg:pt-4">
+			<nav className="flex w-14 shrink-0 flex-col items-center gap-1 pt-16 mr-2 pl-1 lg:w-[72px] lg:pt-4">
 				<RailItem icon={Home} label="Home" href="/" />
-				<div className="my-1.5 h-px w-8 bg-border" />
+				<div className="my-1 h-px w-full bg-border" />
 				{(Object.keys(PANELS) as PanelKey[]).map((key) => {
 					const { label, icon, iconActive } = PANELS[key];
 					const selected = active === key;

--- a/app/components/canvas/panel/LayoutPanel.tsx
+++ b/app/components/canvas/panel/LayoutPanel.tsx
@@ -47,7 +47,7 @@ export function LayoutPanel() {
 							onPositionChange(value as PlayerPositionValue)
 						}
 					>
-						<SelectTrigger aria-label="Player position" className="h-8 text-xs">
+						<SelectTrigger size="sm" aria-label="Player position">
 							<SelectValue />
 						</SelectTrigger>
 						<SelectContent>

--- a/app/components/canvas/panel/PropertiesPanel.tsx
+++ b/app/components/canvas/panel/PropertiesPanel.tsx
@@ -39,7 +39,7 @@ export function PropertiesPanel() {
 					value={transitionType}
 					onValueChange={(value) => setTransitionType(value as TransitionType)}
 				>
-					<SelectTrigger aria-label="Transition" className="h-8 text-xs">
+					<SelectTrigger size="sm" aria-label="Transition">
 						<SelectValue />
 					</SelectTrigger>
 					<SelectContent>

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -138,7 +138,7 @@ function TemplatePill({
 
 	return (
 		<span
-			className=" relative inline-flex self-start shrink-0 items-center gap-1 overflow-hidden rounded-full py-0.5 pl-1 pr-2 text-sm leading-5 text-foreground whitespace-nowrap sm:mt-px sm:self-auto"
+			className=" relative inline-flex self-start shrink-0 items-center gap-1 overflow-hidden rounded-full py-0.5 pl-1 pr-2 font-body text-sm leading-5 text-foreground whitespace-nowrap sm:mt-px sm:self-auto"
 			style={{ backgroundColor: template.color }}
 		>
 			<button

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -59,7 +59,7 @@ function PillTrigger({
 			ref={ref}
 			type="button"
 			className={cn(
-				"inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[12px] text-foreground transition-colors hover:bg-button-hover",
+				"inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-label text-foreground transition-colors hover:bg-button-hover",
 				className,
 			)}
 			{...props}
@@ -108,7 +108,7 @@ function AttachMenu({
 		<ActionMenu
 			items={items}
 			contentClassName="min-w-36 p-0.5"
-			itemClassName="rounded-lg text-[11px] text-muted-foreground"
+			itemClassName="rounded-lg text-label-xs text-muted-foreground"
 		>
 			<button
 				type="button"
@@ -223,7 +223,7 @@ export default function ComposerCopilot({
 							}}
 							placeholder={placeholderText}
 							style={{ fieldSizing: "content" }}
-							className=" w-full resize-none bg-transparent text-sm leading-5 text-foreground caret-accent placeholder:text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:rounded-sm"
+							className=" w-full resize-none bg-transparent font-body text-sm leading-5 text-foreground caret-accent placeholder:text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:rounded-sm"
 						/>
 						{!hasText && !showPill && placeholderOverlay && (
 							<div className=" pointer-events-none overflow-hidden text-sm">

--- a/app/components/copilot/InlineCopilot.tsx
+++ b/app/components/copilot/InlineCopilot.tsx
@@ -29,7 +29,7 @@ function LoadingText() {
 	}, []);
 
 	return (
-		<span className=" pointer-events-none block select-none truncate text-sm text-muted-foreground shimmer">
+		<span className=" pointer-events-none block select-none truncate text-xs text-muted-foreground shimmer">
 			{LOADING_MESSAGES[index]}
 		</span>
 	);
@@ -64,19 +64,19 @@ export default function InlineCopilot({
 
 	return (
 		<div className="grain relative w-full overflow-hidden rounded-xl bg-element-card shadow-elevation-3">
-			<div className="relative z-10 flex items-center px-4 py-3">
+			<div className="relative z-10 flex items-center px-3 py-2">
 				{loading ? (
 					<OrbLoader />
 				) : (
-					<Wand2 className="mr-3 h-5 w-5 shrink-0 text-muted-foreground" />
+					<Wand2 className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />
 				)}
-				<div className="relative min-w-0 flex-1">
+				<div className="relative flex min-w-0 flex-1 items-center">
 					{loading ? (
 						<LoadingText />
 					) : (
 						<>
 							{!hasText && placeholderOverlay && (
-								<div className=" pointer-events-none absolute inset-0 flex items-center overflow-hidden text-sm">
+								<div className=" pointer-events-none absolute inset-0 flex items-center overflow-hidden text-xs">
 									{placeholderOverlay}
 								</div>
 							)}
@@ -87,7 +87,7 @@ export default function InlineCopilot({
 								onChange={(e) => onValueChange(e.target.value)}
 								onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
 								placeholder={placeholderText}
-								className=" w-full bg-transparent text-sm text-foreground caret-accent placeholder:text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:rounded-sm"
+								className=" w-full bg-transparent font-body text-xs text-foreground caret-accent placeholder:text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:rounded-sm"
 							/>
 						</>
 					)}

--- a/app/components/copilot/InlineCopilot.tsx
+++ b/app/components/copilot/InlineCopilot.tsx
@@ -87,7 +87,7 @@ export default function InlineCopilot({
 								onChange={(e) => onValueChange(e.target.value)}
 								onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
 								placeholder={placeholderText}
-								className=" w-full bg-transparent font-body text-xs text-foreground caret-accent placeholder:text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:rounded-sm"
+								className=" w-full bg-transparent font-body text-label text-foreground caret-accent placeholder:text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:rounded-sm"
 							/>
 						</>
 					)}

--- a/app/components/projects/ProjectsList.tsx
+++ b/app/components/projects/ProjectsList.tsx
@@ -53,9 +53,7 @@ export default function ProjectsList({
 					aria-hidden
 					className="dot-grid-bg pointer-events-none absolute inset-0 z-0"
 				/>
-				<div className="fixed top-4 left-4 z-[100]">
-					<UserProfile />
-				</div>
+				<UserProfile />
 				<div className="relative z-10 mx-auto max-w-7xl px-6 pt-20 pb-16">
 					<header className="mb-10 flex items-end justify-between">
 						<div>

--- a/app/components/video/ExportButton.tsx
+++ b/app/components/video/ExportButton.tsx
@@ -58,7 +58,7 @@ export function ExportButton() {
 				align="end"
 				side="top"
 				sideOffset={8}
-				className="w-80 p-4"
+				className="w-80 bg-surface-elevated p-4"
 			>
 				<div className="flex items-center justify-between">
 					<span className="text-sm font-semibold">Export</span>

--- a/app/components/video/ExportButton.tsx
+++ b/app/components/video/ExportButton.tsx
@@ -27,7 +27,7 @@ import { useRender } from "./RenderProvider";
 import { useLayout } from "./VideoLayoutContext";
 
 const triggerClass =
-	"h-11 shrink-0 border-tertiary/50 bg-tertiary/10 px-4 text-tertiary hover:bg-tertiary/20 sm:px-5";
+	"shrink-0 border-tertiary/50 bg-tertiary/10 text-tertiary hover:bg-tertiary/20 sm:px-4";
 
 export function ExportButton() {
 	const { layout, ready } = useLayout();
@@ -44,6 +44,7 @@ export function ExportButton() {
 				<Button
 					type="button"
 					variant="secondary"
+					size="sm"
 					className={triggerClass}
 					aria-label="Export"
 					disabled={disabled}
@@ -58,10 +59,10 @@ export function ExportButton() {
 				align="end"
 				side="top"
 				sideOffset={8}
-				className="w-80 bg-surface-elevated p-4"
+				className="w-80 bg-surface-elevated p-3 font-medium"
 			>
 				<div className="flex items-center justify-between">
-					<span className="text-sm font-semibold">Export</span>
+					<span className="text-xs font-semibold">Export</span>
 					<button
 						type="button"
 						onClick={() => setOpen(false)}
@@ -71,7 +72,7 @@ export function ExportButton() {
 						<X size={16} />
 					</button>
 				</div>
-				<Separator className="my-3" />
+				<Separator className="-mx-3 my-2 data-[orientation=horizontal]:w-[calc(100%+1.5rem)]" />
 
 				{(state.status === "invoking" || state.status === "rendering") && (
 					<div className="animate-fadeInUp flex flex-col gap-2">
@@ -101,7 +102,7 @@ export function ExportButton() {
 								{formatBytes(state.size)}
 							</span>
 						</div>
-						<Button asChild variant="generate" className="h-11 w-full">
+						<Button asChild variant="generate" size="sm" className="w-full">
 							<a href={state.url} download>
 								<Download aria-hidden="true" />
 								Download
@@ -120,12 +121,12 @@ export function ExportButton() {
 				{(state.status === "idle" || state.status === "error") && (
 					<>
 						<div className="flex items-center justify-between gap-3">
-							<span className="text-sm">Resolution</span>
+							<span className="text-xs">Resolution</span>
 							<Select
 								value={String(width)}
 								onValueChange={(value) => setWidth(Number(value))}
 							>
-								<SelectTrigger>
+								<SelectTrigger size="sm">
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
@@ -133,6 +134,7 @@ export function ExportButton() {
 										<SelectItem
 											key={resolution.width}
 											value={String(resolution.width)}
+											className="text-xs"
 										>
 											{resolution.label}
 										</SelectItem>
@@ -143,10 +145,11 @@ export function ExportButton() {
 						{state.status === "error" && (
 							<p className="mt-3 text-xs text-destructive">{state.message}</p>
 						)}
-						<Separator className="my-3" />
+						<Separator className="-mx-3 my-2 data-[orientation=horizontal]:w-[calc(100%+1.5rem)]" />
 						<Button
 							type="button"
 							variant="generate"
+							size="sm"
 							onClick={() => layout && render(layout, scaleForWidth(width))}
 							disabled={disabled}
 							className="w-full"

--- a/app/components/video/ExportButton.tsx
+++ b/app/components/video/ExportButton.tsx
@@ -59,7 +59,7 @@ export function ExportButton() {
 				align="end"
 				side="top"
 				sideOffset={8}
-				className="w-80 bg-surface-elevated p-3 font-medium"
+				className="w-80 p-3 font-medium"
 			>
 				<div className="flex items-center justify-between">
 					<span className="text-xs font-semibold">Export</span>

--- a/app/globals.css
+++ b/app/globals.css
@@ -209,7 +209,7 @@
 	/* Surface overrides (warm near-blacks) */
 	--background: #140e11;
 	--surface-recessed: #140e11;
-	--surface-elevated: #372f32;
+	--surface-elevated: #41393c;
 	--card: #251e21;
 	--popover: #251e21;
 	--button-hover: #372f32;
@@ -327,6 +327,18 @@
 	--font-mono: var(--font-ibm-plex-mono);
 	--font-serif: var(--font-instrument-serif), serif;
 
+	/* Semantic type scale (DESIGN.md typography) */
+	--text-badge-xs: 0.5625rem; /* 9px — uppercase micro tags */
+	--text-badge: 0.625rem; /* 10px — badges, tags, micro labels */
+	--text-label-xs: 0.6875rem; /* 11px — small labels */
+	--text-label: 0.75rem; /* 12px — labels, dense controls */
+	--text-body: 0.875rem; /* 14px — default body & UI text */
+	--text-body-lg: 1rem; /* 16px — emphasized body */
+	--text-heading-sm: 1.125rem; /* 18px */
+	--text-heading: 1.5rem; /* 24px */
+	--text-heading-lg: 2.25rem; /* 36px */
+	--text-display: 3rem; /* 48px */
+
 	--shadow-elevation-1: var(--elevation-1);
 	--shadow-elevation-3: var(--elevation-3);
 	--shadow-elevation-5: var(--elevation-5);
@@ -351,7 +363,7 @@
 	}
 	body {
 		@apply bg-background text-foreground;
-		font-family: var(--font-sans);
+		font-family: var(--font-sloptastic), ui-sans-serif, system-ui, sans-serif;
 		letter-spacing: -0.006em;
 	}
 	button {
@@ -365,14 +377,14 @@
 }
 
 .font-title {
-	font-family: var(--font-sans);
+	font-family: var(--font-sloptastic), ui-sans-serif, system-ui, sans-serif;
 	font-weight: 575;
 	letter-spacing: -0.02em;
 	line-height: 1.2;
 }
 
 .font-body {
-	font-family: var(--font-body);
+	font-family: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
 	font-weight: 425;
 	letter-spacing: -0.011em;
 	line-height: 1.5;

--- a/app/projects/[id]/loading.tsx
+++ b/app/projects/[id]/loading.tsx
@@ -51,12 +51,12 @@ export default function Loading() {
 			</div>
 
 			{/* Refine bar + generate and export buttons */}
-			<div className="z-40 flex w-full shrink-0 items-start gap-3 px-4 py-3 pb-2 pl-16">
+			<div className="z-40 flex w-full shrink-0 items-center gap-3 px-4 py-1.5 pl-16">
 				<div className="hidden flex-1 sm:block" aria-hidden />
-				<Skeleton className="h-12 min-w-0 max-w-2xl flex-1 rounded-xl" />
-				<div className="flex flex-1 justify-end gap-2">
-					<Skeleton className="h-11 w-36 rounded-xl" />
-					<Skeleton className="h-11 w-28 rounded-xl" />
+				<Skeleton className="h-10 min-w-0 max-w-2xl flex-1 rounded-xl" />
+				<div className="flex flex-1 items-center justify-end gap-2">
+					<Skeleton className="h-8 w-28 rounded-md" />
+					<Skeleton className="h-8 w-20 rounded-md" />
 				</div>
 			</div>
 
@@ -64,7 +64,7 @@ export default function Loading() {
 			<div className="flex min-h-0 flex-1 overflow-hidden">
 				<nav className="mr-2 flex w-14 shrink-0 flex-col items-center gap-1 pt-16 pr-0.5 pl-1 lg:w-[72px] lg:pt-4">
 					<RailItemSkeleton />
-					<div className="my-1.5 h-px w-8 bg-border" />
+					<div className="my-1 h-px w-full bg-border" />
 					<RailItemSkeleton />
 					<RailItemSkeleton />
 				</nav>

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -66,7 +66,7 @@ function AlertDialogDescription({
 	return (
 		<AlertDialogPrimitive.Description
 			data-slot="alert-dialog-description"
-			className={cn("text-[12px] text-muted-foreground", className)}
+			className={cn("text-label text-muted-foreground", className)}
 			{...props}
 		/>
 	);

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -37,7 +37,7 @@ function AlertDialogContent({
 			<AlertDialogPrimitive.Content
 				data-slot="alert-dialog-content"
 				className={cn(
-					"fixed left-[50%] top-[50%] z-[60] flex w-[calc(100vw-2rem)] max-w-sm translate-x-[-50%] translate-y-[-50%] flex-col gap-1 rounded-2xl border border-border bg-popover p-5 text-popover-foreground shadow-elevation-10 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+					"fixed left-[50%] top-[50%] z-[60] flex w-[calc(100vw-2rem)] max-w-sm translate-x-[-50%] translate-y-[-50%] flex-col gap-1 rounded-md border border-border bg-popover p-5 text-popover-foreground shadow-elevation-10 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
 					className,
 				)}
 				{...props}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -81,7 +81,7 @@ function DialogContent({
 			<DialogPrimitive.Content
 				data-slot="dialog-content"
 				className={cn(
-					"grain fixed left-[50%] top-[50%] z-50 flex max-h-[calc(100dvh-2rem)] w-[calc(100vw-1rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] flex-col gap-4 overflow-hidden rounded-3xl border border-border bg-popover p-6 text-popover-foreground shadow-elevation-10 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:w-full",
+					"grain fixed left-[50%] top-[50%] z-50 flex max-h-[calc(100dvh-2rem)] w-[calc(100vw-1rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] flex-col gap-4 overflow-hidden rounded-md border border-border bg-popover p-6 text-popover-foreground shadow-elevation-10 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:w-full",
 					className,
 				)}
 				{...props}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -74,7 +74,7 @@ function DropdownMenuItem({
 			data-inset={inset}
 			data-variant={variant}
 			className={cn(
-				"relative flex cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-hidden select-none focus:bg-button-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+				"relative flex cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-label outline-hidden select-none focus:bg-button-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
 				className,
 			)}
 			{...props}
@@ -92,7 +92,7 @@ function DropdownMenuCheckboxItem({
 		<DropdownMenuPrimitive.CheckboxItem
 			data-slot="dropdown-menu-checkbox-item"
 			className={cn(
-				"relative flex cursor-default items-center gap-2 rounded-md py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-button-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"relative flex cursor-default items-center gap-2 rounded-md py-1.5 pr-2 pl-8 text-label outline-hidden select-none focus:bg-button-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			checked={checked}
@@ -128,7 +128,7 @@ function DropdownMenuRadioItem({
 		<DropdownMenuPrimitive.RadioItem
 			data-slot="dropdown-menu-radio-item"
 			className={cn(
-				"relative flex cursor-default items-center gap-2 rounded-md py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-button-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"relative flex cursor-default items-center gap-2 rounded-md py-1.5 pr-2 pl-8 text-label outline-hidden select-none focus:bg-button-hover focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			{...props}
@@ -211,7 +211,7 @@ function DropdownMenuSubTrigger({
 			data-slot="dropdown-menu-sub-trigger"
 			data-inset={inset}
 			className={cn(
-				"flex cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-hidden select-none focus:bg-button-hover focus:text-foreground data-[inset]:pl-8 data-[state=open]:bg-button-hover data-[state=open]:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+				"flex cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-label outline-hidden select-none focus:bg-button-hover focus:text-foreground data-[inset]:pl-8 data-[state=open]:bg-button-hover data-[state=open]:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
 				className,
 			)}
 			{...props}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -42,7 +42,7 @@ function DropdownMenuContent({
 				data-slot="dropdown-menu-content"
 				sideOffset={sideOffset}
 				className={cn(
-					"z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xl border bg-popover p-1 text-popover-foreground shadow-elevation-5 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+					"z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-elevation-3 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
 					className,
 				)}
 				{...props}
@@ -230,7 +230,7 @@ function DropdownMenuSubContent({
 		<DropdownMenuPrimitive.SubContent
 			data-slot="dropdown-menu-sub-content"
 			className={cn(
-				"z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-xl border bg-popover p-1 text-popover-foreground shadow-elevation-5 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+				"z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-elevation-3 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
 				className,
 			)}
 			{...props}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
 			type={type}
 			data-slot="input"
 			className={cn(
-				"flex h-9 w-full min-w-0 rounded-lg border border-border bg-input px-3 py-1 text-sm text-foreground shadow-xs transition-colors outline-none placeholder:text-muted-foreground hover:border-ring/50 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/30",
+				"flex h-9 w-full min-w-0 rounded-md border border-border bg-input px-3 py-1 text-sm text-foreground shadow-xs transition-colors outline-none placeholder:text-muted-foreground hover:border-ring/50 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/30",
 				className,
 			)}
 			{...props}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
 			type={type}
 			data-slot="input"
 			className={cn(
-				"flex h-9 w-full min-w-0 rounded-md border border-border bg-input px-3 py-1 text-sm text-foreground shadow-xs transition-colors outline-none placeholder:text-muted-foreground hover:border-ring/50 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/30",
+				"flex h-9 w-full min-w-0 rounded-md border border-border bg-input px-3 py-1 font-body text-sm text-foreground shadow-xs transition-colors outline-none placeholder:text-muted-foreground hover:border-ring/50 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/30",
 				className,
 			)}
 			{...props}

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -36,7 +36,7 @@ function PopoverContent({
 				align={align}
 				sideOffset={sideOffset}
 				className={cn(
-					"z-50 min-w-48 origin-(--radix-popover-content-transform-origin) rounded-xl border border-border bg-popover p-3 text-popover-foreground shadow-elevation-5 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+					"z-50 min-w-48 origin-(--radix-popover-content-transform-origin) rounded-md bg-popover p-3 text-popover-foreground shadow-elevation-3 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
 					className,
 				)}
 				{...props}

--- a/components/ui/select-menu.tsx
+++ b/components/ui/select-menu.tsx
@@ -45,7 +45,7 @@ export function SelectMenu<T extends string>({
 					<DropdownMenuItem
 						key={option.value}
 						onSelect={() => onChange(option.value)}
-						className="cursor-pointer py-1 text-[11px] text-muted-foreground"
+						className="cursor-pointer py-1 text-label text-muted-foreground"
 					>
 						<span className="flex w-3.5 shrink-0 items-center justify-center">
 							{option.value === value && (

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -35,7 +35,7 @@ function SelectTrigger({
 		<SelectPrimitive.Trigger
 			data-slot="select-trigger"
 			className={cn(
-				"flex h-9 w-fit items-center justify-between gap-2 rounded-lg border border-border bg-input px-3 py-2 text-sm whitespace-nowrap outline-none transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0",
+				"flex h-9 w-fit items-center justify-between gap-2 rounded-md border border-border bg-input px-3 py-2 text-sm whitespace-nowrap outline-none transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0",
 				className,
 			)}
 			{...props}
@@ -60,7 +60,7 @@ function SelectContent({
 				data-slot="select-content"
 				position={position}
 				className={cn(
-					"relative z-50 max-h-(--radix-select-content-available-height) min-w-32 overflow-y-auto overflow-x-hidden rounded-xl border border-border bg-popover text-popover-foreground shadow-elevation-5 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+					"relative z-50 max-h-(--radix-select-content-available-height) min-w-32 overflow-y-auto overflow-x-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-elevation-3 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
 					position === "popper" &&
 						"data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1",
 					className,

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -28,14 +28,18 @@ function SelectValue(
 
 function SelectTrigger({
 	className,
+	size = "default",
 	children,
 	...props
-}: React.ComponentProps<typeof SelectPrimitive.Trigger>) {
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+	size?: "sm" | "default";
+}) {
 	return (
 		<SelectPrimitive.Trigger
 			data-slot="select-trigger"
+			data-size={size}
 			className={cn(
-				"flex h-9 w-fit items-center justify-between gap-2 rounded-md border border-border bg-input px-3 py-2 text-sm whitespace-nowrap outline-none transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0",
+				"flex w-fit items-center justify-between gap-2 rounded-md border border-border bg-input px-3 py-2 whitespace-nowrap outline-none transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=default]:text-sm data-[size=sm]:h-8 data-[size=sm]:text-xs [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0",
 				className,
 			)}
 			{...props}
@@ -105,7 +109,7 @@ function SelectItem({
 		<SelectPrimitive.Item
 			data-slot="select-item"
 			className={cn(
-				"relative flex w-full cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2 text-sm outline-none select-none focus:bg-button-hover data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0",
+				"relative flex w-full cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2 text-label outline-none select-none focus:bg-button-hover data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0",
 				className,
 			)}
 			{...props}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
 		<textarea
 			data-slot="textarea"
 			className={cn(
-				"flex min-h-20 w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground shadow-xs transition-colors outline-none placeholder:text-muted-foreground hover:border-ring/50 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/30",
+				"flex min-h-20 w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground shadow-xs transition-colors outline-none placeholder:text-muted-foreground hover:border-ring/50 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/30",
 				className,
 			)}
 			{...props}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
 		<textarea
 			data-slot="textarea"
 			className={cn(
-				"flex min-h-20 w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground shadow-xs transition-colors outline-none placeholder:text-muted-foreground hover:border-ring/50 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/30",
+				"flex min-h-20 w-full rounded-md border border-border bg-input px-3 py-2 font-body text-sm text-foreground shadow-xs transition-colors outline-none placeholder:text-muted-foreground hover:border-ring/50 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/30",
 				className,
 			)}
 			{...props}

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -42,7 +42,7 @@ function TooltipContent({
 				data-slot="tooltip-content"
 				sideOffset={sideOffset}
 				className={cn(
-					"z-50 rounded-md bg-primary px-2.5 py-1 text-[10px] text-primary-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+					"z-50 rounded-md bg-primary px-2.5 py-1 text-badge text-primary-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
 					className,
 				)}
 				{...props}

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -13,8 +13,10 @@ import { generateForElement } from "./generateForElement";
 import { getGenerationInputs } from "./getGenerationInputs";
 import { serializeInputs, type GenerationInputs } from "./generationInputs";
 
+export type GenerationStatus = "idle" | "queued" | "generating";
+
 export type ElementSnapshot = {
-	status: "idle" | "queued" | "generating";
+	status: GenerationStatus;
 	seconds: number;
 	result: AssetResult | null;
 	error: string | null;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,32 @@
 import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+// Register the custom @theme font-size tokens so tailwind-merge treats them as
+// font-sizes, not text-colors. Otherwise it strips e.g. `text-label-xs` when a
+// class string also sets a text color (`text-muted-foreground`), since it can't
+// tell the token apart from a color.
+const twMerge = extendTailwindMerge({
+	extend: {
+		classGroups: {
+			"font-size": [
+				{
+					text: [
+						"badge-xs",
+						"badge",
+						"label-xs",
+						"label",
+						"body",
+						"body-lg",
+						"heading-sm",
+						"heading",
+						"heading-lg",
+						"display",
+					],
+				},
+			],
+		},
+	},
+});
 
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));


### PR DESCRIPTION
## Summary

Two layers of design-system polish on this branch:

### Overlay radius & elevation
- Overlays — modals, popovers, dropdowns, selects (and the select trigger) — share an 8px `rounded-md` corner instead of the larger `rounded-xl`/`rounded-2xl`/`rounded-3xl` mix.
- Popovers and menus drop from `shadow-elevation-5` to `shadow-elevation-3`; the base popover is borderless (shadow alone separates it).
- Export popover uses `bg-surface-elevated` to read slightly lighter than the page; settings popover keeps its hairline border.

### Typography tokens & sizing discipline
- Replace raw `text-[Npx]`/`text-xs`/`text-sm` arbitraries with named `@theme` font-size tokens (`text-badge`/`text-label`/`text-body`/…) across components and the shared `ui` primitives.
- Register the custom font-size tokens with `tailwind-merge` (`extendTailwindMerge`) so `cn()` no longer strips them when a class string also sets a text color. *(This was the root cause of sidebar/tooltip/dropdown labels rendering oversized.)*
- Apply `font-body` (Inter) to every editable input and the project title; point `body` / `.font-title` / `.font-body` at the next/font variables directly, since the `@theme inline` aliases aren't emitted as CSS variables.
- Size Select triggers and toolbar buttons via the `size` prop instead of hand-sizing with `h-*`/`text-*` in `className` (fixes the layout-panel dropdown label).
- Absorb the fixed positioning into `UserProfile` (all four callers wrapped it identically).
- Share one `GenerationStatus` type between `ElementSnapshot` and `GenerateButton`; replace the nested-ternary label with a small helper.
- DESIGN.md documents the type scale and button-sizing conventions.

## Test plan
- [ ] Overlays (export/settings popovers, Select, dropdown, Dialog/AlertDialog) — 8px corners, lighter shadow; settings keeps hairline border.
- [ ] Sidebar rail, tooltips, and menu items render at their intended small sizes (no oversized labels).
- [ ] Editable fields (script editor, character/attribute fields, copilot prompts, project title) render in Inter.
- [ ] Layout & Properties panel dropdowns show their selected label at the small size.
- [ ] Account avatar stays fixed top-left across pre-prompt, post-prompt, and projects views.
- [ ] Verify light + dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
