### PR TITLE
fix: allow inline character removal in composer

### DIFF
--- a/app/components/canvas/elements/AssetTile.tsx
+++ b/app/components/canvas/elements/AssetTile.tsx
@@ -28,6 +28,8 @@ export function AssetTile({
 	const initial = name?.trim().charAt(0).toUpperCase();
 	const fallbackContent =
 		fallback === "icon" || !initial ? <Icon className="h-5 w-5" /> : initial;
+	const showActions = status !== "generating";
+	const showFullRemove = onRemove && !onEdit;
 	return (
 		<div className="group/tile flex w-16 flex-col gap-1 sm:w-20">
 			<div className="relative aspect-square overflow-hidden rounded-md border border-border bg-card">
@@ -63,7 +65,7 @@ export function AssetTile({
 						<Icon className="h-3 w-3" />
 					</div>
 				)}
-				{onEdit && status !== "generating" && (
+				{onEdit && showActions && (
 					<button
 						type="button"
 						onClick={onEdit}
@@ -73,7 +75,7 @@ export function AssetTile({
 						<Pencil className="h-3.5 w-3.5" />
 					</button>
 				)}
-				{onRemove && status !== "generating" && (
+				{showFullRemove && showActions && (
 					<button
 						type="button"
 						onClick={onRemove}
@@ -81,6 +83,16 @@ export function AssetTile({
 						className="absolute inset-0 flex items-center justify-center bg-background/70 text-foreground opacity-0 transition-opacity group-hover/tile:opacity-100 focus:opacity-100 focus:outline-none"
 					>
 						<X className="h-3.5 w-3.5" />
+					</button>
+				)}
+				{onRemove && onEdit && showActions && (
+					<button
+						type="button"
+						onClick={onRemove}
+						aria-label={`Remove ${name ?? "asset"}`}
+						className="absolute right-1 top-1 z-10 flex size-5 items-center justify-center rounded-md bg-card text-foreground opacity-0 shadow-sm ring-1 ring-border transition-opacity hover:bg-button-hover group-hover/tile:opacity-100 focus:opacity-100 focus:outline-none"
+					>
+						<X className="h-3 w-3" />
 					</button>
 				)}
 			</div>

--- a/app/components/copilot/ComposerAssets.tsx
+++ b/app/components/copilot/ComposerAssets.tsx
@@ -13,6 +13,10 @@ interface ComposerAssetsProps {
 	onEditNarrator: () => void;
 }
 
+export function removeComposerCharacter(projectId: string, name: string) {
+	getProjectStore(projectId).getState().removeCharacter(name);
+}
+
 export function ComposerAssets({
 	uploadingCount,
 	onEditCharacter,
@@ -30,6 +34,8 @@ export function ComposerAssets({
 		getProjectStore(projectId)
 			.getState()
 			.setReferenceImages(referenceImages.filter((_, j) => j !== index));
+	const removeCharacter = (name: string) =>
+		removeComposerCharacter(projectId, name);
 
 	return (
 		<div className="flex flex-wrap gap-2 pb-2">
@@ -49,6 +55,7 @@ export function ComposerAssets({
 					Icon={User}
 					elementId={characterAvatarElementId(name)}
 					onEdit={() => onEditCharacter(name)}
+					onRemove={() => removeCharacter(name)}
 				/>
 			))}
 			{referenceImages.map((url, i) => (

--- a/app/components/copilot/__tests__/ComposerAssets.test.ts
+++ b/app/components/copilot/__tests__/ComposerAssets.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { clearProjectStore, getProjectStore } from "@/lib/project/store";
+import { removeComposerCharacter } from "../ComposerAssets";
+
+describe("removeComposerCharacter", () => {
+	it("removes the selected character without changing other composer assets", () => {
+		const projectId = "composer-assets-remove-character";
+		const store = getProjectStore(projectId);
+		store.getState().setCharacter("Alice", { appearance: "red hair" });
+		store.getState().setCharacter("Bob", { appearance: "blue coat" });
+		store.getState().setReferenceImages(["ref-a.png"]);
+
+		removeComposerCharacter(projectId, "Alice");
+
+		expect(store.getState().metadata.characters).toEqual({
+			Bob: { appearance: "blue coat" },
+		});
+		expect(store.getState().referenceImages).toEqual(["ref-a.png"]);
+
+		clearProjectStore(projectId);
+	});
+});


### PR DESCRIPTION
## Summary
- Adds inline character removal from the hero composer asset row, mirroring the existing reference-image remove affordance.
- Keeps the character edit action available on the tile while showing a separate X remove control when both edit and remove actions exist.
- Adds focused regression coverage for removing only the selected composer character while preserving other composer assets.

## Selected issue
Selected #340 because it is a small, well-scoped UI behavior gap with clear acceptance criteria and an obvious existing pattern (`AssetTile` `onRemove`) to reuse. It does not require auth, secrets, external services, or broader product decisions.

## Validation
- `npm run test:run -- app/components/copilot/__tests__/ComposerAssets.test.ts` — RED first failed with `removeComposerCharacter is not a function`; GREEN passed after implementation.
- `npm run lint` — passed.
- `npm run format:check` — passed.
- `npm run typecheck` — passed.
- `npm run knip` — passed.
- `npm run build` — passed.
- `npm run test:coverage` — passed, 847 tests / 97 files.
- `npm run test:e2e` — initial run failed because port 3000 was already in use.
- `PLAYWRIGHT_PORT=3109 npm run test:e2e` — passed, 3 tests.

## Open PR overlap check
Checked open PRs before editing and again before commit:
- #351 touches video seekbar/scene segment performance.
- #350 touches `/api/v1/tts/voices` route validation.
- #349 touches clip/animated-image duration config and connector types.
- #348 touches canvas preserved attributes/refine type-change behavior.
- #346 touches element type pills/element config/export popover styling.
- #339 touches video preview playhead restoration.
- #338 touches dependency audit files.
- #337 touches shared close-button/dialog/export/character-modal chrome.

This PR touches only `AssetTile`, `ComposerAssets`, and a focused composer-assets test, so it is non-overlapping by file and theme.

## Skipped issue categories
Skipped broad/product-heavy or larger issues such as public feed/social features, BYOK/gateway integrations, fullscreen transport controls, global destructive-button restyling, art-style editing, reference-image upload-after-generation, licensing/legal process, audio crossfades, and multi-part generation/render lifecycle issues.

Closes #340
