### PR TITLE
Use filled square variant for refine copilot bar Stop icon

### DIFF
--- a/app/components/copilot/InlineCopilot.tsx
+++ b/app/components/copilot/InlineCopilot.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type ReactNode, useEffect, useState } from "react";
-import { CornerDownLeft, Square, Wand2 } from "@/components/ui/icon";
+import { CornerDownLeft, SquareFilled, Wand2 } from "@/components/ui/icon";
 import OrbLoader from "../OrbLoader";
 import { ActionButton } from "./ActionButton";
 
@@ -95,7 +95,7 @@ export default function InlineCopilot({
 				{loading ? (
 					<ActionButton
 						label="Stop generation"
-						icon={<Square className="h-3 w-3 fill-current" />}
+						icon={<SquareFilled className="h-3 w-3" />}
 						onClick={() => onStop?.()}
 					/>
 				) : (

--- a/components/ui/icon.tsx
+++ b/components/ui/icon.tsx
@@ -97,6 +97,7 @@ export const SlidersAlt = icon("sliders-alt");
 export const SlidersAltFill = icon("sliders-alt-fill");
 export const Sparkles = icon("magic");
 export const Square = icon("square");
+export const SquareFilled = icon("square-filled");
 export const Trash2 = icon("trash");
 export const User = icon("user");
 export const UserPlus = icon("user-plus");


### PR DESCRIPTION
Fix the Stop button in the refine copilot bar showing a hollow outline square instead of a filled square while loading.

- Add SquareFilled icon export
- Use SquareFilled in InlineCopilot.tsx
- Remove dead fill-current class

Closes #380