### PR TITLE
refactor: nightly maintainability 2026-06-21

### DIFF
--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { ImagePlus, Loader2, Trash2, X } from "@/components/ui/icon";
+import { ImagePlus, Loader2, Trash2 } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
+import { CloseButton } from "@/components/ui/close-button";
 import { IconButton } from "@/components/ui/icon-button";
 import {
 	DialogContent,
@@ -144,14 +145,10 @@ function CharacterEditDialogBody({
 			onEscapeKeyDown={interceptClose}
 			onInteractOutside={interceptClose}
 		>
-			<button
-				type="button"
+			<CloseButton
 				onClick={requestClose}
-				aria-label="Close"
-				className="absolute right-3 top-3 z-10 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:outline-none focus:ring-1 focus:ring-accent/50"
-			>
-				<X className="h-4 w-4" />
-			</button>
+				className="absolute right-3 top-3 z-10 focus:outline-none focus:ring-1 focus:ring-accent/50"
+			/>
 			<DialogHeader className="shrink-0">
 				<DialogTitle>{name}</DialogTitle>
 				<DialogDescription>

--- a/app/components/video/ExportButton.tsx
+++ b/app/components/video/ExportButton.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Download, X } from "@/components/ui/icon";
+import { CloseButton } from "@/components/ui/close-button";
+import { Download } from "@/components/ui/icon";
 import {
 	Popover,
 	PopoverAnchor,
@@ -63,14 +64,7 @@ export function ExportButton() {
 			>
 				<div className="flex items-center justify-between">
 					<span className="text-xs font-semibold">Export</span>
-					<button
-						type="button"
-						onClick={() => setOpen(false)}
-						aria-label="Close"
-						className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-					>
-						<X size={16} />
-					</button>
+					<CloseButton onClick={() => setOpen(false)} />
 				</div>
 				<Separator className="-mx-3 my-2 data-[orientation=horizontal]:w-[calc(100%+1.5rem)]" />
 

--- a/app/components/video/ExportToast.tsx
+++ b/app/components/video/ExportToast.tsx
@@ -2,7 +2,8 @@
 
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Download, X } from "@/components/ui/icon";
+import { CloseButton } from "@/components/ui/close-button";
+import { Download } from "@/components/ui/icon";
 import { Progress } from "@/components/ui/progress";
 import { Spinner } from "@/components/ui/spinner";
 import { formatBytes } from "@/lib/format";
@@ -65,14 +66,11 @@ export function ExportDoneToast({
 					Download
 				</a>
 			</Button>
-			<button
-				type="button"
+			<CloseButton
 				onClick={() => toast.dismiss(toastId)}
-				aria-label="Close"
-				className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-			>
-				<X size={14} />
-			</button>
+				size={14}
+				className="shrink-0"
+			/>
 		</div>
 	);
 }

--- a/components/ui/close-button.tsx
+++ b/components/ui/close-button.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { X } from "@/components/ui/icon";
+import { cn } from "@/lib/utils";
+
+export const CloseButton = React.forwardRef<
+	HTMLButtonElement,
+	React.ComponentProps<"button"> & { size?: number }
+>(function CloseButton({ size = 16, className, ...props }, ref) {
+	return (
+		<button
+			ref={ref}
+			type="button"
+			aria-label="Close"
+			className={cn(
+				"rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+				className,
+			)}
+			{...props}
+		>
+			<X size={size} />
+		</button>
+	);
+});

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { Dialog as DialogPrimitive } from "radix-ui";
-import { X } from "@/components/ui/icon";
+import { CloseButton } from "@/components/ui/close-button";
 
 import { cn } from "@/lib/utils";
 
@@ -98,11 +98,8 @@ function DialogContent({
 					{children}
 				</div>
 				{showCloseButton && (
-					<DialogPrimitive.Close
-						className="absolute right-4 top-4 z-10 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-ring"
-						aria-label="Close"
-					>
-						<X className="h-4 w-4" />
+					<DialogPrimitive.Close asChild>
+						<CloseButton className="absolute right-4 top-4 z-10 focus-ring" />
 					</DialogPrimitive.Close>
 				)}
 			</DialogPrimitive.Content>


### PR DESCRIPTION
## Summary
- Extracts a shared `CloseButton` UI primitive for repeated close-button markup.
- Migrates dialog, character edit modal, export popover, and export toast close buttons to the shared primitive.
- Keeps positioning, icon sizing, and focus styles at each call site so behavior and UI intent remain unchanged.

## Architecture / maintainability
- Centralizes the common close-button contract (`type="button"`, `aria-label="Close"`, rounded-md spacing, muted text, hover state, X icon) in `components/ui/close-button.tsx`.
- Leaves call-site-specific responsibilities (Radix dialog wrapping, modal close interception, popover/toast dismissal, focus styling, layout positioning) at the call sites.
- Reduces drift risk from four hand-rolled close buttons while avoiding a broader UI migration.

## Complexity delta
- 5 files touched.
- Net effect: one small reusable primitive, 4 duplicated close-button implementations replaced.
- Diff is 40 insertions / 31 deletions; repeated class/ARIA/button boilerplate is now defined once.

## Validation
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run knip`
- `npm run build`
- `npm test -- --passWithNoTests` (96 files / 846 tests passed)
- `npm run test:coverage` (96 files / 846 tests passed)
- `PLAYWRIGHT_PORT=3108 npm run test:e2e` (3 passed)
- Independent fresh-context review passed with no security or logic concerns.

## Open PR overlap check
- Considered open PR #336 (`fix: nightly bug fixes 2026-06-21`), which touches `lib/video/elementAttributes.ts` and `lib/video/__tests__/elementAttributes.test.ts` for video volume parsing/default behavior.
- This PR touches only close-button UI primitive usage in `components/ui`, character edit modal chrome, and export UI chrome; no overlapping files or themes.

## Skipped / notes
- No `.claude/commands/*.md` or `.claude/skills/*/SKILL.md` guidance files were present in this checkout.
- Avoided broader design-token or route-validation changes because recent maintainer feedback called out low-value/overengineered churn and behavior-change risk.
