### PR TITLE
fix: nightly bug fixes 2026-07-14

### DIFF
--- a/lib/api/__tests__/video-handler.test.ts
+++ b/lib/api/__tests__/video-handler.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { VideoGenerateParams } from "@/lib/connectors/types";
+import type { JobRow } from "../jobs";
+import { videoHandler } from "../handlers/video";
+
+const mockGenerate = vi.fn();
+const mockPoll = vi.fn();
+const mockUpdateJob = vi.fn();
+
+vi.mock("../providers", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../providers")>()),
+	getVideoProvider: () => ({ generate: mockGenerate, poll: mockPoll }),
+}));
+vi.mock("../jobs", () => ({
+	updateJob: (...args: unknown[]) => mockUpdateJob(...args),
+}));
+
+type VideoJobRow = Omit<JobRow, "request" | "metadata"> & {
+	request: VideoGenerateParams;
+	metadata: { providerJobId?: string; durationSec?: number };
+};
+
+function makeJob(overrides: Partial<VideoJobRow> = {}): VideoJobRow {
+	return {
+		id: "job-1",
+		user_id: "user-1",
+		project_id: null,
+		connector_type: "video",
+		status: "processing",
+		request: { prompt: "a sunset", duration: 8 },
+		result: null,
+		metadata: { providerJobId: "provider-1", durationSec: 8 },
+		error: null,
+		created_at: "",
+		updated_at: "",
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("videoHandler.process", () => {
+	it("keeps the submitted duration in metadata so poll can restore it", async () => {
+		mockGenerate.mockResolvedValue({
+			id: "",
+			provider: "runware",
+			result: {},
+			metadata: { jobId: "provider-1", durationSec: 8 },
+		});
+
+		const outcome = await videoHandler.process(makeJob());
+
+		expect(outcome).toEqual({
+			kind: "pending",
+			metadata: { providerJobId: "provider-1", durationSec: 8 },
+		});
+	});
+
+	it("throws when the provider returns no jobId", async () => {
+		mockGenerate.mockResolvedValue({
+			id: "",
+			provider: "runware",
+			result: {},
+			metadata: {},
+		});
+
+		await expect(videoHandler.process(makeJob())).rejects.toThrow(
+			"Video provider returned no jobId",
+		);
+	});
+});
+
+describe("videoHandler.poll", () => {
+	it("returns the stored row for a completed job without re-polling upstream", async () => {
+		const result = {
+			id: "bundle-1",
+			provider: "runware",
+			result: { video: "https://v.mp4" },
+		};
+		const view = await videoHandler.poll?.(
+			makeJob({ status: "completed", result }),
+		);
+
+		expect(view).toEqual({
+			jobId: "job-1",
+			status: "completed",
+			result,
+			error: null,
+		});
+		expect(mockPoll).not.toHaveBeenCalled();
+		expect(mockUpdateJob).not.toHaveBeenCalled();
+	});
+
+	it("returns the stored row for a failed job without re-polling upstream", async () => {
+		const view = await videoHandler.poll?.(
+			makeJob({ status: "failed", error: "boom" }),
+		);
+
+		expect(view).toMatchObject({ status: "failed", error: "boom" });
+		expect(mockPoll).not.toHaveBeenCalled();
+	});
+
+	it("passes the submitted duration to the provider and persists the result", async () => {
+		const upstream = {
+			id: "bundle-1",
+			provider: "runware",
+			result: { video: "https://v.mp4" },
+			metadata: { jobId: "provider-1", durationSec: 8 },
+		};
+		mockPoll.mockResolvedValue(upstream);
+
+		const view = await videoHandler.poll?.(makeJob());
+
+		expect(mockPoll).toHaveBeenCalledWith("provider-1", 8);
+		expect(mockUpdateJob).toHaveBeenCalledWith("job-1", {
+			status: "completed",
+			result: upstream,
+		});
+		expect(view).toEqual({
+			jobId: "job-1",
+			status: "completed",
+			result: upstream,
+			error: null,
+		});
+	});
+
+	it("marks the job failed when the provider reports failure", async () => {
+		mockPoll.mockResolvedValue({
+			id: "",
+			provider: "runware",
+			result: {},
+			metadata: { jobId: "provider-1", status: "failed", error: "no credits" },
+		});
+
+		const view = await videoHandler.poll?.(makeJob());
+
+		expect(mockUpdateJob).toHaveBeenCalledWith("job-1", {
+			status: "failed",
+			error: "no credits",
+		});
+		expect(view).toMatchObject({ status: "failed", error: "no credits" });
+	});
+
+	it("stays pending while the provider has no video yet", async () => {
+		mockPoll.mockResolvedValue({
+			id: "",
+			provider: "runware",
+			result: {},
+			metadata: { jobId: "provider-1", status: "processing" },
+		});
+
+		const view = await videoHandler.poll?.(makeJob());
+
+		expect(mockUpdateJob).not.toHaveBeenCalled();
+		expect(view).toEqual({
+			jobId: "job-1",
+			status: "processing",
+			result: null,
+			error: null,
+		});
+	});
+
+	it("falls back to the stored row when no provider job was recorded", async () => {
+		const view = await videoHandler.poll?.(makeJob({ metadata: {} }));
+
+		expect(mockPoll).not.toHaveBeenCalled();
+		expect(view).toMatchObject({ jobId: "job-1", status: "processing" });
+	});
+});

--- a/lib/api/handlers/video.ts
+++ b/lib/api/handlers/video.ts
@@ -6,7 +6,7 @@ import { rowView } from "../job-handlers";
 import { updateJob } from "../jobs";
 import { getVideoProvider } from "../providers";
 
-type VideoMetadata = { providerJobId?: string };
+type VideoMetadata = { providerJobId?: string; durationSec?: number };
 
 export const videoHandler: JobHandler<VideoGenerateParams, VideoMetadata> = {
 	process: async (job) => {
@@ -15,13 +15,21 @@ export const videoHandler: JobHandler<VideoGenerateParams, VideoMetadata> = {
 		if (!providerJobId) {
 			throw new Error("Video provider returned no jobId for async generation");
 		}
-		return { kind: "pending", metadata: { providerJobId } };
+		return {
+			kind: "pending",
+			metadata: { providerJobId, durationSec: submitted.metadata?.durationSec },
+		};
 	},
 	poll: async (job): Promise<JobPoll> => {
-		const providerJobId = job.metadata.providerJobId;
+		// A finished job is immutable: re-polling upstream would re-upload the
+		// bundle under a fresh id, or 404 once the provider drops the task.
+		if (job.status === "completed" || job.status === "failed")
+			return rowView(job);
+
+		const { providerJobId, durationSec } = job.metadata;
 		if (!providerJobId) return rowView(job);
 
-		const upstream = await getVideoProvider().poll(providerJobId);
+		const upstream = await getVideoProvider().poll(providerJobId, durationSec);
 		const status = mapVideoStatus(upstream);
 		if (status === "completed") {
 			await updateJob(job.id, { status, result: upstream });

--- a/lib/providers/__tests__/runware-video.test.ts
+++ b/lib/providers/__tests__/runware-video.test.ts
@@ -18,7 +18,10 @@ vi.mock("@runware/sdk-js", () => ({
 	},
 }));
 
+import { AssetBundle } from "@/lib/api/asset-bundle";
 import { RunwareVideo } from "../video/runware";
+
+const mockUpload = vi.mocked(AssetBundle.upload);
 
 describe("RunwareVideo", () => {
 	beforeEach(() => {
@@ -139,9 +142,55 @@ describe("RunwareVideo", () => {
 
 			expect(result.metadata?.durationSec).toBe(10);
 		});
+
+		it("does not upload a bundle for a job that has no video yet", async () => {
+			mockVideoInference.mockResolvedValue({
+				taskUUID: "job-1",
+				status: "processing",
+			});
+
+			const provider = new RunwareVideo("test-key");
+			const result = await provider.generate({ prompt: "a sunset" });
+
+			expect(mockUpload).not.toHaveBeenCalled();
+			expect(result.id).toBe("");
+			expect(result.result).toEqual({});
+		});
 	});
 
 	describe("poll", () => {
+		it("stores the submitted duration on the completed bundle", async () => {
+			mockGetResponse.mockResolvedValue([
+				{
+					taskUUID: "job-1",
+					status: "completed",
+					videoURL: "https://result.mp4",
+				},
+			]);
+
+			const provider = new RunwareVideo("test-key");
+			const result = await provider.poll("job-1", 8);
+
+			expect(result.metadata?.durationSec).toBe(8);
+			expect(mockUpload).toHaveBeenCalledWith(
+				"video",
+				"runware",
+				[{ key: "video", url: "https://result.mp4" }],
+				expect.objectContaining({ durationSec: 8 }),
+			);
+		});
+
+		it("does not upload a bundle while the job is still running", async () => {
+			mockGetResponse.mockResolvedValue([
+				{ taskUUID: "job-1", status: "processing" },
+			]);
+
+			const provider = new RunwareVideo("test-key");
+			await provider.poll("job-1", 8);
+
+			expect(mockUpload).not.toHaveBeenCalled();
+		});
+
 		it("returns BundleResponse when job is completed", async () => {
 			mockGetResponse.mockResolvedValue([
 				{

--- a/lib/providers/video/base.ts
+++ b/lib/providers/video/base.ts
@@ -30,10 +30,8 @@ export abstract class BaseVideoProvider extends BaseProvider<
 		return r.url ? [{ key: "video", url: r.url }] : [];
 	}
 
-	protected abstract _poll(jobId: string): Promise<VideoJob>;
-
-	async poll(jobId: string): Promise<VideoProviderResponse> {
-		const result = await this._poll(jobId);
+	/** A job with no video yet (submitted or still running) has nothing to upload. */
+	protected async store(result: VideoJob): Promise<VideoProviderResponse> {
 		if (this.toFiles(result).length === 0) {
 			return {
 				id: "",
@@ -42,6 +40,27 @@ export abstract class BaseVideoProvider extends BaseProvider<
 				metadata: result.metadata,
 			};
 		}
-		return this.store(result);
+		return super.store(result);
+	}
+
+	protected abstract _poll(jobId: string): Promise<VideoJob>;
+
+	/**
+	 * `durationSec` carries the duration requested at submit time: providers do not
+	 * echo it back on poll, and the rendered timeline sizes the clip from it.
+	 */
+	async poll(
+		jobId: string,
+		durationSec?: number,
+	): Promise<VideoProviderResponse> {
+		const result = await this._poll(jobId);
+		return this.store({
+			...result,
+			metadata: {
+				jobId,
+				...result.metadata,
+				durationSec: result.metadata?.durationSec ?? durationSec,
+			},
+		});
 	}
 }

--- a/lib/providers/video/mock.ts
+++ b/lib/providers/video/mock.ts
@@ -15,12 +15,11 @@ export class MockVideo extends BaseVideoProvider {
 	protected readonly blobConfig = { type: "video", provider: "mock" };
 
 	protected async store(result: VideoJob): Promise<VideoProviderResponse> {
+		if (!result.url) return super.store(result);
 		return {
 			id: result.metadata?.jobId ?? "",
 			provider: this.blobConfig.provider,
-			result: {
-				video: result.url ?? "",
-			},
+			result: { video: result.url },
 			metadata: result.metadata,
 		};
 	}


### PR DESCRIPTION
## Bugs fixed

1. **Real video clips render with zero duration** (`lib/providers/video/base.ts`, `lib/api/handlers/video.ts`)
   - `RunwareVideo._generate` records the requested `duration` in its metadata, but that metadata was discarded — `videoHandler.process` only persisted `{ providerJobId }`. On poll, Runware's response carries just `taskUUID` and `status`, so the completed bundle's manifest had no `durationSec`. Downstream resolves to 0.
   - Fix: `process` now carries `durationSec` alongside `providerJobId` in job metadata. `BaseVideoProvider.poll` accepts an optional `durationSec` and uses it as a fallback when the provider doesn't echo one back.

2. **Polling a finished video job re-uploaded the bundle under a new id** (`lib/api/handlers/video.ts`)
   - `pollJob` called the handler's `poll` unconditionally, and `videoHandler.poll` re-polled upstream whenever `providerJobId` was set — including for jobs already `completed`. Each poll re-ran `store()`, minting a fresh bundle id. Once Runware drops the task, the same call threw and turned a completed job into a 500.
   - Fix: `completed`/`failed` jobs now short-circuit with `rowView(job)` without touching the provider.

3. **Every video submission wrote a junk empty blob** (`lib/providers/video/base.ts`, `mock.ts`)
   - `BaseProvider.generate` always calls `store()`, but at submit time an async video job has no URL. `toFiles()` returned `[]`, yet `AssetBundle.upload` still wrote an empty manifest. `poll()` had an inline guard for this; `generate()` didn't.
   - Fix: Moved the guard into an overridden `store()` so both paths share it.

## Tests added

- `lib/api/__tests__/video-handler.test.ts` (new, 8 tests): Duration survives submit, process throws on missing jobId, completed/failed jobs short-circuit, duration passed to provider.poll, status mappings persist correct shapes.
- `lib/providers/__tests__/runware-video.test.ts` (3 new tests): Generate uploads nothing for job without video, poll stores submitted duration, in-progress poll doesn't upload.

## Open PR overlap check

Open PRs considered: #410 (VideoPreview fullscreen), #409 (architecture rethink — massive scope), #408 (maintainability 7/13), #407 (nightly bugs 7/13), #395 (canvas interaction), #394 (bring-your-own-image). This PR touches only `lib/api/handlers/video.ts`, `lib/providers/video/base.ts`, `lib/providers/video/mock.ts`, and test files — none of which appear in any open PR. No overlap.

## Validation

- `npm test`: 101 files, 877 tests (all passing)
- `npm run build`: TypeScript + Next.js build passes cleanly