### PR TITLE
chore: remove unused color spec from attribute config

### DIFF
--- a/app/components/canvas/elements/AttributeBadge.tsx
+++ b/app/components/canvas/elements/AttributeBadge.tsx
@@ -67,7 +67,6 @@ export function AttributeBadge({
 				attrKey={attrKey}
 				value={value}
 				label={spec.label}
-				color={spec.color}
 				tooltip={tooltip}
 				placeholder={spec.edit.placeholder}
 				rows={spec.edit.rows}

--- a/app/components/canvas/elements/ModelBadge.tsx
+++ b/app/components/canvas/elements/ModelBadge.tsx
@@ -19,7 +19,6 @@ export function ModelBadge({ element }: { element: CanvasContentElement }) {
 		const options =
 			connectorConfig[connector]?.[provider as ProviderKey]?.models ?? [];
 		return {
-			color: "bg-secondary",
 			label: "Model",
 			icon: Codesandbox,
 			edit: { kind: "enum", options },

--- a/app/components/canvas/elements/attributes/TextAttributePopover.tsx
+++ b/app/components/canvas/elements/attributes/TextAttributePopover.tsx
@@ -16,7 +16,6 @@ interface TextAttributePopoverProps {
 	attrKey: string;
 	value: string;
 	label: string;
-	color: string;
 	tooltip: string;
 	placeholder?: string;
 	rows?: number;
@@ -28,7 +27,6 @@ export function TextAttributePopover({
 	attrKey,
 	value,
 	label,
-	color,
 	tooltip,
 	placeholder,
 	rows = 3,
@@ -66,7 +64,7 @@ export function TextAttributePopover({
 					type="button"
 					aria-label={tooltip}
 					title={tooltip}
-					className={`${color} text-foreground text-label px-2 py-1 rounded-md max-w-[140px] inline-flex items-center gap-1.5 cursor-pointer ring-1 ring-inset ring-border hover:ring-border hover:brightness-110 transition-all`}
+					className="bg-secondary text-secondary-foreground text-label px-2 py-1 rounded-md max-w-[140px] inline-flex items-center gap-1.5 cursor-pointer ring-1 ring-inset ring-border hover:bg-button-hover hover:text-foreground transition-colors"
 				>
 					<span className="truncate min-w-0">
 						{!hideLabel && (

--- a/lib/canvas/elementConfigs.tsx
+++ b/lib/canvas/elementConfigs.tsx
@@ -22,7 +22,6 @@ export type AttributeEdit =
 	| { kind: "text"; placeholder?: string; rows?: number };
 
 export interface AttributeSpec {
-	color: string;
 	label: string;
 	/** When set, the badge shows this icon in place of the text label. */
 	icon?: LucideIcon;
@@ -61,45 +60,39 @@ const VOLUME_OPTIONS = [
 const EMOTION_OPTIONS = Object.values(TTSEmotion);
 const CAPTIONS_OPTIONS = ["on", "off"] as const;
 
-const volumeSpec = (color: string): AttributeSpec => ({
-	color,
+const volumeSpec: AttributeSpec = {
 	label: "Volume",
 	edit: { kind: "enum", options: VOLUME_OPTIONS },
-});
+};
 
-const speedSpec = (color: string): AttributeSpec => ({
-	color,
+const speedSpec: AttributeSpec = {
 	label: "Speed",
 	edit: { kind: "enum", options: TTS_SPEEDS },
-});
+};
 
-const motionSpec = (color: string): AttributeSpec => ({
-	color,
+const motionSpec: AttributeSpec = {
 	label: "Motion",
 	edit: { kind: "enum", options: MOTION_EFFECTS },
-});
+};
 
-const durationSpec = (color: string): AttributeSpec => ({
-	color,
+const durationSpec: AttributeSpec = {
 	label: "Duration",
 	edit: { kind: "enum", options: DURATION_OPTIONS },
-});
+};
 
-const captionsSpec = (color: string): AttributeSpec => ({
-	color,
+const captionsSpec: AttributeSpec = {
 	label: "Captions",
 	edit: { kind: "enum", options: CAPTIONS_OPTIONS },
-});
+};
 
-const videoPromptSpec = (color: string): AttributeSpec => ({
-	color,
+const videoPromptSpec: AttributeSpec = {
 	label: "Video prompt",
 	edit: {
 		kind: "text",
 		placeholder: "Describe the camera or subject motion…",
 		rows: 3,
 	},
-});
+};
 
 export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 	narration: {
@@ -119,13 +112,12 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		},
 		visibleAttributes: {
 			emotion: {
-				color: "bg-pink-500",
 				label: "Emotion",
 				edit: { kind: "enum", options: EMOTION_OPTIONS },
 			},
-			speed: speedSpec("bg-slate-500"),
-			volume: volumeSpec("bg-slate-500"),
-			captions: captionsSpec("bg-slate-500"),
+			speed: speedSpec,
+			volume: volumeSpec,
+			captions: captionsSpec,
 		},
 	},
 	character: {
@@ -145,13 +137,12 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		},
 		visibleAttributes: {
 			emotion: {
-				color: "bg-pink-500",
 				label: "Emotion",
 				edit: { kind: "enum", options: EMOTION_OPTIONS },
 			},
-			speed: speedSpec("bg-amber-600"),
-			volume: volumeSpec("bg-amber-600"),
-			captions: captionsSpec("bg-amber-600"),
+			speed: speedSpec,
+			volume: volumeSpec,
+			captions: captionsSpec,
 		},
 	},
 	image: {
@@ -167,7 +158,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 			motion: "none",
 		},
 		visibleAttributes: {
-			motion: motionSpec("bg-cyan-500"),
+			motion: motionSpec,
 		},
 	},
 	animated_image: {
@@ -185,9 +176,9 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 			duration: "5",
 		},
 		visibleAttributes: {
-			videoPrompt: videoPromptSpec("bg-fuchsia-500"),
-			duration: durationSpec("bg-fuchsia-500"),
-			motion: motionSpec("bg-fuchsia-500"),
+			videoPrompt: videoPromptSpec,
+			duration: durationSpec,
+			motion: motionSpec,
 		},
 	},
 	clip: {
@@ -206,9 +197,9 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 			motion: "none",
 		},
 		visibleAttributes: {
-			duration: durationSpec("bg-indigo-500"),
-			volume: volumeSpec("bg-indigo-500"),
-			motion: motionSpec("bg-indigo-500"),
+			duration: durationSpec,
+			volume: volumeSpec,
+			motion: motionSpec,
 		},
 	},
 	sound: {
@@ -227,11 +218,10 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		},
 		visibleAttributes: {
 			loops: {
-				color: "bg-teal-500",
 				label: "Loops",
 				edit: { kind: "enum", options: LOOPS_OPTIONS },
 			},
-			volume: volumeSpec("bg-emerald-500"),
+			volume: volumeSpec,
 		},
 	},
 	music: {
@@ -249,11 +239,10 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		},
 		visibleAttributes: {
 			loops: {
-				color: "bg-violet-500",
 				label: "Loops",
 				edit: { kind: "enum", options: LOOPS_OPTIONS },
 			},
-			volume: volumeSpec("bg-violet-500"),
+			volume: volumeSpec,
 		},
 	},
 };

--- a/lib/canvas/elementConfigs.tsx
+++ b/lib/canvas/elementConfigs.tsx
@@ -85,6 +85,16 @@ const captionsSpec: AttributeSpec = {
 	edit: { kind: "enum", options: CAPTIONS_OPTIONS },
 };
 
+const emotionSpec: AttributeSpec = {
+	label: "Emotion",
+	edit: { kind: "enum", options: EMOTION_OPTIONS },
+};
+
+const loopsSpec: AttributeSpec = {
+	label: "Loops",
+	edit: { kind: "enum", options: LOOPS_OPTIONS },
+};
+
 const videoPromptSpec: AttributeSpec = {
 	label: "Video prompt",
 	edit: {
@@ -111,10 +121,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 			captions: "on",
 		},
 		visibleAttributes: {
-			emotion: {
-				label: "Emotion",
-				edit: { kind: "enum", options: EMOTION_OPTIONS },
-			},
+			emotion: emotionSpec,
 			speed: speedSpec,
 			volume: volumeSpec,
 			captions: captionsSpec,
@@ -136,10 +143,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 			captions: "on",
 		},
 		visibleAttributes: {
-			emotion: {
-				label: "Emotion",
-				edit: { kind: "enum", options: EMOTION_OPTIONS },
-			},
+			emotion: emotionSpec,
 			speed: speedSpec,
 			volume: volumeSpec,
 			captions: captionsSpec,
@@ -217,10 +221,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 			volume: "2",
 		},
 		visibleAttributes: {
-			loops: {
-				label: "Loops",
-				edit: { kind: "enum", options: LOOPS_OPTIONS },
-			},
+			loops: loopsSpec,
 			volume: volumeSpec,
 		},
 	},
@@ -238,10 +239,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 			volume: "2",
 		},
 		visibleAttributes: {
-			loops: {
-				label: "Loops",
-				edit: { kind: "enum", options: LOOPS_OPTIONS },
-			},
+			loops: loopsSpec,
 			volume: volumeSpec,
 		},
 	},


### PR DESCRIPTION
## What

The `color` field on `AttributeSpec` was vestigial: it was only ever read by the text-edit popover path (`videoPrompt`). Every enum attribute (emotion, speed, volume, captions, motion, duration, loops) declared a `color` that was never rendered — those badges go through the `SelectMenu`/pill path which hardcodes neutral tokens. So 6 of 7 element types' attribute colors were dead config, and the one live use painted a single off-palette `bg-fuchsia-500` button.

## Changes

- Drop `color` from the `AttributeSpec` interface
- Collapse the now-paramless spec factories (`volumeSpec`, `speedSpec`, `motionSpec`, `durationSpec`, `captionsSpec`, `videoPromptSpec`) into plain constants
- Stop wiring `spec.color` through `AttributeBadge` → `TextAttributePopover`
- Give the text popover the standard `bg-secondary` surface used by the other badges (replacing the dynamic `${color}` background)
- Drop the stray `color: "bg-secondary"` from `ModelBadge`'s inline spec

Attribute badges now use standard design-system surface tokens by default.

## Checks

lint, format, typecheck, knip (dead-code), and all 851 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)