### PR TITLE
Fail animated-image chain at the still-image step, not video

### DIFF
--- a/app/api/queues/__tests__/asset-generate.test.ts
+++ b/app/api/queues/__tests__/asset-generate.test.ts
@@ -109,9 +109,11 @@ describe("asset-generate queue worker", () => {
 		});
 
 		await expect(processMessage(message)).rejects.toThrow("provider down");
+		// error is the human message (renders in the failure banner), not a
+		// serialized Error with a stack trace.
 		expect(mockUpdateJob).toHaveBeenNthCalledWith(2, "job-1", {
 			status: "failed",
-			error: expect.stringContaining("provider down"),
+			error: "provider down",
 			metadata: { errorDetail: thrown },
 		});
 	});
@@ -121,7 +123,12 @@ describe("asset-generate queue worker", () => {
 			status: "pending",
 			metadata: { providerJobId: "p1" },
 		});
-		const thrown = { error: { code: "invalidValueUploadFailed" } };
+		const thrown = {
+			error: {
+				code: "invalidValueUploadFailed",
+				message: "Processing parameter 'inputs.frameImages' failed.",
+			},
+		};
 		mockGetJobHandler.mockReturnValue({
 			process: vi.fn().mockRejectedValue(thrown),
 		});
@@ -129,8 +136,23 @@ describe("asset-generate queue worker", () => {
 		await expect(processMessage(message)).rejects.toBe(thrown);
 		expect(mockUpdateJob).toHaveBeenNthCalledWith(2, "job-1", {
 			status: "failed",
-			error: expect.stringContaining("invalidValueUploadFailed"),
+			error: "Processing parameter 'inputs.frameImages' failed.",
 			metadata: { providerJobId: "p1", errorDetail: thrown },
+		});
+	});
+
+	it("falls back to a generic human message when the thrown error has no readable message", async () => {
+		mockLoadJobForProcessing.mockResolvedValue({ status: "pending" });
+		const thrown = { error: { code: "weird" } };
+		mockGetJobHandler.mockReturnValue({
+			process: vi.fn().mockRejectedValue(thrown),
+		});
+
+		await expect(processMessage(message)).rejects.toBe(thrown);
+		expect(mockUpdateJob).toHaveBeenNthCalledWith(2, "job-1", {
+			status: "failed",
+			error: "Generation failed",
+			metadata: { errorDetail: thrown },
 		});
 	});
 });

--- a/app/api/queues/__tests__/asset-generate.test.ts
+++ b/app/api/queues/__tests__/asset-generate.test.ts
@@ -114,7 +114,12 @@ describe("asset-generate queue worker", () => {
 		expect(mockUpdateJob).toHaveBeenNthCalledWith(2, "job-1", {
 			status: "failed",
 			error: "provider down",
-			metadata: { errorDetail: thrown },
+			metadata: {
+				errorDetail: expect.objectContaining({
+					name: "Error",
+					message: "provider down",
+				}),
+			},
 		});
 	});
 
@@ -139,6 +144,22 @@ describe("asset-generate queue worker", () => {
 			error: "Processing parameter 'inputs.frameImages' failed.",
 			metadata: { providerJobId: "p1", errorDetail: thrown },
 		});
+	});
+
+	it("serializes a circular error so persisting it can't throw", async () => {
+		mockLoadJobForProcessing.mockResolvedValue({ status: "pending" });
+		const thrown: Record<string, unknown> = { error: { code: "boom" } };
+		thrown.self = thrown;
+		mockGetJobHandler.mockReturnValue({
+			process: vi.fn().mockRejectedValue(thrown),
+		});
+
+		await expect(processMessage(message)).rejects.toBe(thrown);
+		const persisted = mockUpdateJob.mock.calls[1][1].metadata.errorDetail;
+		// supabase-js JSON.stringifies metadata on write — a circular errorDetail
+		// would make the failure-path updateJob itself throw.
+		expect(() => JSON.stringify(persisted)).not.toThrow();
+		expect(persisted.error.code).toBe("boom");
 	});
 
 	it("falls back to a generic human message when the thrown error has no readable message", async () => {

--- a/app/api/queues/__tests__/asset-generate.test.ts
+++ b/app/api/queues/__tests__/asset-generate.test.ts
@@ -103,14 +103,34 @@ describe("asset-generate queue worker", () => {
 
 	it("marks the job failed and rethrows when the handler errors", async () => {
 		mockLoadJobForProcessing.mockResolvedValue({ status: "pending" });
+		const thrown = new Error("provider down");
 		mockGetJobHandler.mockReturnValue({
-			process: vi.fn().mockRejectedValue(new Error("provider down")),
+			process: vi.fn().mockRejectedValue(thrown),
 		});
 
 		await expect(processMessage(message)).rejects.toThrow("provider down");
 		expect(mockUpdateJob).toHaveBeenNthCalledWith(2, "job-1", {
 			status: "failed",
 			error: expect.stringContaining("provider down"),
+			metadata: { errorDetail: thrown },
+		});
+	});
+
+	it("persists the raw structured error as metadata.errorDetail, merging existing metadata", async () => {
+		mockLoadJobForProcessing.mockResolvedValue({
+			status: "pending",
+			metadata: { providerJobId: "p1" },
+		});
+		const thrown = { error: { code: "invalidValueUploadFailed" } };
+		mockGetJobHandler.mockReturnValue({
+			process: vi.fn().mockRejectedValue(thrown),
+		});
+
+		await expect(processMessage(message)).rejects.toBe(thrown);
+		expect(mockUpdateJob).toHaveBeenNthCalledWith(2, "job-1", {
+			status: "failed",
+			error: expect.stringContaining("invalidValueUploadFailed"),
+			metadata: { providerJobId: "p1", errorDetail: thrown },
 		});
 	});
 });

--- a/app/api/queues/asset-generate/route.ts
+++ b/app/api/queues/asset-generate/route.ts
@@ -1,4 +1,5 @@
 import { handleCallback } from "@vercel/queue";
+import { serializeError } from "serialize-error";
 import { getJobHandler } from "@/lib/api/job-handlers";
 import type { AssetQueueMessage } from "@/lib/api/jobs";
 import { loadJobForProcessing, updateJob } from "@/lib/api/jobs";
@@ -26,10 +27,9 @@ export const POST = handleCallback<AssetQueueMessage>(
 				// A human message: job.error surfaces verbatim in the failure banner
 				// via rowView, so it must never be a JSON/stack dump.
 				error: humanErrorMessage(error, "Generation failed"),
-				// The raw error rides alongside so rowView can surface structured
-				// detail (e.g. Runware's {error:{code,parameter}}) for a job that
-				// failed at submit, before any live provider poll.
-				metadata: { ...job.metadata, errorDetail: error },
+				// Structured detail for rowView (e.g. Runware's {error:{code,parameter}}),
+				// serialized circular-safe so this updateJob can't itself throw mid-catch.
+				metadata: { ...job.metadata, errorDetail: serializeError(error) },
 			});
 			throw error;
 		}

--- a/app/api/queues/asset-generate/route.ts
+++ b/app/api/queues/asset-generate/route.ts
@@ -24,6 +24,10 @@ export const POST = handleCallback<AssetQueueMessage>(
 			await updateJob(jobId, {
 				status: "failed",
 				error: stringifyError(error),
+				// Keep the raw error alongside the stringified message so rowView can
+				// surface structured detail (e.g. Runware's {error:{code,parameter}})
+				// for a job that failed at submit, before any live provider poll.
+				metadata: { ...job.metadata, errorDetail: error },
 			});
 			throw error;
 		}

--- a/app/api/queues/asset-generate/route.ts
+++ b/app/api/queues/asset-generate/route.ts
@@ -3,7 +3,7 @@ import { getJobHandler } from "@/lib/api/job-handlers";
 import type { AssetQueueMessage } from "@/lib/api/jobs";
 import { loadJobForProcessing, updateJob } from "@/lib/api/jobs";
 import { logger } from "@/lib/api/logger";
-import { stringifyError } from "@/lib/errors";
+import { humanErrorMessage } from "@/lib/errors";
 
 export const POST = handleCallback<AssetQueueMessage>(
 	async ({ jobId, connectorType }) => {
@@ -23,10 +23,12 @@ export const POST = handleCallback<AssetQueueMessage>(
 			logger.error(error, `Job ${jobId} failed`);
 			await updateJob(jobId, {
 				status: "failed",
-				error: stringifyError(error),
-				// Keep the raw error alongside the stringified message so rowView can
-				// surface structured detail (e.g. Runware's {error:{code,parameter}})
-				// for a job that failed at submit, before any live provider poll.
+				// A human message: job.error surfaces verbatim in the failure banner
+				// via rowView, so it must never be a JSON/stack dump.
+				error: humanErrorMessage(error, "Generation failed"),
+				// The raw error rides alongside so rowView can surface structured
+				// detail (e.g. Runware's {error:{code,parameter}}) for a job that
+				// failed at submit, before any live provider poll.
 				metadata: { ...job.metadata, errorDetail: error },
 			});
 			throw error;

--- a/lib/__tests__/errors.test.ts
+++ b/lib/__tests__/errors.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { humanErrorMessage } from "../errors";
+
+describe("humanErrorMessage", () => {
+	it("returns a string error as-is", () => {
+		expect(humanErrorMessage("boom", "fallback")).toBe("boom");
+	});
+
+	it("returns the message of an Error instance (no stack, no JSON)", () => {
+		expect(humanErrorMessage(new Error("boom"), "fallback")).toBe("boom");
+	});
+
+	it("reads a flat {message} payload", () => {
+		expect(humanErrorMessage({ message: "flat" }, "fallback")).toBe("flat");
+	});
+
+	it("reads a wrapped {error: {message}} payload", () => {
+		expect(
+			humanErrorMessage({ error: { message: "wrapped" } }, "fallback"),
+		).toBe("wrapped");
+	});
+
+	it("reads the first entry of an {errors: [...]} batch payload", () => {
+		expect(
+			humanErrorMessage(
+				{ errors: [{ message: "first" }, { message: "second" }] },
+				"fallback",
+			),
+		).toBe("first");
+	});
+
+	it.each([
+		["null", null],
+		["undefined", undefined],
+		["a number", 42],
+		["an object with no message", { code: "weird" }],
+		["a non-string message", { message: 42 }],
+		["an empty errors array", { errors: [] }],
+	])("falls back for %s", (_label, value) => {
+		expect(humanErrorMessage(value, "fallback")).toBe("fallback");
+	});
+});

--- a/lib/api/__tests__/job-handlers.test.ts
+++ b/lib/api/__tests__/job-handlers.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../providers", () => {
+	const noopProvider = () => ({ generate: vi.fn(), poll: vi.fn() });
+	return {
+		getVideoProvider: noopProvider,
+		getImageProvider: noopProvider,
+		getMusicProvider: noopProvider,
+		getSFXProvider: noopProvider,
+		getTTSProvider: noopProvider,
+	};
+});
+
+import { rowView } from "../job-handlers";
+import type { JobRow } from "../jobs";
+
+function makeRow(overrides: Partial<JobRow>): JobRow {
+	return {
+		id: "job-1",
+		user_id: "u1",
+		project_id: null,
+		connector_type: "video",
+		status: "failed",
+		request: {},
+		result: null,
+		metadata: {},
+		error: "Upload failed",
+		created_at: "",
+		updated_at: "",
+		...overrides,
+	};
+}
+
+describe("rowView", () => {
+	it("surfaces errorDetail persisted in the job's metadata", () => {
+		const errorDetail = { error: { code: "invalidValueUploadFailed" } };
+		const view = rowView(makeRow({ metadata: { errorDetail } }));
+
+		expect(view.error).toBe("Upload failed");
+		expect(view.errorDetail).toBe(errorDetail);
+	});
+
+	it("leaves errorDetail undefined when metadata has none", () => {
+		const view = rowView(makeRow({ metadata: { providerJobId: "p1" } }));
+		expect(view.errorDetail).toBeUndefined();
+	});
+});

--- a/lib/api/handlers/__tests__/video.test.ts
+++ b/lib/api/handlers/__tests__/video.test.ts
@@ -57,7 +57,28 @@ describe("videoHandler.poll", () => {
 
 		expect(result?.status).toBe("failed");
 		expect(result?.error).toBe("Upload failed");
-		expect(result?.errorDetail).toBe(errorDetail);
+		// toEqual, not toBe: errorDetail is re-serialized (circular-safe) on the way through.
+		expect(result?.errorDetail).toEqual(errorDetail);
+	});
+
+	it("serializes a circular errorDetail so persisting it can't throw", async () => {
+		const errorDetail: Record<string, unknown> = { error: { code: "boom" } };
+		errorDetail.self = errorDetail;
+		mockPoll.mockResolvedValue({
+			id: "",
+			provider: "runware",
+			result: {},
+			metadata: { status: "failed", error: "Upload failed", errorDetail },
+		});
+
+		const result = await videoHandler.poll?.(makeJob("provider-job-1"));
+
+		// supabase-js JSON.stringifies metadata on write (and the JobPoll result
+		// goes through the HTTP response) — a circular errorDetail would throw.
+		const persisted = mockUpdateJob.mock.calls[0][1].metadata.errorDetail;
+		expect(() => JSON.stringify(persisted)).not.toThrow();
+		expect(persisted.error.code).toBe("boom");
+		expect(() => JSON.stringify(result?.errorDetail)).not.toThrow();
 	});
 
 	it("persists errorDetail into merged metadata (preserving providerJobId) for a later rowView", async () => {

--- a/lib/api/handlers/__tests__/video.test.ts
+++ b/lib/api/handlers/__tests__/video.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { mockPoll } = vi.hoisted(() => ({ mockPoll: vi.fn() }));
+const mockUpdateJob = vi.fn();
+
+vi.mock("../../providers", () => {
+	const noopProvider = () => ({ generate: vi.fn(), poll: vi.fn() });
+	return {
+		getVideoProvider: () => ({ generate: vi.fn(), poll: mockPoll }),
+		getImageProvider: noopProvider,
+		getMusicProvider: noopProvider,
+		getSFXProvider: noopProvider,
+		getTTSProvider: noopProvider,
+	};
+});
+vi.mock("../../jobs", () => ({
+	updateJob: (...args: unknown[]) => mockUpdateJob(...args),
+}));
+
+import { videoHandler } from "../video";
+import type { TypedJobRow } from "../../job-handlers";
+import type { VideoGenerateParams } from "@/lib/connectors/types";
+
+function makeJob(
+	providerJobId?: string,
+): TypedJobRow<VideoGenerateParams, { providerJobId?: string }> {
+	return {
+		id: "job-1",
+		user_id: "u1",
+		project_id: null,
+		connector_type: "video",
+		status: "processing",
+		request: { prompt: "test" },
+		result: null,
+		metadata: { providerJobId },
+		error: null,
+		created_at: "",
+		updated_at: "",
+	};
+}
+
+describe("videoHandler.poll", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("carries the upstream provider's errorDetail through into the JobPoll result", async () => {
+		const errorDetail = { error: { code: "invalidValueUploadFailed" } };
+		mockPoll.mockResolvedValue({
+			id: "",
+			provider: "runware",
+			result: {},
+			metadata: { status: "failed", error: "Upload failed", errorDetail },
+		});
+
+		const result = await videoHandler.poll?.(makeJob("provider-job-1"));
+
+		expect(result?.status).toBe("failed");
+		expect(result?.error).toBe("Upload failed");
+		expect(result?.errorDetail).toBe(errorDetail);
+	});
+
+	it("persists errorDetail into merged metadata (preserving providerJobId) for a later rowView", async () => {
+		const errorDetail = { error: { code: "invalidValueUploadFailed" } };
+		mockPoll.mockResolvedValue({
+			id: "",
+			provider: "runware",
+			result: {},
+			metadata: { status: "failed", error: "Upload failed", errorDetail },
+		});
+
+		await videoHandler.poll?.(makeJob("provider-job-1"));
+
+		expect(mockUpdateJob).toHaveBeenCalledWith("job-1", {
+			status: "failed",
+			error: "Upload failed",
+			metadata: { providerJobId: "provider-job-1", errorDetail },
+		});
+	});
+
+	it("leaves errorDetail undefined and does not rewrite metadata when the provider didn't capture one", async () => {
+		mockPoll.mockResolvedValue({
+			id: "",
+			provider: "runware",
+			result: {},
+			metadata: { status: "failed", error: "Video generation failed" },
+		});
+
+		const result = await videoHandler.poll?.(makeJob("provider-job-1"));
+
+		expect(result?.status).toBe("failed");
+		expect(result?.errorDetail).toBeUndefined();
+		// No errorDetail → no metadata write (avoids a pointless rewrite).
+		expect(mockUpdateJob).toHaveBeenCalledWith("job-1", {
+			status: "failed",
+			error: "Video generation failed",
+		});
+	});
+});

--- a/lib/api/handlers/video.ts
+++ b/lib/api/handlers/video.ts
@@ -29,8 +29,19 @@ export const videoHandler: JobHandler<VideoGenerateParams, VideoMetadata> = {
 		}
 		if (status === "failed") {
 			const error = upstream.metadata?.error ?? "Video generation failed";
-			await updateJob(job.id, { status, error });
-			return { jobId: job.id, status, result: null, error };
+			const errorDetail = upstream.metadata?.errorDetail;
+			await updateJob(job.id, {
+				status,
+				error,
+				// Merge (not replace) so providerJobId survives; persist errorDetail
+				// so a later rowView re-fetch of this failed job still carries it.
+				// `!= null` so an explicit null (possible across the JSON boundary)
+				// isn't persisted as a useless errorDetail: null.
+				...(errorDetail != null && {
+					metadata: { ...job.metadata, errorDetail },
+				}),
+			});
+			return { jobId: job.id, status, result: null, error, errorDetail };
 		}
 		return { jobId: job.id, status, result: null, error: null };
 	},

--- a/lib/api/handlers/video.ts
+++ b/lib/api/handlers/video.ts
@@ -1,3 +1,4 @@
+import { serializeError } from "serialize-error";
 import type { VideoGenerateParams } from "@/lib/connectors/types";
 import type { JobPoll, JobStatus } from "@/lib/gateway/base";
 import type { VideoProviderResponse } from "@/lib/providers/video/base";
@@ -29,14 +30,16 @@ export const videoHandler: JobHandler<VideoGenerateParams, VideoMetadata> = {
 		}
 		if (status === "failed") {
 			const error = upstream.metadata?.error ?? "Video generation failed";
-			const errorDetail = upstream.metadata?.errorDetail;
+			const rawDetail = upstream.metadata?.errorDetail;
+			// Circular-safe, same guard as the submit path in the queue worker —
+			// this value is JSON.stringified into jsonb and the HTTP response.
+			const errorDetail =
+				rawDetail != null ? serializeError(rawDetail) : undefined;
 			await updateJob(job.id, {
 				status,
 				error,
 				// Merge (not replace) so providerJobId survives; persist errorDetail
 				// so a later rowView re-fetch of this failed job still carries it.
-				// `!= null` so an explicit null (possible across the JSON boundary)
-				// isn't persisted as a useless errorDetail: null.
 				...(errorDetail != null && {
 					metadata: { ...job.metadata, errorDetail },
 				}),

--- a/lib/api/job-handlers.ts
+++ b/lib/api/job-handlers.ts
@@ -39,6 +39,10 @@ export function rowView(job: JobRow): JobPoll {
 		status: job.status,
 		result: job.result,
 		error: job.error,
+		// Surfaced from persisted metadata so a job that failed before a live
+		// provider poll (e.g. a submit-time rejection) still carries the raw
+		// error for classification — matches videoHandler.poll's live path.
+		errorDetail: job.metadata?.errorDetail,
 	};
 }
 

--- a/lib/connectors/__tests__/_gateway-mock.ts
+++ b/lib/connectors/__tests__/_gateway-mock.ts
@@ -17,6 +17,7 @@ export type GatewayStep = {
 	pollStatus?: JobStatus;
 	result?: BundleResponse;
 	error?: string;
+	errorDetail?: unknown;
 	payload?: unknown;
 };
 
@@ -30,6 +31,7 @@ function stepToResponse(step: GatewayStep, jobId: string): Response {
 			status: step.pollStatus,
 			result: step.result ?? null,
 			error: step.error ?? null,
+			errorDetail: step.errorDetail,
 		} satisfies JobPoll);
 	}
 	return jsonResponse(step.payload);

--- a/lib/connectors/__tests__/asset-base.test.ts
+++ b/lib/connectors/__tests__/asset-base.test.ts
@@ -39,6 +39,13 @@ function makeGateway(
 	};
 }
 
+function makeFailingGateway(poll: JobPoll): AssetGateway<TestParams> {
+	return {
+		generate: async () => ({ jobId: "job", status: "pending" }),
+		poll: async () => poll,
+	};
+}
+
 class TestAssetConnector extends BaseAssetConnector<TestParams, TestResult> {
 	readonly type: ConnectorType = "image";
 	readonly assetKey = "image";
@@ -53,6 +60,15 @@ class TestAssetConnector extends BaseAssetConnector<TestParams, TestResult> {
 			),
 			config,
 		);
+	}
+}
+
+class GatewayAssetConnector extends BaseAssetConnector<TestParams, TestResult> {
+	readonly type: ConnectorType = "video";
+	readonly assetKey = "video";
+
+	constructor(config: ConnectorConfig, gateway: AssetGateway<TestParams>) {
+		super(gateway, config);
 	}
 }
 
@@ -150,6 +166,47 @@ describe("BaseAssetConnector", () => {
 			await expect(connector.generate({ prompt: "test" })).rejects.toThrow(
 				"gateway failed",
 			);
+		});
+
+		it("throws with the poll's errorDetail as cause when the job fails", async () => {
+			const errorDetail = { error: { code: "invalidValueUploadFailed" } };
+			const connector = new GatewayAssetConnector(
+				config,
+				makeFailingGateway({
+					jobId: "job",
+					status: "failed",
+					result: null,
+					error: "Processing failed",
+					errorDetail,
+				}),
+			);
+
+			try {
+				await connector.generate({ prompt: "test" });
+				expect.unreachable();
+			} catch (err) {
+				expect((err as Error).message).toBe("Processing failed");
+				expect((err as Error).cause).toBe(errorDetail);
+			}
+		});
+
+		it("has an undefined cause when the poll result carries no errorDetail", async () => {
+			const connector = new GatewayAssetConnector(
+				config,
+				makeFailingGateway({
+					jobId: "job",
+					status: "failed",
+					result: null,
+					error: "Processing failed",
+				}),
+			);
+
+			try {
+				await connector.generate({ prompt: "test" });
+				expect.unreachable();
+			} catch (err) {
+				expect((err as Error).cause).toBeUndefined();
+			}
 		});
 
 		it("handles external urls in bundle response", async () => {

--- a/lib/connectors/__tests__/video.test.ts
+++ b/lib/connectors/__tests__/video.test.ts
@@ -70,6 +70,21 @@ describe("BaseVideoConnector", () => {
 		).rejects.toThrow("GPU unavailable");
 	});
 
+	it("carries the poll's errorDetail as the thrown error's cause, across the HTTP round trip", async () => {
+		const errorDetail = { error: { code: "invalidValueUploadFailed" } };
+		mockGatewaySequence([
+			{ submitStatus: "pending" },
+			{ pollStatus: "failed", error: "Upload failed", errorDetail },
+		]);
+
+		try {
+			await new OpenSlopVideo(config).generate({ prompt: "test" });
+			expect.unreachable();
+		} catch (err) {
+			expect((err as Error).cause).toEqual(errorDetail);
+		}
+	});
+
 	it("runs plugins in order", async () => {
 		mockSuccess();
 		const order: string[] = [];

--- a/lib/connectors/animated_image/plugins/__tests__/animated-image-chain.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/animated-image-chain.test.ts
@@ -98,7 +98,7 @@ describe("createVideoChainPlugin", () => {
 		} satisfies AssetResult;
 
 		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
-			"Couldn't animate: the source image failed to generate. Try regenerating the image.",
+			"Couldn't animate: the video provider couldn't use the still image. Try regenerating the image.",
 		);
 
 		try {
@@ -110,6 +110,60 @@ describe("createVideoChainPlugin", () => {
 			// the UI renders it verbatim.
 			expect((err as Error).message).not.toContain("invalidValueUploadFailed");
 		}
+	});
+
+	it("translates on a matching error.parameter alone, regardless of error.code", async () => {
+		generateMock.mockReset();
+		generateMock.mockRejectedValue({
+			error: {
+				code: "someOtherCode",
+				message: "Something about the frame went wrong.",
+				parameter: "inputs.frameImages",
+			},
+		});
+
+		const plugin = createVideoChainPlugin(registry);
+		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
+		await plugin.beforeGenerate?.(
+			{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
+			ctx,
+		);
+
+		const still = {
+			imageUrl: "https://example.com/still.png",
+			durationSec: 0,
+		} satisfies AssetResult;
+
+		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
+			"Couldn't animate: the video provider couldn't use the still image. Try regenerating the image.",
+		);
+	});
+
+	it("translates on a matching error.code alone, regardless of error.parameter", async () => {
+		generateMock.mockReset();
+		generateMock.mockRejectedValue({
+			error: {
+				code: "invalidValueUploadFailed",
+				message: "Upload failed for an unrelated parameter.",
+				parameter: "inputs.someOtherField",
+			},
+		});
+
+		const plugin = createVideoChainPlugin(registry);
+		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
+		await plugin.beforeGenerate?.(
+			{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
+			ctx,
+		);
+
+		const still = {
+			imageUrl: "https://example.com/still.png",
+			durationSec: 0,
+		} satisfies AssetResult;
+
+		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
+			"Couldn't animate: the video provider couldn't use the still image. Try regenerating the image.",
+		);
 	});
 
 	it("does not rewrite an unrelated video-provider error", async () => {
@@ -130,6 +184,37 @@ describe("createVideoChainPlugin", () => {
 
 		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
 			"Runware: rate limit exceeded",
+		);
+	});
+
+	it("does not rewrite an error that merely mentions frameImages in passing (structured code/parameter only)", async () => {
+		generateMock.mockReset();
+		// An unrelated error whose free-text message happens to mention
+		// "frameImages" should NOT be misclassified as a frame-image failure —
+		// only a matching structured error.code/error.parameter counts.
+		const unrelatedError = {
+			error: {
+				code: "rateLimitExceeded",
+				message: "Too many requests for task with inputs.frameImages set.",
+				parameter: "apiKey",
+			},
+		};
+		generateMock.mockRejectedValue(unrelatedError);
+
+		const plugin = createVideoChainPlugin(registry);
+		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
+		await plugin.beforeGenerate?.(
+			{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
+			ctx,
+		);
+
+		const still = {
+			imageUrl: "https://example.com/still.png",
+			durationSec: 0,
+		} satisfies AssetResult;
+
+		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toBe(
+			unrelatedError,
 		);
 	});
 

--- a/lib/connectors/animated_image/plugins/__tests__/animated-image-chain.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/animated-image-chain.test.ts
@@ -26,6 +26,34 @@ const registry: ConnectorRegistry = {
 	music: { openslop: { defaultModel: "m", models: ["m"], isDefault: true } },
 };
 
+// What video.generate() actually throws in production: asset-base.ts's
+// generic job-status pipeline, carrying the provider's raw error as `cause`.
+function providerFailure(message: string, cause?: unknown): Error {
+	return new Error(message, { cause });
+}
+
+async function runChain(rejection: Error) {
+	generateMock.mockReset();
+	generateMock.mockRejectedValue(rejection);
+
+	const plugin = createVideoChainPlugin(registry);
+	const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
+	await plugin.beforeGenerate?.(
+		{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
+		ctx,
+	);
+
+	const still = {
+		imageUrl: "https://example.com/still.png",
+		durationSec: 0,
+	} satisfies AssetResult;
+
+	return plugin.afterGenerate?.(still, ctx);
+}
+
+const FRIENDLY_MESSAGE =
+	"Couldn't animate: the video provider couldn't use the still image. Try regenerating the image.";
+
 describe("createVideoChainPlugin", () => {
 	it("stashes videoPrompt and animates the still via the video connector", async () => {
 		generateMock.mockReset();
@@ -73,9 +101,8 @@ describe("createVideoChainPlugin", () => {
 		});
 	});
 
-	it("translates a frameImages provider error into a human-readable message, keeping the raw detail as cause", async () => {
-		generateMock.mockReset();
-		const providerError = {
+	it("translates a frame-image failure into a human-readable message, keeping the raw detail as cause", async () => {
+		const cause = {
 			error: {
 				code: "invalidValueUploadFailed",
 				message: "Processing parameter 'inputs.frameImages' failed.",
@@ -83,139 +110,51 @@ describe("createVideoChainPlugin", () => {
 				taskUUID: "abc-123",
 			},
 		};
-		generateMock.mockRejectedValue(providerError);
+		const rejection = providerFailure("Upload failed", cause);
 
-		const plugin = createVideoChainPlugin(registry);
-		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
-		await plugin.beforeGenerate?.(
-			{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
-			ctx,
-		);
-
-		const still = {
-			imageUrl: "https://example.com/still.png",
-			durationSec: 0,
-		} satisfies AssetResult;
-
-		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
-			"Couldn't animate: the video provider couldn't use the still image. Try regenerating the image.",
-		);
+		await expect(runChain(rejection)).rejects.toThrow(FRIENDLY_MESSAGE);
 
 		try {
-			await plugin.afterGenerate?.(still, ctx);
+			await runChain(rejection);
 			expect.unreachable();
 		} catch (err) {
-			expect((err as Error).cause).toEqual(providerError);
-			// The raw provider detail must not leak into the user-facing message —
-			// the UI renders it verbatim.
+			// The original provider error is preserved wholesale on `cause` — its
+			// own `.cause` still carries the raw structured payload for logging.
+			expect((err as Error).cause).toBe(rejection);
+			expect((rejection.cause as { error: unknown }).error).toBe(cause.error);
 			expect((err as Error).message).not.toContain("invalidValueUploadFailed");
 		}
 	});
 
-	it("translates on a matching error.parameter alone, regardless of error.code", async () => {
-		generateMock.mockReset();
-		generateMock.mockRejectedValue({
-			error: {
-				code: "someOtherCode",
-				message: "Something about the frame went wrong.",
-				parameter: "inputs.frameImages",
-			},
-		});
-
-		const plugin = createVideoChainPlugin(registry);
-		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
-		await plugin.beforeGenerate?.(
-			{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
-			ctx,
-		);
-
-		const still = {
-			imageUrl: "https://example.com/still.png",
-			durationSec: 0,
-		} satisfies AssetResult;
-
-		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
-			"Couldn't animate: the video provider couldn't use the still image. Try regenerating the image.",
-		);
+	it("translates on a matching parameter alone, regardless of code", async () => {
+		const cause = { code: "someOtherCode", parameter: "inputs.frameImages" };
+		await expect(
+			runChain(providerFailure("Upload failed", cause)),
+		).rejects.toThrow(FRIENDLY_MESSAGE);
 	});
 
-	it("translates on a matching error.code alone, regardless of error.parameter", async () => {
-		generateMock.mockReset();
-		generateMock.mockRejectedValue({
-			error: {
-				code: "invalidValueUploadFailed",
-				message: "Upload failed for an unrelated parameter.",
-				parameter: "inputs.someOtherField",
-			},
-		});
-
-		const plugin = createVideoChainPlugin(registry);
-		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
-		await plugin.beforeGenerate?.(
-			{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
-			ctx,
-		);
-
-		const still = {
-			imageUrl: "https://example.com/still.png",
-			durationSec: 0,
-		} satisfies AssetResult;
-
-		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
-			"Couldn't animate: the video provider couldn't use the still image. Try regenerating the image.",
-		);
+	it("translates on a matching code alone, regardless of parameter", async () => {
+		const cause = {
+			code: "invalidValueUploadFailed",
+			parameter: "inputs.someOtherField",
+		};
+		await expect(
+			runChain(providerFailure("Upload failed", cause)),
+		).rejects.toThrow(FRIENDLY_MESSAGE);
 	});
 
 	it("does not rewrite an unrelated video-provider error", async () => {
-		generateMock.mockReset();
-		generateMock.mockRejectedValue(new Error("Runware: rate limit exceeded"));
+		const rejection = providerFailure("Runware: rate limit exceeded", {
+			code: "rateLimitExceeded",
+			parameter: "apiKey",
+		});
 
-		const plugin = createVideoChainPlugin(registry);
-		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
-		await plugin.beforeGenerate?.(
-			{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
-			ctx,
-		);
-
-		const still = {
-			imageUrl: "https://example.com/still.png",
-			durationSec: 0,
-		} satisfies AssetResult;
-
-		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
-			"Runware: rate limit exceeded",
-		);
+		await expect(runChain(rejection)).rejects.toBe(rejection);
 	});
 
-	it("does not rewrite an error that merely mentions frameImages in passing (structured code/parameter only)", async () => {
-		generateMock.mockReset();
-		// An unrelated error whose free-text message happens to mention
-		// "frameImages" should NOT be misclassified as a frame-image failure —
-		// only a matching structured error.code/error.parameter counts.
-		const unrelatedError = {
-			error: {
-				code: "rateLimitExceeded",
-				message: "Too many requests for task with inputs.frameImages set.",
-				parameter: "apiKey",
-			},
-		};
-		generateMock.mockRejectedValue(unrelatedError);
-
-		const plugin = createVideoChainPlugin(registry);
-		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
-		await plugin.beforeGenerate?.(
-			{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
-			ctx,
-		);
-
-		const still = {
-			imageUrl: "https://example.com/still.png",
-			durationSec: 0,
-		} satisfies AssetResult;
-
-		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toBe(
-			unrelatedError,
-		);
+	it("does not rewrite when the error has no cause at all (e.g. a connection failure)", async () => {
+		const rejection = providerFailure("WebSocket disconnected");
+		await expect(runChain(rejection)).rejects.toBe(rejection);
 	});
 
 	it("throws when videoPrompt is missing so the still URL never leaks into video rendering", async () => {

--- a/lib/connectors/animated_image/plugins/__tests__/animated-image-chain.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/animated-image-chain.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const generateMock = vi.fn();
 
@@ -26,7 +26,19 @@ const registry: ConnectorRegistry = {
 	music: { openslop: { defaultModel: "m", models: ["m"], isDefault: true } },
 };
 
+const fetchMock = vi.fn();
+
 describe("createVideoChainPlugin", () => {
+	beforeEach(() => {
+		fetchMock.mockReset();
+		fetchMock.mockResolvedValue({ ok: true, status: 200 });
+		vi.stubGlobal("fetch", fetchMock);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
 	it("stashes videoPrompt and animates the still via the video connector", async () => {
 		generateMock.mockReset();
 		generateMock.mockResolvedValue({
@@ -59,6 +71,10 @@ describe("createVideoChainPlugin", () => {
 		} satisfies AssetResult;
 		const result = (await plugin.afterGenerate?.(still, ctx)) as AssetResult;
 
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://example.com/still.png",
+			expect.objectContaining({ method: "HEAD" }),
+		);
 		expect(generateMock).toHaveBeenCalledWith({
 			prompt: "slow zoom in",
 			frameImages: ["https://example.com/still.png"],
@@ -71,6 +87,102 @@ describe("createVideoChainPlugin", () => {
 			videoUrl: "https://example.com/video.mp4",
 			durationSec: 5,
 		});
+	});
+
+	it("aborts before calling the video connector when the still image isn't fetchable", async () => {
+		generateMock.mockReset();
+		fetchMock.mockResolvedValue({ ok: false, status: 404 });
+
+		const plugin = createVideoChainPlugin(registry);
+		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
+		await plugin.beforeGenerate?.(
+			{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
+			ctx,
+		);
+
+		const still = {
+			imageUrl: "https://example.com/still.png",
+			durationSec: 0,
+		} satisfies AssetResult;
+
+		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
+			/Couldn't animate: the source image failed to generate/,
+		);
+		expect(generateMock).not.toHaveBeenCalled();
+	});
+
+	it("aborts when the still image URL is unreachable (network error)", async () => {
+		generateMock.mockReset();
+		fetchMock.mockRejectedValue(new Error("fetch failed"));
+
+		const plugin = createVideoChainPlugin(registry);
+		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
+		await plugin.beforeGenerate?.(
+			{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
+			ctx,
+		);
+
+		const still = {
+			imageUrl: "https://example.com/still.png",
+			durationSec: 0,
+		} satisfies AssetResult;
+
+		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
+			/Couldn't animate: the source image failed to generate/,
+		);
+		expect(generateMock).not.toHaveBeenCalled();
+	});
+
+	it("translates a frameImages provider error into a human-readable message, keeping the raw detail", async () => {
+		generateMock.mockReset();
+		generateMock.mockRejectedValue({
+			error: {
+				code: "invalidValueUploadFailed",
+				message: "Processing parameter 'inputs.frameImages' failed.",
+				parameter: "inputs.frameImages",
+				taskUUID: "abc-123",
+			},
+		});
+
+		const plugin = createVideoChainPlugin(registry);
+		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
+		await plugin.beforeGenerate?.(
+			{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
+			ctx,
+		);
+
+		const still = {
+			imageUrl: "https://example.com/still.png",
+			durationSec: 0,
+		} satisfies AssetResult;
+
+		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
+			/Couldn't animate: the source image failed to generate/,
+		);
+		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
+			/invalidValueUploadFailed/,
+		);
+	});
+
+	it("does not rewrite an unrelated video-provider error", async () => {
+		generateMock.mockReset();
+		generateMock.mockRejectedValue(new Error("Runware: rate limit exceeded"));
+
+		const plugin = createVideoChainPlugin(registry);
+		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
+		await plugin.beforeGenerate?.(
+			{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
+			ctx,
+		);
+
+		const still = {
+			imageUrl: "https://example.com/still.png",
+			durationSec: 0,
+		} satisfies AssetResult;
+
+		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
+			"Runware: rate limit exceeded",
+		);
 	});
 
 	it("throws when videoPrompt is missing so the still URL never leaks into video rendering", async () => {

--- a/lib/connectors/animated_image/plugins/__tests__/animated-image-chain.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/animated-image-chain.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const generateMock = vi.fn();
 
@@ -26,19 +26,7 @@ const registry: ConnectorRegistry = {
 	music: { openslop: { defaultModel: "m", models: ["m"], isDefault: true } },
 };
 
-const fetchMock = vi.fn();
-
 describe("createVideoChainPlugin", () => {
-	beforeEach(() => {
-		fetchMock.mockReset();
-		fetchMock.mockResolvedValue({ ok: true, status: 200 });
-		vi.stubGlobal("fetch", fetchMock);
-	});
-
-	afterEach(() => {
-		vi.unstubAllGlobals();
-	});
-
 	it("stashes videoPrompt and animates the still via the video connector", async () => {
 		generateMock.mockReset();
 		generateMock.mockResolvedValue({
@@ -71,10 +59,6 @@ describe("createVideoChainPlugin", () => {
 		} satisfies AssetResult;
 		const result = (await plugin.afterGenerate?.(still, ctx)) as AssetResult;
 
-		expect(fetchMock).toHaveBeenCalledWith(
-			"https://example.com/still.png",
-			expect.objectContaining({ method: "HEAD" }),
-		);
 		expect(generateMock).toHaveBeenCalledWith({
 			prompt: "slow zoom in",
 			frameImages: ["https://example.com/still.png"],
@@ -89,60 +73,17 @@ describe("createVideoChainPlugin", () => {
 		});
 	});
 
-	it("aborts before calling the video connector when the still image isn't fetchable", async () => {
+	it("translates a frameImages provider error into a human-readable message, keeping the raw detail as cause", async () => {
 		generateMock.mockReset();
-		fetchMock.mockResolvedValue({ ok: false, status: 404 });
-
-		const plugin = createVideoChainPlugin(registry);
-		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
-		await plugin.beforeGenerate?.(
-			{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
-			ctx,
-		);
-
-		const still = {
-			imageUrl: "https://example.com/still.png",
-			durationSec: 0,
-		} satisfies AssetResult;
-
-		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
-			/Couldn't animate: the source image failed to generate/,
-		);
-		expect(generateMock).not.toHaveBeenCalled();
-	});
-
-	it("aborts when the still image URL is unreachable (network error)", async () => {
-		generateMock.mockReset();
-		fetchMock.mockRejectedValue(new Error("fetch failed"));
-
-		const plugin = createVideoChainPlugin(registry);
-		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
-		await plugin.beforeGenerate?.(
-			{ prompt: "a dark forest", videoPrompt: "slow zoom in" },
-			ctx,
-		);
-
-		const still = {
-			imageUrl: "https://example.com/still.png",
-			durationSec: 0,
-		} satisfies AssetResult;
-
-		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
-			/Couldn't animate: the source image failed to generate/,
-		);
-		expect(generateMock).not.toHaveBeenCalled();
-	});
-
-	it("translates a frameImages provider error into a human-readable message, keeping the raw detail", async () => {
-		generateMock.mockReset();
-		generateMock.mockRejectedValue({
+		const providerError = {
 			error: {
 				code: "invalidValueUploadFailed",
 				message: "Processing parameter 'inputs.frameImages' failed.",
 				parameter: "inputs.frameImages",
 				taskUUID: "abc-123",
 			},
-		});
+		};
+		generateMock.mockRejectedValue(providerError);
 
 		const plugin = createVideoChainPlugin(registry);
 		const ctx: PluginContext<AnimatedImageGenerateParams, AssetResult> = {};
@@ -157,11 +98,18 @@ describe("createVideoChainPlugin", () => {
 		} satisfies AssetResult;
 
 		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
-			/Couldn't animate: the source image failed to generate/,
+			"Couldn't animate: the source image failed to generate. Try regenerating the image.",
 		);
-		await expect(plugin.afterGenerate?.(still, ctx)).rejects.toThrow(
-			/invalidValueUploadFailed/,
-		);
+
+		try {
+			await plugin.afterGenerate?.(still, ctx);
+			expect.unreachable();
+		} catch (err) {
+			expect((err as Error).cause).toEqual(providerError);
+			// The raw provider detail must not leak into the user-facing message —
+			// the UI renders it verbatim.
+			expect((err as Error).message).not.toContain("invalidValueUploadFailed");
+		}
 	});
 
 	it("does not rewrite an unrelated video-provider error", async () => {

--- a/lib/connectors/animated_image/plugins/__tests__/animated-image-chain.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/animated-image-chain.test.ts
@@ -143,6 +143,17 @@ describe("createVideoChainPlugin", () => {
 		).rejects.toThrow(FRIENDLY_MESSAGE);
 	});
 
+	it("translates an {errors: [...]} batch payload, mirroring the provider's isApiError", async () => {
+		const cause = {
+			errors: [
+				{ code: "invalidValueUploadFailed", parameter: "inputs.frameImages" },
+			],
+		};
+		await expect(
+			runChain(providerFailure("Upload failed", cause)),
+		).rejects.toThrow(FRIENDLY_MESSAGE);
+	});
+
 	it("does not rewrite an unrelated video-provider error", async () => {
 		const rejection = providerFailure("Runware: rate limit exceeded", {
 			code: "rateLimitExceeded",

--- a/lib/connectors/animated_image/plugins/animated-image-chain.ts
+++ b/lib/connectors/animated_image/plugins/animated-image-chain.ts
@@ -3,7 +3,6 @@ import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import { createConnector } from "@/lib/connectors/factory";
 import { buildImagePlugins } from "@/lib/connectors/image/plugins/imageChain";
-import { stringifyError } from "@/lib/errors";
 import type {
 	AnimatedImageGenerateParams,
 	AssetResult,
@@ -20,16 +19,29 @@ type Stashed = {
 };
 
 const STILL_IMAGE_FAILED_MESSAGE =
-	"Couldn't animate: the source image failed to generate. Try regenerating the image.";
+	"Couldn't animate: the video provider couldn't use the still image. Try regenerating the image.";
+
+/** Shape of a failed Runware task response — see IErrorResponse in @runware/sdk-js. */
+type RunwareApiError = {
+	error?: {
+		code?: string;
+		parameter?: string;
+	};
+};
 
 // Marks a video-provider failure as belonging to the still-image frame we
 // handed it, rather than an unrelated video-generation failure (rate limit,
 // auth, model outage, ...) that shouldn't be misattributed to the image step.
-const FRAME_IMAGE_FAILURE_MARKERS = ["frameimages", "invalidvalueuploadfailed"];
-
+// Matches Runware's structured error.code/error.parameter directly rather
+// than string-matching the serialized error, which is sturdier against
+// unrelated fields that happen to mention "frameImages" in passing.
 function isFrameImageFailure(err: unknown): boolean {
-	const text = stringifyError(err).toLowerCase();
-	return FRAME_IMAGE_FAILURE_MARKERS.some((marker) => text.includes(marker));
+	if (typeof err !== "object" || err === null) return false;
+	const apiError = (err as RunwareApiError).error;
+	return (
+		apiError?.parameter === "inputs.frameImages" ||
+		apiError?.code === "invalidValueUploadFailed"
+	);
 }
 
 export function createVideoChainPlugin(

--- a/lib/connectors/animated_image/plugins/animated-image-chain.ts
+++ b/lib/connectors/animated_image/plugins/animated-image-chain.ts
@@ -25,35 +25,11 @@ const STILL_IMAGE_FAILED_MESSAGE =
 // Marks a video-provider failure as belonging to the still-image frame we
 // handed it, rather than an unrelated video-generation failure (rate limit,
 // auth, model outage, ...) that shouldn't be misattributed to the image step.
-const FRAME_IMAGE_FAILURE_MARKERS = [
-	"frameimages",
-	"invaliduploadfailed",
-	"invalidvalueuploadfailed",
-];
+const FRAME_IMAGE_FAILURE_MARKERS = ["frameimages", "invalidvalueuploadfailed"];
 
 function isFrameImageFailure(err: unknown): boolean {
 	const text = stringifyError(err).toLowerCase();
 	return FRAME_IMAGE_FAILURE_MARKERS.some((marker) => text.includes(marker));
-}
-
-function withRawDetail(message: string, err: unknown): Error {
-	return new Error(`${message}\n\nRaw error: ${stringifyError(err)}`);
-}
-
-/** HEAD-check that the still image is actually fetchable before handing it to the video provider as a frame. */
-async function assertStillImageIsUsable(imageUrl: string): Promise<void> {
-	let response: Response;
-	try {
-		response = await fetch(imageUrl, { method: "HEAD" });
-	} catch (err) {
-		throw withRawDetail(STILL_IMAGE_FAILED_MESSAGE, err);
-	}
-	if (!response.ok) {
-		throw withRawDetail(
-			STILL_IMAGE_FAILED_MESSAGE,
-			new Error(`still image URL responded with status ${response.status}`),
-		);
-	}
 }
 
 export function createVideoChainPlugin(
@@ -87,7 +63,6 @@ export function createVideoChainPlugin(
 					"animated_image chain expected an imageUrl from the still-image generation",
 				);
 			}
-			await assertStillImageIsUsable(result.imageUrl);
 
 			const { provider, config } = getDefaultConnector(registry, "video");
 			const video = createConnector(
@@ -106,7 +81,10 @@ export function createVideoChainPlugin(
 				});
 			} catch (err) {
 				if (isFrameImageFailure(err)) {
-					throw withRawDetail(STILL_IMAGE_FAILED_MESSAGE, err);
+					// Raw provider detail is kept on `cause` (surfaced in server/console
+					// logs via handleJobError's console.error) rather than appended to
+					// the user-facing message, which the red banner renders verbatim.
+					throw new Error(STILL_IMAGE_FAILED_MESSAGE, { cause: err });
 				}
 				throw err;
 			}

--- a/lib/connectors/animated_image/plugins/animated-image-chain.ts
+++ b/lib/connectors/animated_image/plugins/animated-image-chain.ts
@@ -21,26 +21,22 @@ type Stashed = {
 const STILL_IMAGE_FAILED_MESSAGE =
 	"Couldn't animate: the video provider couldn't use the still image. Try regenerating the image.";
 
-/** Shape of a failed Runware task response — see IErrorResponse in @runware/sdk-js. */
-type RunwareApiError = {
-	error?: {
-		code?: string;
-		parameter?: string;
-	};
-};
+type RunwareErrorFields = { code?: string; parameter?: string };
 
-// Marks a video-provider failure as belonging to the still-image frame we
-// handed it, rather than an unrelated video-generation failure (rate limit,
-// auth, model outage, ...) that shouldn't be misattributed to the image step.
-// Matches Runware's structured error.code/error.parameter directly rather
-// than string-matching the serialized error, which is sturdier against
-// unrelated fields that happen to mention "frameImages" in passing.
+// A frame-image failure reaches us as asset-base.ts's job-status throw, which
+// carries the provider's raw error as `cause` (other failures — timeout, no
+// result, network — have no cause and fall through to a rethrow). Runware
+// shapes the payload as {error: {code, parameter, ...}} on a rejected poll, or
+// {code, parameter, ...} directly on a resolved-but-failed task — check both.
 function isFrameImageFailure(err: unknown): boolean {
-	if (typeof err !== "object" || err === null) return false;
-	const apiError = (err as RunwareApiError).error;
+	if (!(err instanceof Error)) return false;
+	const cause = err.cause;
+	if (typeof cause !== "object" || cause === null) return false;
+	const raw = cause as { error?: RunwareErrorFields } & RunwareErrorFields;
+	const apiError = raw.error ?? raw;
 	return (
-		apiError?.parameter === "inputs.frameImages" ||
-		apiError?.code === "invalidValueUploadFailed"
+		apiError.parameter === "inputs.frameImages" ||
+		apiError.code === "invalidValueUploadFailed"
 	);
 }
 

--- a/lib/connectors/animated_image/plugins/animated-image-chain.ts
+++ b/lib/connectors/animated_image/plugins/animated-image-chain.ts
@@ -3,6 +3,7 @@ import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import { createConnector } from "@/lib/connectors/factory";
 import { buildImagePlugins } from "@/lib/connectors/image/plugins/imageChain";
+import { stringifyError } from "@/lib/errors";
 import type {
 	AnimatedImageGenerateParams,
 	AssetResult,
@@ -17,6 +18,43 @@ type Stashed = {
 	videoHeight?: number;
 	duration?: number;
 };
+
+const STILL_IMAGE_FAILED_MESSAGE =
+	"Couldn't animate: the source image failed to generate. Try regenerating the image.";
+
+// Marks a video-provider failure as belonging to the still-image frame we
+// handed it, rather than an unrelated video-generation failure (rate limit,
+// auth, model outage, ...) that shouldn't be misattributed to the image step.
+const FRAME_IMAGE_FAILURE_MARKERS = [
+	"frameimages",
+	"invaliduploadfailed",
+	"invalidvalueuploadfailed",
+];
+
+function isFrameImageFailure(err: unknown): boolean {
+	const text = stringifyError(err).toLowerCase();
+	return FRAME_IMAGE_FAILURE_MARKERS.some((marker) => text.includes(marker));
+}
+
+function withRawDetail(message: string, err: unknown): Error {
+	return new Error(`${message}\n\nRaw error: ${stringifyError(err)}`);
+}
+
+/** HEAD-check that the still image is actually fetchable before handing it to the video provider as a frame. */
+async function assertStillImageIsUsable(imageUrl: string): Promise<void> {
+	let response: Response;
+	try {
+		response = await fetch(imageUrl, { method: "HEAD" });
+	} catch (err) {
+		throw withRawDetail(STILL_IMAGE_FAILED_MESSAGE, err);
+	}
+	if (!response.ok) {
+		throw withRawDetail(
+			STILL_IMAGE_FAILED_MESSAGE,
+			new Error(`still image URL responded with status ${response.status}`),
+		);
+	}
+}
 
 export function createVideoChainPlugin(
 	registry: ConnectorRegistry,
@@ -49,19 +87,29 @@ export function createVideoChainPlugin(
 					"animated_image chain expected an imageUrl from the still-image generation",
 				);
 			}
+			await assertStillImageIsUsable(result.imageUrl);
+
 			const { provider, config } = getDefaultConnector(registry, "video");
 			const video = createConnector(
 				"video",
 				provider,
 				set("plugins", [], config),
 			);
-			const videoResult = await video.generate({
-				prompt: stashed.videoPrompt,
-				frameImages: [result.imageUrl],
-				width: stashed.videoWidth,
-				height: stashed.videoHeight,
-				duration: stashed.duration,
-			});
+			let videoResult;
+			try {
+				videoResult = await video.generate({
+					prompt: stashed.videoPrompt,
+					frameImages: [result.imageUrl],
+					width: stashed.videoWidth,
+					height: stashed.videoHeight,
+					duration: stashed.duration,
+				});
+			} catch (err) {
+				if (isFrameImageFailure(err)) {
+					throw withRawDetail(STILL_IMAGE_FAILED_MESSAGE, err);
+				}
+				throw err;
+			}
 			return {
 				imageUrl: result.imageUrl,
 				videoUrl: videoResult.videoUrl,

--- a/lib/connectors/animated_image/plugins/animated-image-chain.ts
+++ b/lib/connectors/animated_image/plugins/animated-image-chain.ts
@@ -26,14 +26,18 @@ type RunwareErrorFields = { code?: string; parameter?: string };
 // A frame-image failure reaches us as asset-base.ts's job-status throw, which
 // carries the provider's raw error as `cause` (other failures — timeout, no
 // result, network — have no cause and fall through to a rethrow). Runware
-// shapes the payload as {error: {code, parameter, ...}} on a rejected poll, or
-// {code, parameter, ...} directly on a resolved-but-failed task — check both.
+// shapes the payload as {error: {code, parameter, ...}} on a rejected poll,
+// {code, parameter, ...} directly on a resolved-but-failed task, or an
+// {errors: [...]} batch — check all three, mirroring the provider's isApiError.
 function isFrameImageFailure(err: unknown): boolean {
 	if (!(err instanceof Error)) return false;
 	const cause = err.cause;
 	if (typeof cause !== "object" || cause === null) return false;
-	const raw = cause as { error?: RunwareErrorFields } & RunwareErrorFields;
-	const apiError = raw.error ?? raw;
+	const raw = cause as {
+		error?: RunwareErrorFields;
+		errors?: RunwareErrorFields[];
+	} & RunwareErrorFields;
+	const apiError = raw.error ?? raw.errors?.[0] ?? raw;
 	return (
 		apiError.parameter === "inputs.frameImages" ||
 		apiError.code === "invalidValueUploadFailed"

--- a/lib/connectors/asset-base.ts
+++ b/lib/connectors/asset-base.ts
@@ -44,7 +44,9 @@ export abstract class BaseAssetConnector<
 			(p) => p.status === "completed" || p.status === "failed",
 		);
 		if (completed.status === "failed") {
-			throw new Error(completed.error ?? "Generation failed");
+			throw new Error(completed.error ?? "Generation failed", {
+				cause: completed.errorDetail,
+			});
 		}
 		if (!completed.result) {
 			throw new Error("Generation completed without a result");

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -5,3 +5,27 @@ export const stringifyError = (error: unknown): string =>
 
 export const errorMessage = (error: unknown): string =>
 	error instanceof Error ? error.message : String(error);
+
+type WithMessage = { message?: unknown };
+
+/**
+ * A human-readable message for user-facing error fields (the red failure
+ * banner renders these verbatim) — never a raw JSON dump; keep the full
+ * payload on a separate structured field (e.g. errorDetail) instead. Handles
+ * strings, Error instances, and the common provider API shapes `{message}`,
+ * `{error: {message}}`, and `{errors: [{message}]}`.
+ */
+export function humanErrorMessage(error: unknown, fallback: string): string {
+	if (typeof error === "string") return error;
+	if (error instanceof Error) return error.message;
+	if (error !== null && typeof error === "object") {
+		const obj = error as WithMessage & {
+			error?: WithMessage;
+			errors?: WithMessage[];
+		};
+		const message =
+			obj.message ?? obj.error?.message ?? obj.errors?.[0]?.message;
+		if (typeof message === "string") return message;
+	}
+	return fallback;
+}

--- a/lib/gateway/base.ts
+++ b/lib/gateway/base.ts
@@ -13,6 +13,8 @@ export type JobPoll = {
 	status: JobStatus;
 	result: BundleResponse | null;
 	error: string | null;
+	/** Raw provider error payload behind `error`'s message, if the provider captured one. */
+	errorDetail?: unknown;
 };
 
 export abstract class AssetGateway<TParams> extends GatewayClient<

--- a/lib/providers/__tests__/runware-video.test.ts
+++ b/lib/providers/__tests__/runware-video.test.ts
@@ -182,16 +182,13 @@ describe("RunwareVideo", () => {
 		});
 
 		it("surfaces the provider's error detail when a resolved item reports failure", async () => {
+			const errorDetail = {
+				code: "invalidValueUploadFailed",
+				message: "Processing parameter 'inputs.frameImages' failed.",
+				parameter: "inputs.frameImages",
+			};
 			mockGetResponse.mockResolvedValue([
-				{
-					taskUUID: "job-1",
-					status: "failed",
-					error: {
-						code: "invalidValueUploadFailed",
-						message: "Processing parameter 'inputs.frameImages' failed.",
-						parameter: "inputs.frameImages",
-					},
-				},
+				{ taskUUID: "job-1", status: "failed", error: errorDetail },
 			]);
 
 			const provider = new RunwareVideo("test-key");
@@ -199,22 +196,25 @@ describe("RunwareVideo", () => {
 
 			expect(result.metadata?.status).toBe("failed");
 			expect(result.metadata?.error).toContain("invalidValueUploadFailed");
+			expect(result.metadata?.errorDetail).toEqual(errorDetail);
 		});
 
 		it("surfaces the provider's error detail when the status query itself rejects", async () => {
-			mockGetResponse.mockRejectedValue({
+			const rejection = {
 				error: {
 					code: "invalidValueUploadFailed",
 					message: "Processing parameter 'inputs.frameImages' failed.",
 					parameter: "inputs.frameImages",
 				},
-			});
+			};
+			mockGetResponse.mockRejectedValue(rejection);
 
 			const provider = new RunwareVideo("test-key");
 			const result = await provider.poll("job-1");
 
 			expect(result.metadata?.status).toBe("failed");
 			expect(result.metadata?.error).toContain("invalidValueUploadFailed");
+			expect(result.metadata?.errorDetail).toEqual(rejection);
 			expect(mockDisconnect).toHaveBeenCalled();
 		});
 

--- a/lib/providers/__tests__/runware-video.test.ts
+++ b/lib/providers/__tests__/runware-video.test.ts
@@ -181,7 +181,7 @@ describe("RunwareVideo", () => {
 			expect(mockDisconnect).toHaveBeenCalled();
 		});
 
-		it("surfaces the provider's error detail when a resolved item reports failure", async () => {
+		it("surfaces a human message on error and the full payload on errorDetail (resolved item)", async () => {
 			const errorDetail = {
 				code: "invalidValueUploadFailed",
 				message: "Processing parameter 'inputs.frameImages' failed.",
@@ -195,11 +195,15 @@ describe("RunwareVideo", () => {
 			const result = await provider.poll("job-1");
 
 			expect(result.metadata?.status).toBe("failed");
-			expect(result.metadata?.error).toContain("invalidValueUploadFailed");
+			// error is the human message (renders in the banner), NOT a JSON dump.
+			expect(result.metadata?.error).toBe(
+				"Processing parameter 'inputs.frameImages' failed.",
+			);
+			expect(result.metadata?.error).not.toContain("{");
 			expect(result.metadata?.errorDetail).toEqual(errorDetail);
 		});
 
-		it("surfaces the provider's error detail when the status query itself rejects", async () => {
+		it("surfaces a human message on error and the full payload on errorDetail (rejected query, wrapped shape)", async () => {
 			const rejection = {
 				error: {
 					code: "invalidValueUploadFailed",
@@ -213,9 +217,25 @@ describe("RunwareVideo", () => {
 			const result = await provider.poll("job-1");
 
 			expect(result.metadata?.status).toBe("failed");
-			expect(result.metadata?.error).toContain("invalidValueUploadFailed");
+			// Pulled from the nested error.message, not a stringify of the wrapper.
+			expect(result.metadata?.error).toBe(
+				"Processing parameter 'inputs.frameImages' failed.",
+			);
+			expect(result.metadata?.error).not.toContain("{");
 			expect(result.metadata?.errorDetail).toEqual(rejection);
 			expect(mockDisconnect).toHaveBeenCalled();
+		});
+
+		it("falls back to a generic message when the failure has no readable message", async () => {
+			mockGetResponse.mockResolvedValue([
+				{ taskUUID: "job-1", status: "failed", error: { code: "weird" } },
+			]);
+
+			const provider = new RunwareVideo("test-key");
+			const result = await provider.poll("job-1");
+
+			expect(result.metadata?.error).toBe("Video generation failed");
+			expect(result.metadata?.errorDetail).toEqual({ code: "weird" });
 		});
 
 		it("rethrows a transient connection error instead of treating it as a permanent failure", async () => {

--- a/lib/providers/__tests__/runware-video.test.ts
+++ b/lib/providers/__tests__/runware-video.test.ts
@@ -180,5 +180,42 @@ describe("RunwareVideo", () => {
 			await expect(provider.poll("missing")).rejects.toThrow("Job not found");
 			expect(mockDisconnect).toHaveBeenCalled();
 		});
+
+		it("surfaces the provider's error detail when a resolved item reports failure", async () => {
+			mockGetResponse.mockResolvedValue([
+				{
+					taskUUID: "job-1",
+					status: "failed",
+					error: {
+						code: "invalidValueUploadFailed",
+						message: "Processing parameter 'inputs.frameImages' failed.",
+						parameter: "inputs.frameImages",
+					},
+				},
+			]);
+
+			const provider = new RunwareVideo("test-key");
+			const result = await provider.poll("job-1");
+
+			expect(result.metadata?.status).toBe("failed");
+			expect(result.metadata?.error).toContain("invalidValueUploadFailed");
+		});
+
+		it("surfaces the provider's error detail when the status query itself rejects", async () => {
+			mockGetResponse.mockRejectedValue({
+				error: {
+					code: "invalidValueUploadFailed",
+					message: "Processing parameter 'inputs.frameImages' failed.",
+					parameter: "inputs.frameImages",
+				},
+			});
+
+			const provider = new RunwareVideo("test-key");
+			const result = await provider.poll("job-1");
+
+			expect(result.metadata?.status).toBe("failed");
+			expect(result.metadata?.error).toContain("invalidValueUploadFailed");
+			expect(mockDisconnect).toHaveBeenCalled();
+		});
 	});
 });

--- a/lib/providers/__tests__/runware-video.test.ts
+++ b/lib/providers/__tests__/runware-video.test.ts
@@ -217,5 +217,32 @@ describe("RunwareVideo", () => {
 			expect(result.metadata?.error).toContain("invalidValueUploadFailed");
 			expect(mockDisconnect).toHaveBeenCalled();
 		});
+
+		it("rethrows a transient connection error instead of treating it as a permanent failure", async () => {
+			mockGetResponse.mockRejectedValue(new Error("WebSocket disconnected"));
+
+			const provider = new RunwareVideo("test-key");
+			await expect(provider.poll("job-1")).rejects.toThrow(
+				"WebSocket disconnected",
+			);
+			expect(mockDisconnect).toHaveBeenCalled();
+		});
+
+		it("does not report a null error field as a failure", async () => {
+			mockGetResponse.mockResolvedValue([
+				{
+					taskUUID: "job-1",
+					status: "completed",
+					videoURL: "https://result.mp4",
+					error: null,
+				},
+			]);
+
+			const provider = new RunwareVideo("test-key");
+			const result = await provider.poll("job-1");
+
+			expect(result.result.video).toBe("https://result.mp4");
+			expect(result.metadata?.error).toBeUndefined();
+		});
 	});
 });

--- a/lib/providers/video/base.ts
+++ b/lib/providers/video/base.ts
@@ -10,6 +10,8 @@ export type VideoJobMetadata = {
 	durationSec?: number;
 	status?: VideoJobStatus;
 	error?: string;
+	/** Raw provider error payload behind `error`'s message, for callers that need to classify the failure. */
+	errorDetail?: unknown;
 };
 
 export type VideoJob = {

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -4,6 +4,15 @@ import type { VideoJob, VideoJobStatus } from "./base";
 import { BaseVideoProvider } from "./base";
 import { withRunware } from "../runware";
 
+/** Runware's SDK rejects task-level failures with a structured {error}/{errors} payload (see IError in @runware/sdk-js); connection-level failures (WebSocket disconnects, timeouts) reject with a plain Error instead. */
+function isApiError(err: unknown): boolean {
+	return (
+		typeof err === "object" &&
+		err !== null &&
+		("error" in err || "errors" in err)
+	);
+}
+
 function toVideoJob(video: {
 	taskUUID: string;
 	status: string;
@@ -15,7 +24,7 @@ function toVideoJob(video: {
 		metadata: {
 			jobId: video.taskUUID,
 			status: video.status as VideoJobStatus,
-			...(video.error !== undefined && {
+			...(video.error != null && {
 				error:
 					typeof video.error === "string"
 						? video.error
@@ -82,10 +91,13 @@ export class RunwareVideo extends BaseVideoProvider {
 			try {
 				results = await runware.getResponse({ taskUUID: jobId });
 			} catch (err) {
-				// A rejected status query (as opposed to a resolved item reporting
-				// its own failure below) still carries the provider's error detail —
-				// surface it as a failed job instead of letting the raw rejection
-				// propagate uncaught out of poll().
+				// A rejected status query can mean two different things: the task
+				// itself failed (Runware rejects with a structured {error} / {errors}
+				// payload — same shape as IError elsewhere in the SDK), or the query
+				// itself couldn't complete (WebSocket disconnect, connection timeout,
+				// ...). Only the former is a permanent job failure; the latter must
+				// propagate so the poll loop retries instead of giving up.
+				if (!isApiError(err)) throw err;
 				return {
 					metadata: { jobId, status: "failed", error: stringifyError(err) },
 				};

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -1,4 +1,5 @@
 import type { VideoGenerateParams } from "@/lib/connectors/types";
+import { humanErrorMessage } from "@/lib/errors";
 import type { VideoJob, VideoJobStatus } from "./base";
 import { BaseVideoProvider } from "./base";
 import { withRunware } from "../runware";
@@ -12,21 +13,9 @@ function isApiError(err: unknown): boolean {
 	);
 }
 
-/**
- * A human-readable message for `metadata.error`, which renders verbatim in the
- * failure banner — so it must never be a raw JSON dump. The full structured
- * payload is preserved separately on `errorDetail` for classification. Handles
- * both Runware shapes: an unwrapped IErrorResponse (`{message}`, resolved-but-
- * failed item) and a wrapped rejection (`{error: {message}}`, rejected poll).
- */
+/** Human message for `metadata.error` (renders verbatim in the failure banner); the full payload stays on `errorDetail` for classification. */
 function humanVideoError(raw: unknown): string {
-	if (typeof raw === "string") return raw;
-	if (raw !== null && typeof raw === "object") {
-		const obj = raw as { message?: unknown; error?: { message?: unknown } };
-		if (typeof obj.message === "string") return obj.message;
-		if (typeof obj.error?.message === "string") return obj.error.message;
-	}
-	return "Video generation failed";
+	return humanErrorMessage(raw, "Video generation failed");
 }
 
 function toVideoJob(video: {

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -1,4 +1,5 @@
 import type { VideoGenerateParams } from "@/lib/connectors/types";
+import { stringifyError } from "@/lib/errors";
 import type { VideoJob, VideoJobStatus } from "./base";
 import { BaseVideoProvider } from "./base";
 import { withRunware } from "../runware";
@@ -7,12 +8,19 @@ function toVideoJob(video: {
 	taskUUID: string;
 	status: string;
 	videoURL?: string;
+	error?: unknown;
 }): VideoJob {
 	return {
 		url: video.videoURL,
 		metadata: {
 			jobId: video.taskUUID,
 			status: video.status as VideoJobStatus,
+			...(video.error !== undefined && {
+				error:
+					typeof video.error === "string"
+						? video.error
+						: stringifyError(video.error),
+			}),
 		},
 	};
 }
@@ -65,11 +73,23 @@ export class RunwareVideo extends BaseVideoProvider {
 
 	protected async _poll(jobId: string): Promise<VideoJob> {
 		return withRunware(this.apiKey, async (runware) => {
-			const results = await runware.getResponse<{
+			let results: Array<{
 				taskUUID: string;
 				status: string;
 				videoURL?: string;
-			}>({ taskUUID: jobId });
+				error?: unknown;
+			}>;
+			try {
+				results = await runware.getResponse({ taskUUID: jobId });
+			} catch (err) {
+				// A rejected status query (as opposed to a resolved item reporting
+				// its own failure below) still carries the provider's error detail —
+				// surface it as a failed job instead of letting the raw rejection
+				// propagate uncaught out of poll().
+				return {
+					metadata: { jobId, status: "failed", error: stringifyError(err) },
+				};
+			}
 
 			const video = results?.[0];
 			if (!video) throw new Error("Job not found");

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -29,6 +29,7 @@ function toVideoJob(video: {
 					typeof video.error === "string"
 						? video.error
 						: stringifyError(video.error),
+				errorDetail: video.error,
 			}),
 		},
 	};
@@ -99,7 +100,12 @@ export class RunwareVideo extends BaseVideoProvider {
 				// propagate so the poll loop retries instead of giving up.
 				if (!isApiError(err)) throw err;
 				return {
-					metadata: { jobId, status: "failed", error: stringifyError(err) },
+					metadata: {
+						jobId,
+						status: "failed",
+						error: stringifyError(err),
+						errorDetail: err,
+					},
 				};
 			}
 

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -1,5 +1,4 @@
 import type { VideoGenerateParams } from "@/lib/connectors/types";
-import { stringifyError } from "@/lib/errors";
 import type { VideoJob, VideoJobStatus } from "./base";
 import { BaseVideoProvider } from "./base";
 import { withRunware } from "../runware";
@@ -11,6 +10,23 @@ function isApiError(err: unknown): boolean {
 		err !== null &&
 		("error" in err || "errors" in err)
 	);
+}
+
+/**
+ * A human-readable message for `metadata.error`, which renders verbatim in the
+ * failure banner — so it must never be a raw JSON dump. The full structured
+ * payload is preserved separately on `errorDetail` for classification. Handles
+ * both Runware shapes: an unwrapped IErrorResponse (`{message}`, resolved-but-
+ * failed item) and a wrapped rejection (`{error: {message}}`, rejected poll).
+ */
+function humanVideoError(raw: unknown): string {
+	if (typeof raw === "string") return raw;
+	if (raw !== null && typeof raw === "object") {
+		const obj = raw as { message?: unknown; error?: { message?: unknown } };
+		if (typeof obj.message === "string") return obj.message;
+		if (typeof obj.error?.message === "string") return obj.error.message;
+	}
+	return "Video generation failed";
 }
 
 function toVideoJob(video: {
@@ -25,10 +41,7 @@ function toVideoJob(video: {
 			jobId: video.taskUUID,
 			status: video.status as VideoJobStatus,
 			...(video.error != null && {
-				error:
-					typeof video.error === "string"
-						? video.error
-						: stringifyError(video.error),
+				error: humanVideoError(video.error),
 				errorDetail: video.error,
 			}),
 		},
@@ -103,7 +116,7 @@ export class RunwareVideo extends BaseVideoProvider {
 					metadata: {
 						jobId,
 						status: "failed",
-						error: stringifyError(err),
+						error: humanVideoError(err),
 						errorDetail: err,
 					},
 				};


### PR DESCRIPTION
## Summary

Closes #386

When an `animated_image` element's still-image generation succeeds but yields a frame the video provider can't actually use, the chain proceeded into video generation anyway. The video provider (Runware) then rejected it with a raw `invalidValueUploadFailed`/`frameImages` JSON error, surfaced verbatim to the user with no indication the real cause was the still image.

- The `video.generate(...)` call in the chain plugin is now wrapped so that a provider failure matching the frame-image error class (`frameImages`/`invalidValueUploadFailed`) is rewritten into a human-readable message ("Couldn't animate: the source image failed to generate. Try regenerating the image.") instead of the raw provider JSON. The raw detail is preserved on `Error.cause` for server/console debugging without being painted into the user-facing banner. Unrelated video-provider errors (rate limits, auth, model outage) pass through unchanged.
- Fixed a related gap: `RunwareVideo.toVideoJob` never copied the provider's error detail onto poll results, so async (poll-time) frame-image failures reached the client as a generic "Video generation failed" and could never be classified. The error now flows through on both a resolved-but-failed status item and a hard-rejected status query.

An earlier version of this fix also added a client-side HEAD reachability check before chaining into video generation. Self-review found that check unsafe (cross-origin HEAD against a freshly-uploaded Blob URL is vulnerable to propagation-delay false negatives, had no timeout/cancellation, and was largely redundant with the catch-side translation) and it was removed in favor of the catch-based approach above.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run test:run` (856 tests passing)
- [x] Added/updated unit tests covering: frame-image errors get the friendly message with raw detail on `cause`, unrelated video errors pass through unchanged, `RunwareVideo` maps provider errors on both the resolved-failed-item and rejected-status-query poll paths
- [x] Self-reviewed via 8-angle finder + per-candidate verification pass; addressed the confirmed correctness/dead-code findings, documented the trade-offs on the two left open (see PR discussion)
