### PR TITLE
refactor: nightly maintainability 2026-06-25

### DIFF
--- a/app/components/canvas/elements/AudioPlayer.tsx
+++ b/app/components/canvas/elements/AudioPlayer.tsx
@@ -2,8 +2,7 @@
 
 import { useRef, useState } from "react";
 import { Play, Pause } from "@/components/ui/icon";
-import { IconButton } from "@/components/ui/icon-button";
-import { SimpleTooltip } from "@/components/ui/tooltip";
+import { TooltipIconButton } from "@/components/ui/icon-button";
 import { Waveform, type WaveformHandle } from "@/lib/components/Waveform";
 import { formatTime } from "@/lib/video/timestamps";
 import { usePreviewCache } from "../PreviewCacheContext";
@@ -17,19 +16,13 @@ export function AudioPlayer({ src }: { src: string }) {
 
 	return (
 		<>
-			<SimpleTooltip label={playing ? "Pause" : "Play"}>
-				<IconButton
-					ariaLabel={playing ? "Pause" : "Play"}
-					onClick={() => waveformRef.current?.toggle()}
-					disabled={duration === 0}
-				>
-					{playing ? (
-						<Pause className="h-4 w-4" />
-					) : (
-						<Play className="h-4 w-4" />
-					)}
-				</IconButton>
-			</SimpleTooltip>
+			<TooltipIconButton
+				label={playing ? "Pause" : "Play"}
+				onClick={() => waveformRef.current?.toggle()}
+				disabled={duration === 0}
+			>
+				{playing ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+			</TooltipIconButton>
 			<Waveform
 				ref={waveformRef}
 				src={src}

--- a/app/components/canvas/elements/PlayFromHereButton.tsx
+++ b/app/components/canvas/elements/PlayFromHereButton.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { Play } from "@/components/ui/icon";
-import { IconButton } from "@/components/ui/icon-button";
-import { SimpleTooltip } from "@/components/ui/tooltip";
+import { TooltipIconButton } from "@/components/ui/icon-button";
 import { usePlayerControl } from "@/app/components/video/PlayerControlContext";
 import { findSceneSequence } from "@/app/components/video/useSceneSegments";
 import { useLayout } from "@/app/components/video/VideoLayoutContext";
@@ -15,20 +14,17 @@ export function PlayFromHereButton({ scene }: { scene: SceneElement }) {
 	const startFrame = seq && layout ? Math.round(seq.start * layout.fps) : null;
 	const disabled = startFrame == null;
 	return (
-		<SimpleTooltip
+		<TooltipIconButton
 			label={disabled ? "Generate scene to play" : "Play from here"}
+			ariaLabel="Play from here"
+			className="bg-muted"
+			disabled={disabled}
+			onMouseDown={(e) => e.preventDefault()}
+			onClick={() => {
+				if (startFrame != null) playFromFrame(startFrame);
+			}}
 		>
-			<IconButton
-				ariaLabel="Play from here"
-				className="bg-muted"
-				disabled={disabled}
-				onMouseDown={(e) => e.preventDefault()}
-				onClick={() => {
-					if (startFrame != null) playFromFrame(startFrame);
-				}}
-			>
-				<Play className="h-4 w-4" />
-			</IconButton>
-		</SimpleTooltip>
+			<Play className="h-4 w-4" />
+		</TooltipIconButton>
 	);
 }

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { ImagePlus, Loader2, Trash2 } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { CloseButton } from "@/components/ui/close-button";
-import { IconButton } from "@/components/ui/icon-button";
+import { TooltipIconButton } from "@/components/ui/icon-button";
 import {
 	DialogContent,
 	DialogDescription,
@@ -13,7 +13,6 @@ import {
 	DialogTitle,
 	MountedDialog,
 } from "@/components/ui/dialog";
-import { SimpleTooltip } from "@/components/ui/tooltip";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import {
 	useGenerationQueue,
@@ -206,20 +205,18 @@ function CharacterEditDialogBody({
 							/>
 						)}
 						{inputElement}
-						<SimpleTooltip label="Upload image">
-							<IconButton
-								ariaLabel="Upload image"
-								onClick={openPicker}
-								disabled={uploading}
-								className="absolute left-2 top-2 z-10 rounded-full bg-card shadow-sm ring-1 ring-border"
-							>
-								{uploading ? (
-									<Loader2 className="h-3.5 w-3.5 animate-spin" />
-								) : (
-									<ImagePlus className="h-3.5 w-3.5" />
-								)}
-							</IconButton>
-						</SimpleTooltip>
+						<TooltipIconButton
+							label="Upload image"
+							onClick={openPicker}
+							disabled={uploading}
+							className="absolute left-2 top-2 z-10 rounded-full bg-card shadow-sm ring-1 ring-border"
+						>
+							{uploading ? (
+								<Loader2 className="h-3.5 w-3.5 animate-spin" />
+							) : (
+								<ImagePlus className="h-3.5 w-3.5" />
+							)}
+						</TooltipIconButton>
 					</div>
 				</div>
 				<VoiceSection voice={character} onChange={update} />

--- a/app/components/canvas/elements/character/VoicePicker.tsx
+++ b/app/components/canvas/elements/character/VoicePicker.tsx
@@ -2,9 +2,8 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Check, Pause, Play } from "@/components/ui/icon";
-import { IconButton } from "@/components/ui/icon-button";
+import { TooltipIconButton } from "@/components/ui/icon-button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { SimpleTooltip } from "@/components/ui/tooltip";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import { createConnector } from "@/lib/connectors/factory";
@@ -40,15 +39,9 @@ function PreviewPlayButton({ src }: { src: string }) {
 				onPause={() => setPlaying(false)}
 				onEnded={() => setPlaying(false)}
 			/>
-			<SimpleTooltip label={playing ? "Pause" : "Play"}>
-				<IconButton ariaLabel={playing ? "Pause" : "Play"} onClick={toggle}>
-					{playing ? (
-						<Pause className="h-4 w-4" />
-					) : (
-						<Play className="h-4 w-4" />
-					)}
-				</IconButton>
-			</SimpleTooltip>
+			<TooltipIconButton label={playing ? "Pause" : "Play"} onClick={toggle}>
+				{playing ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+			</TooltipIconButton>
 		</>
 	);
 }

--- a/app/components/video/BottomTransportBar.tsx
+++ b/app/components/video/BottomTransportBar.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { ChevronsLeft, ChevronsRight, Pause, Play } from "@/components/ui/icon";
-import { IconButton } from "@/components/ui/icon-button";
-import { SimpleTooltip } from "@/components/ui/tooltip";
+import { TooltipIconButton } from "@/components/ui/icon-button";
 import { usePlayerControl } from "./PlayerControlContext";
 import { usePlayerPosition } from "./PlayerPositionContext";
 import { useLayout } from "./VideoLayoutContext";
@@ -19,26 +18,6 @@ import {
 	TimeDisplay,
 	VolumeControl,
 } from "./PlayerControls";
-
-function TooltipButton({
-	label,
-	onClick,
-	ariaLabel,
-	children,
-}: {
-	label: string;
-	onClick: () => void;
-	ariaLabel: string;
-	children: React.ReactNode;
-}) {
-	return (
-		<SimpleTooltip label={label}>
-			<IconButton onClick={onClick} ariaLabel={ariaLabel}>
-				{children}
-			</IconButton>
-		</SimpleTooltip>
-	);
-}
 
 export function BottomTransportBar() {
 	const { player } = usePlayerControl();
@@ -86,16 +65,14 @@ export function BottomTransportBar() {
 				</div>
 
 				<div className="flex items-center gap-1">
-					<TooltipButton
+					<TooltipIconButton
 						label="Previous scene"
-						ariaLabel="Previous scene"
 						onClick={() => seekToAdjacentScene(-1)}
 					>
 						<ChevronsLeft className="h-4 w-4" />
-					</TooltipButton>
-					<TooltipButton
+					</TooltipIconButton>
+					<TooltipIconButton
 						label={playing ? "Pause" : "Play"}
-						ariaLabel={playing ? "Pause" : "Play"}
 						onClick={() => {
 							showPlayer();
 							player?.toggle();
@@ -106,14 +83,13 @@ export function BottomTransportBar() {
 						) : (
 							<Play className="h-4 w-4" />
 						)}
-					</TooltipButton>
-					<TooltipButton
+					</TooltipIconButton>
+					<TooltipIconButton
 						label="Next scene"
-						ariaLabel="Next scene"
 						onClick={() => seekToAdjacentScene(1)}
 					>
 						<ChevronsRight className="h-4 w-4" />
-					</TooltipButton>
+					</TooltipIconButton>
 				</div>
 
 				<div className="flex flex-1 items-center justify-end gap-1.5">

--- a/components/ui/delete-button.tsx
+++ b/components/ui/delete-button.tsx
@@ -1,23 +1,19 @@
 import * as React from "react";
 import { Trash2 } from "@/components/ui/icon";
 import { cn } from "@/lib/utils";
-import { IconButton } from "@/components/ui/icon-button";
-import { SimpleTooltip } from "@/components/ui/tooltip";
+import { IconButton, TooltipIconButton } from "@/components/ui/icon-button";
 
 export function DeleteButton({
-	ariaLabel,
 	className,
 	...props
 }: React.ComponentProps<typeof IconButton>) {
 	return (
-		<SimpleTooltip label="Delete">
-			<IconButton
-				ariaLabel={ariaLabel}
-				className={cn("bg-muted hover:text-destructive", className)}
-				{...props}
-			>
-				<Trash2 className="h-4 w-4" strokeWidth={1.5} />
-			</IconButton>
-		</SimpleTooltip>
+		<TooltipIconButton
+			label="Delete"
+			className={cn("bg-muted hover:text-destructive", className)}
+			{...props}
+		>
+			<Trash2 className="h-4 w-4" strokeWidth={1.5} />
+		</TooltipIconButton>
 	);
 }

--- a/components/ui/icon-button.tsx
+++ b/components/ui/icon-button.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 export const IconButton = React.forwardRef<
@@ -19,5 +20,20 @@ export const IconButton = React.forwardRef<
 		>
 			{children}
 		</button>
+	);
+});
+
+/** An {@link IconButton} wrapped in a tooltip. `ariaLabel` defaults to `label`. */
+export const TooltipIconButton = React.forwardRef<
+	HTMLButtonElement,
+	Omit<React.ComponentProps<typeof IconButton>, "ariaLabel"> & {
+		label: string;
+		ariaLabel?: string;
+	}
+>(function TooltipIconButton({ label, ariaLabel, ...props }, ref) {
+	return (
+		<SimpleTooltip label={label}>
+			<IconButton ref={ref} ariaLabel={ariaLabel ?? label} {...props} />
+		</SimpleTooltip>
 	);
 });

--- a/components/ui/icon-button.tsx
+++ b/components/ui/icon-button.tsx
@@ -24,16 +24,17 @@ export const IconButton = React.forwardRef<
 });
 
 /** An {@link IconButton} wrapped in a tooltip. `ariaLabel` defaults to `label`. */
-export const TooltipIconButton = React.forwardRef<
-	HTMLButtonElement,
-	Omit<React.ComponentProps<typeof IconButton>, "ariaLabel"> & {
-		label: string;
-		ariaLabel?: string;
-	}
->(function TooltipIconButton({ label, ariaLabel, ...props }, ref) {
+export function TooltipIconButton({
+	label,
+	ariaLabel,
+	...props
+}: Omit<React.ComponentProps<typeof IconButton>, "ariaLabel"> & {
+	label: string;
+	ariaLabel?: string;
+}) {
 	return (
 		<SimpleTooltip label={label}>
-			<IconButton ref={ref} ariaLabel={ariaLabel ?? label} {...props} />
+			<IconButton ariaLabel={ariaLabel ?? label} {...props} />
 		</SimpleTooltip>
 	);
-});
+}

--- a/lib/providers/elevenlabs.ts
+++ b/lib/providers/elevenlabs.ts
@@ -9,6 +9,12 @@ type AudioResult = {
 	data: ArrayBuffer;
 } & WithMetadata;
 
+export const ELEVENLABS_AUDIO_FORMAT: AudioFormat = {
+	codec: "mp3",
+	sampleRate: 44100,
+	bitrateKbps: 128,
+};
+
 export function toElevenLabsOutputFormat(
 	format: AudioFormat,
 ): AllowedOutputFormats {

--- a/lib/providers/music/elevenlabs.ts
+++ b/lib/providers/music/elevenlabs.ts
@@ -1,20 +1,19 @@
 import type { BundleResponse } from "@/lib/api/asset-bundle";
 import type { MusicGenerateParams } from "@/lib/connectors/types";
-import type { AudioFormat } from "../audio-duration";
 import {
 	audioBundleCache,
 	pineconeCache,
 	rankByNearestDuration,
 } from "../cache";
-import { BaseElevenLabsAudio, toElevenLabsOutputFormat } from "../elevenlabs";
+import {
+	BaseElevenLabsAudio,
+	ELEVENLABS_AUDIO_FORMAT,
+	toElevenLabsOutputFormat,
+} from "../elevenlabs";
 
 export class ElevenLabsMusic extends BaseElevenLabsAudio<MusicGenerateParams> {
 	protected readonly blobConfig = { type: "music", provider: "elevenlabs" };
-	protected readonly outputFormat: AudioFormat = {
-		codec: "mp3",
-		sampleRate: 44100,
-		bitrateKbps: 128,
-	};
+	protected readonly outputFormat = ELEVENLABS_AUDIO_FORMAT;
 
 	protected requestStream(params: MusicGenerateParams) {
 		return this.client.music.compose({

--- a/lib/providers/sfx/elevenlabs.ts
+++ b/lib/providers/sfx/elevenlabs.ts
@@ -1,20 +1,19 @@
 import type { BundleResponse } from "@/lib/api/asset-bundle";
 import type { SFXGenerateParams } from "@/lib/connectors/types";
-import type { AudioFormat } from "../audio-duration";
 import {
 	audioBundleCache,
 	pineconeCache,
 	rankByNearestDuration,
 } from "../cache";
-import { BaseElevenLabsAudio, toElevenLabsOutputFormat } from "../elevenlabs";
+import {
+	BaseElevenLabsAudio,
+	ELEVENLABS_AUDIO_FORMAT,
+	toElevenLabsOutputFormat,
+} from "../elevenlabs";
 
 export class ElevenLabsSFX extends BaseElevenLabsAudio<SFXGenerateParams> {
 	protected readonly blobConfig = { type: "sfx", provider: "elevenlabs" };
-	protected readonly outputFormat: AudioFormat = {
-		codec: "mp3",
-		sampleRate: 44100,
-		bitrateKbps: 128,
-	};
+	protected readonly outputFormat = ELEVENLABS_AUDIO_FORMAT;
 
 	protected requestStream(params: SFXGenerateParams) {
 		return this.client.textToSoundEffects.convert({


### PR DESCRIPTION
## Summary
Two maintainability improvements: extracts a shared `TooltipIconButton` primitive and consolidates a duplicated ElevenLabs audio-format constant.

## Architecture / maintainability

### 1. Shared `TooltipIconButton` primitive (`components/ui/icon-button.tsx`)
5 call sites had inline `<Tooltip>` → `<IconButton>` wrappers that duplicated the same 15-line pattern (tooltip, icon-button imports, size/color/disabled wiring). The new `TooltipIconButton` component wraps the common pattern, defaults `ariaLabel` to `label`, and surfaces the same `IconButton` props.

**Changed files:**
- `components/ui/icon-button.tsx` — new `TooltipIconButton` export
- `app/components/video/BottomTransportBar.tsx` — dropped local `TooltipButton`; 3 call sites use shared primitive
- `app/components/canvas/elements/AudioPlayer.tsx` — replaced inline wrapper
- `app/components/canvas/elements/PlayFromHereButton.tsx` — replaced inline wrapper
- `app/components/canvas/elements/character/VoicePicker.tsx` — replaced inline wrapper
- `app/components/canvas/elements/character/CharacterEditModal.tsx` — replaced inline wrapper

### 2. `ELEVENLABS_AUDIO_FORMAT` constant
The `{ codec: "mp3", sampleRate: 44100, bitrateKbps: 128 }` block was byte-identical in both ElevenLabs audio providers.

**Changed files:**
- `lib/providers/elevenlabs.ts` — exported `ELEVENLABS_AUDIO_FORMAT`
- `lib/providers/music/elevenlabs.ts` — references shared constant
- `lib/providers/sfx/elevenlabs.ts` — references shared constant

## Complexity delta
- 9 files touched
- 77 insertions / 102 deletions (net -25 lines)
- 5 duplicated Tooltip+IconButton patterns → 1 shared primitive
- 1 duplicated audio-format literal → 1 shared constant

## Deliberately skipped
- **fetchJson/postJson consolidation** (4 copies) — error-message formats differ per call site; unifying would change error surfaces (behavior change).
- **Shared 600_000 timeout constant** — poll deadline and Runware client timeout are separate concerns; forcing a shared constant adds coupling.
- **.catch(undefined) schema fallbacks** — intentional resilience against untrusted LLM-generated XML attributes; changing them would be a behavior change.

## Open PR overlap check
No open PRs at time of branching. No overlap risk.

## Validation
- `npm run lint` ✓
- `npm run format:check` ✓
- `npm run typecheck` ✓
- `npm run build` ✓
- `npm test -- --passWithNoTests` ✓ (97 files, 851 tests)