### PR TITLE
Lower cartesia tts volume to unity gain

### DIFF
--- a/lib/providers/tts/cartesia.ts
+++ b/lib/providers/tts/cartesia.ts
@@ -30,7 +30,7 @@ type RawTTSResult = {
 const SAMPLE_RATE = 44100;
 const NUM_CHANNELS = 1;
 const ENCODING = "pcm_f32le";
-const CARTESIA_VOLUME = 1.5;
+const CARTESIA_VOLUME = 1.0;
 
 const CARTESIA_SPEED: Record<TTSSpeed, number> = {
 	slow: 0.6,


### PR DESCRIPTION
## Summary
- Drop `CARTESIA_VOLUME` from 1.5 to 1.0 to avoid clipping/distortion on TTS output.

## Test plan
- Generate a Cartesia TTS clip and confirm audio is clean (no clipping) at unity gain.