### PR TITLE
Add animate button to image elements

### DIFF
--- a/app/components/EditorToolbar.tsx
+++ b/app/components/EditorToolbar.tsx
@@ -13,21 +13,19 @@ import {
 } from "@/lib/generation/GenerationQueueProvider";
 import InlineCopilot from "./copilot/InlineCopilot";
 import { useGenerateAll } from "./canvas/hooks/useGenerateAll";
-import { useRefineScript } from "./canvas/hooks/useRefineScript";
+import { useRefine } from "./canvas/RefineProvider";
 import { ExportButton } from "./video/ExportButton";
 import editorStyles from "./Editor.module.css";
 
 function RefineComposer({
-	editor,
 	loading,
 	onStop,
 }: {
-	editor: Editor;
 	loading: boolean;
 	onStop: () => void;
 }) {
 	const [value, setValue] = useState("");
-	const { refineScript, refineLoading, stopRefine } = useRefineScript(editor);
+	const { refineScript, refineLoading, stopRefine } = useRefine();
 	return (
 		<InlineCopilot
 			value={value}
@@ -64,11 +62,7 @@ export function EditorToolbar({ editor }: { editor: Editor }) {
 			<div className="flex w-full items-center gap-3">
 				<div className="hidden flex-1 sm:block" aria-hidden />
 				<div className="min-w-0 max-w-2xl flex-1">
-					<RefineComposer
-						editor={editor}
-						loading={loading}
-						onStop={stopGeneration}
-					/>
+					<RefineComposer loading={loading} onStop={stopGeneration} />
 				</div>
 				<div className="flex flex-1 items-center justify-end gap-2 max-sm:flex-none">
 					<Button

--- a/app/components/canvas/CanvasProviders.tsx
+++ b/app/components/canvas/CanvasProviders.tsx
@@ -8,6 +8,7 @@ import { RenderProvider } from "../video/RenderProvider";
 import { ActiveSceneProvider } from "../scene-selection/ActiveSceneContext";
 import { AutoScrollProvider } from "../scene-selection/AutoScrollContext";
 import { ViewModeProvider } from "./ViewModeContext";
+import { RefineProvider } from "./RefineProvider";
 
 /**
  * Composes the editor's canvas-scoped providers (render, video layout, player
@@ -32,7 +33,7 @@ export function CanvasProviders({
 					<ActiveSceneProvider>
 						<AutoScrollProvider>
 							<ViewModeProvider sceneIds={sceneIds}>
-								{children}
+								<RefineProvider editor={editor}>{children}</RefineProvider>
 							</ViewModeProvider>
 						</AutoScrollProvider>
 					</ActiveSceneProvider>

--- a/app/components/canvas/RefineProvider.tsx
+++ b/app/components/canvas/RefineProvider.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { Editor } from "slate";
+import { createRequiredContext } from "@/lib/components/createRequiredContext";
+import { useRefineScript } from "./hooks/useRefineScript";
+
+type RefineContextValue = ReturnType<typeof useRefineScript>;
+
+const [RefineContext, useRefine] =
+	createRequiredContext<RefineContextValue>("RefineProvider");
+export { useRefine };
+
+export function RefineProvider({
+	editor,
+	children,
+}: {
+	editor: Editor;
+	children: ReactNode;
+}) {
+	const refine = useRefineScript(editor);
+	return <RefineContext value={refine}>{children}</RefineContext>;
+}

--- a/app/components/canvas/elements/AnimateButton.tsx
+++ b/app/components/canvas/elements/AnimateButton.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { MagicVideo } from "@/components/ui/icon";
+import { Button } from "@/components/ui/button";
+import { animateImagePrompt } from "@/lib/script/refine/animatePrompt";
+import type { CanvasContentElement } from "@/lib/canvas/types";
+import { useRefine } from "../RefineProvider";
+
+export function AnimateButton({ element }: { element: CanvasContentElement }) {
+	const { refineScript, refineLoading } = useRefine();
+
+	if (element.type !== "image") return null;
+
+	return (
+		<Button
+			type="button"
+			variant="ghost"
+			size="sm"
+			tooltip="Animate this image"
+			className="shrink-0"
+			disabled={refineLoading}
+			onMouseDown={(e) => e.preventDefault()}
+			onClick={() => refineScript(animateImagePrompt(element.id))}
+		>
+			<MagicVideo aria-hidden="true" />
+			<span className="hidden sm:inline">Animate</span>
+		</Button>
+	);
+}

--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -12,7 +12,8 @@ import { CompactElement } from "./CompactElement";
 import { SceneContainer } from "./SceneContainer";
 import { ElementCharacters } from "./ElementCharacters";
 import { AttributeBadge } from "./AttributeBadge";
-import { ElementGenerateButton } from "./GenerateButton";
+import { ElementGenerateButton, ElementStaleIndicator } from "./GenerateButton";
+import { AnimateButton } from "./AnimateButton";
 import { ModelBadge } from "./ModelBadge";
 import {
 	Popover,
@@ -122,9 +123,11 @@ export function ElementContainer({
 						</div>
 					</div>
 					<div
-						className="mt-2 flex justify-end select-none"
+						className="mt-2 flex items-center justify-end gap-2 select-none"
 						contentEditable={false}
 					>
+						<ElementStaleIndicator element={element} />
+						<AnimateButton element={element} />
 						<ElementGenerateButton element={element} />
 					</div>
 				</div>

--- a/app/components/canvas/elements/GenerateButton.tsx
+++ b/app/components/canvas/elements/GenerateButton.tsx
@@ -19,6 +19,16 @@ export function StaleIndicator() {
 	);
 }
 
+export function ElementStaleIndicator({
+	element,
+}: {
+	element: CanvasContentElement;
+}) {
+	const { stale } = useGenerate(element);
+	if (!stale) return null;
+	return <StaleIndicator />;
+}
+
 function generateLabel(status: GenerationStatus, hasResult: boolean) {
 	if (status === "generating") return "Generating…";
 	if (status === "queued") return "Queued";
@@ -47,6 +57,7 @@ export function GenerateButton({
 			onMouseDown={(e) => e.preventDefault()}
 			onClick={onGenerate}
 			aria-label={label}
+			tooltip={hasResult ? "Regenerate this element" : "Generate this element"}
 		>
 			{status === "generating" ? (
 				<Spinner className="text-current" />
@@ -65,17 +76,13 @@ export function ElementGenerateButton({
 }: {
 	element: CanvasContentElement;
 }) {
-	const { hasPrompt, hasResult, stale, status, generate } =
-		useGenerate(element);
+	const { hasPrompt, hasResult, status, generate } = useGenerate(element);
 	return (
-		<div className="flex items-center gap-2">
-			{stale && hasResult && <StaleIndicator />}
-			<GenerateButton
-				status={status}
-				hasResult={hasResult}
-				disabled={!hasPrompt || status !== "idle"}
-				onGenerate={generate}
-			/>
-		</div>
+		<GenerateButton
+			status={status}
+			hasResult={hasResult}
+			disabled={!hasPrompt || status !== "idle"}
+			onGenerate={generate}
+		/>
 	);
 }

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -104,7 +104,6 @@ function CharacterEditDialogBody({
 
 	const isStale =
 		!character.avatarUploaded &&
-		!!avatarSnapshot.result &&
 		isStaleResult(
 			avatarSnapshot,
 			getGenerationInputs(

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -3,6 +3,7 @@ import { Slot } from "radix-ui";
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 
 const buttonVariants = cva(
 	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,background-color,border-color,box-shadow,filter] focus-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0",
@@ -42,19 +43,24 @@ function Button({
 	variant,
 	size,
 	asChild = false,
+	tooltip,
 	...props
 }: React.ComponentProps<"button"> &
 	VariantProps<typeof buttonVariants> & {
 		asChild?: boolean;
+		tooltip?: string;
 	}) {
 	const Comp = asChild ? Slot.Root : "button";
-	return (
+	const button = (
 		<Comp
 			data-slot="button"
+			aria-label={tooltip}
 			className={cn(buttonVariants({ variant, size, className }))}
 			{...props}
 		/>
 	);
+	if (tooltip == null) return button;
+	return <SimpleTooltip label={tooltip}>{button}</SimpleTooltip>;
 }
 
 export { Button, buttonVariants };

--- a/components/ui/icon.tsx
+++ b/components/ui/icon.tsx
@@ -80,6 +80,7 @@ export const ImagePlus = icon("add-image");
 export const Layout = icon("layout");
 export const Loader2 = icon("spinner");
 export const LogOut = icon("log-out");
+export const MagicVideo = icon("magic-video");
 export const Maximize = icon("maximize");
 export const Mic = icon("mic");
 export const Motion = icon("motion");

--- a/lib/generation/__tests__/generationInputs.test.ts
+++ b/lib/generation/__tests__/generationInputs.test.ts
@@ -22,8 +22,8 @@ const snapshot = (
 const result = { url: "x", durationSec: 0 };
 
 describe("isStaleResult", () => {
-	it("is true when no result has been produced yet", () => {
-		expect(isStaleResult(snapshot(), inputs("anything"))).toBe(true);
+	it("is false when no result has been produced yet", () => {
+		expect(isStaleResult(snapshot(), inputs("anything"))).toBe(false);
 	});
 
 	it("is true when resultInputs is null even if a result exists", () => {

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -28,11 +28,8 @@ export function isStaleResult(
 	snapshot: ElementSnapshot,
 	currentInputs: GenerationInputs,
 ): boolean {
-	return (
-		!isActive(snapshot.status) &&
-		(isNil(snapshot.resultInputs) ||
-			!isEqual(currentInputs, snapshot.resultInputs))
-	);
+	if (isNil(snapshot.result)) return false;
+	return !isEqual(currentInputs, snapshot.resultInputs);
 }
 
 export type GenerationJob = {

--- a/lib/providers/llm/mock.ts
+++ b/lib/providers/llm/mock.ts
@@ -2,6 +2,7 @@ import type {
 	LLMGenerateParams,
 	LLMGenerateResult,
 } from "@/lib/connectors/types";
+import { matchAnimateImagePrompt } from "@/lib/script/refine/animatePrompt";
 import { BaseProvider } from "../base";
 import { pickRandom } from "../mock-utils";
 
@@ -196,6 +197,10 @@ function mockResponse(params: LLMGenerateParams): string {
 }
 
 function buildRefineResponse(params: LLMGenerateParams): string {
+	const animateId = matchAnimateImagePrompt(params.prompt);
+	if (animateId) {
+		return `{"op":"set","id":"${animateId}","type":"animated_image","attrs":{"videoPrompt":"slow cinematic push-in with gentle parallax","motion":"kenBurnsIn"}}`;
+	}
 	const ids = extractIds(params.prompt);
 	const factory = pickRandom(MOCK_REFINEMENTS);
 	return factory(ids);

--- a/lib/script/refine/animatePrompt.ts
+++ b/lib/script/refine/animatePrompt.ts
@@ -1,0 +1,13 @@
+const ANIMATE_IMAGE_INSTRUCTION = "animate the image element with id";
+const ANIMATE_IMAGE_PATTERN = new RegExp(
+	`${ANIMATE_IMAGE_INSTRUCTION}="([^"]+)"`,
+	"i",
+);
+
+export function animateImagePrompt(id: string): string {
+	return `${ANIMATE_IMAGE_INSTRUCTION}="${id}"`;
+}
+
+export function matchAnimateImagePrompt(prompt: string): string | null {
+	return ANIMATE_IMAGE_PATTERN.exec(prompt)?.[1] ?? null;
+}


### PR DESCRIPTION
## Summary
- Adds a one-click **Animate** button on image elements (magic-video icon) that fires the refine copilot to convert the element into an `animated_image`, targeting it by `element.id`. Responsive: the label collapses to an icon below `sm`.
- Introduces a shared `RefineProvider` (mounted in `CanvasProviders`) so the toolbar copilot and the new button share a single `useRefineScript` instance and `refineLoading` state.
- Adds a `tooltip` prop to the `Button` primitive (doubles as the accessible label), replacing hand-rolled `SimpleTooltip` + button wrappers; wires tooltips onto Animate and the per-element Generate button.
- Single-sources the animate instruction string in `lib/script/refine/animatePrompt.ts` (builder + matcher) so the button and the mock LLM can't drift; adds a deterministic animate response to the mock LLM.
- Tightens `isStaleResult` to mean "has an outdated result" (returns false when there's no result), letting `ElementStaleIndicator` and `CharacterEditModal` drop redundant result checks. Moves the stale indicator ahead of the action buttons and flattens `ElementGenerateButton`.

## Test plan
- [ ] `npm run lint`, `npm run typecheck`, `npm run knip`, `npm run format:check`, `npm test` all pass (846 tests).
- [ ] On an image element, hover shows **Animate**; clicking runs the copilot and converts it to an animated image (with the mock provider, deterministically).
- [ ] Verify Animate is absent on non-image elements, and the label collapses to icon-only on a narrow viewport with the tooltip intact.
- [ ] Confirm the stale badge still appears after editing a generated element's prompt.