### PR TITLE
fix: nightly bug fixes 2026-07-12

### DIFF
--- a/lib/providers/__tests__/runware-image.test.ts
+++ b/lib/providers/__tests__/runware-image.test.ts
@@ -16,6 +16,7 @@ vi.mock("@runware/sdk-js", () => ({
 	},
 }));
 
+import { AssetBundle } from "@/lib/api/asset-bundle";
 import { RunwareImage } from "../image/runware";
 
 describe("RunwareImage", () => {
@@ -38,10 +39,34 @@ describe("RunwareImage", () => {
 			width: 2848,
 			height: 1600,
 			outputType: "base64Data",
+			outputFormat: "PNG",
 			numberResults: 1,
 			referenceImages: undefined,
 		});
 		expect(mockDisconnect).toHaveBeenCalled();
+	});
+
+	it("requests PNG output so bytes match the png filename and mime type", async () => {
+		mockImageInference.mockResolvedValue([{ imageBase64Data: "abc123" }]);
+
+		const provider = new RunwareImage("test-key");
+		await provider.generate({ prompt: "a cat" });
+
+		// Runware defaults to JPG when outputFormat is omitted, but the bundle
+		// labels the asset image/png. The request must pin PNG so the persisted
+		// bytes actually match the declared filename and content type.
+		expect(mockImageInference).toHaveBeenCalledWith(
+			expect.objectContaining({ outputFormat: "PNG" }),
+		);
+
+		const files = vi.mocked(AssetBundle.upload).mock.calls[0][2];
+		expect(files).toEqual([
+			expect.objectContaining({
+				key: "image",
+				filename: "output.png",
+				contentType: "image/png",
+			}),
+		]);
 	});
 
 	it("passes custom dimensions and model", async () => {

--- a/lib/providers/image/runware.ts
+++ b/lib/providers/image/runware.ts
@@ -39,6 +39,7 @@ export class RunwareImage extends BaseProvider<
 				width: params.width || 2848,
 				height: params.height || 1600,
 				outputType: "base64Data",
+				outputFormat: "PNG",
 				numberResults: 1,
 				referenceImages: params.referenceImages,
 			});


### PR DESCRIPTION
## Summary

Nightly correctness bug-fix pass. One real bug found and fixed with regression test.

## Bugs fixed

### 1. RunwareImage: PNG content-type mismatch (`lib/providers/image/runware.ts`)

The Runware API defaults to JPEG output when `outputFormat` is omitted, but the provider was labeling the returned bytes as PNG (`contentType: "image/png"`, `filename: "output.png"`). This caused a content-type mismatch where JPEG bytes were served as `image/png`. The fix pins `outputFormat: "PNG"` on the Runware API call so the bytes, filename, and content type are consistent.

## Tests added

- `lib/providers/__tests__/runware-image.test.ts` — new test verifying:
  - `outputFormat: "PNG"` is present in the Runware API request
  - The files passed to `AssetBundle.upload` carry the correct PNG filename and content type

## Validation

- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run typecheck` ✅
- `npm test -- --passWithNoTests` ✅ (99 files, 866 tests)
- `npm run build` ✅

## Open PR overlap check

Considered open PRs #401, #400, #399, #396, #395, and #394. This PR touches only `lib/providers/image/runware.ts` and `lib/providers/__tests__/runware-image.test.ts` — zero file or theme overlap with any open PR. (#396 touches `lib/providers/video/runware.ts` and `lib/providers/__tests__/runware-video.test.ts` — different files, different provider.)

## Skipped items / rationale

- **No other changes made** — Claude Code timeout at 80 turns after finding this single real bug. Additional provider audits (other Runware call sites) were skipped: RunwareVideo is already covered by PR #396's error-handling work.
- **No broader cleanups** — kept changes scoped to the real content-type mismatch per the runbook constraints.
- **No style/cosmetic/refactor-only changes.**

Generated with Hermes Agent (scheduled cron)
