### PR TITLE
Add animated image duration to refine prompt

### DIFF
--- a/lib/canvas/elementConfigs.tsx
+++ b/lib/canvas/elementConfigs.tsx
@@ -8,7 +8,11 @@ import {
 	Waveform,
 	type LucideIcon,
 } from "@/components/ui/icon";
-import type { CanvasElementType, ResultKind } from "@/lib/canvas/types";
+import {
+	DURATION_OPTIONS,
+	type CanvasElementType,
+	type ResultKind,
+} from "@/lib/canvas/types";
 import type { ConnectorType } from "@/lib/connectors/types";
 import { TTSEmotion, TTS_SPEEDS } from "@/lib/connectors/tts/enums";
 import { MOTION_EFFECTS } from "@/lib/video/motionEffects";
@@ -56,7 +60,6 @@ const VOLUME_OPTIONS = [
 ] as const;
 const EMOTION_OPTIONS = Object.values(TTSEmotion);
 const CAPTIONS_OPTIONS = ["on", "off"] as const;
-const DURATION_OPTIONS = Array.from({ length: 12 }, (_, i) => String(i + 4));
 
 const volumeSpec = (color: string): AttributeSpec => ({
 	color,

--- a/lib/canvas/types.ts
+++ b/lib/canvas/types.ts
@@ -22,6 +22,10 @@ export const CANVAS_ELEMENT_TYPES = new Set<CanvasElementType>([
 	"music",
 ]);
 
+export const DURATION_OPTIONS = Array.from({ length: 12 }, (_, i) =>
+	String(i + 4),
+);
+
 export const SCENE_TYPE = "scene" as const;
 
 export const FOREGROUND_TYPES: ReadonlySet<CanvasElementType> = new Set([

--- a/lib/connectors/llm/plugins/refine.ts
+++ b/lib/connectors/llm/plugins/refine.ts
@@ -1,5 +1,5 @@
 import dedent from "dedent";
-import { CANVAS_ELEMENT_TYPES } from "@/lib/canvas/types";
+import { CANVAS_ELEMENT_TYPES, DURATION_OPTIONS } from "@/lib/canvas/types";
 import { MOTION_EFFECTS } from "@/lib/video/motionEffects";
 import { MusicLength } from "@/lib/connectors/music/enums";
 import type { LLMPlugin } from "@/lib/connectors/types";
@@ -36,10 +36,10 @@ const REFINE_SYSTEM_PROMPT = dedent`
   - **narration**: emotion, captions (on | off)
   - **character**: name, emotion, captions (on | off)
   - **image**: overlays, motion (${MOTION_EFFECTS.join(" | ")})
-  - **animated_image**: videoPrompt (camera/subject motion description), overlays, motion (${MOTION_EFFECTS.join(" | ")})
+  - **animated_image**: videoPrompt (camera/subject motion description), duration (${DURATION_OPTIONS.join(" | ")}), overlays, motion (${MOTION_EFFECTS.join(" | ")})
   - **sound**: loops (number, default 1)
   - **music**: length (${vals(MusicLength)}), loops (number, default 1)
-  - **clip**: duration (in seconds), volume (0-10), motion (${MOTION_EFFECTS.join(" | ")})
+  - **clip**: duration (${DURATION_OPTIONS.join(" | ")}), volume (0-10), motion (${MOTION_EFFECTS.join(" | ")})
   - All non-null attributes should be strings
 
   ## Rules


### PR DESCRIPTION
## Summary
- Surface the `animated_image` `duration` attribute in the refine LLM prompt so refinements can set it (previously absent).
- Scope both `clip` and `animated_image` duration to the allowed 4–15s values by sharing `DURATION_OPTIONS` from `lib/canvas/types` instead of hardcoding the range.

## Context
PR #349 added a 4–15s duration dropdown to clip and animated image elements but the refine prompt didn't expose `duration` for `animated_image`. This wires it through and keeps the allowed values DRY across `elementConfigs.tsx` and the refine prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)