### PR TITLE
Let users set clip and animated image duration

### DIFF
--- a/lib/canvas/elementConfigs.tsx
+++ b/lib/canvas/elementConfigs.tsx
@@ -54,6 +54,7 @@ const VOLUME_OPTIONS = [
 ] as const;
 const EMOTION_OPTIONS = Object.values(TTSEmotion);
 const CAPTIONS_OPTIONS = ["on", "off"] as const;
+const DURATION_OPTIONS = Array.from({ length: 12 }, (_, i) => String(i + 4));
 
 const volumeSpec = (color: string): AttributeSpec => ({
 	color,
@@ -71,6 +72,12 @@ const motionSpec = (color: string): AttributeSpec => ({
 	color,
 	label: "Motion",
 	edit: { kind: "enum", options: MOTION_EFFECTS },
+});
+
+const durationSpec = (color: string): AttributeSpec => ({
+	color,
+	label: "Duration",
+	edit: { kind: "enum", options: DURATION_OPTIONS },
 });
 
 const captionsSpec = (color: string): AttributeSpec => ({
@@ -172,9 +179,11 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		defaultAttributes: {
 			motion: "none",
 			videoPrompt: "slow cinematic pan",
+			duration: "5",
 		},
 		visibleAttributes: {
 			videoPrompt: videoPromptSpec("bg-fuchsia-500"),
+			duration: durationSpec("bg-fuchsia-500"),
 			motion: motionSpec("bg-fuchsia-500"),
 		},
 	},
@@ -193,7 +202,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 			motion: "none",
 		},
 		visibleAttributes: {
-			duration: { color: "bg-indigo-500", label: "Duration" },
+			duration: durationSpec("bg-indigo-500"),
 			volume: volumeSpec("bg-indigo-500"),
 			motion: motionSpec("bg-indigo-500"),
 		},

--- a/lib/connectors/animated_image/plugins/__tests__/animated-image-chain.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/animated-image-chain.test.ts
@@ -43,6 +43,7 @@ describe("createVideoChainPlugin", () => {
 				videoPrompt: "slow zoom in",
 				videoWidth: 1280,
 				videoHeight: 720,
+				duration: 8,
 			},
 			ctx,
 		)) as AnimatedImageGenerateParams;
@@ -50,6 +51,7 @@ describe("createVideoChainPlugin", () => {
 		expect(cleaned).not.toHaveProperty("videoPrompt");
 		expect(cleaned).not.toHaveProperty("videoWidth");
 		expect(cleaned).not.toHaveProperty("videoHeight");
+		expect(cleaned).not.toHaveProperty("duration");
 
 		const still = {
 			imageUrl: "https://example.com/still.png",
@@ -62,6 +64,7 @@ describe("createVideoChainPlugin", () => {
 			frameImages: ["https://example.com/still.png"],
 			width: 1280,
 			height: 720,
+			duration: 8,
 		});
 		expect(result).toEqual({
 			imageUrl: "https://example.com/still.png",

--- a/lib/connectors/animated_image/plugins/animated-image-chain.ts
+++ b/lib/connectors/animated_image/plugins/animated-image-chain.ts
@@ -15,6 +15,7 @@ type Stashed = {
 	videoPrompt: string;
 	videoWidth?: number;
 	videoHeight?: number;
+	duration?: number;
 };
 
 export function createVideoChainPlugin(
@@ -23,13 +24,15 @@ export function createVideoChainPlugin(
 	return {
 		name: "video-chain",
 		beforeGenerate(params, ctx) {
-			const { videoPrompt, videoWidth, videoHeight, ...rest } = params;
+			const { videoPrompt, videoWidth, videoHeight, duration, ...rest } =
+				params;
 			if (videoPrompt && ctx) {
 				ctx.data ??= {};
 				ctx.data[STASH_KEY] = {
 					videoPrompt,
 					videoWidth,
 					videoHeight,
+					duration,
 				} satisfies Stashed;
 			}
 			return rest as AnimatedImageGenerateParams;
@@ -57,6 +60,7 @@ export function createVideoChainPlugin(
 				frameImages: [result.imageUrl],
 				width: stashed.videoWidth,
 				height: stashed.videoHeight,
+				duration: stashed.duration,
 			});
 			return {
 				imageUrl: result.imageUrl,

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -124,6 +124,7 @@ export type AnimatedImageGenerateParams = ImageGenerateParams & {
 	videoPrompt?: string;
 	videoWidth?: number;
 	videoHeight?: number;
+	duration?: number;
 };
 
 // TTS types


### PR DESCRIPTION
## Summary

Adds a **4–15s duration dropdown** to `clip` and `animated_image` elements.

- **Clip** duration was displayed but read-only — it's now editable.
- **Animated image** had no duration control at all, and the value was dropped before the video step — it's now settable and carried through to generation.

## Changes

- `lib/canvas/elementConfigs.tsx` — duration attribute/control for clip and animated image
- `lib/connectors/animated_image/plugins/animated-image-chain.ts` — propagate duration into the video step (+ test)
- `lib/connectors/types.ts` — supporting type

🤖 Generated with [Claude Code](https://claude.com/claude-code)