### PR TITLE
refactor: rethink openslop architecture 2026-06-20

### DIFF
--- a/app/components/canvas/elements/AttributeBadge.tsx
+++ b/app/components/canvas/elements/AttributeBadge.tsx
@@ -1,7 +1,7 @@
 import { ChevronDown } from "@/components/ui/icon";
-import { ReactEditor, useSlateStatic } from "slate-react";
+import { useSlateStatic } from "slate-react";
 import { SelectMenu } from "@/components/ui/select-menu";
-import { setNodeAttrs } from "@/lib/canvas/editorOps";
+import { updateElementAttrs } from "@/app/components/canvas/utils/nodeOps";
 import type { AttributeSpec } from "@/lib/canvas/elementConfigs";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { TextAttributePopover } from "./attributes/TextAttributePopover";
@@ -77,8 +77,7 @@ export function AttributeBadge({
 	}
 
 	const handleSelect = (next: string) => {
-		const path = ReactEditor.findPath(editor, element);
-		setNodeAttrs(editor, path, element, { [attrKey]: next });
+		updateElementAttrs(editor, element, { [attrKey]: next });
 	};
 
 	return (

--- a/app/components/canvas/elements/CharactersPicker.tsx
+++ b/app/components/canvas/elements/CharactersPicker.tsx
@@ -2,7 +2,7 @@
 
 import { Check, UserPlus } from "@/components/ui/icon";
 import { Editor } from "slate";
-import { ReactEditor, useSlateStatic } from "slate-react";
+import { useSlateStatic } from "slate-react";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { getElementCharacterNames } from "@/lib/canvas/characterNames";
-import { setNodeAttrs } from "@/lib/canvas/editorOps";
+import { updateElementAttrs } from "@/app/components/canvas/utils/nodeOps";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useProjectStore } from "@/lib/project/store";
@@ -28,9 +28,8 @@ function writeCharacters(
 	element: CanvasContentElement,
 	names: string[],
 ): void {
-	const path = ReactEditor.findPath(editor, element);
 	const joined = names.join(", ");
-	setNodeAttrs(editor, path, element, { characters: joined || null });
+	updateElementAttrs(editor, element, { characters: joined || null });
 }
 
 export function toggleCharacter(
@@ -62,8 +61,7 @@ function setCharacterName(
 	element: CanvasContentElement,
 	name: string,
 ): void {
-	const path = ReactEditor.findPath(editor, element);
-	setNodeAttrs(editor, path, element, { name });
+	updateElementAttrs(editor, element, { name });
 }
 
 /** Dropdown listing the project's characters with checkmarks for selected ones. */

--- a/app/components/canvas/elements/DeleteButton.tsx
+++ b/app/components/canvas/elements/DeleteButton.tsx
@@ -1,6 +1,6 @@
-import { Transforms } from "slate";
-import { ReactEditor, useSlateStatic } from "slate-react";
+import { useSlateStatic } from "slate-react";
 import { DeleteButton as DeleteIconButton } from "@/components/ui/delete-button";
+import { removeElement } from "@/app/components/canvas/utils/nodeOps";
 import type { CanvasElement } from "@/lib/canvas/types";
 
 export function DeleteButton({ element }: { element: CanvasElement }) {
@@ -11,8 +11,7 @@ export function DeleteButton({ element }: { element: CanvasElement }) {
 			ariaLabel="Delete element"
 			onMouseDown={(e) => {
 				e.preventDefault();
-				const path = ReactEditor.findPath(editor, element);
-				Transforms.removeNodes(editor, { at: path });
+				removeElement(editor, element);
 			}}
 		/>
 	);

--- a/app/components/canvas/elements/attributes/TextAttributePopover.tsx
+++ b/app/components/canvas/elements/attributes/TextAttributePopover.tsx
@@ -2,14 +2,14 @@
 
 import { ChevronDown } from "@/components/ui/icon";
 import { useCallback, useRef, useState } from "react";
-import { ReactEditor, useSlateStatic } from "slate-react";
+import { useSlateStatic } from "slate-react";
 import {
 	Popover,
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
 import type { CanvasContentElement } from "@/lib/canvas/types";
-import { setNodeAttrs } from "@/lib/canvas/editorOps";
+import { updateElementAttrs } from "@/app/components/canvas/utils/nodeOps";
 
 interface TextAttributePopoverProps {
 	element: CanvasContentElement;
@@ -42,8 +42,7 @@ export function TextAttributePopover({
 	const commit = useCallback(
 		(next: string) => {
 			if (next === value) return;
-			const path = ReactEditor.findPath(editor, element);
-			setNodeAttrs(editor, path, element, { [attrKey]: next });
+			updateElementAttrs(editor, element, { [attrKey]: next });
 		},
 		[editor, element, attrKey, value],
 	);

--- a/app/components/canvas/utils/nodeOps.ts
+++ b/app/components/canvas/utils/nodeOps.ts
@@ -1,0 +1,18 @@
+import { type Editor, Transforms } from "slate";
+import { ReactEditor } from "slate-react";
+import { setNodeAttrs } from "@/lib/canvas/editorOps";
+import type { CanvasContentElement, CanvasElement } from "@/lib/canvas/types";
+
+/** Merge attrs into a live element's customAttributes (a null value deletes the key). */
+export function updateElementAttrs(
+	editor: Editor,
+	element: CanvasContentElement,
+	attrs: Record<string, string | null>,
+): void {
+	setNodeAttrs(editor, ReactEditor.findPath(editor, element), element, attrs);
+}
+
+/** Remove a live element from the canvas. */
+export function removeElement(editor: Editor, element: CanvasElement): void {
+	Transforms.removeNodes(editor, { at: ReactEditor.findPath(editor, element) });
+}


### PR DESCRIPTION
## App understanding

OpenSlop turns a text prompt into a short AI-generated video. The LLM connector streams OSML over SSE into a SlateJS canvas; stale elements are queued client-side and generated via `POST /api/v1/{asset}` (image/video/music/sfx/tts) through a three-layer pipeline — **connectors** (editor-facing, plugin-pipelined) → **gateways** (thin HTTP clients to `/api/v1/*`, the seam for a future BYOK gateway) → **providers** (server adapters for Runware/ElevenLabs/Cartesia/Anthropic). Jobs run on Vercel Queue, assets land in Vercel Blob, project state persists to Supabase Postgres (RLS). Render fans the composition across Remotion Lambdas. Main workflows: submit prompt → edit canvas → generate assets → preview/play → export render.

## From-scratch architecture vs. current

The current layering (connector/gateway/provider, queue, Zustand project store, Slate canvas) is already close to what a clean rebuild would produce, and the connector/gateway split is intentional (multiple providers + BYOK planned), so it was left intact. The one rough edge a from-scratch design would avoid: **UI components reaching directly into Slate path-resolution plumbing** (`ReactEditor.findPath(editor, element)` immediately followed by a mutation) to edit a canvas node. That mechanic belongs behind a named helper, not copy-pasted into each element component.

## Implemented simplification

Centralized the "mutate a live canvas element" mechanic into `app/components/canvas/utils/nodeOps.ts`:

- `updateElementAttrs(editor, element, attrs)` — resolves the path and merges custom attributes.
- `removeElement(editor, element)` — resolves the path and removes the node.

Refactored every UI call site to use these instead of hand-rolling `ReactEditor.findPath` + `setNodeAttrs`/`Transforms.removeNodes`:

- `AttributeBadge.tsx`, `attributes/TextAttributePopover.tsx`, `CharactersPicker.tsx` (×2) — drop the `ReactEditor.findPath` line and the `ReactEditor`/`setNodeAttrs` imports.
- `DeleteButton.tsx` — drop the `ReactEditor`/`Transforms` imports.

Net effect: UI components no longer import `ReactEditor`/`Transforms` for node edits; the slate-path mechanic lives in one place. Behavior is identical (the helpers compose the exact same already-tested `setNodeAttrs`/`removeNodes` calls). Pure functions, not a wrapper hook — consistent with the existing `insertElement`/`setNodeAttrs` style.

Deliberately followed `setNodeAttrs` (in pure-slate `lib/canvas/editorOps.ts`, used by `lib/script/refine/applyOps.ts` with a non-React path from `findNodeById`) unchanged, so the new findPath-based helpers stay in the UI layer and `editorOps` remains React-free and unit-testable.

## Validation

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run knip` ✅
- `npm run format:check` ✅
- `npm run test:run` ✅ (96 files / 846 tests)
- `npm run build` ✅
- `npm run test:e2e` — not run locally (Playwright browser + Supabase env); change is an internal behavior-preserving refactor with no markup/route changes, covered by build + unit tests.

## Skipped items / risks

- **Connector/gateway/provider subclass boilerplate** — intentional layering (multiple providers + BYOK gateway planned); collapsing into factories would fight the design. Skipped.
- **`OutputPreview` dispatch** — genuinely polymorphic (audio / animated_image / media are different shapes), not duplication; a generic wrapper would add indirection. Skipped.
- **Parent-scene-id cast dedup** (`(Node.parent(...) as SceneElement).id` in `SortableContent` + `ElementContainer`) — would require editing `ElementContainer.tsx`, which overlaps open PR #322. Skipped to avoid the overlap; single remaining caller isn't worth extracting.
- Risk: low. No behavior, route, schema, or UI change.

## Best-practice review

`/simplify`, `/vercel-composition-patterns`, `/vercel-react-best-practices`, `/web-design-guidelines` applied as review lenses: the change removes duplication and indirection (simplify), uses plain composable functions rather than boolean-prop or wrapper-hook patterns (composition / react best practices), and touches no markup (web-design N/A).

## Open PR overlap check

Checked against open PRs:
- **#324** (lib/connectors/llm/plugins, avatar/reference-style) — no overlap.
- **#323** (app/api/v1/tts/voices, lib/project/types.ts, api routes test) — no overlap.
- **#322** (DESIGN.md + `ElementContainer.tsx` + components/ui overlay styling) — **no overlap**: this PR deliberately does not touch `ElementContainer.tsx` or any UI overlay file. Files changed are limited to `AttributeBadge.tsx`, `CharactersPicker.tsx`, `DeleteButton.tsx`, `attributes/TextAttributePopover.tsx`, and the new `utils/nodeOps.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)