### PR TITLE
feat: inline character removal in the hero composer

### DIFF
--- a/app/components/canvas/elements/AssetTile.tsx
+++ b/app/components/canvas/elements/AssetTile.tsx
@@ -19,7 +19,7 @@ function OverlayButton({
 			type="button"
 			onClick={onClick}
 			aria-label={label}
-			className="flex flex-1 items-center justify-center bg-background/70 text-foreground focus:outline-none"
+			className="focus-ring flex flex-1 items-center justify-center bg-background/70 text-foreground transition-colors hover:bg-background/90 focus-visible:ring-inset"
 		>
 			<Icon className="h-3.5 w-3.5" />
 		</button>

--- a/app/components/canvas/elements/AssetTile.tsx
+++ b/app/components/canvas/elements/AssetTile.tsx
@@ -19,7 +19,7 @@ function OverlayButton({
 			type="button"
 			onClick={onClick}
 			aria-label={label}
-			className="absolute inset-0 flex items-center justify-center bg-background/70 text-foreground opacity-0 transition-opacity group-hover/tile:opacity-100 focus:opacity-100 focus:outline-none"
+			className="flex flex-1 items-center justify-center bg-background/70 text-foreground focus:outline-none"
 		>
 			<Icon className="h-3.5 w-3.5" />
 		</button>
@@ -84,19 +84,23 @@ export function AssetTile({
 						<Icon className="h-3 w-3" />
 					</div>
 				)}
-				{onEdit && status !== "generating" && (
-					<OverlayButton
-						icon={Pencil}
-						label={`Edit ${name ?? "asset"}`}
-						onClick={onEdit}
-					/>
-				)}
-				{onRemove && status !== "generating" && (
-					<OverlayButton
-						icon={X}
-						label={`Remove ${name ?? "asset"}`}
-						onClick={onRemove}
-					/>
+				{(onEdit || onRemove) && status !== "generating" && (
+					<div className="absolute inset-0 flex opacity-0 transition-opacity focus-within:opacity-100 group-hover/tile:opacity-100">
+						{onEdit && (
+							<OverlayButton
+								icon={Pencil}
+								label={`Edit ${name ?? "asset"}`}
+								onClick={onEdit}
+							/>
+						)}
+						{onRemove && (
+							<OverlayButton
+								icon={X}
+								label={`Remove ${name ?? "asset"}`}
+								onClick={onRemove}
+							/>
+						)}
+					</div>
 				)}
 			</div>
 			{name && (

--- a/app/components/canvas/elements/AssetTile.tsx
+++ b/app/components/canvas/elements/AssetTile.tsx
@@ -4,6 +4,7 @@ import { Pencil, X, type LucideIcon } from "@/components/ui/icon";
 import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
 import { ImageWithShimmer } from "@/lib/components/ImageWithShimmer";
 import { GenerationIndicator } from "./GenerationIndicator";
+import { RemoveCrossButton } from "./RemoveCrossButton";
 
 function OverlayButton({
 	icon: Icon,
@@ -19,7 +20,7 @@ function OverlayButton({
 			type="button"
 			onClick={onClick}
 			aria-label={label}
-			className="focus-ring flex flex-1 items-center justify-center bg-background/70 text-foreground transition-colors hover:bg-background/90 focus-visible:ring-inset"
+			className="focus-ring absolute inset-0 flex items-center justify-center bg-background/70 text-foreground opacity-0 transition group-hover/tile:opacity-100 hover:bg-background/90 focus-visible:opacity-100 focus-visible:ring-inset"
 		>
 			<Icon className="h-3.5 w-3.5" />
 		</button>
@@ -33,6 +34,7 @@ export function AssetTile({
 	elementId,
 	onEdit,
 	onRemove,
+	removeAffordance = "overlay",
 	fallback = "initial",
 }: {
 	name?: string;
@@ -41,6 +43,8 @@ export function AssetTile({
 	elementId?: string;
 	onEdit?: () => void;
 	onRemove?: () => void;
+	/** "corner" pins a pill-style cross outside the tile so it can coexist with the edit overlay. */
+	removeAffordance?: "overlay" | "corner";
 	fallback?: "initial" | "icon";
 }) {
 	const status = useQueueSelector(
@@ -50,7 +54,7 @@ export function AssetTile({
 	const fallbackContent =
 		fallback === "icon" || !initial ? <Icon className="h-5 w-5" /> : initial;
 	return (
-		<div className="group/tile flex w-16 flex-col gap-1 sm:w-20">
+		<div className="group/tile relative flex w-16 flex-col gap-1 sm:w-20">
 			<div className="relative aspect-square overflow-hidden rounded-md border border-border bg-card">
 				{previewUrl ? (
 					<ImageWithShimmer
@@ -84,25 +88,30 @@ export function AssetTile({
 						<Icon className="h-3 w-3" />
 					</div>
 				)}
-				{(onEdit || onRemove) && status !== "generating" && (
-					<div className="absolute inset-0 flex opacity-0 transition-opacity focus-within:opacity-100 group-hover/tile:opacity-100">
-						{onEdit && (
-							<OverlayButton
-								icon={Pencil}
-								label={`Edit ${name ?? "asset"}`}
-								onClick={onEdit}
-							/>
-						)}
-						{onRemove && (
-							<OverlayButton
-								icon={X}
-								label={`Remove ${name ?? "asset"}`}
-								onClick={onRemove}
-							/>
-						)}
-					</div>
+				{onEdit && status !== "generating" && (
+					<OverlayButton
+						icon={Pencil}
+						label={`Edit ${name ?? "asset"}`}
+						onClick={onEdit}
+					/>
 				)}
+				{onRemove &&
+					removeAffordance === "overlay" &&
+					status !== "generating" && (
+						<OverlayButton
+							icon={X}
+							label={`Remove ${name ?? "asset"}`}
+							onClick={onRemove}
+						/>
+					)}
 			</div>
+			{onRemove && removeAffordance === "corner" && status !== "generating" && (
+				<RemoveCrossButton
+					label={`Remove ${name ?? "asset"}`}
+					onClick={onRemove}
+					className="z-10 opacity-0 group-hover/tile:opacity-100"
+				/>
+			)}
 			{name && (
 				<span
 					className="truncate text-badge text-muted-foreground"

--- a/app/components/canvas/elements/CharacterPill.tsx
+++ b/app/components/canvas/elements/CharacterPill.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { User, X } from "@/components/ui/icon";
+import { User } from "@/components/ui/icon";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useProjectStore } from "@/lib/project/store";
+import { RemoveCrossButton } from "./RemoveCrossButton";
 
 function useCharacterAvatarUrl(name?: string) {
 	const { projectId } = useConfig();
@@ -65,15 +66,11 @@ export function CharacterPill({
 			/>
 			{name && <CharacterName name={name} />}
 			{onRemove && (
-				<button
-					type="button"
-					aria-label={`Remove ${name}`}
-					onMouseDown={(e) => e.preventDefault()}
+				<RemoveCrossButton
+					label={`Remove ${name}`}
 					onClick={onRemove}
-					className="absolute -top-1 -right-1 flex cursor-pointer items-center justify-center rounded-full border border-border bg-popover p-0.5 opacity-0 transition-opacity group-hover/pill:opacity-100 hover:bg-muted"
-				>
-					<X className="h-2.5 w-2.5 text-foreground" />
-				</button>
+					className="opacity-0 group-hover/pill:opacity-100"
+				/>
 			)}
 		</div>
 	);

--- a/app/components/canvas/elements/RemoveCrossButton.tsx
+++ b/app/components/canvas/elements/RemoveCrossButton.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { X } from "@/components/ui/icon";
+import { cn } from "@/lib/utils";
+
+/**
+ * Small cross pinned outside an item's top-right corner — the shared removal
+ * affordance for pills and tiles. Callers pass their own reveal classes
+ * (e.g. `opacity-0 group-hover/pill:opacity-100`).
+ */
+export function RemoveCrossButton({
+	label,
+	onClick,
+	className,
+}: {
+	label: string;
+	onClick: () => void;
+	className?: string;
+}) {
+	return (
+		<button
+			type="button"
+			aria-label={label}
+			onMouseDown={(e) => e.preventDefault()}
+			onClick={onClick}
+			className={cn(
+				"focus-ring absolute -right-1 -top-1 flex cursor-pointer items-center justify-center rounded-full border border-border bg-popover p-0.5 transition-opacity hover:bg-muted focus-visible:opacity-100",
+				className,
+			)}
+		>
+			<X className="h-2.5 w-2.5 text-foreground" />
+		</button>
+	);
+}

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -25,6 +25,7 @@ import {
 	characterAvatarElement,
 	characterAvatarElementId,
 } from "@/lib/project/ensureCharacterAvatars";
+import { deleteCharacter } from "@/lib/project/deleteCharacter";
 import { useProjectStore } from "@/lib/project/store";
 import type { MetadataCharacter } from "@/lib/project/types";
 import { useImageUpload } from "@/lib/upload/useImageUpload";
@@ -68,7 +69,6 @@ function CharacterEditDialogBody({
 	const metadata = useProjectStore(projectId, (s) => s.metadata);
 	const character = metadata.characters[name];
 	const setCharacter = useProjectStore(projectId, (s) => s.setCharacter);
-	const removeCharacter = useProjectStore(projectId, (s) => s.removeCharacter);
 
 	const [confirmDelete, setConfirmDelete] = useState(false);
 	const [closeConfirm, setCloseConfirm] = useState(false);
@@ -131,8 +131,7 @@ function CharacterEditDialogBody({
 			setConfirmDelete(true);
 			return;
 		}
-		queue.discard(avatarElementId);
-		removeCharacter(name);
+		deleteCharacter(projectId, queue, name);
 		onClose();
 	};
 

--- a/app/components/canvas/elements/character/DeleteCharacterDialog.tsx
+++ b/app/components/canvas/elements/character/DeleteCharacterDialog.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+export function DeleteCharacterDialog({
+	name,
+	onOpenChange,
+	onDelete,
+}: {
+	name?: string;
+	onOpenChange: (open: boolean) => void;
+	onDelete: () => void;
+}) {
+	return (
+		<AlertDialog open={name !== undefined} onOpenChange={onOpenChange}>
+			<AlertDialogContent>
+				<AlertDialogTitle>Delete {name}?</AlertDialogTitle>
+				<AlertDialogDescription>
+					This permanently removes the character and its avatar. It can&apos;t
+					be undone.
+				</AlertDialogDescription>
+				<AlertDialogFooter>
+					<AlertDialogCancel className="rounded-md px-2.5 py-1 text-label text-muted-foreground transition-colors hover:text-foreground">
+						Cancel
+					</AlertDialogCancel>
+					<AlertDialogAction
+						onClick={onDelete}
+						className="rounded-md bg-destructive px-3 py-1 text-label font-medium text-destructive-foreground shadow-elevation-5 transition hover:brightness-110"
+					>
+						Delete character
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/app/components/copilot/ComposerAssets.tsx
+++ b/app/components/copilot/ComposerAssets.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import { Mic, Palette, User } from "@/components/ui/icon";
 import { AssetTile } from "@/app/components/canvas/elements/AssetTile";
+import { DeleteCharacterDialog } from "@/app/components/canvas/elements/character/DeleteCharacterDialog";
 import { characterAvatarElementId } from "@/lib/project/ensureCharacterAvatars";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
@@ -26,8 +28,15 @@ export function ComposerAssets({
 	const narration = useProject((s) => s.metadata.narration);
 	const removeReferenceImage = useProject((s) => s.removeReferenceImage);
 
+	const [deletingName, setDeletingName] = useState<string>();
+
 	const hasNarration = Object.keys(narration).length > 0;
 	const characterEntries = Object.entries(characters);
+
+	const confirmDelete = () => {
+		if (deletingName) deleteCharacter(projectId, queue, deletingName);
+		setDeletingName(undefined);
+	};
 
 	return (
 		<div className="flex flex-wrap gap-2 pb-2">
@@ -47,7 +56,8 @@ export function ComposerAssets({
 					Icon={User}
 					elementId={characterAvatarElementId(name)}
 					onEdit={() => onEditCharacter(name)}
-					onRemove={() => deleteCharacter(projectId, queue, name)}
+					onRemove={() => setDeletingName(name)}
+					removeAffordance="corner"
 				/>
 			))}
 			{referenceImages.map((url, i) => (
@@ -65,6 +75,13 @@ export function ComposerAssets({
 					className="aspect-square w-16 shrink-0 rounded-md shimmer-surface sm:w-20"
 				/>
 			))}
+			<DeleteCharacterDialog
+				name={deletingName}
+				onOpenChange={(open) => {
+					if (!open) setDeletingName(undefined);
+				}}
+				onDelete={confirmDelete}
+			/>
 		</div>
 	);
 }

--- a/app/components/copilot/ComposerAssets.tsx
+++ b/app/components/copilot/ComposerAssets.tsx
@@ -3,6 +3,7 @@
 import { Mic, Palette, User } from "@/components/ui/icon";
 import { AssetTile } from "@/app/components/canvas/elements/AssetTile";
 import { characterAvatarElementId } from "@/lib/project/ensureCharacterAvatars";
+import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
 import { useProject } from "@/lib/project/useProject";
 
 interface ComposerAssetsProps {
@@ -16,13 +17,20 @@ export function ComposerAssets({
 	onEditCharacter,
 	onEditNarrator,
 }: ComposerAssetsProps) {
+	const queue = useGenerationQueue();
 	const referenceImages = useProject((s) => s.referenceImages);
 	const characters = useProject((s) => s.metadata.characters);
 	const narration = useProject((s) => s.metadata.narration);
 	const removeReferenceImage = useProject((s) => s.removeReferenceImage);
+	const removeCharacterFromStore = useProject((s) => s.removeCharacter);
 
 	const hasNarration = Object.keys(narration).length > 0;
 	const characterEntries = Object.entries(characters);
+
+	const removeCharacter = (name: string) => {
+		queue.discard(characterAvatarElementId(name));
+		removeCharacterFromStore(name);
+	};
 
 	return (
 		<div className="flex flex-wrap gap-2 pb-2">
@@ -42,6 +50,7 @@ export function ComposerAssets({
 					Icon={User}
 					elementId={characterAvatarElementId(name)}
 					onEdit={() => onEditCharacter(name)}
+					onRemove={() => removeCharacter(name)}
 				/>
 			))}
 			{referenceImages.map((url, i) => (

--- a/app/components/copilot/ComposerAssets.tsx
+++ b/app/components/copilot/ComposerAssets.tsx
@@ -3,7 +3,9 @@
 import { Mic, Palette, User } from "@/components/ui/icon";
 import { AssetTile } from "@/app/components/canvas/elements/AssetTile";
 import { characterAvatarElementId } from "@/lib/project/ensureCharacterAvatars";
+import { useConfig } from "@/lib/config/ConfigProvider";
 import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
+import { deleteCharacter } from "@/lib/project/deleteCharacter";
 import { useProject } from "@/lib/project/useProject";
 
 interface ComposerAssetsProps {
@@ -17,20 +19,15 @@ export function ComposerAssets({
 	onEditCharacter,
 	onEditNarrator,
 }: ComposerAssetsProps) {
+	const { projectId } = useConfig();
 	const queue = useGenerationQueue();
 	const referenceImages = useProject((s) => s.referenceImages);
 	const characters = useProject((s) => s.metadata.characters);
 	const narration = useProject((s) => s.metadata.narration);
 	const removeReferenceImage = useProject((s) => s.removeReferenceImage);
-	const removeCharacterFromStore = useProject((s) => s.removeCharacter);
 
 	const hasNarration = Object.keys(narration).length > 0;
 	const characterEntries = Object.entries(characters);
-
-	const removeCharacter = (name: string) => {
-		queue.discard(characterAvatarElementId(name));
-		removeCharacterFromStore(name);
-	};
 
 	return (
 		<div className="flex flex-wrap gap-2 pb-2">
@@ -50,7 +47,7 @@ export function ComposerAssets({
 					Icon={User}
 					elementId={characterAvatarElementId(name)}
 					onEdit={() => onEditCharacter(name)}
-					onRemove={() => removeCharacter(name)}
+					onRemove={() => deleteCharacter(projectId, queue, name)}
 				/>
 			))}
 			{referenceImages.map((url, i) => (

--- a/app/components/copilot/ComposerAssets.tsx
+++ b/app/components/copilot/ComposerAssets.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Mic, Palette, User } from "@/components/ui/icon";
 import { AssetTile } from "@/app/components/canvas/elements/AssetTile";
-import { DeleteCharacterDialog } from "@/app/components/canvas/elements/character/DeleteCharacterDialog";
+import { ConfirmDeleteDialog } from "@/components/ui/confirm-delete-dialog";
 import { characterAvatarElementId } from "@/lib/project/ensureCharacterAvatars";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
@@ -75,12 +75,15 @@ export function ComposerAssets({
 					className="aspect-square w-16 shrink-0 rounded-md shimmer-surface sm:w-20"
 				/>
 			))}
-			<DeleteCharacterDialog
-				name={deletingName}
+			<ConfirmDeleteDialog
+				open={deletingName !== undefined}
 				onOpenChange={(open) => {
 					if (!open) setDeletingName(undefined);
 				}}
-				onDelete={confirmDelete}
+				title={`Delete ${deletingName}?`}
+				description="This permanently removes the character and its avatar. It can't be undone."
+				actionLabel="Delete character"
+				onConfirm={confirmDelete}
 			/>
 		</div>
 	);

--- a/app/components/projects/ProjectsList.tsx
+++ b/app/components/projects/ProjectsList.tsx
@@ -9,6 +9,7 @@ import type { ProjectRow } from "@/lib/project/api";
 import { ImageWithShimmer } from "@/lib/components/ImageWithShimmer";
 import UserProfile from "@/app/components/UserProfile";
 import { Button } from "@/components/ui/button";
+import { ConfirmDeleteDialog } from "@/components/ui/confirm-delete-dialog";
 import { DeleteButton } from "@/components/ui/delete-button";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { relativeTime } from "@/lib/project/relativeTime";
@@ -19,6 +20,7 @@ export default function ProjectsList({
 	initialProjects: ProjectRow[];
 }) {
 	const [projects, setProjects] = useState(initialProjects);
+	const [deleting, setDeleting] = useState<ProjectRow>();
 	const [pending, startTransition] = useTransition();
 	const router = useRouter();
 
@@ -99,7 +101,7 @@ export default function ProjectsList({
 									<div className="absolute top-2 right-2 opacity-0 transition-opacity group-hover:opacity-100">
 										<DeleteButton
 											ariaLabel={`Delete ${project.name}`}
-											onClick={() => handleDelete(project.id)}
+											onClick={() => setDeleting(project)}
 										/>
 									</div>
 								</div>
@@ -123,6 +125,19 @@ export default function ProjectsList({
 					</ul>
 				</div>
 			</div>
+			<ConfirmDeleteDialog
+				open={deleting !== undefined}
+				onOpenChange={(open) => {
+					if (!open) setDeleting(undefined);
+				}}
+				title={`Delete ${deleting?.name}?`}
+				description="This permanently deletes the project and everything generated in it. It can't be undone."
+				actionLabel="Delete project"
+				onConfirm={() => {
+					if (deleting) handleDelete(deleting.id);
+					setDeleting(undefined);
+				}}
+			/>
 		</TooltipProvider>
 	);
 }

--- a/components/ui/confirm-delete-dialog.tsx
+++ b/components/ui/confirm-delete-dialog.tsx
@@ -10,32 +10,36 @@ import {
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 
-export function DeleteCharacterDialog({
-	name,
+/** Confirmation gate for deletions the app cannot undo. */
+export function ConfirmDeleteDialog({
+	open,
 	onOpenChange,
-	onDelete,
+	title,
+	description,
+	actionLabel,
+	onConfirm,
 }: {
-	name?: string;
+	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	onDelete: () => void;
+	title: string;
+	description: string;
+	actionLabel: string;
+	onConfirm: () => void;
 }) {
 	return (
-		<AlertDialog open={name !== undefined} onOpenChange={onOpenChange}>
+		<AlertDialog open={open} onOpenChange={onOpenChange}>
 			<AlertDialogContent>
-				<AlertDialogTitle>Delete {name}?</AlertDialogTitle>
-				<AlertDialogDescription>
-					This permanently removes the character and its avatar. It can&apos;t
-					be undone.
-				</AlertDialogDescription>
+				<AlertDialogTitle>{title}</AlertDialogTitle>
+				<AlertDialogDescription>{description}</AlertDialogDescription>
 				<AlertDialogFooter>
 					<AlertDialogCancel className="rounded-md px-2.5 py-1 text-label text-muted-foreground transition-colors hover:text-foreground">
 						Cancel
 					</AlertDialogCancel>
 					<AlertDialogAction
-						onClick={onDelete}
+						onClick={onConfirm}
 						className="rounded-md bg-destructive px-3 py-1 text-label font-medium text-destructive-foreground shadow-elevation-5 transition hover:brightness-110"
 					>
-						Delete character
+						{actionLabel}
 					</AlertDialogAction>
 				</AlertDialogFooter>
 			</AlertDialogContent>

--- a/components/ui/confirm-delete-dialog.tsx
+++ b/components/ui/confirm-delete-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -26,11 +27,23 @@ export function ConfirmDeleteDialog({
 	actionLabel: string;
 	onConfirm: () => void;
 }) {
+	// Radix keeps the dialog mounted through its exit animation; latch the
+	// content so it doesn't flash cleared values after the caller resets state.
+	const [latched, setLatched] = useState({ title, description, actionLabel });
+	if (
+		open &&
+		(latched.title !== title ||
+			latched.description !== description ||
+			latched.actionLabel !== actionLabel)
+	) {
+		setLatched({ title, description, actionLabel });
+	}
+
 	return (
 		<AlertDialog open={open} onOpenChange={onOpenChange}>
 			<AlertDialogContent>
-				<AlertDialogTitle>{title}</AlertDialogTitle>
-				<AlertDialogDescription>{description}</AlertDialogDescription>
+				<AlertDialogTitle>{latched.title}</AlertDialogTitle>
+				<AlertDialogDescription>{latched.description}</AlertDialogDescription>
 				<AlertDialogFooter>
 					<AlertDialogCancel className="rounded-md px-2.5 py-1 text-label text-muted-foreground transition-colors hover:text-foreground">
 						Cancel
@@ -39,7 +52,7 @@ export function ConfirmDeleteDialog({
 						onClick={onConfirm}
 						className="rounded-md bg-destructive px-3 py-1 text-label font-medium text-destructive-foreground shadow-elevation-5 transition hover:brightness-110"
 					>
-						{actionLabel}
+						{latched.actionLabel}
 					</AlertDialogAction>
 				</AlertDialogFooter>
 			</AlertDialogContent>

--- a/lib/project/deleteCharacter.ts
+++ b/lib/project/deleteCharacter.ts
@@ -1,0 +1,13 @@
+import type { GenerationQueue } from "@/lib/generation/queue";
+import { characterAvatarElementId } from "./ensureCharacterAvatars";
+import { getProjectStore } from "./store";
+
+/** Remove a character and discard its pending avatar generation. */
+export function deleteCharacter(
+	projectId: string,
+	queue: GenerationQueue,
+	name: string,
+) {
+	queue.discard(characterAvatarElementId(name));
+	getProjectStore(projectId).getState().removeCharacter(name);
+}


### PR DESCRIPTION
## Summary
- Character tiles in the hero composer (`ComposerAssets`) now expose an inline remove affordance — no more edit-modal round-trip to delete a character
- Per review, the affordance is the **corner-cross pattern** from the element-container character pills: a small circular X pinned outside the tile's top-right corner, revealed on hover/focus. Extracted into a shared `RemoveCrossButton` used by both `CharacterPill` and `AssetTile`, so the deletion affordance stays consistent across the app by construction
- Deletion routes through a shared `lib/project/deleteCharacter` helper (discard pending avatar job → remove from store), called by both the composer and `CharacterEditModal`, so the two delete paths cannot drift
- Since character deletion is unrecoverable (no undo/redo for project assets), the inline remove asks for confirmation via a new generic `ConfirmDeleteDialog` (built on the existing `AlertDialog` pattern). Project deletion in the gallery — previously an instant hard delete from a hover-revealed button — now goes through the same dialog. Canvas element/scene deletion stays instant since Slate history makes it Ctrl+Z-recoverable; pill removal stays instant since it is scene-scoped and re-addable
<img width="742" height="533" alt="Screenshot 2026-07-02 201331" src="https://github.com/user-attachments/assets/9ecb8eea-6136-44ad-9b19-feeb65ea00c1" />

- `AssetTile` overlay buttons gained hover feedback and the standard `focus-ring` (inset) for keyboard navigation, per review

Fixes #340

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run test:run` (852 tests passing)
- [x] Verified in a running dev server: corner-cross reveal on hover/focus, confirm dialog on character delete, project-delete confirmation in the gallery, element/scene delete still instant + undoable
