### PR TITLE
fix: nightly bug fixes 2026-07-13

### DIFF
--- a/app/api/queues/__tests__/asset-generate.test.ts
+++ b/app/api/queues/__tests__/asset-generate.test.ts
@@ -45,13 +45,23 @@ describe("asset-generate queue worker", () => {
 		expect(mockUpdateJob).not.toHaveBeenCalled();
 	});
 
-	it("skips jobs that already failed", async () => {
-		mockLoadJobForProcessing.mockResolvedValue({ status: "failed" });
+	it("reprocesses a failed job so queue redelivery can retry it", async () => {
+		const job = { status: "failed", id: "job-1" };
+		mockLoadJobForProcessing.mockResolvedValue(job);
+		const handler = {
+			process: vi
+				.fn()
+				.mockResolvedValue({ kind: "completed", result: { url: "u" } }),
+		};
+		mockGetJobHandler.mockReturnValue(handler);
 
 		await processMessage(message);
 
-		expect(mockGetJobHandler).not.toHaveBeenCalled();
-		expect(mockUpdateJob).not.toHaveBeenCalled();
+		expect(handler.process).toHaveBeenCalledWith(job);
+		expect(mockUpdateJob).toHaveBeenNthCalledWith(2, "job-1", {
+			status: "completed",
+			result: { url: "u" },
+		});
 	});
 
 	it("throws when no handler is registered for the connector type", async () => {

--- a/app/api/queues/asset-generate/route.ts
+++ b/app/api/queues/asset-generate/route.ts
@@ -8,7 +8,9 @@ import { stringifyError } from "@/lib/errors";
 export const POST = handleCallback<AssetQueueMessage>(
 	async ({ jobId, connectorType }) => {
 		const job = await loadJobForProcessing(jobId);
-		if (job.status === "completed" || job.status === "failed") return;
+		// Only `completed` is final. A `failed` job is redelivered by the queue
+		// after the rethrow below, so it must stay eligible for reprocessing.
+		if (job.status === "completed") return;
 
 		const handler = getJobHandler(connectorType);
 		if (!handler) {

--- a/app/components/PostPromptView.tsx
+++ b/app/components/PostPromptView.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import { useScriptInitial } from "@/lib/script/ScriptProvider";
 import { useConfig } from "@/lib/config/ConfigProvider";
-import { getContentElements, isSceneElement } from "@/lib/canvas/scenes";
+import { isSceneElement } from "@/lib/canvas/scenes";
 import { getLayoutKey } from "@/lib/video/layoutKey";
 import { useTransitionType } from "@/lib/video/useTransitionType";
 import UserProfile from "./UserProfile";
@@ -35,7 +35,7 @@ function PostPromptViewInner() {
 
 	const transitionType = useTransitionType();
 	const layoutKey = useMemo(
-		() => getLayoutKey(getContentElements(value), transitionType),
+		() => getLayoutKey(value, transitionType),
 		[value, transitionType],
 	);
 	const sceneIds = useMemo(

--- a/app/components/video/useRendering.ts
+++ b/app/components/video/useRendering.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ProgressResponse } from "@/app/api/render/progress/route";
 import { stringifyError } from "@/lib/errors";
 import type { VideoLayout } from "@/lib/video/types";
@@ -19,13 +19,29 @@ type RenderState =
 
 const POLL_INTERVAL_MS = 5000;
 
-const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+const wait = (ms: number, signal: AbortSignal) =>
+	new Promise<void>((resolve, reject) => {
+		const timer = setTimeout(resolve, ms);
+		signal.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timer);
+				reject(signal.reason);
+			},
+			{ once: true },
+		);
+	});
 
-async function postJSON<T>(url: string, body: unknown): Promise<T> {
+async function postJSON<T>(
+	url: string,
+	body: unknown,
+	signal: AbortSignal,
+): Promise<T> {
 	const res = await fetch(url, {
 		method: "POST",
 		headers: { "content-type": "application/json" },
 		body: JSON.stringify(body),
+		signal,
 	});
 	if (!res.ok) throw new Error(await res.text());
 	return res.json() as Promise<T>;
@@ -33,45 +49,66 @@ async function postJSON<T>(url: string, body: unknown): Promise<T> {
 
 export function useRendering() {
 	const [state, setState] = useState<RenderState>({ status: "idle" });
+	const abortRef = useRef<AbortController | null>(null);
 
-	const render = useCallback(async (layout: VideoLayout, scale?: number) => {
-		setState({ status: "invoking" });
-		try {
-			const { renderId, bucketName } = await postJSON<{
-				renderId: string;
-				bucketName: string;
-			}>("/api/render", { inputProps: layout, scale });
-
-			setState({ status: "rendering", renderId, bucketName, progress: 0 });
-
-			for (;;) {
-				const result = await postJSON<ProgressResponse>(
-					"/api/render/progress",
-					{ renderId, bucketName },
-				);
-
-				if (result.type === "error") {
-					setState({ status: "error", message: result.message });
-					return;
-				}
-				if (result.type === "done") {
-					setState({ status: "done", url: result.url, size: result.size });
-					return;
-				}
-				setState({
-					status: "rendering",
-					renderId,
-					bucketName,
-					progress: result.progress,
-				});
-				await wait(POLL_INTERVAL_MS);
-			}
-		} catch (err) {
-			setState({ status: "error", message: stringifyError(err) });
-		}
+	const abort = useCallback(() => {
+		abortRef.current?.abort();
+		abortRef.current = null;
 	}, []);
 
-	const reset = useCallback(() => setState({ status: "idle" }), []);
+	useEffect(() => abort, [abort]);
+
+	const render = useCallback(
+		async (layout: VideoLayout, scale?: number) => {
+			abort();
+			const controller = new AbortController();
+			abortRef.current = controller;
+			const { signal } = controller;
+
+			setState({ status: "invoking" });
+			try {
+				const { renderId, bucketName } = await postJSON<{
+					renderId: string;
+					bucketName: string;
+				}>("/api/render", { inputProps: layout, scale }, signal);
+
+				setState({ status: "rendering", renderId, bucketName, progress: 0 });
+
+				for (;;) {
+					const result = await postJSON<ProgressResponse>(
+						"/api/render/progress",
+						{ renderId, bucketName },
+						signal,
+					);
+
+					if (result.type === "error") {
+						setState({ status: "error", message: result.message });
+						return;
+					}
+					if (result.type === "done") {
+						setState({ status: "done", url: result.url, size: result.size });
+						return;
+					}
+					setState({
+						status: "rendering",
+						renderId,
+						bucketName,
+						progress: result.progress,
+					});
+					await wait(POLL_INTERVAL_MS, signal);
+				}
+			} catch (err) {
+				if (signal.aborted) return;
+				setState({ status: "error", message: stringifyError(err) });
+			}
+		},
+		[abort],
+	);
+
+	const reset = useCallback(() => {
+		abort();
+		setState({ status: "idle" });
+	}, [abort]);
 
 	return { state, render, reset };
 }

--- a/lib/api/route-handler.ts
+++ b/lib/api/route-handler.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import type { User } from "@supabase/supabase-js";
 import { z } from "zod";
 import type { ConnectorType } from "@/lib/connectors/types";
+import { isTerminal } from "@/lib/gateway/base";
 import { withApiAccess, withSession } from "./with-auth";
 import { getJobHandler, rowView } from "./job-handlers";
 import { createJob, enqueueJob, getJob } from "./jobs";
@@ -73,6 +74,7 @@ export async function pollJob(
 		if (!jobId) return badRequest("jobId is required");
 		const job = await getJob(jobId, user.id);
 		if (!job) return NextResponse.json({ error: "Not found" }, { status: 404 });
+		if (isTerminal(job.status)) return NextResponse.json(rowView(job));
 		const view =
 			(await getJobHandler(job.connector_type)?.poll?.(job)) ?? rowView(job);
 		return NextResponse.json(view);

--- a/lib/api/sse.ts
+++ b/lib/api/sse.ts
@@ -87,6 +87,12 @@ export async function* readSSE<T>(body: ReadableStream): AsyncGenerator<T> {
 			}
 		}
 	} finally {
+		// A consumer that breaks out early leaves the upstream body open. Cancel
+		// failures are logged, never rethrown: this runs in `finally`, so throwing
+		// here would mask the error that ended the stream.
+		await reader
+			.cancel()
+			.catch((err) => logger.warn({ err }, "SSE: reader cancel failed"));
 		reader.releaseLock();
 	}
 }

--- a/lib/canvas/osmlSerializer.ts
+++ b/lib/canvas/osmlSerializer.ts
@@ -1,6 +1,7 @@
 import { Descendant } from "slate";
 import type { CanvasContentElement, ParsedElement } from "@/lib/canvas/types";
 import { getContentElements, isSceneElement } from "@/lib/canvas/scenes";
+import { escapeXmlAttribute } from "./xmlEntities";
 
 export const SCENE_MARKER_PATTERN = /^---\s*Scene\s+\d+\s*---\s*$/m;
 const sceneMarker = (n: number) => `\n--- Scene ${n} ---\n`;
@@ -12,7 +13,7 @@ export function getElementText(element: ParsedElement): string {
 function serializeElement(element: CanvasContentElement): string {
 	const attributes = element.customAttributes ?? {};
 	const attrString = Object.entries({ id: element.id, ...attributes })
-		.map(([key, value]) => ` ${key}="${value}"`)
+		.map(([key, value]) => ` ${key}="${escapeXmlAttribute(value)}"`)
 		.join("");
 	return `<${element.type}${attrString}>${getElementText(element)}</${element.type}>\n`;
 }

--- a/lib/canvas/osmlStreamParser.ts
+++ b/lib/canvas/osmlStreamParser.ts
@@ -53,6 +53,7 @@ export class OSMLStreamParser {
 			if (openTag) {
 				const { tag, ...attributes } = parseXmlTag(openTag);
 				this.appendNext(tag, attributes, connectors);
+				updated = true;
 			}
 			lastIndex = match.index + match[0].length;
 		}

--- a/lib/canvas/parseXmlTag.ts
+++ b/lib/canvas/parseXmlTag.ts
@@ -1,13 +1,16 @@
-export function parseXmlTag(tagString: string): Record<string, string> {
-	const [rawTag, ...rest] = tagString.trim().split(/\s+/);
-	const tag = rawTag.replace(/\/$/, "");
-	const attributesString = rest.join(" ");
-	const attributes: Record<string, string> = { tag };
-	const regex = /(\w+)="([^"]*)"/g;
-	let match: RegExpExecArray | null;
+import { unescapeXmlEntities } from "./xmlEntities";
 
-	while ((match = regex.exec(attributesString)) !== null) {
-		attributes[match[1]] = match[2];
+const ATTRIBUTE_PATTERN = /([\w-]+)="([^"]*)"/g;
+
+export function parseXmlTag(tagString: string): Record<string, string> {
+	const body = tagString.trim().replace(/\/$/, "");
+	const tag = /^\S*/.exec(body)?.[0] ?? "";
+	const attributes: Record<string, string> = { tag };
+
+	ATTRIBUTE_PATTERN.lastIndex = 0;
+	let match: RegExpExecArray | null;
+	while ((match = ATTRIBUTE_PATTERN.exec(body)) !== null) {
+		attributes[match[1]] = unescapeXmlEntities(match[2]);
 	}
 
 	return attributes;

--- a/lib/canvas/xmlEntities.ts
+++ b/lib/canvas/xmlEntities.ts
@@ -1,0 +1,28 @@
+const ESCAPES: Record<string, string> = {
+	"&": "&amp;",
+	'"': "&quot;",
+	"<": "&lt;",
+	">": "&gt;",
+};
+
+const ENTITIES: Record<string, string> = {
+	amp: "&",
+	quot: '"',
+	apos: "'",
+	lt: "<",
+	gt: ">",
+};
+
+/**
+ * OSML attribute values are delimited by `"` and terminated by `>`, so a raw
+ * quote or angle bracket in a prompt silently truncates or drops the attribute
+ * when the script round-trips through the DB and back into the parser.
+ */
+export const escapeXmlAttribute = (value: string): string =>
+	value.replace(/[&"<>]/g, (char) => ESCAPES[char] ?? char);
+
+export const unescapeXmlEntities = (value: string): string =>
+	value.replace(
+		/&(amp|quot|apos|lt|gt);/g,
+		(entity, name: string) => ENTITIES[name] ?? entity,
+	);

--- a/lib/gateway/base.ts
+++ b/lib/gateway/base.ts
@@ -6,6 +6,10 @@ export abstract class GatewayClient<TParams = unknown, TResult = unknown> {
 
 export type JobStatus = "pending" | "processing" | "completed" | "failed";
 
+/** A terminal job has a settled result; it must never be re-processed or re-polled upstream. */
+export const isTerminal = (status: JobStatus): boolean =>
+	status === "completed" || status === "failed";
+
 export type JobSubmission = { jobId: string; status: JobStatus };
 
 export type JobPoll = {

--- a/lib/providers/tts/cartesia.ts
+++ b/lib/providers/tts/cartesia.ts
@@ -101,6 +101,8 @@ export async function collectVoices(
 		});
 		voices.push(...page.data);
 		if (!page.has_more || !page.next_page) break;
+		// An empty page or a cursor that doesn't advance would page forever.
+		if (page.data.length === 0 || page.next_page === cursor) break;
 		cursor = page.next_page;
 	}
 	return voices;

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -30,7 +30,13 @@ export async function updateSession(request: NextRequest) {
 	} = await supabase.auth.getUser();
 
 	if (user && AUTH_ROUTES.includes(request.nextUrl.pathname)) {
-		return NextResponse.redirect(new URL("/", request.url));
+		const redirect = NextResponse.redirect(new URL("/", request.url));
+		// getUser() may have rotated the session; those cookies live on
+		// supabaseResponse, and dropping them signs the user back out.
+		for (const cookie of supabaseResponse.cookies.getAll()) {
+			redirect.cookies.set(cookie);
+		}
+		return redirect;
 	}
 
 	return supabaseResponse;

--- a/lib/video/__tests__/layoutKey.test.ts
+++ b/lib/video/__tests__/layoutKey.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { CanvasContentElement } from "@/lib/canvas/types";
+import type { CanvasContentElement, SceneElement } from "@/lib/canvas/types";
+import { SCENE_TYPE } from "@/lib/canvas/types";
 import { getLayoutKey } from "../layoutKey";
 
 function el(
@@ -14,64 +15,89 @@ function el(
 	};
 }
 
+function scene(id: string, children: CanvasContentElement[]): SceneElement {
+	return { id, type: SCENE_TYPE, children };
+}
+
+/** A single scene holding every element — the common case for these assertions. */
+const one = (children: CanvasContentElement[]) => [scene("sc1", children)];
+
 describe("getLayoutKey", () => {
 	it("returns the same key for identical element lists", () => {
-		const a = [el("s1", { loops: "2" }), el("s2")];
-		const b = [el("s1", { loops: "2" }), el("s2")];
+		const a = one([el("s1", { loops: "2" }), el("s2")]);
+		const b = one([el("s1", { loops: "2" }), el("s2")]);
 		expect(getLayoutKey(a, "none")).toBe(getLayoutKey(b, "none"));
 	});
 
 	it("changes when elements are reordered", () => {
-		const a = [el("s1"), el("s2")];
-		const b = [el("s2"), el("s1")];
+		const a = one([el("s1"), el("s2")]);
+		const b = one([el("s2"), el("s1")]);
 		expect(getLayoutKey(a, "none")).not.toBe(getLayoutKey(b, "none"));
 	});
 
 	it("changes when an element is added", () => {
-		const a = [el("s1")];
-		const b = [el("s1"), el("s2")];
+		const a = one([el("s1")]);
+		const b = one([el("s1"), el("s2")]);
 		expect(getLayoutKey(a, "none")).not.toBe(getLayoutKey(b, "none"));
 	});
 
 	it("changes when an element is removed", () => {
-		const a = [el("s1"), el("s2")];
-		const b = [el("s1")];
+		const a = one([el("s1"), el("s2")]);
+		const b = one([el("s1")]);
 		expect(getLayoutKey(a, "none")).not.toBe(getLayoutKey(b, "none"));
 	});
 
 	it("changes when loops changes on any element", () => {
-		const a = [el("s1", { loops: "1" })];
-		const b = [el("s1", { loops: "4" })];
+		const a = one([el("s1", { loops: "1" })]);
+		const b = one([el("s1", { loops: "4" })]);
 		expect(getLayoutKey(a, "none")).not.toBe(getLayoutKey(b, "none"));
 	});
 
 	it("changes when volume changes on any element", () => {
-		const a = [el("s1", { volume: "10" })];
-		const b = [el("s1", { volume: "3" })];
+		const a = one([el("s1", { volume: "10" })]);
+		const b = one([el("s1", { volume: "3" })]);
 		expect(getLayoutKey(a, "none")).not.toBe(getLayoutKey(b, "none"));
 	});
 
 	it("is stable across unrelated attribute changes", () => {
-		const a = [el("s1", { emotion: "happy" })];
-		const b = [el("s1", { emotion: "sad" })];
+		const a = one([el("s1", { emotion: "happy" })]);
+		const b = one([el("s1", { emotion: "sad" })]);
 		expect(getLayoutKey(a, "none")).toBe(getLayoutKey(b, "none"));
 	});
 
 	it("is stable across text edits (text is not in the element body)", () => {
-		// text lives on children — layout key doesn't reach into it
-		const a = [el("s1")];
-		const b: CanvasContentElement[] = [
+		const a = one([el("s1")]);
+		const b = one([
 			{
 				id: "s1",
 				type: "sound",
 				children: [{ id: "s1-t", type: "sound", text: "rain" }],
 			},
-		];
+		]);
 		expect(getLayoutKey(a, "none")).toBe(getLayoutKey(b, "none"));
 	});
 
 	it("changes when transition type changes", () => {
-		const els = [el("s1")];
-		expect(getLayoutKey(els, "none")).not.toBe(getLayoutKey(els, "fade"));
+		const nodes = one([el("s1")]);
+		expect(getLayoutKey(nodes, "none")).not.toBe(getLayoutKey(nodes, "fade"));
+	});
+
+	it("changes when an element moves to another scene, even though flat order is unchanged", () => {
+		const before = [scene("sc1", [el("s1")]), scene("sc2", [el("s2")])];
+		const after = [scene("sc1", []), scene("sc2", [el("s1"), el("s2")])];
+		expect(getLayoutKey(before, "none")).not.toBe(getLayoutKey(after, "none"));
+	});
+
+	it("changes when scenes split, even though flat order is unchanged", () => {
+		const merged = one([el("s1"), el("s2")]);
+		const split = [scene("sc1", [el("s1")]), scene("sc2", [el("s2")])];
+		expect(getLayoutKey(merged, "none")).not.toBe(getLayoutKey(split, "none"));
+	});
+
+	it("ignores content elements that sit outside a scene, as the resolver does", () => {
+		const withOrphan = [scene("sc1", [el("s1")]), el("orphan")];
+		expect(getLayoutKey(withOrphan, "none")).toBe(
+			getLayoutKey(one([el("s1")]), "none"),
+		);
 	});
 });

--- a/lib/video/elementAttributes.ts
+++ b/lib/video/elementAttributes.ts
@@ -18,21 +18,34 @@ const VOLUME_MIN = 0;
 const VOLUME_MAX = 10;
 const DEFAULT_VOLUME = VOLUME_MAX;
 
+/**
+ * A blank attribute means "unset", not zero — `Number("")` is a finite 0, which
+ * would silently mute audio or read as a zero loop count.
+ */
+function numericAttribute(
+	element: CanvasContentElement,
+	key: string,
+): number | undefined {
+	const raw = element.customAttributes?.[key]?.trim();
+	if (!raw) return undefined;
+	const value = Number(raw);
+	return Number.isFinite(value) ? value : undefined;
+}
+
 /** Volume coerced to a finite number clamped to [0, 10], defaulting to 10. */
 export function getVolume(element: CanvasContentElement): number {
-	const raw = Number(element.customAttributes?.volume);
-	return Number.isFinite(raw)
-		? clamp(raw, VOLUME_MIN, VOLUME_MAX)
-		: DEFAULT_VOLUME;
+	const raw = numericAttribute(element, "volume");
+	return raw === undefined
+		? DEFAULT_VOLUME
+		: clamp(raw, VOLUME_MIN, VOLUME_MAX);
 }
 
 const LOOPS_MAX = 1000;
 
 /** Loop count coerced to an integer in [1, 1000], defaulting to 1. */
 export function getLoops(element: CanvasContentElement): number {
-	const raw = Number(element.customAttributes?.loops);
-	if (!Number.isFinite(raw)) return 1;
-	return clamp(Math.floor(raw), 1, LOOPS_MAX);
+	const raw = numericAttribute(element, "loops");
+	return raw === undefined ? 1 : clamp(Math.floor(raw), 1, LOOPS_MAX);
 }
 
 /** Motion effect validated against the known set, defaulting to "none". */

--- a/lib/video/layoutKey.ts
+++ b/lib/video/layoutKey.ts
@@ -1,19 +1,31 @@
+import type { Descendant } from "slate";
 import type { CanvasContentElement } from "@/lib/canvas/types";
+import { isSceneElement } from "@/lib/canvas/scenes";
 import type { TransitionType } from "./transitions";
 import { layoutAttributeSignature } from "./elementAttributes";
 
+const elementSignature = (el: CanvasContentElement) =>
+	`${el.id}:${el.type}:${layoutAttributeSignature(el)}`;
+
 /**
  * Stable key over every element field that resolveElements/buildVideoLayout
- * actually read, plus project-wide layout-affecting settings. The set of
- * layout-affecting attributes lives in `LAYOUT_ATTRIBUTE_KEYS` so this key and
- * the resolver stay in lockstep — add new attributes there, not here.
+ * actually read, plus the scene grouping and project-wide layout-affecting
+ * settings. Scene membership belongs in the key because consumers derive scene
+ * segments alongside the layout, and moving an element between scenes can leave
+ * the flat element order untouched. The set of layout-affecting attributes
+ * lives in `LAYOUT_ATTRIBUTE_KEYS` so this key and the resolver stay in
+ * lockstep — add new attributes there, not here.
  */
 export function getLayoutKey(
-	elements: CanvasContentElement[],
+	nodes: Descendant[],
 	transitionType: TransitionType,
 ): string {
-	const elementsKey = elements
-		.map((el) => `${el.id}:${el.type}:${layoutAttributeSignature(el)}`)
+	const scenesKey = nodes
+		.filter(isSceneElement)
+		.map(
+			(scene) =>
+				`${scene.id}[${scene.children.map(elementSignature).join("|")}]`,
+		)
 		.join("|");
-	return `${transitionType}|${elementsKey}`;
+	return `${transitionType}|${scenesKey}`;
 }


### PR DESCRIPTION
## Summary

Nightly correctness bug hunt and test coverage pass.

## Open PR overlap check

Reviewed open PRs #395 (canvas-interaction-bugs) and #394 (bring-your-own-image). This PR does not touch any files or modules covered by those PRs. No overlap.

## Bugs fixed

1. **Asset queue: failed jobs were silently skipped instead of retried** — The route handler returned early for `"failed"` jobs, treating them as terminal. But the queue redelivers failed jobs after the rethrow, so they must stay eligible for reprocessing. Only `"completed"` is truly terminal now.

2. **Video render polling: no abort mechanism, stale closure on unmount** — Added AbortController support so the polling loop is cleanly cancelled on reset or unmount. fetch and wait now accept a signal. Added proper useEffect cleanup and fixed stale closure.

3. **Supabase middleware: session cookie dropped on auth-route redirect** — When getUser() refreshes the session, new cookies live on supabaseResponse. If the middleware then redirects (authenticated user visiting login page), those cookies were dropped. Now forwarded onto the redirect.

4. **Cartesia TTS: infinite pagination guard** — Added safety break if the API returns an empty page or stale cursor.

5. **XML serialization: unescaped quotes/angle brackets in OSML attributes** — Raw quote or `>` in a user prompt silently truncates the attribute on round-trip. Added XML entity escaping on serialization and unescaping on parsing.

6. **XML tag parsing: split-on-whitespace bug** — Old approach split tag string on spaces, potentially including `<scene` (with `<` prefix) in the tag name. Switched to regex extraction.

7. **OSML stream parser: missing `updated` flag on open tags** — Callers polling the parser didn't know new content arrived.

8. **Volume/loops: Number("") footgun silently mutes audio** — Blank value for volume or loops would silently mute audio or set loops to 0. Now treats blank strings as undefined, falling back to correct defaults.

9. **Layout key: scene grouping ignored** — Moving an element between scenes produced the same key even though the resolved layout would differ. Now incorporates scene membership.

10. **Poll job: unnecessary upstream polling for terminal jobs** — Added isTerminal short-circuit to avoid unnecessary upstream calls.

11. **SSE reader: unreleased stream on early consumer break** — Added reader.cancel() in finally block.

12. **PostPromptView.tsx: dead import and stale function signature** — Cleaned up unused getContentElements import, updated getLayoutKey call site.

## Tests added

- **layoutKey.test.ts** — Restructured to use scene-wrapped elements. Added 3 new test cases: element moves between scenes (key changes), scenes split (key changes), orphan elements ignored (consistent with resolver).

- **asset-generate.test.ts** — Updated "skips failed jobs" to "reprocesses a failed job" with assertions that the handler is invoked and result stored.

## Validation

- `npm test -- --passWithNoTests`: 100 files, 869 tests — all passing
- `npm run build`: compiles successfully
- `npm run typecheck`: no errors
- `npm run lint`: no errors
- `npm run format:check`: all files pass
