### PR TITLE
perf: nightly performance optimizations 2026-06-22

### DIFF
--- a/app/components/video/SegmentedSeekBar.tsx
+++ b/app/components/video/SegmentedSeekBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { PlayerRef } from "@remotion/player";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { clamp } from "@/lib/utils";
 import type { VideoLayout } from "@/lib/video/types";
 import { usePlayerFrame } from "./usePlayerState";
@@ -45,28 +45,35 @@ export function SegmentedSeekBar({
 		[],
 	);
 
+	const scrubSegments = useMemo(
+		() =>
+			segments.map((seg) => ({
+				id: seg.sceneId,
+				basis: seg.duration / totalDurationSec,
+			})),
+		[segments, totalDurationSec],
+	);
+
+	const onHoverChange = useCallback(
+		(h: ScrubHover | null) => {
+			setHover(h);
+			if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
+			if (!h) {
+				setHoverIndex(null);
+				setSettledIndex(null);
+				return;
+			}
+			const index = findSegmentIndexAt(segments, h.ratio * totalDurationSec);
+			setHoverIndex(index);
+			settleTimerRef.current = setTimeout(
+				() => setSettledIndex(index),
+				HOVER_SETTLE_MS,
+			);
+		},
+		[segments, totalDurationSec],
+	);
+
 	if (segments.length === 0) return null;
-
-	const scrubSegments = segments.map((seg) => ({
-		id: seg.sceneId,
-		basis: seg.duration / totalDurationSec,
-	}));
-
-	const onHoverChange = (h: ScrubHover | null) => {
-		setHover(h);
-		if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
-		if (!h) {
-			setHoverIndex(null);
-			setSettledIndex(null);
-			return;
-		}
-		const index = findSegmentIndexAt(segments, h.ratio * totalDurationSec);
-		setHoverIndex(index);
-		settleTimerRef.current = setTimeout(
-			() => setSettledIndex(index),
-			HOVER_SETTLE_MS,
-		);
-	};
 
 	const hoverSegment = hoverIndex != null ? segments[hoverIndex] : null;
 	const thumbnailSegment =

--- a/app/components/video/useSceneSegments.ts
+++ b/app/components/video/useSceneSegments.ts
@@ -29,11 +29,15 @@ export function findSegmentIndexAt(
 	timeSec: number,
 ): number {
 	if (segments.length === 0) return -1;
-	for (let i = 0; i < segments.length; i++) {
-		const seg = segments[i];
-		if (timeSec < seg.start + seg.duration) return i;
+	let lo = 0;
+	let hi = segments.length - 1;
+	while (lo < hi) {
+		const mid = Math.floor((lo + hi) / 2);
+		const seg = segments[mid];
+		if (timeSec < seg.start + seg.duration) hi = mid;
+		else lo = mid + 1;
 	}
-	return segments.length - 1;
+	return lo;
 }
 
 export function useSceneSegments(): SceneSegment[] {


### PR DESCRIPTION
## Summary
- Optimizes the playback transport seekbar hot path by memoizing scene-to-scrub segment projection across frame ticks.
- Switches scene lookup for frame/hover updates from a linear scan to binary search over sorted scene segment end times.
- Preserves existing boundary behavior covered by `useSceneSegments` tests: empty segments return `-1`, boundaries advance to the next segment, and out-of-range times clamp to the nearest available segment.

## Why this matters
The bottom transport bar receives Remotion `frameupdate` events during playback. Active-scene lookup and seekbar rendering are therefore on a per-frame UI path; reducing repeated O(n) scans and allocations keeps playback controls snappier as project scene counts grow.

## Open PR overlap check
Considered open PRs #350, #349, #348, #346, #339, #338, and #337. This PR only touches `app/components/video/SegmentedSeekBar.tsx` and `app/components/video/useSceneSegments.ts`, which are outside the listed open-PR file/theme overlap areas.

## Skipped
- Slate selection-only/state-setter guards and one-off callback tweaks: too trivial per prior maintainer feedback.
- Bundle/TTFB/dynamic import churn: no clear in-app runtime UX impact for this pass.
- Open PR overlap areas, including ExportButton/VideoPreview/package deps/API routes/connectors currently in flight.

## Validation
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run knip`
- `npm run build`
- `npm test -- --passWithNoTests`
- `npm run test:coverage`
- `PLAYWRIGHT_PORT=3001 npm run test:e2e`

Note: plain `npm run test:e2e` initially failed locally because port 3000 is occupied by the Hermes WhatsApp bridge (`bridge.js --port 3000`), so the same Playwright suite was rerun successfully on port 3001.