### PR TITLE
fix: suppress character nameplates leaking into scene images

### DIFF
--- a/lib/connectors/__tests__/character-references.test.ts
+++ b/lib/connectors/__tests__/character-references.test.ts
@@ -48,7 +48,7 @@ describe("character-references plugin", () => {
 		});
 
 		expect(result).toEqual({
-			prompt: "Red meets Granny",
+			prompt: "Red meets Granny. No nameplates",
 			referenceImages: ["https://img/red.png", "https://img/granny.png"],
 		});
 	});
@@ -85,7 +85,7 @@ describe("character-references plugin", () => {
 		});
 
 		expect(result).toEqual({
-			prompt: "Hello",
+			prompt: "Hello. No nameplates",
 			referenceImages: ["https://img/alice.png", "https://img/bob.png"],
 		});
 	});
@@ -102,7 +102,7 @@ describe("character-references plugin", () => {
 		});
 
 		expect(result).toEqual({
-			prompt: "Hello",
+			prompt: "Hello. No nameplates",
 			referenceImages: ["https://img/alice.png"],
 		});
 	});
@@ -118,7 +118,7 @@ describe("character-references plugin", () => {
 		});
 
 		expect(result).toEqual({
-			prompt: "Hello",
+			prompt: "Hello. No nameplates",
 			referenceImages: ["https://img/alice.png"],
 		});
 	});

--- a/lib/connectors/image/plugins/character-references.ts
+++ b/lib/connectors/image/plugins/character-references.ts
@@ -19,9 +19,12 @@ export function createCharacterReferencesPlugin(
 				.map((name) => chars[name]?.avatarUrl)
 				.filter(Boolean);
 
+			if (referenceImages.length === 0) return rest;
+
 			return {
 				...rest,
-				...(referenceImages.length > 0 && { referenceImages }),
+				prompt: `${rest.prompt}. No nameplates`,
+				referenceImages,
 			};
 		},
 	};


### PR DESCRIPTION
## Problem

Generated character avatars intentionally bake a nameplate into the image (`A small rectangular nameplate at the bottom of the frame reads "<name>" ...`) so the image model can tell referenced characters apart. Those same avatars are then passed straight through as `referenceImages` when generating scene images, so the model copies the baked-in nameplate into the scene and the character's name badge leaks into the final rendered images.

## Fix

Append a `No nameplates` negative instruction in the `character-references` plugin whenever it attaches reference avatars to a generation. This is the natural home — it's the plugin that injects the avatars as references, and `buildImagePlugins` (which includes it) is reused by the animated-image chain, so both scene images and animated images are covered by one change.

The instruction is only appended when reference images are actually present, so prompts without character refs are untouched.

## Tests

Updated `character-references.test.ts` cases that resolve reference images to expect the appended suffix; the no-reference cases stay unchanged, locking in the conditional.

Checks run locally: lint, format, typecheck, knip, and the full connector test suite (123 passed).

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)