### PR TITLE
Retain characters when converting image to animated image

### DIFF
--- a/lib/canvas/__tests__/preservedAttributes.test.ts
+++ b/lib/canvas/__tests__/preservedAttributes.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { preservedAttributes } from "../preservedAttributes";
+import type { CanvasContentElement } from "../types";
+
+function element(
+	type: CanvasContentElement["type"],
+	customAttributes?: Record<string, string>,
+): CanvasContentElement {
+	return { id: "n1", type, customAttributes, children: [] };
+}
+
+describe("preservedAttributes", () => {
+	it("carries shared attributes between types in the same group", () => {
+		const source = element("image", { characters: "Red,Granny" });
+		expect(preservedAttributes(source, "animated_image")).toEqual({
+			characters: "Red,Granny",
+		});
+	});
+
+	it("drops attributes when the target type is outside the group", () => {
+		const source = element("image", { characters: "Red,Granny" });
+		expect(preservedAttributes(source, "narration")).toEqual({});
+	});
+
+	it("never carries attributes that are not declared shared", () => {
+		const source = element("image", {
+			characters: "Red",
+			url: "https://example.com/old.png",
+		});
+		expect(preservedAttributes(source, "animated_image")).toEqual({
+			characters: "Red",
+		});
+	});
+
+	it("returns an empty object when there are no custom attributes", () => {
+		expect(preservedAttributes(element("image"), "animated_image")).toEqual({});
+	});
+});

--- a/lib/canvas/preservedAttributes.ts
+++ b/lib/canvas/preservedAttributes.ts
@@ -1,0 +1,24 @@
+import type { CanvasContentElement, CanvasElementType } from "./types";
+
+type ElementTypeGroup = readonly CanvasElementType[];
+
+/**
+ * A map of attribute name and the types within which it's preserved
+ */
+const PRESERVED_ATTRIBUTE_TYPES: Record<string, ElementTypeGroup> = {
+	characters: ["image", "animated_image"],
+};
+
+export function preservedAttributes(
+	source: CanvasContentElement,
+	targetType: CanvasElementType,
+): Record<string, string> {
+	const attrs = source.customAttributes ?? {};
+	const preserved: Record<string, string> = {};
+	for (const [attribute, types] of Object.entries(PRESERVED_ATTRIBUTE_TYPES)) {
+		if (attrs[attribute] && types.includes(targetType)) {
+			preserved[attribute] = attrs[attribute];
+		}
+	}
+	return preserved;
+}

--- a/lib/script/refine/__tests__/applyOps.test.ts
+++ b/lib/script/refine/__tests__/applyOps.test.ts
@@ -29,6 +29,14 @@ vi.mock("@/lib/canvas/elementConfigs", () => ({
 			defaultAttributes: undefined,
 			visibleAttributes: {},
 		},
+		animated_image: {
+			type: "animated_image",
+			connector: "animated_image",
+			outputKind: "video",
+			label: "Animated image",
+			defaultAttributes: { duration: "5" },
+			visibleAttributes: {},
+		},
 		character: {
 			type: "character",
 			connector: "tts",
@@ -119,6 +127,14 @@ function getContentIds(editor: Editor): string[] {
 		ids.push((node as CanvasContentElement).id);
 	}
 	return ids;
+}
+
+function getNode(editor: Editor, id: string): CanvasContentElement {
+	const [node] = Editor.nodes(editor, {
+		at: [],
+		match: (n) => Element.isElement(n) && n.id === id,
+	});
+	return node[0] as CanvasContentElement;
 }
 
 const ZWSP = "\u200B";
@@ -337,11 +353,7 @@ describe("applyRefineOp — set", () => {
 			connectors,
 		);
 
-		const [node] = Editor.nodes(editor, {
-			at: [],
-			match: (n) => Element.isElement(n) && n.id === "n1",
-		});
-		const el = node[0] as CanvasContentElement;
+		const el = getNode(editor, "n1");
 		expect(el.customAttributes).toEqual({
 			name: "Lyra",
 			emotion: "excited",
@@ -365,11 +377,7 @@ describe("applyRefineOp — set", () => {
 			connectors,
 		);
 
-		const [node] = Editor.nodes(editor, {
-			at: [],
-			match: (n) => Element.isElement(n) && n.id === "n1",
-		});
-		const el = node[0] as CanvasContentElement;
+		const el = getNode(editor, "n1");
 		expect(el.customAttributes).toEqual({ name: "Lyra" });
 	});
 
@@ -390,11 +398,7 @@ describe("applyRefineOp — set", () => {
 			connectors,
 		);
 
-		const [node] = Editor.nodes(editor, {
-			at: [],
-			match: (n) => Element.isElement(n) && n.id === "n1",
-		});
-		const el = node[0] as CanvasContentElement;
+		const el = getNode(editor, "n1");
 		expect(el.customAttributes).toEqual({ name: "Alice", emotion: "happy" });
 		expect(el.children.map((c) => c.text).join("")).toBe("Hello!");
 	});
@@ -410,6 +414,39 @@ describe("applyRefineOp — set", () => {
 		);
 
 		expect(getContentTexts(editor)).toEqual(["hello"]);
+	});
+
+	it("preserves shared attributes across a type change, dropping stale ones", () => {
+		const editor = makeEditor([
+			scene([
+				content("image", "n1", "a red riding hood", {
+					characters: "Red,Granny",
+					url: "https://example.com/old.png",
+					motion: "none",
+				}),
+			]),
+		]);
+
+		applyRefineOp(
+			editor,
+			{
+				op: "set",
+				id: "n1",
+				type: "animated_image",
+				attrs: { videoPrompt: "slow push-in", motion: "kenBurnsIn" },
+			},
+			{},
+			connectors,
+		);
+
+		const el = getNode(editor, "n1");
+		expect(el.type).toBe("animated_image");
+		expect(el.customAttributes).toEqual({
+			characters: "Red,Granny",
+			duration: "5",
+			videoPrompt: "slow push-in",
+			motion: "kenBurnsIn",
+		});
 	});
 });
 

--- a/lib/script/refine/applyOps.ts
+++ b/lib/script/refine/applyOps.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/canvas/editorOps";
 import { insertElement } from "@/lib/canvas/insertElement";
 import { createCanvasNode } from "@/lib/canvas/createCanvasNode";
+import { preservedAttributes } from "@/lib/canvas/preservedAttributes";
 import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import type { RefineOp } from "./types";
 
@@ -83,7 +84,10 @@ function applySet(
 	let [element, path] = entry;
 
 	if (op.type && op.type !== element.type) {
-		const replacement = createCanvasNode(op.type, connectors, { id: op.id });
+		const replacement = createCanvasNode(op.type, connectors, {
+			id: op.id,
+			attrs: preservedAttributes(element, op.type),
+		});
 		Transforms.setNodes(
 			editor,
 			{ type: op.type, customAttributes: replacement.customAttributes },


### PR DESCRIPTION
## Problem

The **Animate** button converts an `image` element into an `animated_image` via a refine `set` op that changes the element `type`. `applySet` rebuilt the node from the new type's defaults and replaced `customAttributes` wholesale — silently dropping the character cast (`characters`) assigned to the shot.

## Fix

Add a small declarative policy — `lib/canvas/preservedAttributes.ts` — as the single source of truth for *which attributes survive a type change*: a map of attribute → the element types that use it. An attribute is preserved when the **target** type still uses it.

- Cross-type authoring intent (the cast) carries over: `characters` is shared by `image` ↔ `animated_image`.
- Stale generation-result metadata (`url`, `durationSec`) and connector config (`model`/`provider`) are **not** carried — they're correctly reset/re-derived for the new type by `createCanvasNode`.
- Type-specific config (`motion`, etc.) is reset to the new type's defaults.

`applySet` feeds the preserved attributes through `createCanvasNode`'s existing `attrs` merge, so the refine layer stays thin and an explicit attr in the op still wins.

## Tests

- New `preservedAttributes.test.ts`: carries within the group, drops when the target is outside it, ignores non-listed keys like `url`, handles missing attributes.
- New `applyOps` case asserting `characters` survives `image → animated_image` while a stale `url` is dropped — also the first coverage of `applySet`'s type-change branch.

All CI checks (lint, format, typecheck, knip) pass; 851 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)