### PR TITLE
refactor: rethink openslop architecture 2026-06-26

### DIFF
--- a/app/components/canvas/elements/AssetsSection.tsx
+++ b/app/components/canvas/elements/AssetsSection.tsx
@@ -6,9 +6,7 @@ import { useConfig } from "@/lib/config/ConfigProvider";
 import { useProjectStore } from "@/lib/project/store";
 import { characterAvatarElementId } from "@/lib/project/ensureCharacterAvatars";
 import { AssetTile } from "./AssetTile";
-import { CharacterEditModal } from "./character/CharacterEditModal";
-import { NarratorEditModal } from "./character/NarratorEditModal";
-import { NewCharacterDialog } from "./character/NewCharacterDialog";
+import { useAssetEditDialogs } from "./character/useAssetEditDialogs";
 import { CollapsibleHeader } from "./CollapsibleHeader";
 
 export function AssetsSection() {
@@ -16,14 +14,13 @@ export function AssetsSection() {
 	const hydrated = useProjectStore(projectId, (s) => s.hydrated);
 	const characters = useProjectStore(projectId, (s) => s.metadata.characters);
 	const referenceImages = useProjectStore(projectId, (s) => s.referenceImages);
-	const setReferenceImages = useProjectStore(
+	const removeReferenceImage = useProjectStore(
 		projectId,
-		(s) => s.setReferenceImages,
+		(s) => s.removeReferenceImage,
 	);
 	const [collapsed, setCollapsed] = useState(false);
-	const [editingName, setEditingName] = useState<string | undefined>();
-	const [editingNarrator, setEditingNarrator] = useState(false);
-	const [creating, setCreating] = useState(false);
+	const { openCreateCharacter, editCharacter, openNarrator, dialogs } =
+		useAssetEditDialogs();
 
 	if (!hydrated) return null;
 
@@ -41,11 +38,11 @@ export function AssetsSection() {
 						name="Narrator"
 						Icon={Mic}
 						fallback="icon"
-						onEdit={() => setEditingNarrator(true)}
+						onEdit={openNarrator}
 					/>
 					<button
 						type="button"
-						onClick={() => setCreating(true)}
+						onClick={openCreateCharacter}
 						aria-label="Add character"
 						className="flex w-16 flex-col gap-1 sm:w-20"
 					>
@@ -63,7 +60,7 @@ export function AssetsSection() {
 							previewUrl={ch.avatarUrl}
 							Icon={User}
 							elementId={characterAvatarElementId(name)}
-							onEdit={() => setEditingName(name)}
+							onEdit={() => editCharacter(name)}
 						/>
 					))}
 					{referenceImages.map((url, i) => (
@@ -72,30 +69,12 @@ export function AssetsSection() {
 							name={`Reference ${i + 1}`}
 							previewUrl={url}
 							Icon={Palette}
-							onRemove={() =>
-								setReferenceImages(referenceImages.filter((_, j) => j !== i))
-							}
+							onRemove={() => removeReferenceImage(i)}
 						/>
 					))}
 				</div>
 			)}
-			<NewCharacterDialog
-				open={creating}
-				onOpenChange={setCreating}
-				onCreated={(name) => {
-					setCreating(false);
-					setEditingName(name);
-				}}
-			/>
-			<CharacterEditModal
-				open={editingName !== undefined}
-				onOpenChange={(open) => !open && setEditingName(undefined)}
-				name={editingName}
-			/>
-			<NarratorEditModal
-				open={editingNarrator}
-				onOpenChange={setEditingNarrator}
-			/>
+			{dialogs}
 		</section>
 	);
 }

--- a/app/components/canvas/elements/character/useAssetEditDialogs.tsx
+++ b/app/components/canvas/elements/character/useAssetEditDialogs.tsx
@@ -6,9 +6,8 @@ import { NarratorEditModal } from "./NarratorEditModal";
 import { NewCharacterDialog } from "./NewCharacterDialog";
 
 /**
- * Owns the create-character / edit-character / edit-narrator dialog flow shared
- * by the editor's assets panel and the composer. Returns imperative openers plus
- * the rendered dialogs (mirrors the `useImageUpload` → `inputElement` pattern).
+ * Returns rendered dialogs as JSX (mirrors the `useImageUpload` → `inputElement`
+ * pattern) plus imperative openers.
  */
 export function useAssetEditDialogs() {
 	const [creating, setCreating] = useState(false);
@@ -39,7 +38,7 @@ export function useAssetEditDialogs() {
 
 	return {
 		openCreateCharacter: () => setCreating(true),
-		editCharacter: setEditingName,
+		editCharacter: (name: string) => setEditingName(name),
 		openNarrator: () => setEditingNarrator(true),
 		dialogs,
 	};

--- a/app/components/canvas/elements/character/useAssetEditDialogs.tsx
+++ b/app/components/canvas/elements/character/useAssetEditDialogs.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import { CharacterEditModal } from "./CharacterEditModal";
+import { NarratorEditModal } from "./NarratorEditModal";
+import { NewCharacterDialog } from "./NewCharacterDialog";
+
+/**
+ * Owns the create-character / edit-character / edit-narrator dialog flow shared
+ * by the editor's assets panel and the composer. Returns imperative openers plus
+ * the rendered dialogs (mirrors the `useImageUpload` → `inputElement` pattern).
+ */
+export function useAssetEditDialogs() {
+	const [creating, setCreating] = useState(false);
+	const [editingName, setEditingName] = useState<string | undefined>();
+	const [editingNarrator, setEditingNarrator] = useState(false);
+
+	const dialogs = (
+		<>
+			<NewCharacterDialog
+				open={creating}
+				onOpenChange={setCreating}
+				onCreated={(name) => {
+					setCreating(false);
+					setEditingName(name);
+				}}
+			/>
+			<CharacterEditModal
+				open={editingName !== undefined}
+				onOpenChange={(open) => !open && setEditingName(undefined)}
+				name={editingName}
+			/>
+			<NarratorEditModal
+				open={editingNarrator}
+				onOpenChange={setEditingNarrator}
+			/>
+		</>
+	);
+
+	return {
+		openCreateCharacter: () => setCreating(true),
+		editCharacter: setEditingName,
+		openNarrator: () => setEditingNarrator(true),
+		dialogs,
+	};
+}

--- a/app/components/copilot/ComposerAssets.tsx
+++ b/app/components/copilot/ComposerAssets.tsx
@@ -3,9 +3,7 @@
 import { Mic, Palette, User } from "@/components/ui/icon";
 import { AssetTile } from "@/app/components/canvas/elements/AssetTile";
 import { characterAvatarElementId } from "@/lib/project/ensureCharacterAvatars";
-import { useConfig } from "@/lib/config/ConfigProvider";
 import { useProject } from "@/lib/project/useProject";
-import { getProjectStore } from "@/lib/project/store";
 
 interface ComposerAssetsProps {
 	uploadingCount: number;
@@ -18,18 +16,13 @@ export function ComposerAssets({
 	onEditCharacter,
 	onEditNarrator,
 }: ComposerAssetsProps) {
-	const { projectId } = useConfig();
 	const referenceImages = useProject((s) => s.referenceImages);
 	const characters = useProject((s) => s.metadata.characters);
 	const narration = useProject((s) => s.metadata.narration);
+	const removeReferenceImage = useProject((s) => s.removeReferenceImage);
 
 	const hasNarration = Object.keys(narration).length > 0;
 	const characterEntries = Object.entries(characters);
-
-	const removeReferenceImage = (index: number) =>
-		getProjectStore(projectId)
-			.getState()
-			.setReferenceImages(referenceImages.filter((_, j) => j !== index));
 
 	return (
 		<div className="flex flex-wrap gap-2 pb-2">

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactNode, useState } from "react";
+import type { ReactNode } from "react";
 import {
 	ChevronDown,
 	CornerDownLeft,
@@ -15,9 +15,7 @@ import {
 import { ActionMenu, type ActionMenuItem } from "@/components/ui/action-menu";
 import { SelectMenu, type SelectMenuOption } from "@/components/ui/select-menu";
 import { cn } from "@/lib/utils";
-import { CharacterEditModal } from "@/app/components/canvas/elements/character/CharacterEditModal";
-import { NarratorEditModal } from "@/app/components/canvas/elements/character/NarratorEditModal";
-import { NewCharacterDialog } from "@/app/components/canvas/elements/character/NewCharacterDialog";
+import { useAssetEditDialogs } from "@/app/components/canvas/elements/character/useAssetEditDialogs";
 import { TEMPLATES, getTemplateById } from "@/lib/templates/templates";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getProjectStore } from "@/lib/project/store";
@@ -170,11 +168,8 @@ export default function ComposerCopilot({
 	const { projectId, mode, setMode, selectedTemplateId, applyTemplate } =
 		useConfig();
 	const aspectRatio = useAspectRatio();
-	const [creatingCharacter, setCreatingCharacter] = useState(false);
-	const [editingCharacterName, setEditingCharacterName] = useState<
-		string | undefined
-	>();
-	const [editingNarrator, setEditingNarrator] = useState(false);
+	const { openCreateCharacter, editCharacter, openNarrator, dialogs } =
+		useAssetEditDialogs();
 
 	const { openPicker, uploading, uploadingCount, inputElement } =
 		useImageUpload({
@@ -201,8 +196,8 @@ export default function ComposerCopilot({
 			<div className="px-4 py-3">
 				<ComposerAssets
 					uploadingCount={uploadingCount}
-					onEditCharacter={setEditingCharacterName}
-					onEditNarrator={() => setEditingNarrator(true)}
+					onEditCharacter={editCharacter}
+					onEditNarrator={openNarrator}
 				/>
 				<div className="flex flex-col gap-1 sm:flex-row sm:items-baseline">
 					{showPill && (
@@ -238,8 +233,8 @@ export default function ComposerCopilot({
 						<AttachMenu
 							openPicker={openPicker}
 							uploading={uploading}
-							onCreateCharacter={() => setCreatingCharacter(true)}
-							onSelectNarrator={() => setEditingNarrator(true)}
+							onCreateCharacter={openCreateCharacter}
+							onSelectNarrator={openNarrator}
 						/>
 						<SelectMenu
 							value={mode}
@@ -302,23 +297,7 @@ export default function ComposerCopilot({
 					/>
 				</div>
 			</div>
-			<NewCharacterDialog
-				open={creatingCharacter}
-				onOpenChange={setCreatingCharacter}
-				onCreated={(name) => {
-					setCreatingCharacter(false);
-					setEditingCharacterName(name);
-				}}
-			/>
-			<CharacterEditModal
-				open={editingCharacterName !== undefined}
-				onOpenChange={(open) => !open && setEditingCharacterName(undefined)}
-				name={editingCharacterName}
-			/>
-			<NarratorEditModal
-				open={editingNarrator}
-				onOpenChange={setEditingNarrator}
-			/>
+			{dialogs}
 		</div>
 	);
 }

--- a/lib/project/__tests__/store.test.ts
+++ b/lib/project/__tests__/store.test.ts
@@ -97,6 +97,14 @@ describe("project store updateMetadata", () => {
 		});
 	});
 
+	it("removeReferenceImage drops only the image at the given index", () => {
+		const store = getProjectStore(PROJECT_ID);
+		store.getState().setReferenceImages(["a.png", "b.png", "c.png"]);
+		store.getState().removeReferenceImage(1);
+
+		expect(store.getState().referenceImages).toEqual(["a.png", "c.png"]);
+	});
+
 	it("removeCharacter deletes the entry", () => {
 		const store = getProjectStore(PROJECT_ID);
 		store.getState().setCharacter("Alice", { appearance: "A girl" });

--- a/lib/project/store.ts
+++ b/lib/project/store.ts
@@ -18,6 +18,7 @@ export type ProjectContext = {
 	removeCharacter: (name: string) => void;
 	setNarration: (narration: MetadataVoice) => void;
 	setReferenceImages: (urls: string[]) => void;
+	removeReferenceImage: (index: number) => void;
 	markHydrated: () => void;
 	reset: () => void;
 };
@@ -57,6 +58,10 @@ export function getProjectStore(projectId: string): ProjectStore {
 				setReferenceImages: (urls) =>
 					set((state) => {
 						state.referenceImages = urls;
+					}),
+				removeReferenceImage: (index) =>
+					set((state) => {
+						state.referenceImages.splice(index, 1);
 					}),
 				markHydrated: () =>
 					set((state) => {


### PR DESCRIPTION
## App understanding

OpenSlop is an AI creative-media studio: a SlateJS storyboard editor + canvas where users describe a story/script/template, the LLM connector streams **OSML** into the canvas, and a generation pipeline (connectors → gateways → providers) renders each storyboard element (image, animated image, clip, narration, music, sound, character) into assets, finally composited to an MP4 via Remotion Lambda. State lives in Zustand (`lib/project/store.ts`) + Slate; generation is queued client-side and polled. Auth/persistence is Supabase with RLS; assets go to Vercel Blob.

**Architectural boundaries** (already audited clean in prior passes): `lib/` is the domain layer and never imports from `app/`; the connector/gateway/provider split is intentional and stays. So this pass targets the **UI layer**, where the real remaining duplication lives.

## From-scratch architecture vs. current

Asset management (characters, narrator, reference images) is surfaced in two unrelated component trees — the editor's left **assets panel** (`AssetsSection`) and the **composer** (`ComposerCopilot` + `ComposerAssets`). A from-scratch design would own each asset-edit interaction (open create / edit a character / edit the narrator) and each store mutation (remove a reference image) in exactly one place, and let both surfaces call it. The current code instead repeated that wiring verbatim in both trees.

## Implemented simplifications

1. **`useAssetEditDialogs` hook** (`app/components/canvas/elements/character/useAssetEditDialogs.tsx`) — owns the create-character / edit-character / edit-narrator dialog state and rendering. Previously `AssetsSection` (3 `useState` + 3 modal renders) and `ComposerCopilot` (the same 3 `useState` + the same 3 modal renders) carried byte-identical boilerplate. Both now call the hook and drop the modal imports. Follows the codebase's existing "hook returns JSX" convention (`useImageUpload` → `inputElement`).
2. **`removeReferenceImage(index)` store action** (`lib/project/store.ts`) — replaces two copies of `setReferenceImages(referenceImages.filter((_, j) => j !== i))` (in `ComposerAssets` and `AssetsSection`) with one store mutation. `ComposerAssets` no longer needs `useConfig`/`getProjectStore` for the removal.

Net: existing files lose 69 lines, gain 33; logic consolidated into one small hook + one store action. No behavior change.

## Validation

- `typecheck` ✅
- `lint` ✅
- `format:check` ✅
- `knip` ✅ (no dead code)
- `build` ✅
- `test:run` ✅ — 852 tests pass (added a store test for `removeReferenceImage`)

## Skipped items (deliberately out of scope)

- Generic attribute/zod-schema centralization and connector/gateway/provider consolidation — prior nightly audits marked these clean; avoided per "no speculative abstractions" guidance.
- Unifying the `AssetsSection` vs `ComposerAssets` tile rows — they differ meaningfully (New-character button + collapsible header vs. upload shimmers), so merging the rows risked behavior change for marginal gain.
- Duplicated `useGenerate()` calls across sibling element components — these are independent Zustand selector subscriptions; collapsing them risks re-render behavior changes.
- Magic-number centralization in video components — cosmetic.

## Open PR overlap check

Considered open PRs #371, #372, #373, #376, #377. This PR touches only `AssetsSection.tsx`, `ComposerCopilot.tsx`, `ComposerAssets.tsx`, a new `useAssetEditDialogs.tsx`, `lib/project/store.ts`, and `lib/project/__tests__/store.test.ts` — none of which appear in those PRs' file lists (#372 covers `AssetTile.tsx` but not `AssetsSection.tsx`; #376 covers `app/api/v1/__tests__/routes.test.ts` and `lib/video`/`lib/api`/`lib/connectors` files, not `lib/project/store.ts`). Non-overlapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)