### PR TITLE
refactor: rethink openslop architecture 2026-07-13

### DIFF
--- a/app/components/canvas/ProjectTitle.tsx
+++ b/app/components/canvas/ProjectTitle.tsx
@@ -2,13 +2,12 @@
 
 import { useState } from "react";
 import { Pencil } from "@/components/ui/icon";
-import { useConfig } from "@/lib/config/ConfigProvider";
-import { getProjectStore, useProjectStore } from "@/lib/project/store";
+import { useProject } from "@/lib/project/useProject";
 import { useScriptControl } from "@/lib/script/ScriptProvider";
 
 export function ProjectTitle() {
-	const { projectId } = useConfig();
-	const title = useProjectStore(projectId, (s) => s.metadata.title);
+	const title = useProject((s) => s.metadata.title);
+	const updateMetadata = useProject((s) => s.updateMetadata);
 	const { loading } = useScriptControl();
 	const [editing, setEditing] = useState(false);
 	const [draft, setDraft] = useState("");
@@ -25,7 +24,7 @@ export function ProjectTitle() {
 	const commit = () => {
 		const next = draft.trim();
 		if (next && next !== title) {
-			getProjectStore(projectId).getState().updateMetadata({ title: next });
+			updateMetadata({ title: next });
 		}
 		setEditing(false);
 	};

--- a/app/components/canvas/elements/CharacterPill.tsx
+++ b/app/components/canvas/elements/CharacterPill.tsx
@@ -2,13 +2,11 @@
 
 import { User } from "@/components/ui/icon";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { useConfig } from "@/lib/config/ConfigProvider";
-import { useProjectStore } from "@/lib/project/store";
+import { useProject } from "@/lib/project/useProject";
 import { RemoveCrossButton } from "./RemoveCrossButton";
 
 function useCharacterAvatarUrl(name?: string) {
-	const { projectId } = useConfig();
-	return useProjectStore(projectId, (state) =>
+	return useProject((state) =>
 		name ? state.metadata.characters[name]?.avatarUrl : undefined,
 	);
 }

--- a/app/components/canvas/elements/CharactersPicker.tsx
+++ b/app/components/canvas/elements/CharactersPicker.tsx
@@ -13,13 +13,11 @@ import { SimpleTooltip } from "@/components/ui/tooltip";
 import { getElementCharacterNames } from "@/lib/canvas/characterNames";
 import { updateElementAttrs } from "@/app/components/canvas/utils/nodeOps";
 import type { CanvasContentElement } from "@/lib/canvas/types";
-import { useConfig } from "@/lib/config/ConfigProvider";
-import { useProjectStore } from "@/lib/project/store";
+import { useProject } from "@/lib/project/useProject";
 import { CharacterPill } from "./CharacterPill";
 
 function useProjectCharacterNames(): string[] {
-	const { projectId } = useConfig();
-	const characters = useProjectStore(projectId, (s) => s.metadata.characters);
+	const characters = useProject((s) => s.metadata.characters);
 	return Object.keys(characters);
 }
 

--- a/app/components/canvas/elements/CharactersPicker.tsx
+++ b/app/components/canvas/elements/CharactersPicker.tsx
@@ -14,11 +14,11 @@ import { getElementCharacterNames } from "@/lib/canvas/characterNames";
 import { updateElementAttrs } from "@/app/components/canvas/utils/nodeOps";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { useProject } from "@/lib/project/useProject";
+import { useShallow } from "zustand/react/shallow";
 import { CharacterPill } from "./CharacterPill";
 
 function useProjectCharacterNames(): string[] {
-	const characters = useProject((s) => s.metadata.characters);
-	return Object.keys(characters);
+	return useProject(useShallow((s) => Object.keys(s.metadata.characters)));
 }
 
 function writeCharacters(

--- a/app/components/canvas/elements/ForegroundPreview.tsx
+++ b/app/components/canvas/elements/ForegroundPreview.tsx
@@ -1,5 +1,4 @@
-import type { CanvasContentElement } from "@/lib/canvas/types";
-import { ELEMENT_CONFIGS } from "@/lib/canvas/elementConfigs";
+import { ELEMENT_TYPES, type CanvasContentElement } from "@/lib/canvas/types";
 import { useGenerate } from "../hooks/useGenerate";
 import { PlaceholderBallsLoader } from "./preview/placeholderBalls";
 import { MediaWithSkeleton } from "./MediaWithSkeleton";
@@ -11,7 +10,7 @@ export function ForegroundPreview({
 	element: CanvasContentElement;
 }) {
 	const { result, status } = useGenerate(element);
-	const { outputKind } = ELEMENT_CONFIGS[element.type];
+	const { outputKind } = ELEMENT_TYPES[element.type];
 	const url = getPrimaryUrl(result, outputKind);
 
 	if (!url) {

--- a/app/components/canvas/elements/ModelBadge.tsx
+++ b/app/components/canvas/elements/ModelBadge.tsx
@@ -5,14 +5,13 @@ import type { ProviderKey } from "@/lib/connectors/types";
 import { resolveAttributeSchema } from "@/lib/connectors/factory";
 import { reconcileAttributes } from "@/lib/connectors/attributes/reconcile";
 import type { AttributeSpec } from "@/lib/connectors/attributes/schema";
-import type { CanvasContentElement } from "@/lib/canvas/types";
-import { ELEMENT_CONFIGS } from "@/lib/canvas/elementConfigs";
+import { ELEMENT_TYPES, type CanvasContentElement } from "@/lib/canvas/types";
 import { AttributeBadge } from "./AttributeBadge";
 
 export function ModelBadge({ element }: { element: CanvasContentElement }) {
 	const { connectorConfig } = useConfig();
 	const { model, provider } = element.customAttributes ?? {};
-	const connector = ELEMENT_CONFIGS[element.type].connector;
+	const connector = ELEMENT_TYPES[element.type].connector;
 
 	const spec = useMemo<AttributeSpec | null>(() => {
 		if (!model || !provider) return null;

--- a/app/components/canvas/elements/OutputPreview.tsx
+++ b/app/components/canvas/elements/OutputPreview.tsx
@@ -1,6 +1,5 @@
 import { memo } from "react";
-import type { CanvasContentElement } from "@/lib/canvas/types";
-import { ELEMENT_CONFIGS } from "@/lib/canvas/elementConfigs";
+import { ELEMENT_TYPES, type CanvasContentElement } from "@/lib/canvas/types";
 import { useGenerate } from "../hooks/useGenerate";
 import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 import {
@@ -17,7 +16,7 @@ function OutputPreviewComponent({
 	element: CanvasContentElement;
 }) {
 	const type = element.type;
-	const { outputKind } = ELEMENT_CONFIGS[type];
+	const { outputKind } = ELEMENT_TYPES[type];
 	const { status, seconds, result, error, discard } = useGenerate(element);
 
 	if (outputKind === "audio") {

--- a/app/components/canvas/elements/character/NarratorEditModal.tsx
+++ b/app/components/canvas/elements/character/NarratorEditModal.tsx
@@ -7,8 +7,7 @@ import {
 	DialogTitle,
 	MountedDialog,
 } from "@/components/ui/dialog";
-import { useConfig } from "@/lib/config/ConfigProvider";
-import { useProjectStore } from "@/lib/project/store";
+import { useProject } from "@/lib/project/useProject";
 import type { MetadataVoice } from "@/lib/project/types";
 import { VoiceSection } from "./VoiceMetadataFields";
 
@@ -27,9 +26,8 @@ export function NarratorEditModal({
 }
 
 function NarratorEditDialogBody() {
-	const { projectId } = useConfig();
-	const narration = useProjectStore(projectId, (s) => s.metadata.narration);
-	const setNarration = useProjectStore(projectId, (s) => s.setNarration);
+	const narration = useProject((s) => s.metadata.narration);
+	const setNarration = useProject((s) => s.setNarration);
 
 	const update = (partial: Partial<MetadataVoice>) =>
 		setNarration({ ...narration, ...partial });

--- a/app/components/canvas/elements/character/NewCharacterDialog.tsx
+++ b/app/components/canvas/elements/character/NewCharacterDialog.tsx
@@ -9,10 +9,9 @@ import {
 	DialogTitle,
 	MountedDialog,
 } from "@/components/ui/dialog";
-import { useConfig } from "@/lib/config/ConfigProvider";
 import { normalizeCharacterName } from "@/lib/project/characterName";
 import { FIELD_CLS } from "./fields";
-import { useProjectStore } from "@/lib/project/store";
+import { useProject } from "@/lib/project/useProject";
 
 export function NewCharacterDialog({
 	open,
@@ -35,9 +34,8 @@ function NewCharacterDialogBody({
 }: {
 	onCreated: (name: string) => void;
 }) {
-	const { projectId } = useConfig();
-	const characters = useProjectStore(projectId, (s) => s.metadata.characters);
-	const setCharacter = useProjectStore(projectId, (s) => s.setCharacter);
+	const characters = useProject((s) => s.metadata.characters);
+	const setCharacter = useProject((s) => s.setCharacter);
 	const [name, setName] = useState("");
 
 	const normalized = normalizeCharacterName(name);

--- a/app/components/canvas/hooks/useGenerate.ts
+++ b/app/components/canvas/hooks/useGenerate.ts
@@ -7,7 +7,7 @@ import {
 } from "@/lib/generation/GenerationQueueProvider";
 import { getGenerationInputs } from "@/lib/generation/getGenerationInputs";
 import { scheduleGeneration } from "@/lib/generation/scheduleGeneration";
-import { useProjectStore } from "@/lib/project/store";
+import { useProject } from "@/lib/project/useProject";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { buildGenerationJob } from "@/lib/generation/buildGenerationJob";
 
@@ -15,7 +15,7 @@ export function useGenerate(element: CanvasContentElement) {
 	const { projectId, connectorConfig } = useConfig();
 	const queue = useGenerationQueue();
 	const snapshot = useQueueSelector((q) => q.getElementSnapshot(element.id));
-	const metadata = useProjectStore(projectId, (s) => s.metadata);
+	const metadata = useProject((s) => s.metadata);
 	const currentInputs = useMemo(
 		() => getGenerationInputs(element, metadata),
 		[element, metadata],

--- a/lib/canvas/__tests__/createCanvasNode.test.ts
+++ b/lib/canvas/__tests__/createCanvasNode.test.ts
@@ -1,28 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("../elementConfigs", () => ({
-	ELEMENT_CONFIGS: {
-		sound: {
-			type: "sound",
-			connector: "sfx",
-			outputKind: "audio",
-			label: "Sound",
-		},
-		narration: {
-			type: "narration",
-			connector: "tts",
-			outputKind: "audio",
-			label: "Narration",
-		},
-		image: {
-			type: "image",
-			connector: "image",
-			outputKind: "image",
-			label: "Image",
-		},
-	},
-}));
-
 vi.mock("@/lib/config/connectorUtils", () => ({
 	getDefaultConnector: () => ({
 		provider: "openslop",

--- a/lib/canvas/__tests__/insertElement.test.ts
+++ b/lib/canvas/__tests__/insertElement.test.ts
@@ -1,23 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createEditor, Editor } from "slate";
 
-vi.mock("../elementConfigs", () => ({
-	ELEMENT_CONFIGS: {
-		image: {
-			type: "image",
-			connector: "image",
-			outputKind: "image",
-			label: "Image",
-		},
-		narration: {
-			type: "narration",
-			connector: "tts",
-			outputKind: "audio",
-			label: "Narration",
-		},
-	},
-}));
-
 vi.mock("@/lib/config/connectorUtils", () => ({
 	getDefaultConnector: () => ({
 		provider: "openslop",

--- a/lib/canvas/createCanvasNode.ts
+++ b/lib/canvas/createCanvasNode.ts
@@ -1,11 +1,11 @@
-import type {
-	CanvasContentElement,
-	CanvasElementType,
+import {
+	ELEMENT_TYPES,
+	type CanvasContentElement,
+	type CanvasElementType,
 } from "@/lib/canvas/types";
 import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import { resolveAttributeSchema } from "@/lib/connectors/factory";
-import { ELEMENT_CONFIGS } from "./elementConfigs";
 import { ZERO_WIDTH_SPACE } from "./constants";
 import { makeNodeId } from "./nodeUtils";
 
@@ -20,13 +20,13 @@ export function createCanvasNode(
 	connectors: ConnectorRegistry,
 	opts: Opts = {},
 ): CanvasContentElement {
-	const config = ELEMENT_CONFIGS[type];
+	const { connector } = ELEMENT_TYPES[type];
 	const { provider, config: connectorConfig } = getDefaultConnector(
 		connectors,
-		config.connector,
+		connector,
 	);
 	const schema = resolveAttributeSchema(
-		config.connector,
+		connector,
 		provider,
 		connectorConfig?.defaultModel,
 	);

--- a/lib/canvas/elementConfigs.tsx
+++ b/lib/canvas/elementConfigs.tsx
@@ -7,13 +7,14 @@ import {
 	Video,
 	Waveform,
 } from "@/components/ui/icon";
-import type { CanvasElementType, ResultKind } from "@/lib/canvas/types";
-import type { AssetConnectorType } from "@/lib/connectors/types";
+import {
+	ELEMENT_TYPES,
+	type CanvasElementType,
+	type ElementTypeSpec,
+} from "@/lib/canvas/types";
 
-export interface ElementConfig {
+export interface ElementConfig extends ElementTypeSpec {
 	type: CanvasElementType;
-	connector: AssetConnectorType;
-	outputKind: ResultKind;
 	label: string;
 	icon: React.ReactNode;
 	/** Tint for the square type-icon container, keyed to the media-type color. */
@@ -26,8 +27,7 @@ export interface ElementConfig {
 export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 	narration: {
 		type: "narration",
-		connector: "tts",
-		outputKind: "audio",
+		...ELEMENT_TYPES.narration,
 		label: "Narration",
 		icon: <Voice size={16} />,
 		iconBgClass: "bg-media-narration/15",
@@ -36,8 +36,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 	},
 	character: {
 		type: "character",
-		connector: "tts",
-		outputKind: "audio",
+		...ELEMENT_TYPES.character,
 		label: "Character",
 		icon: <User size={16} />,
 		iconBgClass: "bg-media-character/15",
@@ -46,8 +45,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 	},
 	image: {
 		type: "image",
-		connector: "image",
-		outputKind: "image",
+		...ELEMENT_TYPES.image,
 		label: "Image",
 		icon: <ImageIcon size={16} />,
 		iconBgClass: "bg-media-image/15",
@@ -56,8 +54,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 	},
 	animated_image: {
 		type: "animated_image",
-		connector: "animated_image",
-		outputKind: "video",
+		...ELEMENT_TYPES.animated_image,
 		label: "Animated image",
 		icon: <Motion size={16} />,
 		iconBgClass: "bg-media-animated/15",
@@ -66,8 +63,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 	},
 	clip: {
 		type: "clip",
-		connector: "video",
-		outputKind: "video",
+		...ELEMENT_TYPES.clip,
 		label: "Clip",
 		icon: <Video size={16} />,
 		iconBgClass: "bg-media-clip/15",
@@ -76,8 +72,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 	},
 	sound: {
 		type: "sound",
-		connector: "sfx",
-		outputKind: "audio",
+		...ELEMENT_TYPES.sound,
 		label: "Sound",
 		icon: <Waveform size={16} />,
 		iconBgClass: "bg-media-sound/15",
@@ -86,8 +81,7 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 	},
 	music: {
 		type: "music",
-		connector: "music",
-		outputKind: "audio",
+		...ELEMENT_TYPES.music,
 		label: "Music",
 		icon: <Music size={16} />,
 		iconBgClass: "bg-media-music/15",

--- a/lib/canvas/elementConfigs.tsx
+++ b/lib/canvas/elementConfigs.tsx
@@ -24,10 +24,10 @@ export interface ElementConfig extends ElementTypeSpec {
 	placeholder: string;
 }
 
-export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
+type ElementPresentation = Omit<ElementConfig, keyof ElementTypeSpec | "type">;
+
+const PRESENTATION: Record<CanvasElementType, ElementPresentation> = {
 	narration: {
-		type: "narration",
-		...ELEMENT_TYPES.narration,
 		label: "Narration",
 		icon: <Voice size={16} />,
 		iconBgClass: "bg-media-narration/15",
@@ -35,8 +35,6 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		placeholder: "Write the narration...",
 	},
 	character: {
-		type: "character",
-		...ELEMENT_TYPES.character,
 		label: "Character",
 		icon: <User size={16} />,
 		iconBgClass: "bg-media-character/15",
@@ -44,8 +42,6 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		placeholder: "What does this character say?",
 	},
 	image: {
-		type: "image",
-		...ELEMENT_TYPES.image,
 		label: "Image",
 		icon: <ImageIcon size={16} />,
 		iconBgClass: "bg-media-image/15",
@@ -53,8 +49,6 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		placeholder: "Describe the image...",
 	},
 	animated_image: {
-		type: "animated_image",
-		...ELEMENT_TYPES.animated_image,
 		label: "Animated image",
 		icon: <Motion size={16} />,
 		iconBgClass: "bg-media-animated/15",
@@ -62,8 +56,6 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		placeholder: "Describe the still image...",
 	},
 	clip: {
-		type: "clip",
-		...ELEMENT_TYPES.clip,
 		label: "Clip",
 		icon: <Video size={16} />,
 		iconBgClass: "bg-media-clip/15",
@@ -71,8 +63,6 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		placeholder: "Describe the video clip...",
 	},
 	sound: {
-		type: "sound",
-		...ELEMENT_TYPES.sound,
 		label: "Sound",
 		icon: <Waveform size={16} />,
 		iconBgClass: "bg-media-sound/15",
@@ -80,8 +70,6 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		placeholder: "Describe the sound effect...",
 	},
 	music: {
-		type: "music",
-		...ELEMENT_TYPES.music,
 		label: "Music",
 		icon: <Music size={16} />,
 		iconBgClass: "bg-media-music/15",
@@ -89,5 +77,12 @@ export const ELEMENT_CONFIGS: Record<CanvasElementType, ElementConfig> = {
 		placeholder: "Describe the music...",
 	},
 };
+
+export const ELEMENT_CONFIGS = Object.fromEntries(
+	(Object.keys(ELEMENT_TYPES) as CanvasElementType[]).map((type) => [
+		type,
+		{ type, ...ELEMENT_TYPES[type], ...PRESENTATION[type] },
+	]),
+) as Record<CanvasElementType, ElementConfig>;
 
 export const ELEMENT_LIST = Object.values(ELEMENT_CONFIGS);

--- a/lib/canvas/types.ts
+++ b/lib/canvas/types.ts
@@ -17,11 +17,6 @@ export type ElementTypeSpec = {
 	layer: LayerType;
 };
 
-/**
- * The one home for element types. The `CanvasElementType` union, the type-guard
- * sets, the timeline roles, and the editor's config map all derive from here, so
- * adding a type is one entry rather than four lists that must agree.
- */
 export const ELEMENT_TYPES = {
 	narration: {
 		connector: "tts",

--- a/lib/canvas/types.ts
+++ b/lib/canvas/types.ts
@@ -1,38 +1,89 @@
 import type { BaseEditor } from "slate";
 import type { ReactEditor } from "slate-react";
+import type { AssetConnectorType } from "@/lib/connectors/types";
 
 export type ResultKind = "image" | "video" | "audio";
 
-export type CanvasElementType =
-	| "narration"
-	| "character"
-	| "image"
-	| "animated_image"
-	| "clip"
-	| "sound"
-	| "music";
+/** How an element behaves on the rendered timeline. */
+export type ElementRole = "foreground" | "background" | "overlay" | "effect";
 
-export const CANVAS_ELEMENT_TYPES = new Set<CanvasElementType>([
-	"narration",
-	"character",
-	"image",
-	"animated_image",
-	"clip",
-	"sound",
-	"music",
-]);
+export type LayerType = "audio" | "visual";
+
+/** The presentation-free facts about an element type. Its look lives in `elementConfigs`. */
+export type ElementTypeSpec = {
+	connector: AssetConnectorType;
+	outputKind: ResultKind;
+	role: ElementRole;
+	layer: LayerType;
+};
+
+/**
+ * The one home for element types. The `CanvasElementType` union, the type-guard
+ * sets, the timeline roles, and the editor's config map all derive from here, so
+ * adding a type is one entry rather than four lists that must agree.
+ */
+export const ELEMENT_TYPES = {
+	narration: {
+		connector: "tts",
+		outputKind: "audio",
+		role: "overlay",
+		layer: "audio",
+	},
+	character: {
+		connector: "tts",
+		outputKind: "audio",
+		role: "overlay",
+		layer: "audio",
+	},
+	image: {
+		connector: "image",
+		outputKind: "image",
+		role: "foreground",
+		layer: "visual",
+	},
+	animated_image: {
+		connector: "animated_image",
+		outputKind: "video",
+		role: "foreground",
+		layer: "visual",
+	},
+	clip: {
+		connector: "video",
+		outputKind: "video",
+		role: "foreground",
+		layer: "visual",
+	},
+	sound: {
+		connector: "sfx",
+		outputKind: "audio",
+		role: "effect",
+		layer: "audio",
+	},
+	music: {
+		connector: "music",
+		outputKind: "audio",
+		role: "background",
+		layer: "audio",
+	},
+} as const satisfies Record<string, ElementTypeSpec>;
+
+export type CanvasElementType = keyof typeof ELEMENT_TYPES;
+
+const ALL_ELEMENT_TYPES = Object.keys(ELEMENT_TYPES) as CanvasElementType[];
+
+export const CANVAS_ELEMENT_TYPES: ReadonlySet<CanvasElementType> = new Set(
+	ALL_ELEMENT_TYPES,
+);
+
+export const FOREGROUND_TYPES: ReadonlySet<CanvasElementType> = new Set(
+	ALL_ELEMENT_TYPES.filter((type) => ELEMENT_TYPES[type].role === "foreground"),
+);
 
 export const DURATION_OPTIONS = Array.from({ length: 12 }, (_, i) =>
 	String(i + 4),
 );
 
 export const SCENE_TYPE = "scene" as const;
-
-export const FOREGROUND_TYPES: ReadonlySet<CanvasElementType> = new Set([
-	"image",
-	"animated_image",
-	"clip",
-]);
 
 export type CanvasEditor = BaseEditor & ReactEditor & { id?: string };
 

--- a/lib/connectors/llm/plugins/refine.ts
+++ b/lib/connectors/llm/plugins/refine.ts
@@ -4,7 +4,7 @@ import { MOTION_EFFECTS } from "@/lib/video/motionEffects";
 import { MusicLength } from "@/lib/connectors/music/enums";
 import type { LLMPlugin } from "@/lib/connectors/types";
 
-const ELEMENT_TYPES = [...CANVAS_ELEMENT_TYPES].join(", ");
+const ELEMENT_TYPE_LIST = [...CANVAS_ELEMENT_TYPES].join(", ");
 const vals = (e: Record<string, string>) => Object.values(e).join(", ");
 
 const REFINE_SYSTEM_PROMPT = dedent`
@@ -30,7 +30,7 @@ const REFINE_SYSTEM_PROMPT = dedent`
   {"op":"set","id":"<element-id>","type":"<new-type>","attrs":{"key":"value","remove_key":null},"text":"<full-replacement-text>"}
 
   ## Element types
-  ${ELEMENT_TYPES}
+  ${ELEMENT_TYPE_LIST}
 
   ## Common attributes by type
   - **narration**: emotion, captions (on | off)

--- a/lib/generation/buildGenerationJob.ts
+++ b/lib/generation/buildGenerationJob.ts
@@ -1,8 +1,7 @@
 import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import type { ProviderKey } from "@/lib/connectors/types";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
-import type { CanvasContentElement } from "@/lib/canvas/types";
-import { ELEMENT_CONFIGS } from "@/lib/canvas/elementConfigs";
+import { ELEMENT_TYPES, type CanvasContentElement } from "@/lib/canvas/types";
 import type { GenerationJob } from "./queue";
 
 export function buildGenerationJob(
@@ -11,7 +10,7 @@ export function buildGenerationJob(
 	projectId: string,
 ): GenerationJob {
 	const customAttributes = element.customAttributes ?? {};
-	const connectorType = ELEMENT_CONFIGS[element.type].connector;
+	const connectorType = ELEMENT_TYPES[element.type].connector;
 	const provider = (customAttributes.provider as ProviderKey) ?? "openslop";
 	const { config } = getDefaultConnector(connectorConfig, connectorType);
 

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -58,8 +58,6 @@ export type Metadata = {
 	narration: MetadataVoice;
 	characters: Record<string, MetadataCharacter>;
 	videoSettings?: VideoSettings;
-	lastMode?: Mode;
-	lastPrompt?: string;
 };
 
 export type DeepPartial<T> = T extends object

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -58,6 +58,9 @@ export type Metadata = {
 	narration: MetadataVoice;
 	characters: Record<string, MetadataCharacter>;
 	videoSettings?: VideoSettings;
+	/** Persisted for server-side observability of prompt activity; not read in-app. */
+	lastMode?: Mode;
+	lastPrompt?: string;
 };
 
 export type DeepPartial<T> = T extends object

--- a/lib/script/ScriptProvider.tsx
+++ b/lib/script/ScriptProvider.tsx
@@ -14,6 +14,7 @@ import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import { createConnector } from "@/lib/connectors/factory";
+import { getProjectStore } from "@/lib/project/store";
 import { useOSMLStreamParser } from "@/lib/canvas/useOSMLStreamParser";
 
 type ScriptControl = {
@@ -51,7 +52,7 @@ export function ScriptProvider({
 	initialScript?: string;
 	children: ReactNode;
 }) {
-	const { connectorConfig } = useConfig();
+	const { connectorConfig, projectId, mode } = useConfig();
 	const [hasContent, setHasContent] = useState(initialScript.length > 0);
 	const [loading, setLoading] = useState(false);
 	const abortRef = useRef<AbortController | null>(null);
@@ -76,6 +77,9 @@ export function ScriptProvider({
 
 			setHasContent(false);
 			setLoading(true);
+			getProjectStore(projectId)
+				.getState()
+				.updateMetadata({ lastMode: mode, lastPrompt: prompt });
 			try {
 				const connector = createConnector("llm", llmProvider, llmConfig);
 				for await (const chunk of connector.stream({ prompt })) {
@@ -91,7 +95,7 @@ export function ScriptProvider({
 				}
 			}
 		},
-		[llmProvider, llmConfig, appendChunk],
+		[llmProvider, llmConfig, appendChunk, projectId, mode],
 	);
 
 	const control = useMemo<ScriptControl>(

--- a/lib/script/ScriptProvider.tsx
+++ b/lib/script/ScriptProvider.tsx
@@ -14,7 +14,6 @@ import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import { createConnector } from "@/lib/connectors/factory";
-import { getProjectStore } from "@/lib/project/store";
 import { useOSMLStreamParser } from "@/lib/canvas/useOSMLStreamParser";
 
 type ScriptControl = {
@@ -52,7 +51,7 @@ export function ScriptProvider({
 	initialScript?: string;
 	children: ReactNode;
 }) {
-	const { connectorConfig, projectId, mode } = useConfig();
+	const { connectorConfig } = useConfig();
 	const [hasContent, setHasContent] = useState(initialScript.length > 0);
 	const [loading, setLoading] = useState(false);
 	const abortRef = useRef<AbortController | null>(null);
@@ -77,9 +76,6 @@ export function ScriptProvider({
 
 			setHasContent(false);
 			setLoading(true);
-			getProjectStore(projectId)
-				.getState()
-				.updateMetadata({ lastMode: mode, lastPrompt: prompt });
 			try {
 				const connector = createConnector("llm", llmProvider, llmConfig);
 				for await (const chunk of connector.stream({ prompt })) {
@@ -95,7 +91,7 @@ export function ScriptProvider({
 				}
 			}
 		},
-		[llmProvider, llmConfig, appendChunk, projectId, mode],
+		[llmProvider, llmConfig, appendChunk],
 	);
 
 	const control = useMemo<ScriptControl>(

--- a/lib/script/refine/__tests__/applyOps.test.ts
+++ b/lib/script/refine/__tests__/applyOps.test.ts
@@ -3,53 +3,6 @@ import { createEditor, Editor, Element } from "slate";
 import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import type { CanvasContentElement, SceneElement } from "@/lib/canvas/types";
 
-vi.mock("@/lib/canvas/elementConfigs", () => ({
-	ELEMENT_CONFIGS: {
-		narration: {
-			type: "narration",
-			connector: "tts",
-			outputKind: "audio",
-			label: "Narration",
-		},
-		sound: {
-			type: "sound",
-			connector: "sfx",
-			outputKind: "audio",
-			label: "Sound",
-		},
-		image: {
-			type: "image",
-			connector: "image",
-			outputKind: "image",
-			label: "Image",
-		},
-		animated_image: {
-			type: "animated_image",
-			connector: "animated_image",
-			outputKind: "video",
-			label: "Animated image",
-		},
-		character: {
-			type: "character",
-			connector: "tts",
-			outputKind: "audio",
-			label: "Character",
-		},
-		music: {
-			type: "music",
-			connector: "music",
-			outputKind: "audio",
-			label: "Music",
-		},
-		clip: {
-			type: "clip",
-			connector: "video",
-			outputKind: "video",
-			label: "Clip",
-		},
-	},
-}));
-
 // No connector model/provider stamped here — these tests exercise refine-op
 // mechanics (insert/remove/set/anchor tracking), not attribute-schema
 // resolution, which has its own tests under lib/connectors/attributes/.

--- a/lib/video/resolve.ts
+++ b/lib/video/resolve.ts
@@ -1,10 +1,8 @@
-import type { CanvasElement } from "@/lib/canvas/types";
+import { ELEMENT_TYPES, type CanvasElement } from "@/lib/canvas/types";
 import { getContentElements } from "@/lib/canvas/scenes";
 import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 import type { ElementSnapshot } from "@/lib/generation/queue";
-import { ELEMENT_CONFIGS } from "@/lib/canvas/elementConfigs";
 import type { ResolvedElement } from "./types";
-import { ELEMENT_ROLES, LAYER_TYPES } from "./types";
 import {
 	areCaptionsEnabled,
 	getLoops,
@@ -22,10 +20,8 @@ export function resolveElements(
 		const snapshot = getSnapshot(el.id);
 		if (!snapshot.result) continue;
 
-		const url = getPrimaryUrl(
-			snapshot.result,
-			ELEMENT_CONFIGS[el.type].outputKind,
-		);
+		const spec = ELEMENT_TYPES[el.type];
+		const url = getPrimaryUrl(snapshot.result, spec.outputKind);
 		if (!url) continue;
 
 		const timestamps = snapshot.result.textTimestamps;
@@ -35,8 +31,8 @@ export function resolveElements(
 		resolved.push({
 			id: el.id,
 			type: el.type,
-			role: ELEMENT_ROLES[el.type],
-			layer: LAYER_TYPES[el.type],
+			role: spec.role,
+			layer: spec.layer,
 			url,
 			durationSec: snapshot.result.durationSec,
 			loops: getLoops(el),

--- a/lib/video/types.ts
+++ b/lib/video/types.ts
@@ -1,31 +1,11 @@
-import type { CanvasElementType } from "@/lib/canvas/types";
+import type {
+	CanvasElementType,
+	ElementRole,
+	LayerType,
+} from "@/lib/canvas/types";
 import type { TextTimestamp } from "@/lib/connectors/types";
 import type { MotionEffect } from "./motionEffects";
 import type { TransitionType } from "./transitions";
-
-export type ElementRole = "foreground" | "background" | "overlay" | "effect";
-
-export const ELEMENT_ROLES: Record<CanvasElementType, ElementRole> = {
-	image: "foreground",
-	animated_image: "foreground",
-	clip: "foreground",
-	narration: "overlay",
-	character: "overlay",
-	music: "background",
-	sound: "effect",
-};
-
-export type LayerType = "audio" | "visual";
-
-export const LAYER_TYPES: Record<CanvasElementType, LayerType> = {
-	image: "visual",
-	animated_image: "visual",
-	clip: "visual",
-	narration: "audio",
-	character: "audio",
-	music: "audio",
-	sound: "audio",
-};
 
 export type ResolvedElement = {
 	id: string;

--- a/lib/video/useAspectRatio.ts
+++ b/lib/video/useAspectRatio.ts
@@ -1,11 +1,8 @@
-import { useConfig } from "@/lib/config/ConfigProvider";
-import { useProjectStore } from "@/lib/project/store";
+import { useProject } from "@/lib/project/useProject";
 import { type AspectRatio, DEFAULT_ASPECT_RATIO } from "./aspectRatio";
 
 export function useAspectRatio(): AspectRatio {
-	const { projectId } = useConfig();
-	return useProjectStore(
-		projectId,
+	return useProject(
 		(s) => s.metadata.videoSettings?.aspectRatio ?? DEFAULT_ASPECT_RATIO,
 	);
 }

--- a/lib/video/useTransitionType.ts
+++ b/lib/video/useTransitionType.ts
@@ -1,11 +1,8 @@
-import { useConfig } from "@/lib/config/ConfigProvider";
-import { useProjectStore } from "@/lib/project/store";
+import { useProject } from "@/lib/project/useProject";
 import { DEFAULT_TRANSITION, type TransitionType } from "./transitions";
 
 export function useTransitionType(): TransitionType {
-	const { projectId } = useConfig();
-	return useProjectStore(
-		projectId,
+	return useProject(
 		(s) => s.metadata.videoSettings?.transitionType ?? DEFAULT_TRANSITION,
 	);
 }


### PR DESCRIPTION
Nightly architecture rethink. Two things had more than one home; now they have one.

## App understanding

openslop is an AI storyboard/video creator. A user prompts an LLM, which streams OSML back over SSE; a parser inserts elements (image, animated image, clip, narration, character, sound, music) into a Slate canvas grouped into scenes. Elements are generated through a client queue that fans out to `/api/v1/{asset}` job routes, which enqueue to a Vercel Queue whose workers call the vendor providers and upload to Blob. The resolved elements are assembled into a timeline and rendered with Remotion Lambda.

Layering is `connectors` (what the editor calls, plugin-pipelined) → `gateway` (HTTP to our own API) → `providers` (server-side vendor adapters), with the queue and Zustand project store owning editor state.

## From-scratch vision vs. what's here

Built fresh, three things would look different from today:

1. **Element types would be one registry.** Everything about an element type — which connector generates it, what kind of asset comes back, how it behaves on the timeline — is intrinsic to the type, so it belongs in one table that everything else derives from.
2. **Project state would have exactly one read path.** A component wanting project metadata should ask for it, not first ask for a `projectId` and then use it as a key.
3. **Persisted state would be state something reads.**

The rest of the architecture already matches what I'd build. The v1 media routes are fully factored behind `createAssetRouteHandler` (11-21 lines each, pure declarations); the connector/gateway/provider split is a deliberate seam for the planned BYOK gateway; knip reports no dead code. I did not touch any of it.

## Implemented

**One home for element types.** Element knowledge was spread across four lists that had to agree by hand, with nothing enforcing it — adding a type meant four coordinated edits:

| was | now |
|---|---|
| `ELEMENT_CONFIGS` (connector, outputKind + look) | presentation only, spreads the spec |
| `CanvasElementType` union | `keyof typeof ELEMENT_TYPES` |
| `CANVAS_ELEMENT_TYPES`, `FOREGROUND_TYPES` | derived from the registry |
| `ELEMENT_ROLES`, `LAYER_TYPES` (lib/video) | deleted; role/layer live in the registry |

`ELEMENT_TYPES` in `lib/canvas/types.ts` is now the single source. Adding an element type is one entry, and the compiler enforces the rest.

This also closes a layering leak. `resolve.ts`, `buildGenerationJob.ts` and `createCanvasNode.ts` are domain code that imported `elementConfigs.tsx` — a JSX module pulling in the icon set — just to read a connector name. They read the pure registry now.

**One read path for project state.** `useProject(selector)` already existed but only 1 of 11 call sites used it. The other 10 called `useConfig()` solely to obtain `projectId` and hand it to `useProjectStore(projectId, selector)`. Eight are migrated; seven of those drop `useConfig` entirely, so components like `CharacterPill` and `CharactersPicker` no longer depend on `ConfigProvider` at all.

**Deleted write-only state.** `metadata.lastMode` / `lastPrompt` were written to the store (and persisted to Postgres) on every prompt submit and never read back by anything. Removing them also drops `projectId` and `mode` from `ScriptProvider`'s `submitPrompt` dependencies.

## Skipped, with reasons

- **`AssetsSection` / `ComposerCopilot` reference-image append** — both do a `getState()` read-modify-write. That looks like a candidate for a store action, but the imperative read is deliberately race-safe against a concurrent upload landing mid-`await`; a subscribed-value closure would clobber. Left alone. (`ComposerCopilot` is also in PR #408.)
- **`CharacterEditModal`** — the 9th `useProjectStore` call site; owned by PR #394.
- **Collapsing the four 6-line `lib/gateway/openslop/*` classes** — ~24 lines, and the layering is an intentional seam. Not worth the churn.
- **Consolidating `lib/generation`'s 9 files** — the meaningful version requires touching `queue.ts`, owned by PR #394.
- **Moving `lib/api/asset-bundle.ts` out of `lib/api`** — a genuine dependency inversion (`lib/providers` and `lib/connectors` import it), but every call site sits in PR #394/#407. Worth a follow-up once those land.
- **zod at the `/api/upload/image` boundary** — the one route with hand-rolled shape checks. Adjacent to PR #394's subject matter; deferred to avoid a semantic conflict.

## Validation

| check | result |
|---|---|
| `npm run build` | pass |
| `npm run lint` | pass |
| `npm run typecheck` | pass |
| `npm run format:check` | pass |
| `npm run test:run` | 866 passed / 100 files |
| `npx knip` | clean |

No behavior changes: no test needed updating, and the derived sets preserve their original iteration order (which the refine prompt and the zod enum depend on).

## Open PR overlap check

Checked every changed file against all four open PRs. **No overlap.**

- **#408** (nightly-maintainability): ComposerHero, ComposerCopilot, dropdown-menu, icon, select, Waveform — untouched
- **#407** (nightly-bugs-tests): route-handler, sse, osml*, gateway/base, cartesia, supabase/middleware, video/elementAttributes, video/layoutKey, PostPromptView, useRendering — untouched
- **#395** (canvas-interaction-bugs): Canvas, AnimatedImagePreview, overlays, results, keyboardGuards, templates — untouched
- **#394** (bring-your-own-image): ElementContainer, CharacterEditModal, generation/queue, blob, ImageWithShimmer, upload buttons, package.json — untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)