### PR TITLE
fix: nightly bug fixes 2026-06-20

### DIFF
--- a/app/api/v1/__tests__/routes.test.ts
+++ b/app/api/v1/__tests__/routes.test.ts
@@ -477,6 +477,40 @@ describe("API routes", () => {
 			expect(json.voices[0].name).toBe("Voice 1");
 		});
 
+		it("returns 400 for malformed filters before calling the provider", async () => {
+			const { GET } = await import("@/app/api/v1/tts/voices/route");
+
+			const req = makeRequest(
+				"/api/v1/tts/voices?gender=robot&limit=abc",
+				undefined,
+				"GET",
+			);
+			const res = await GET(req);
+
+			expect(res.status).toBe(400);
+			expect((await res.json()).error).toContain(
+				"Invalid voice search parameters",
+			);
+			expect(mockTTSSearch).not.toHaveBeenCalled();
+		});
+
+		it("returns 400 for blank limit filters before calling the provider", async () => {
+			const { GET } = await import("@/app/api/v1/tts/voices/route");
+
+			const req = makeRequest(
+				"/api/v1/tts/voices?limit=%20%20%20",
+				undefined,
+				"GET",
+			);
+			const res = await GET(req);
+
+			expect(res.status).toBe(400);
+			expect((await res.json()).error).toContain(
+				"Invalid voice search parameters",
+			);
+			expect(mockTTSSearch).not.toHaveBeenCalled();
+		});
+
 		it("returns 500 on error", async () => {
 			const { GET } = await import("@/app/api/v1/tts/voices/route");
 			mockTTSSearch.mockRejectedValue(new Error("api down"));

--- a/app/api/v1/tts/voices/route.ts
+++ b/app/api/v1/tts/voices/route.ts
@@ -1,14 +1,56 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { getTTSProvider } from "@/lib/api/providers";
+import { badRequest } from "@/lib/api/response";
 import { withApiAccess } from "@/lib/api/with-auth";
-import { voiceSearchParamsSchema } from "@/lib/project/types";
+import {
+	TTS_ACCENTS,
+	TTS_AGES,
+	TTS_GENDERS,
+	TTS_LANGUAGES,
+	TTS_PITCHES,
+} from "@/lib/connectors/tts/enums";
+
+const nonBlankString = z.string().min(1);
+const queryLimitSchema = z
+	.union([z.number(), z.string()])
+	.transform((value) =>
+		typeof value === "string" && value.trim() === "" ? NaN : Number(value),
+	)
+	.refine((value) => Number.isFinite(value), {
+		message: "must be a finite number",
+	})
+	.refine((value) => Number.isInteger(value) && value > 0, {
+		message: "must be a positive integer",
+	})
+	.optional();
+
+const voiceSearchQuerySchema = z
+	.object({
+		gender: z.enum(TTS_GENDERS).optional(),
+		age: z.enum(TTS_AGES).optional(),
+		pitch: z.enum(TTS_PITCHES).optional(),
+		accent: z.enum(TTS_ACCENTS).optional(),
+		description: nonBlankString.optional(),
+		language: z.enum(TTS_LANGUAGES).optional(),
+		query: nonBlankString.optional(),
+		name: nonBlankString.optional(),
+		limit: queryLimitSchema,
+	})
+	.strict();
 
 export async function GET(request: NextRequest) {
 	return withApiAccess("Voice search", async () => {
-		const params = voiceSearchParamsSchema.parse(
+		const parsed = voiceSearchQuerySchema.safeParse(
 			Object.fromEntries(request.nextUrl.searchParams),
 		);
-		const voices = await getTTSProvider().search(params);
+		if (!parsed.success) {
+			return badRequest(
+				`Invalid voice search parameters: ${parsed.error.issues[0]?.message ?? "unknown error"}`,
+			);
+		}
+
+		const voices = await getTTSProvider().search(parsed.data);
 		return NextResponse.json({ voices });
 	});
 }

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -31,12 +31,6 @@ export const MetadataVoiceSchema = voiceTraitsSchema.extend({
 	resolvedVoiceId: optionalString,
 });
 
-export const voiceSearchParamsSchema = voiceTraitsSchema.extend({
-	query: optionalString,
-	name: optionalString,
-	limit: z.coerce.number().int().positive().optional().catch(undefined),
-});
-
 export type MetadataVoice = z.infer<typeof MetadataVoiceSchema>;
 
 export type MetadataCharacter = MetadataVoice & {


### PR DESCRIPTION
## Summary
- Add strict route-boundary validation for `GET /api/v1/tts/voices` query parameters.
- Reject malformed voice search filters before invoking the TTS provider instead of silently dropping them via the permissive persisted-metadata parser.
- Remove the now-unused permissive voice search schema from `lib/project/types.ts` so API validation stays separate from metadata parsing.

## Bugs fixed
- `gender=robot`, `limit=abc`, and blank `limit` values previously parsed to `undefined` and still called the provider, returning a successful voice search with client filters silently ignored.
- Malformed public API requests now return `400` with actionable context and do not call `getTTSProvider().search()`.

## Tests added
- Added API route regressions covering malformed voice filters and blank numeric limits.
- Both tests assert the route returns `400` before the provider is called.

## Validation
- Verified RED first: `npm test -- --run app/api/v1/__tests__/routes.test.ts` failed on the two new regression tests before the fix (`200` instead of `400`).
- `npm test -- --run app/api/v1/__tests__/routes.test.ts` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run typecheck` ✅
- `npm run knip` ✅
- `npm test -- --passWithNoTests` ✅
- `npm run build` ✅
- `npm run test:coverage` ✅
- `npx playwright install --with-deps chromium` attempted, but this local cron environment cannot sudo-install OS deps (`sudo: a terminal is required`).
- `PLAYWRIGHT_PORT=3001 npm run test:e2e` ✅ (reused an already-running local Next dev server after default port 3000/alternate 3100 were occupied by an existing dev lock).

## Open PR overlap check
- Considered open PR #322 (`umair/overlay-radius-polish`): touches `DESIGN.md`, canvas/export UI, and `components/ui/*` overlay/input/select/textarea styling.
- This PR only touches `app/api/v1/tts/voices`, its API route tests, and `lib/project/types.ts`; no file or workflow overlap with #322.

## Skipped items / rationale
- Did not touch UI or visual files, so `DESIGN.md` decisions were not needed.
- Did not broaden this into a global validation refactor; the change is scoped to the real TTS voice-search route bug.
