### PR TITLE
fix: nightly bug fixes 2026-06-21

### DIFF
--- a/lib/video/__tests__/elementAttributes.test.ts
+++ b/lib/video/__tests__/elementAttributes.test.ts
@@ -18,8 +18,10 @@ function el(customAttributes?: Record<string, string>): CanvasContentElement {
 }
 
 describe("getVolume", () => {
-	it("defaults to 10 when missing or non-numeric", () => {
+	it("defaults to 10 when missing, blank, or non-numeric", () => {
 		expect(getVolume(el())).toBe(10);
+		expect(getVolume(el({ volume: "" }))).toBe(10);
+		expect(getVolume(el({ volume: "   " }))).toBe(10);
 		expect(getVolume(el({ volume: "not-a-number" }))).toBe(10);
 	});
 

--- a/lib/video/elementAttributes.ts
+++ b/lib/video/elementAttributes.ts
@@ -18,12 +18,16 @@ const VOLUME_MIN = 0;
 const VOLUME_MAX = 10;
 const DEFAULT_VOLUME = VOLUME_MAX;
 
+function parseFiniteNumber(value: string | undefined): number | undefined {
+	if (value == null || value.trim() === "") return undefined;
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 /** Volume coerced to a finite number clamped to [0, 10], defaulting to 10. */
 export function getVolume(element: CanvasContentElement): number {
-	const raw = Number(element.customAttributes?.volume);
-	return Number.isFinite(raw)
-		? clamp(raw, VOLUME_MIN, VOLUME_MAX)
-		: DEFAULT_VOLUME;
+	const raw = parseFiniteNumber(element.customAttributes?.volume);
+	return raw == null ? DEFAULT_VOLUME : clamp(raw, VOLUME_MIN, VOLUME_MAX);
 }
 
 const LOOPS_MAX = 1000;


### PR DESCRIPTION
## Summary
- Fix blank/whitespace video volume attributes being coerced to `0` by `Number(...)`.
- Preserve valid numeric volumes, including explicit `0`, and keep clamping behavior unchanged.
- Add regression coverage for blank and whitespace volume attributes.

## Bugs fixed
- A persisted or edited blank `customAttributes.volume` value muted media because `Number("")` and `Number("   ")` evaluate to `0`; blank volume now falls back to the existing default volume of `10`.

## Tests added / areas covered
- Extended `lib/video/__tests__/elementAttributes.test.ts` to cover blank and whitespace volume values.
- Verified the regression test failed before the production fix with `expected +0 to be 10`.

## Validation
- `npm test -- lib/video/__tests__/elementAttributes.test.ts`
- `npm test -- --passWithNoTests`
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run knip`
- `npm run test:coverage`
- `PLAYWRIGHT_PORT=3107 npm run test:e2e`

Note: the first plain `npm run test:e2e` attempt hit an existing process on port 3000 (`EADDRINUSE`); reran successfully on `PLAYWRIGHT_PORT=3107` per the Playwright config.

## Open PR overlap check
- `gh pr list --state open --json number,title,headRefName,url,files,body --limit 50` returned no open PRs at the start of the run.
- Final diff only touches `lib/video/elementAttributes.ts` and its focused test, so there is no open-PR overlap.

## Skipped / notes
- Claude Code core pass was invoked as required, but the broad run timed out after 10 minutes without leaving a diff; Hermes completed a narrow TDD fallback pass for the real bug above.
