### PR TITLE
refactor: nightly maintainability 2026-06-20

### DIFF
--- a/lib/connectors/__tests__/character-avatars.test.ts
+++ b/lib/connectors/__tests__/character-avatars.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	isGeneratedCharacter,
 	listCharacterAvatars,
 	listUploadedCharacterAvatarUrls,
 } from "@/lib/connectors/llm/plugins/character-avatars";
@@ -51,5 +52,12 @@ describe("character avatar plugin helpers", () => {
 		expect(listUploadedCharacterAvatarUrls(characters)).toEqual([
 			"https://example.com/uploaded.png",
 		]);
+	});
+
+	it("treats only uploaded characters as non-generated", () => {
+		expect(isGeneratedCharacter(characters.Uploaded)).toBe(false);
+		expect(isGeneratedCharacter(characters.Generated)).toBe(true);
+		expect(isGeneratedCharacter(characters.LegacyGenerated)).toBe(true);
+		expect(isGeneratedCharacter(characters.MissingAvatar)).toBe(true);
 	});
 });

--- a/lib/connectors/__tests__/character-avatars.test.ts
+++ b/lib/connectors/__tests__/character-avatars.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+	listCharacterAvatars,
+	listUploadedCharacterAvatarUrls,
+} from "@/lib/connectors/llm/plugins/character-avatars";
+import type { MetadataCharacter } from "@/lib/project/types";
+
+const characters: Record<string, MetadataCharacter> = {
+	Uploaded: {
+		appearance: "",
+		avatarUrl: "https://example.com/uploaded.png",
+		avatarUploaded: true,
+	},
+	Generated: {
+		appearance: "green hair",
+		avatarUrl: "https://example.com/generated.png",
+		avatarUploaded: false,
+	},
+	LegacyGenerated: {
+		appearance: "purple coat",
+		avatarUrl: "https://example.com/legacy-generated.png",
+	},
+	MissingAvatar: { appearance: "blue hair" },
+};
+
+describe("character avatar plugin helpers", () => {
+	it("classifies character avatar urls once for LLM plugins", () => {
+		expect(listCharacterAvatars(characters)).toEqual([
+			{
+				name: "Uploaded",
+				character: characters.Uploaded,
+				url: "https://example.com/uploaded.png",
+				source: "uploaded",
+			},
+			{
+				name: "Generated",
+				character: characters.Generated,
+				url: "https://example.com/generated.png",
+				source: "generated",
+			},
+			{
+				name: "LegacyGenerated",
+				character: characters.LegacyGenerated,
+				url: "https://example.com/legacy-generated.png",
+				source: "generated",
+			},
+		]);
+	});
+
+	it("exposes only uploaded avatars as global style references", () => {
+		expect(listUploadedCharacterAvatarUrls(characters)).toEqual([
+			"https://example.com/uploaded.png",
+		]);
+	});
+});

--- a/lib/connectors/__tests__/reference-style.test.ts
+++ b/lib/connectors/__tests__/reference-style.test.ts
@@ -55,6 +55,15 @@ describe("createReferenceStylePlugin", () => {
 		expect(result).toContain("a knight and a dragon");
 	});
 
+	it("filters empty reference image slots before deciding whether to call the gateway", async () => {
+		const { gateway, transformPrompt, ctx } = setup("p-empty", [""]);
+
+		const result = await transformPrompt("a knight and a dragon", ctx);
+
+		expect(result).toBe("a knight and a dragon");
+		expect(gateway.generate).not.toHaveBeenCalled();
+	});
+
 	it("combines reference images with uploaded avatars but excludes generated ones", async () => {
 		const projectId = "p4";
 		const referenceImage = "https://example.com/reference.jpg";

--- a/lib/connectors/llm/plugins/character-avatar-style.ts
+++ b/lib/connectors/llm/plugins/character-avatar-style.ts
@@ -1,5 +1,6 @@
 import dedent from "dedent";
 import { getProjectStore } from "@/lib/project/store";
+import { listCharacterAvatars } from "./character-avatars";
 import type {
 	LLMGenerateParams,
 	LLMGenerateResult,
@@ -16,15 +17,12 @@ export function createCharacterAvatarStylePlugin(projectId: string): LLMPlugin {
 		) {
 			const characters =
 				getProjectStore(projectId).getState().metadata.characters;
-			const withAvatar = Object.entries(characters).flatMap(([name, c]) =>
-				c.avatarUrl ? [{ name, character: c, url: c.avatarUrl }] : [],
-			);
+			const withAvatar = listCharacterAvatars(characters);
 			if (withAvatar.length === 0) return prompt;
 
 			const described = await Promise.all(
-				withAvatar.map(async ({ name, character, url }) => {
-					// Reuse appearance text from generated avatars
-					if (!character.avatarUploaded && character.appearance.trim())
+				withAvatar.map(async ({ name, character, source, url }) => {
+					if (source === "generated" && character.appearance.trim())
 						return `- ${name}: ${character.appearance.trim()}`;
 
 					if (!ctx?.gateway)

--- a/lib/connectors/llm/plugins/character-avatars.ts
+++ b/lib/connectors/llm/plugins/character-avatars.ts
@@ -9,6 +9,10 @@ export type CharacterAvatarReference = {
 	source: CharacterAvatarSource;
 };
 
+export function isGeneratedCharacter(character: MetadataCharacter): boolean {
+	return !character.avatarUploaded;
+}
+
 export function listCharacterAvatars(
 	characters: Record<string, MetadataCharacter>,
 ): CharacterAvatarReference[] {
@@ -19,7 +23,7 @@ export function listCharacterAvatars(
 				name,
 				character,
 				url: character.avatarUrl,
-				source: character.avatarUploaded ? "uploaded" : "generated",
+				source: isGeneratedCharacter(character) ? "generated" : "uploaded",
 			},
 		];
 	});
@@ -28,7 +32,9 @@ export function listCharacterAvatars(
 export function listUploadedCharacterAvatarUrls(
 	characters: Record<string, MetadataCharacter>,
 ): string[] {
-	return listCharacterAvatars(characters).flatMap((avatar) =>
-		avatar.source === "uploaded" ? [avatar.url] : [],
+	return Object.values(characters).flatMap((character) =>
+		character.avatarUrl && !isGeneratedCharacter(character)
+			? [character.avatarUrl]
+			: [],
 	);
 }

--- a/lib/connectors/llm/plugins/character-avatars.ts
+++ b/lib/connectors/llm/plugins/character-avatars.ts
@@ -1,0 +1,34 @@
+import type { MetadataCharacter } from "@/lib/project/types";
+
+type CharacterAvatarSource = "uploaded" | "generated";
+
+export type CharacterAvatarReference = {
+	name: string;
+	character: MetadataCharacter;
+	url: string;
+	source: CharacterAvatarSource;
+};
+
+export function listCharacterAvatars(
+	characters: Record<string, MetadataCharacter>,
+): CharacterAvatarReference[] {
+	return Object.entries(characters).flatMap(([name, character]) => {
+		if (!character.avatarUrl) return [];
+		return [
+			{
+				name,
+				character,
+				url: character.avatarUrl,
+				source: character.avatarUploaded ? "uploaded" : "generated",
+			},
+		];
+	});
+}
+
+export function listUploadedCharacterAvatarUrls(
+	characters: Record<string, MetadataCharacter>,
+): string[] {
+	return listCharacterAvatars(characters).flatMap((avatar) =>
+		avatar.source === "uploaded" ? [avatar.url] : [],
+	);
+}

--- a/lib/connectors/llm/plugins/project-metadata.ts
+++ b/lib/connectors/llm/plugins/project-metadata.ts
@@ -6,6 +6,7 @@ import type {
 	MetadataCharacter,
 	MetadataVoice,
 } from "@/lib/project/types";
+import { isGeneratedCharacter } from "./character-avatars";
 import { prependSystemPrompt } from "./system-prompt";
 
 const VOICE_FIELDS: (keyof MetadataVoice)[] = [
@@ -28,7 +29,7 @@ function renderVoice(voice: MetadataVoice): string {
 function renderCharacter(name: string, character: MetadataCharacter): string {
 	const voiceLines = renderVoice(character);
 	const appearanceLine =
-		character.appearance && !character.avatarUploaded
+		character.appearance && isGeneratedCharacter(character)
 			? `- appearance: ${character.appearance}`
 			: "";
 	const body = [voiceLines, appearanceLine].filter(Boolean).join("\n");

--- a/lib/connectors/llm/plugins/reference-style.ts
+++ b/lib/connectors/llm/plugins/reference-style.ts
@@ -1,6 +1,7 @@
 import dedent from "dedent";
 import compact from "lodash/compact";
 import { getProjectStore } from "@/lib/project/store";
+import { listUploadedCharacterAvatarUrls } from "./character-avatars";
 import type {
 	LLMGenerateParams,
 	LLMGenerateResult,
@@ -19,9 +20,7 @@ export function createReferenceStylePlugin(projectId: string): LLMPlugin {
 				getProjectStore(projectId).getState();
 			const styleReferenceImages = compact([
 				...referenceImages,
-				...Object.values(metadata.characters).map((character) =>
-					character.avatarUploaded ? character.avatarUrl : undefined,
-				),
+				...listUploadedCharacterAvatarUrls(metadata.characters),
 			]);
 			if (styleReferenceImages.length === 0) return prompt;
 			if (!ctx?.gateway)


### PR DESCRIPTION
## Summary
- Extracts character-avatar classification for LLM plugins into a shared helper.
- Updates reference-style and character-avatar-style plugins to consume the shared avatar contract.
- Adds focused tests for uploaded/generated avatar classification and preserved falsey reference-image filtering.

## Architecture / maintainability
- Creates a narrow `character-avatars` helper boundary for deciding whether avatar URLs are uploaded style references or generated avatar fallbacks.
- Removes duplicate avatar URL/classification logic from two LLM plugins while keeping their plugin-specific orchestration separate.
- Preserves the existing `compact([...referenceImages, ...uploadedAvatarUrls])` behavior so empty reference-image slots are still filtered before gateway calls.

## Complexity delta
- Consolidates two inline avatar-selection branches behind one tested helper.
- Adds regression coverage for uploaded-only global style references, generated/legacy generated avatars, missing avatar URLs, and empty reference-image slots.

## Validation
- `npm test -- --run lib/connectors/__tests__/character-avatars.test.ts lib/connectors/__tests__/reference-style.test.ts lib/connectors/__tests__/character-avatar-style.test.ts` — passed (14 tests)
- `npm run lint` — passed
- `npm run format:check` — passed
- `npm run typecheck` — passed
- `npm run knip` — passed
- `npm run build` — passed
- `npm test -- --passWithNoTests` — passed (849 tests)
- `npm run test:coverage` — passed (849 tests)
- `PLAYWRIGHT_PORT=3100 npm run test:e2e` — passed (3 tests)

## Open PR overlap check
Considered current open PRs:
- #323 touches `app/api/v1/__tests__/routes.test.ts`, `app/api/v1/tts/voices/route.ts`, `lib/project/types.ts` for voice/API validation work.
- #322 touches `DESIGN.md`, UI primitives, canvas element container, and export UI for visual polish.

This PR only changes LLM connector plugin helper/test files and does not overlap those files or themes.

## Review notes
- Claude Code was invoked per runbook but timed out without producing a diff, so the same runbook constraints were applied directly.
- Independent review initially flagged possible behavior drift from dropping `compact`; the final diff keeps `compact` and adds the empty-slot regression test.

## Skipped
- No UI or docs changes; the useful maintainability target was in the LLM connector boundary, and docs would not add signal for this small helper.
