### PR TITLE
fix: nightly bug fixes 2026-06-22

### DIFF
--- a/app/api/v1/__tests__/routes.test.ts
+++ b/app/api/v1/__tests__/routes.test.ts
@@ -465,7 +465,7 @@ describe("API routes", () => {
 			]);
 
 			const req = makeRequest(
-				"/api/v1/tts/voices?query=english",
+				"/api/v1/tts/voices?query=english&limit=5",
 				undefined,
 				"GET",
 			);
@@ -475,6 +475,47 @@ describe("API routes", () => {
 			expect(res.status).toBe(200);
 			expect(json.voices).toHaveLength(1);
 			expect(json.voices[0].name).toBe("Voice 1");
+			expect(mockTTSSearch).toHaveBeenCalledWith({
+				query: "english",
+				limit: 5,
+			});
+		});
+
+		it("returns 400 for blank voice search limit", async () => {
+			const { GET } = await import("@/app/api/v1/tts/voices/route");
+
+			const req = makeRequest("/api/v1/tts/voices?limit=+", undefined, "GET");
+			const res = await GET(req);
+
+			expect(res.status).toBe(400);
+			expect((await res.json()).error).toContain("must be a finite number");
+			expect(mockTTSSearch).not.toHaveBeenCalled();
+		});
+
+		it("returns 400 for malformed voice search limit", async () => {
+			const { GET } = await import("@/app/api/v1/tts/voices/route");
+
+			const req = makeRequest(
+				"/api/v1/tts/voices?limit=not-a-number",
+				undefined,
+				"GET",
+			);
+			const res = await GET(req);
+
+			expect(res.status).toBe(400);
+			expect((await res.json()).error).toContain("must be a finite number");
+			expect(mockTTSSearch).not.toHaveBeenCalled();
+		});
+
+		it("returns 400 for non-positive voice search limit", async () => {
+			const { GET } = await import("@/app/api/v1/tts/voices/route");
+
+			const req = makeRequest("/api/v1/tts/voices?limit=0", undefined, "GET");
+			const res = await GET(req);
+
+			expect(res.status).toBe(400);
+			expect((await res.json()).error).toContain("must be positive");
+			expect(mockTTSSearch).not.toHaveBeenCalled();
 		});
 
 		it("returns 500 on error", async () => {

--- a/app/api/v1/tts/voices/route.ts
+++ b/app/api/v1/tts/voices/route.ts
@@ -1,14 +1,35 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { getTTSProvider } from "@/lib/api/providers";
+import { badRequest } from "@/lib/api/response";
 import { withApiAccess } from "@/lib/api/with-auth";
 import { voiceSearchParamsSchema } from "@/lib/project/types";
 
+const voiceSearchQuerySchema = voiceSearchParamsSchema.extend({
+	limit: z
+		.string()
+		.transform((value) => (value.trim() === "" ? NaN : Number(value)))
+		.refine((value) => Number.isFinite(value), {
+			message: "limit must be a finite number",
+		})
+		.refine((value) => Number.isInteger(value), {
+			message: "limit must be an integer",
+		})
+		.refine((value) => value > 0, { message: "limit must be positive" })
+		.optional(),
+});
+
 export async function GET(request: NextRequest) {
 	return withApiAccess("Voice search", async () => {
-		const params = voiceSearchParamsSchema.parse(
+		const parsed = voiceSearchQuerySchema.safeParse(
 			Object.fromEntries(request.nextUrl.searchParams),
 		);
-		const voices = await getTTSProvider().search(params);
+		if (!parsed.success) {
+			return badRequest(
+				parsed.error.issues[0]?.message ?? "Invalid voice search query",
+			);
+		}
+		const voices = await getTTSProvider().search(parsed.data);
 		return NextResponse.json({ voices });
 	});
 }


### PR DESCRIPTION
## Summary
- Makes `GET /api/v1/tts/voices` validate the `limit` query parameter before calling the TTS provider.
- Returns a client-facing 400 for blank, malformed, non-integer, or non-positive limits instead of silently dropping invalid values or treating blank input as `0`.
- Keeps persisted metadata parsing untouched; this change is limited to the API route boundary.

## Bugs fixed
- The voice search API used the permissive persisted metadata schema at a public route boundary. Because `z.coerce.number().optional().catch(undefined)` was used for `limit`, requests like `?limit=+`, `?limit=not-a-number`, or `?limit=0` could silently proceed without a valid limit instead of failing loudly.

## Tests added / areas covered
- Added route regression coverage for:
  - valid string limit coercion and provider forwarding (`limit=5`)
  - blank/whitespace limit (`limit=+`)
  - malformed limit (`limit=not-a-number`)
  - non-positive limit (`limit=0`)

## Validation
- `npm test -- app/api/v1/__tests__/routes.test.ts` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run typecheck` ✅
- `npm test -- --passWithNoTests` ✅
- `npm run build` ✅
- `npm run knip` ✅
- `npm run test:coverage` ✅
- `npm run test:e2e` initially hit port 3000 in use; retried with `PLAYWRIGHT_PORT=3107 npm run test:e2e` ✅

## Open PR overlap check
Considered open PRs #349, #348, #346, #339, #338, and #337. This PR only changes `app/api/v1/tts/voices/route.ts` and `app/api/v1/__tests__/routes.test.ts`, which do not overlap with the files or themes in those PRs.

## Runner note
The required Claude Code core pass was invoked in YOLO print mode, but it produced no output or diff after a bounded wait and was killed as unavailable for this run. I completed a narrow Hermes-driven TDD correctness pass instead, then independently validated the result.
