### PR TITLE
fix: improve video generation defaults

### DIFF
--- a/lib/connectors/__tests__/osml.test.ts
+++ b/lib/connectors/__tests__/osml.test.ts
@@ -22,4 +22,11 @@ describe("osmlPlugin", () => {
 			"ALL CAPS",
 		);
 	});
+
+	it("asks for image changes on every narrative line by default", () => {
+		const result = beforeGenerate({ prompt: "hello" });
+		expect((result as { systemPrompt: string }).systemPrompt).toContain(
+			"Change the image for every narrative line",
+		);
+	});
 });

--- a/lib/connectors/llm/plugins/osml.ts
+++ b/lib/connectors/llm/plugins/osml.ts
@@ -56,7 +56,7 @@ const OSML_SYSTEM_PROMPT = dedent`
 	- characters: Include a comma-separated list of character names that occur in the image. These should be characters from the story with their exact names. Example:
 		<image characters="Red,Granny">Red hands the basket to Granny at the cottage door.</image>
   - After the metadata tags, open the story with an <image> tag that describes the image for the opening scene.
-  - Frequently change the image at least every 2 narrative lines.
+  - Change the image for every narrative line by default.
   - As appropriate, add an overlays attribute to the <image> tag. Example: <image overlays="smoke,lightning">A thunderclap echoes through the forest. A bolt of lightning strikes a tree.</image>
   - For example, if there is rain in the image, add the rain overlay. If there is smoke, add the smoke overlay. If there is lightning, add the lightning overlay. If there are multiple effects, add all of them.
   - Overlays should be a comma-separated list containing any of the following: ${Object.values(

--- a/lib/video/__tests__/scene-builder.test.ts
+++ b/lib/video/__tests__/scene-builder.test.ts
@@ -51,6 +51,11 @@ describe("buildVideoLayout", () => {
 			expect(layout.totalDurationSec).toBe(0);
 			expect(layout.totalFrames).toBe(2);
 		});
+
+		it("defaults to smooth fade transitions", () => {
+			const layout = buildVideoLayout([]);
+			expect(layout.transitionType).toBe("fade");
+		});
 	});
 
 	describe("foreground elements (image, clip)", () => {

--- a/lib/video/transitions.ts
+++ b/lib/video/transitions.ts
@@ -21,7 +21,7 @@ export const TRANSITION_TYPES = [
 
 export type TransitionType = (typeof TRANSITION_TYPES)[number];
 
-export const DEFAULT_TRANSITION: TransitionType = "none";
+export const DEFAULT_TRANSITION: TransitionType = "fade";
 export const TRANSITION_DURATION_SEC = 0.4;
 export const AUDIO_FADE_SEC = 2;
 // Lead time to mount foreground video before it's visible so it decodes ahead


### PR DESCRIPTION
## Summary
- Change the default video transition from `none` to `fade` for smoother generated videos.
- Tighten the OSML image-cadence instruction so generated scripts change images for every narrative line by default.
- Add focused regression tests for both defaults.

## Selected issue
Selected #252 because it is labeled `good first issue`, has two small default-value changes with clear acceptance criteria, and touches isolated generation/render defaults that can be validated locally without auth, secrets, or product decisions.

Closes #252

## Validation
- `npm run test:run -- lib/video/__tests__/scene-builder.test.ts lib/connectors/__tests__/osml.test.ts` (red before implementation; failed on the new assertions)
- `npm run test:run -- lib/video/__tests__/scene-builder.test.ts lib/connectors/__tests__/osml.test.ts` (green after implementation; 36 passed)
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run knip`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`
- `npm run test:coverage` (96 files / 848 tests passed)
- `PLAYWRIGHT_PORT=3100 NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run test:e2e` (3 passed)

Note: default `npm run test:e2e` initially could not start because port 3000 was already occupied, so I retried on the supported `PLAYWRIGHT_PORT=3100` per `playwright.config.ts`.

## Open PR overlap check
Reviewed open PRs #322, #323, #324, and #325 before and after the change. None touched `lib/video/transitions.ts`, `lib/video/__tests__/scene-builder.test.ts`, `lib/connectors/llm/plugins/osml.ts`, or `lib/connectors/__tests__/osml.test.ts`, and none covered the default-transition/image-cadence issue theme.

## Skipped issue categories
Skipped broader/product-context or larger items such as visible editable art-style state (#321), reference-image semantics (#320), language selector (#319), license migration/sign-off (#317), audio crossfading (#316), and broad canvas/UI readability or interaction bundles (#245/#242).