### PR TITLE
refactor: rethink openslop architecture 2026-06-25

### DIFF
--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -15,7 +15,6 @@ import { isSceneElement } from "@/lib/canvas/scenes";
 import { SortableScene } from "./dnd/SortableScene";
 import { SortableContent } from "./dnd/SortableContent";
 import { DragOverlayContent } from "./dnd/DragOverlay";
-import { renderCanvasElement } from "./elements/ElementContainer";
 import { AssetsSection } from "./elements/AssetsSection";
 
 export default function Canvas({
@@ -51,20 +50,10 @@ export default function Canvas({
 	const renderElement = useCallback((props: RenderElementProps) => {
 		const { element } = props;
 		if (isSceneElement(element)) {
-			return (
-				<SortableScene
-					{...props}
-					element={element}
-					renderElement={renderCanvasElement}
-				/>
-			);
+			return <SortableScene {...props} element={element} />;
 		}
 		return (
-			<SortableContent
-				{...props}
-				element={element as CanvasContentElement}
-				renderElement={renderCanvasElement}
-			/>
+			<SortableContent {...props} element={element as CanvasContentElement} />
 		);
 	}, []);
 

--- a/app/components/canvas/dnd/SortableContent.tsx
+++ b/app/components/canvas/dnd/SortableContent.tsx
@@ -28,12 +28,10 @@ export function SortableContent({
 	attributes,
 	element,
 	children,
-	renderElement,
 }: {
 	attributes: RenderElementProps["attributes"];
 	element: CanvasContentElement;
 	children: React.ReactNode;
-	renderElement: (props: RenderElementProps) => React.ReactNode;
 }) {
 	const editor = useSlateStatic();
 	const { connectorConfig } = useConfig();
@@ -75,7 +73,6 @@ export function SortableContent({
 			disabled={collapsed}
 			attributes={attributes}
 			element={element}
-			renderElement={renderElement}
 		>
 			{children}
 		</SortableItem>

--- a/app/components/canvas/dnd/SortableItem.tsx
+++ b/app/components/canvas/dnd/SortableItem.tsx
@@ -5,6 +5,7 @@ import { RenderElementProps } from "slate-react";
 import type { CanvasElement, CanvasElementType } from "@/lib/canvas/types";
 import styles from "../styles/sortable.module.css";
 import { SortableActions, type InsertOption } from "./SortableActions";
+import { renderCanvasElement } from "../elements/ElementContainer";
 
 interface SortableItemProps {
 	sceneId: string;
@@ -17,7 +18,6 @@ interface SortableItemProps {
 	attributes: RenderElementProps["attributes"];
 	element: CanvasElement;
 	children: React.ReactNode;
-	renderElement: (props: RenderElementProps) => React.ReactNode;
 }
 
 export function SortableItem({
@@ -31,7 +31,6 @@ export function SortableItem({
 	attributes,
 	element,
 	children,
-	renderElement,
 }: SortableItemProps) {
 	const {
 		listeners,
@@ -78,7 +77,7 @@ export function SortableItem({
 							/>
 						</div>
 					)}
-					<div>{renderElement({ attributes, children, element })}</div>
+					<div>{renderCanvasElement({ attributes, children, element })}</div>
 				</div>
 			</div>
 		</div>

--- a/app/components/canvas/dnd/SortableScene.tsx
+++ b/app/components/canvas/dnd/SortableScene.tsx
@@ -10,12 +10,10 @@ export function SortableScene({
 	attributes,
 	element,
 	children,
-	renderElement,
 }: {
 	attributes: RenderElementProps["attributes"];
 	element: SceneElement;
 	children: React.ReactNode;
-	renderElement: (props: RenderElementProps) => React.ReactNode;
 }) {
 	const isActive = useActiveSceneId() === element.id;
 	const { isCollapsed } = useViewMode();
@@ -27,7 +25,6 @@ export function SortableScene({
 			wrapperClassName={`border-t border-border pt-3 mt-3 first:border-t-0 first:pt-0 first:mt-0 ${isActive ? ACTIVE_SCENE_CLASS : ""}`}
 			attributes={attributes}
 			element={element}
-			renderElement={renderElement}
 		>
 			{children}
 		</SortableItem>

--- a/app/components/canvas/elements/AssetTile.tsx
+++ b/app/components/canvas/elements/AssetTile.tsx
@@ -5,6 +5,27 @@ import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
 import { ImageWithShimmer } from "@/lib/components/ImageWithShimmer";
 import { GenerationIndicator } from "./GenerationIndicator";
 
+function OverlayButton({
+	icon: Icon,
+	label,
+	onClick,
+}: {
+	icon: LucideIcon;
+	label: string;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			aria-label={label}
+			className="absolute inset-0 flex items-center justify-center bg-background/70 text-foreground opacity-0 transition-opacity group-hover/tile:opacity-100 focus:opacity-100 focus:outline-none"
+		>
+			<Icon className="h-3.5 w-3.5" />
+		</button>
+	);
+}
+
 export function AssetTile({
 	name,
 	previewUrl,
@@ -64,24 +85,18 @@ export function AssetTile({
 					</div>
 				)}
 				{onEdit && status !== "generating" && (
-					<button
-						type="button"
+					<OverlayButton
+						icon={Pencil}
+						label={`Edit ${name ?? "asset"}`}
 						onClick={onEdit}
-						aria-label={`Edit ${name ?? "asset"}`}
-						className="absolute inset-0 flex items-center justify-center bg-background/70 text-foreground opacity-0 transition-opacity group-hover/tile:opacity-100 focus:opacity-100 focus:outline-none"
-					>
-						<Pencil className="h-3.5 w-3.5" />
-					</button>
+					/>
 				)}
 				{onRemove && status !== "generating" && (
-					<button
-						type="button"
+					<OverlayButton
+						icon={X}
+						label={`Remove ${name ?? "asset"}`}
 						onClick={onRemove}
-						aria-label={`Remove ${name ?? "asset"}`}
-						className="absolute inset-0 flex items-center justify-center bg-background/70 text-foreground opacity-0 transition-opacity group-hover/tile:opacity-100 focus:opacity-100 focus:outline-none"
-					>
-						<X className="h-3.5 w-3.5" />
-					</button>
+					/>
 				)}
 			</div>
 			{name && (


### PR DESCRIPTION
## App Understanding

OpenSlop is an AI creative-media studio: a SlateJS storyboard editor where a prompt streams OSML over SSE into canvas elements (scenes, characters, image/clip/animated/music/sound/narration). Stale elements are queued client-side and generated via `/api/v1/*` routes (connector → gateway → provider), with results cached in Vercel Blob and the composition rendered to MP4 through Remotion Lambdas. State persists per-project in Supabase. Main workflows: submit prompt → generate assets → arrange/refine on the canvas → preview → export.

## From-Scratch Architecture

The existing three-layer generation pipeline (connectors / gateways / providers) plus the route factory and Zustand stores is already the right shape and was recently audited clean. A from-scratch build would keep that. The only genuine drift is in the **app/canvas UI tree**, where a small amount of plumbing exists that a clean build wouldn't: a module-constant renderer threaded as a prop, and a duplicated overlay-button.

## Implemented Simplifications

1. **Remove the `renderElement` prop-drill in the canvas dnd tree.** `renderCanvasElement` is a module-level constant, but it was passed `Canvas → SortableScene/SortableContent → SortableItem` purely to be invoked at the leaf. `SortableItem` now imports it directly — matching how `DragOverlay` already consumes it — and the prop is dropped from three component interfaces (`SortableItem`, `SortableScene`, `SortableContent`). The import also moves out of `Canvas`, where it was no longer used. Fewer cross-tree props, one consistent way to reach the renderer. Verified acyclic (`dnd → elements/ElementContainer` only; nothing in `elements/` imports `SortableItem`).
2. **Dedupe `AssetTile` overlay buttons.** The edit/remove hover buttons shared an identical 90-char className and structure; extracted a local `OverlayButton` to remove the duplication and the sync hazard.

## Open PR Overlap Check

- Considered the only open PR: **#371** (`refactor: nightly maintainability 2026-06-25`).
- #371 touches `BottomTransportBar`, `AudioPlayer`, `PlayFromHereButton`, `CharacterEditModal`, `VoicePicker`, `icon-button`, and the three ElevenLabs providers, plus the shared `TooltipIconButton` / audio-format-constant themes.
- This PR touches `Canvas.tsx`, `SortableContent.tsx`, `SortableItem.tsx`, `SortableScene.tsx`, `AssetTile.tsx` — **zero file overlap** and none of #371's themes (no TooltipIconButton wrapper, no ElevenLabs constants).

## Validation

| Check | Result |
| --- | --- |
| `npm run typecheck` | pass |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run knip` | pass (no new issues) |
| `npm run build` | pass |
| `npm run test:run` | pass (851/851) |

## Skipped Items / Risks

Exploration surfaced many candidates that were deliberately **not** taken because they were speculative, risky, or trivial:
- **Move pure helpers to `lib/` "for reuse"** (`formatAttributeValue`, `getInitial`, `findSegmentIndexAt`, `refineScript`, `useResize`): each has a single consumer today, or — like `findSegmentIndexAt` — is *already* a shared export living in a hook file. Moving them is speculative abstraction (against CLAUDE.md) with no current second caller.
- **Merge `useMetadataSync` + `useScriptSync`**: they solve distinct concerns (store metadata vs editor text); the claimed "redundant subscription" perf win is illusory under React batching, and merging reduces clarity.
- **Collapse `ActiveSceneContext`'s value/setter split**: that split is a deliberate re-render-isolation pattern; collapsing it risks a perf regression.
- **Merge video contexts / extract player-action helpers**: the video context boundaries are intentional and the overlapping logic largely lives in `BottomTransportBar` (off-limits, #371). No safe, non-churny win here.

Risk on the shipped changes is minimal: no behavior change, pure plumbing/dedup, full green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)