### PR TITLE
fix: enable player controls in fullscreen

### DIFF
--- a/app/components/video/VideoPreview.tsx
+++ b/app/components/video/VideoPreview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { PlayerRef } from "@remotion/player";
+import type { CallbackListener, PlayerRef } from "@remotion/player";
 import dynamic from "next/dynamic";
 import { useEffect, useState, type MutableRefObject, type Ref } from "react";
 import type { VideoLayout } from "@/lib/video/types";
@@ -74,10 +74,12 @@ export function VideoPreview({ layout, restoreFrameRef }: VideoPreviewProps) {
 	}, [player, registerPlayer]);
 	usePreservedPlayhead(player, restoreFrameRef, layout.totalFrames);
 	useEffect(() => {
-		const handler = () => setIsFullscreen(!!document.fullscreenElement);
-		document.addEventListener("fullscreenchange", handler);
-		return () => document.removeEventListener("fullscreenchange", handler);
-	}, []);
+		if (!player) return;
+		const handler: CallbackListener<"fullscreenchange"> = (e) =>
+			setIsFullscreen(e.detail.isFullscreen);
+		player.addEventListener("fullscreenchange", handler);
+		return () => player.removeEventListener("fullscreenchange", handler);
+	}, [player]);
 	const toggleAndFlash = () => {
 		if (!player) return;
 		const willPlay = !player.isPlaying();

--- a/app/components/video/VideoPreview.tsx
+++ b/app/components/video/VideoPreview.tsx
@@ -24,9 +24,11 @@ const RemotionPlayer = dynamic(
 		function RemotionPlayerInner({
 			layout,
 			playerRef,
+			controls,
 		}: {
 			layout: VideoLayout;
 			playerRef: Ref<PlayerRef>;
+			controls: boolean;
 		}) {
 			return (
 				<Player
@@ -39,6 +41,7 @@ const RemotionPlayer = dynamic(
 					compositionHeight={layout.height}
 					style={fullSizeStyle}
 					clickToPlay={false}
+					controls={controls}
 					acknowledgeRemotionLicense
 					numberOfSharedAudioTags={10}
 				/>
@@ -57,6 +60,7 @@ type VideoPreviewProps = {
 
 export function VideoPreview({ layout, restoreFrameRef }: VideoPreviewProps) {
 	const [player, setPlayer] = useState<PlayerRef | null>(null);
+	const [isFullscreen, setIsFullscreen] = useState(false);
 	const segments = useSceneSegments();
 	const activeIndex = useActiveSegmentIndex(player, segments, layout.fps);
 	useActiveSceneSync(player, segments, activeIndex);
@@ -69,6 +73,11 @@ export function VideoPreview({ layout, restoreFrameRef }: VideoPreviewProps) {
 		return () => registerPlayer(null);
 	}, [player, registerPlayer]);
 	usePreservedPlayhead(player, restoreFrameRef, layout.totalFrames);
+	useEffect(() => {
+		const handler = () => setIsFullscreen(!!document.fullscreenElement);
+		document.addEventListener("fullscreenchange", handler);
+		return () => document.removeEventListener("fullscreenchange", handler);
+	}, []);
 	const toggleAndFlash = () => {
 		if (!player) return;
 		const willPlay = !player.isPlaying();
@@ -78,7 +87,11 @@ export function VideoPreview({ layout, restoreFrameRef }: VideoPreviewProps) {
 	return (
 		<div className={`relative h-full w-full ${styles.player}`}>
 			<ToastErrorBoundary label="Player">
-				<RemotionPlayer layout={layout} playerRef={setPlayer} />
+				<RemotionPlayer
+					layout={layout}
+					playerRef={setPlayer}
+					controls={isFullscreen}
+				/>
 			</ToastErrorBoundary>
 			<div
 				className="absolute inset-0 cursor-pointer"


### PR DESCRIPTION
## Summary

Enables the Remotion Player's built-in controls (play/pause, seek bar, volume, time display, fullscreen button) in fullscreen mode, where the custom `BottomTransportBar` is hidden.

## Bug fixed

- **Fullscreen player has no play/pause/seek controls** (#343) — When a user entered fullscreen via the `BottomTransportBar`'s fullscreen button, only click-to-toggle play/pause worked (via the transparent overlay in `VideoPreview`). There was no visible transport, no seek bar, no volume control, and no time display.

## Change

- `app/components/video/VideoPreview.tsx` — Added fullscreen state tracking via the browser Fullscreen API (`document.fullscreenElement` + `fullscreenchange` event). Passes `controls={isFullscreen}` to the dynamically-imported `RemotionPlayer`, enabling Remotion's built-in transport overlay only when fullscreen is active. In normal (non-fullscreen) mode, the custom `BottomTransportBar` is used as before.

## Validation

| check | result |
|---|---|
| `npm run lint` | pass |
| `npm run typecheck` | pass |
| `npm run format:check` | pass |
| `npm run test:run` | 866 passed / 100 files |
| `npm run build` | pass |
| `npx knip` | clean |

## Open PR overlap check

Checked `VideoPreview.tsx` against all five open PRs (#394, #395, #407, #408, #409). None touch this file or the video player transport area. No overlap.

## Skipped items

- Did not attempt to style Remotion's built-in controls to match OpenSlop's design system. The custom `BottomTransportBar` already serves that role in normal view; in fullscreen, the native Remotion controls are functional and acceptable.
- Did not add a dedicated fullscreen transport overlay using the app's own components — that would be a larger feature requiring UX decisions about placement, auto-hide behavior, and mobile layout. The Remotion built-in controls are the minimal fix.

Closes #343
