### PR TITLE
refactor: rethink openslop architecture 2026-07-11

### DIFF
--- a/app/components/canvas/ProjectTitle.tsx
+++ b/app/components/canvas/ProjectTitle.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import { Pencil } from "@/components/ui/icon";
 import { useConfig } from "@/lib/config/ConfigProvider";
-import { getProjectStore, useProjectStore } from "@/lib/project/store";
+import { setProjectTitle } from "@/lib/project/projectName";
+import { useProjectStore } from "@/lib/project/store";
 import { useScriptControl } from "@/lib/script/ScriptProvider";
 
 export function ProjectTitle() {
@@ -25,7 +26,7 @@ export function ProjectTitle() {
 	const commit = () => {
 		const next = draft.trim();
 		if (next && next !== title) {
-			getProjectStore(projectId).getState().updateMetadata({ title: next });
+			setProjectTitle(projectId, next);
 		}
 		setEditing(false);
 	};

--- a/app/components/canvas/panel/PropertiesPanel.tsx
+++ b/app/components/canvas/panel/PropertiesPanel.tsx
@@ -8,9 +8,11 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { useConfig } from "@/lib/config/ConfigProvider";
-import { getProjectStore } from "@/lib/project/store";
 import { TRANSITION_TYPES, type TransitionType } from "@/lib/video/transitions";
-import { useTransitionType } from "@/lib/video/useTransitionType";
+import {
+	setTransitionType,
+	useTransitionType,
+} from "@/lib/video/useTransitionType";
 import { PanelCard, PanelField } from "./PanelCard";
 
 const LABELS: Record<TransitionType, string> = {
@@ -27,17 +29,14 @@ export function PropertiesPanel() {
 	const { projectId } = useConfig();
 	const transitionType = useTransitionType();
 
-	const setTransitionType = (value: TransitionType) =>
-		getProjectStore(projectId)
-			.getState()
-			.updateMetadata({ videoSettings: { transitionType: value } });
-
 	return (
 		<PanelCard title="Transition">
 			<PanelField label="Transition">
 				<Select
 					value={transitionType}
-					onValueChange={(value) => setTransitionType(value as TransitionType)}
+					onValueChange={(value) =>
+						setTransitionType(projectId, value as TransitionType)
+					}
 				>
 					<SelectTrigger size="sm" aria-label="Transition">
 						<SelectValue />

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -21,7 +21,7 @@ import { useConfig } from "@/lib/config/ConfigProvider";
 import { getProjectStore } from "@/lib/project/store";
 import type { Mode } from "@/lib/project/types";
 import type { AspectRatio } from "@/lib/video/aspectRatio";
-import { useAspectRatio } from "@/lib/video/useAspectRatio";
+import { setAspectRatio, useAspectRatio } from "@/lib/video/useAspectRatio";
 import { useImageUpload } from "@/lib/upload/useImageUpload";
 import { ActionButton } from "./ActionButton";
 import { ComposerAssets } from "./ComposerAssets";
@@ -254,11 +254,7 @@ export default function ComposerCopilot({
 						</SelectMenu>
 						<SelectMenu
 							value={aspectRatio}
-							onChange={(next: AspectRatio) => {
-								getProjectStore(projectId)
-									.getState()
-									.updateMetadata({ videoSettings: { aspectRatio: next } });
-							}}
+							onChange={(next: AspectRatio) => setAspectRatio(projectId, next)}
 							options={ASPECT_RATIO_OPTIONS}
 							itemClassName="rounded-lg text-label-xs"
 						>

--- a/lib/project/__tests__/projectName.test.ts
+++ b/lib/project/__tests__/projectName.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { deriveProjectName } from "../projectName";
+import { beforeEach, describe, expect, it } from "vitest";
+import { deriveProjectName, setProjectTitle } from "../projectName";
+import { clearProjectStore, getProjectStore } from "../store";
 import type { Metadata } from "../types";
 
 const base: Metadata = {
@@ -23,5 +24,23 @@ describe("deriveProjectName", () => {
 		expect(deriveProjectName({ ...base, title: "  My Slop  " })).toBe(
 			"My Slop",
 		);
+	});
+});
+
+describe("setProjectTitle", () => {
+	const PROJECT_ID = "project-title-test";
+	beforeEach(() => clearProjectStore(PROJECT_ID));
+
+	it("writes the title into metadata", () => {
+		setProjectTitle(PROJECT_ID, "My Slop");
+		expect(getProjectStore(PROJECT_ID).getState().metadata.title).toBe(
+			"My Slop",
+		);
+	});
+
+	it("leaves sibling metadata untouched", () => {
+		getProjectStore(PROJECT_ID).getState().updateMetadata({ style: "noir" });
+		setProjectTitle(PROJECT_ID, "My Slop");
+		expect(getProjectStore(PROJECT_ID).getState().metadata.style).toBe("noir");
 	});
 });

--- a/lib/project/projectName.ts
+++ b/lib/project/projectName.ts
@@ -1,6 +1,11 @@
+import { getProjectStore } from "./store";
 import type { Metadata } from "./types";
 
 export function deriveProjectName(metadata: Metadata | undefined): string {
 	const title = metadata?.title?.trim();
 	return title && title.length > 0 ? title : "Untitled";
+}
+
+export function setProjectTitle(projectId: string, title: string) {
+	getProjectStore(projectId).getState().updateMetadata({ title });
 }

--- a/lib/video/__tests__/videoSettings.test.ts
+++ b/lib/video/__tests__/videoSettings.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { clearProjectStore, getProjectStore } from "@/lib/project/store";
+import { DEFAULT_ASPECT_RATIO } from "../aspectRatio";
+import { DEFAULT_TRANSITION } from "../transitions";
+import { setAspectRatio } from "../useAspectRatio";
+import { setTransitionType } from "../useTransitionType";
+
+const PROJECT_ID = "video-settings-test";
+
+const settings = () =>
+	getProjectStore(PROJECT_ID).getState().metadata.videoSettings;
+
+describe("video settings writers", () => {
+	beforeEach(() => clearProjectStore(PROJECT_ID));
+
+	it("writes the aspect ratio into videoSettings", () => {
+		setAspectRatio(PROJECT_ID, "9:16");
+		expect(settings()?.aspectRatio).toBe("9:16");
+	});
+
+	it("writes the transition type into videoSettings", () => {
+		setTransitionType(PROJECT_ID, "fade");
+		expect(settings()?.transitionType).toBe("fade");
+	});
+
+	it("does not clobber a sibling setting", () => {
+		setAspectRatio(PROJECT_ID, "9:16");
+		setTransitionType(PROJECT_ID, "wipe");
+		expect(settings()).toEqual({ aspectRatio: "9:16", transitionType: "wipe" });
+	});
+
+	it("leaves defaults untouched until written", () => {
+		expect(settings()?.aspectRatio ?? DEFAULT_ASPECT_RATIO).toBe(
+			DEFAULT_ASPECT_RATIO,
+		);
+		expect(settings()?.transitionType ?? DEFAULT_TRANSITION).toBe(
+			DEFAULT_TRANSITION,
+		);
+	});
+});

--- a/lib/video/useAspectRatio.ts
+++ b/lib/video/useAspectRatio.ts
@@ -1,5 +1,5 @@
 import { useConfig } from "@/lib/config/ConfigProvider";
-import { useProjectStore } from "@/lib/project/store";
+import { getProjectStore, useProjectStore } from "@/lib/project/store";
 import { type AspectRatio, DEFAULT_ASPECT_RATIO } from "./aspectRatio";
 
 export function useAspectRatio(): AspectRatio {
@@ -8,4 +8,10 @@ export function useAspectRatio(): AspectRatio {
 		projectId,
 		(s) => s.metadata.videoSettings?.aspectRatio ?? DEFAULT_ASPECT_RATIO,
 	);
+}
+
+export function setAspectRatio(projectId: string, aspectRatio: AspectRatio) {
+	getProjectStore(projectId)
+		.getState()
+		.updateMetadata({ videoSettings: { aspectRatio } });
 }

--- a/lib/video/useTransitionType.ts
+++ b/lib/video/useTransitionType.ts
@@ -1,5 +1,5 @@
 import { useConfig } from "@/lib/config/ConfigProvider";
-import { useProjectStore } from "@/lib/project/store";
+import { getProjectStore, useProjectStore } from "@/lib/project/store";
 import { DEFAULT_TRANSITION, type TransitionType } from "./transitions";
 
 export function useTransitionType(): TransitionType {
@@ -8,4 +8,13 @@ export function useTransitionType(): TransitionType {
 		projectId,
 		(s) => s.metadata.videoSettings?.transitionType ?? DEFAULT_TRANSITION,
 	);
+}
+
+export function setTransitionType(
+	projectId: string,
+	transitionType: TransitionType,
+) {
+	getProjectStore(projectId)
+		.getState()
+		.updateMetadata({ videoSettings: { transitionType } });
 }


### PR DESCRIPTION
## App understanding

OpenSlop is an AI creative-media studio: a prompt streams OSML markup into a SlateJS canvas, users generate media assets (image/video/music/sfx/voice) per element through a three-layer pipeline (Connectors → Gateways → Providers), and projects save/restore to Supabase with Remotion-Lambda rendering. Per-project editor state lives in a Zustand store (`lib/project/store.ts`), read through selector hooks and mutated through its actions (`updateMetadata`, `setCharacter`, …).

## From-scratch architecture notes

Rebuilt today, the store seam would follow one rule consistently: **UI reads through selector hooks and writes through named `lib/` functions — never by reaching into the store's nested update shape inline.** The read side already honors this (`useAspectRatio`, `useTransitionType`, `deriveProjectName`), and most writes do too (`deleteCharacter(projectId, …)`, `applyTemplate(projectId, …)` are plain `lib/` functions taking `projectId`). The gap was a handful of UI components that still re-stated the store's `{ videoSettings: { … } }` / `{ title }` update shape by hand — the one read/write asymmetry left in the metadata path.

## Implemented simplifications

Closed that asymmetry so **no UI component knows the store's metadata write shape**:

- `setAspectRatio(projectId, ratio)` next to `useAspectRatio`.
- `setTransitionType(projectId, type)` next to `useTransitionType`.
- `setProjectTitle(projectId, title)` next to `deriveProjectName`.
- Repointed `ComposerCopilot`, `PropertiesPanel`, and `ProjectTitle` at the writers; dropped the now-unused `getProjectStore` imports.
- Added `videoSettings` and `projectName` write-seam tests.

Behavior is preserved; this is a pure coupling reduction (UI no longer imports the store to mutate it) that mirrors the pattern the rest of the app already follows.

## Validation

- `npm run lint` — clean
- `npm run format:check` — clean
- `npm run typecheck` — clean
- `npm run test:run` — 871 passed (100 files)
- `npm run knip` — clean

## Deliberately skipped

Evaluated and rejected as out of scope for a *safe* nightly (per the repo's own conventions):

- **Extract a `shouldGenerate`/`isElementStale` helper** (`useGenerate` / `useGenerateAll` / `CharacterEditModal`). The three sites genuinely differ — `useGenerate` already holds `currentInputs` for `restoreResult`, `useGenerateAll` composes a "prompt && (!result || stale)" policy, and `CharacterEditModal` builds a synthetic element with an extra `!avatarUploaded` guard. A single helper would double-compute inputs or only partially fit — a speculative abstraction below the rule-of-three bar.
- **`useCharacterAvatar` extraction from `CharacterEditModal`** — high leverage but a behavior-sensitive state-machine extraction from a 249-line component; too risky for an unattended nightly.
- **Composer-input / asset-tile de-duplication** — rule-of-two only; and the asset-tile / reference-image surfaces overlap in-flight image-upload work (PR #394). Left untouched.
- **Adopting `useProject(selector)` at ~9 raw `useConfig()+useProjectStore` sites** — mechanical churn, not architecture.

All open-PR-owned files (PRs #394/#395/#396/#399) were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)