### PR TITLE
fix: nightly bug fixes 2026-07-15

### DIFF
--- a/lib/__tests__/format.test.ts
+++ b/lib/__tests__/format.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { formatBytes } from "../format";
+
+describe("formatBytes", () => {
+	it("formats raw bytes below 1 KB", () => {
+		expect(formatBytes(0)).toBe("0 B");
+		expect(formatBytes(512)).toBe("512 B");
+		expect(formatBytes(1023)).toBe("1023 B");
+	});
+
+	it("formats KB, MB, and GB ranges", () => {
+		expect(formatBytes(1024)).toBe("1.0 KB");
+		expect(formatBytes(1536)).toBe("1.5 KB");
+		expect(formatBytes(1024 * 1024)).toBe("1.0 MB");
+		expect(formatBytes(5 * 1024 * 1024)).toBe("5.0 MB");
+		expect(formatBytes(1024 * 1024 * 1024)).toBe("1.0 GB");
+	});
+
+	it("rolls over to the next unit when rounding reaches 1024", () => {
+		// 1023.994 KB rounds to 1024.0, which must promote to MB.
+		expect(formatBytes(1048570)).toBe("1.0 MB");
+		// Just below the MB→GB boundary.
+		expect(formatBytes(1073740000)).toBe("1.0 GB");
+	});
+
+	it("keeps very large sizes in GB", () => {
+		expect(formatBytes(2 * 1024 * 1024 * 1024)).toBe("2.0 GB");
+		expect(formatBytes(1024 * 1024 * 1024 * 1024)).toBe("1024.0 GB");
+	});
+});

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,8 +1,14 @@
+const BYTE_UNITS = ["KB", "MB", "GB"] as const;
+
 export function formatBytes(bytes: number): string {
 	if (bytes < 1024) return `${bytes} B`;
-	const kb = bytes / 1024;
-	if (kb < 1024) return `${kb.toFixed(1)} KB`;
-	const mb = kb / 1024;
-	if (mb < 1024) return `${mb.toFixed(1)} MB`;
-	return `${(mb / 1024).toFixed(1)} GB`;
+	let value = bytes / 1024;
+	let unit = 0;
+	// Promote on the rounded value so a size that rounds up to 1024.0 rolls over
+	// to the next unit (e.g. 1023.99 KB → "1.0 MB", not "1024.0 KB").
+	while (unit < BYTE_UNITS.length - 1 && Math.round(value * 10) / 10 >= 1024) {
+		value /= 1024;
+		unit += 1;
+	}
+	return `${value.toFixed(1)} ${BYTE_UNITS[unit]}`;
 }

--- a/lib/providers/__tests__/runware-image.test.ts
+++ b/lib/providers/__tests__/runware-image.test.ts
@@ -38,6 +38,7 @@ describe("RunwareImage", () => {
 			width: 2848,
 			height: 1600,
 			outputType: "base64Data",
+			outputFormat: "PNG",
 			numberResults: 1,
 			referenceImages: undefined,
 		});

--- a/lib/providers/image/runware.ts
+++ b/lib/providers/image/runware.ts
@@ -39,6 +39,7 @@ export class RunwareImage extends BaseProvider<
 				width: params.width || 2848,
 				height: params.height || 1600,
 				outputType: "base64Data",
+				outputFormat: "PNG",
 				numberResults: 1,
 				referenceImages: params.referenceImages,
 			});


### PR DESCRIPTION
## Summary

Nightly correctness bug hunt + test pass.

### Bugs fixed

1. **formatBytes rollover bug**: When a byte value rounds to exactly 1024.0 in the current unit (e.g., 1,048,570 bytes → 1023.994 KB → rounds to 1024.0 KB), it should promote to the next unit (1.0 MB) instead of displaying "1024.0 KB". The old code handled this by cascading through hardcoded divisions; the new code uses a loop that checks the rounded value and promotes it.

2. **Runware image provider output format**: The Runware image provider was not specifying `outputFormat`, which could cause the provider to return a different format than the declared `.png` filename and `image/png` content type in the asset bundle. Now explicitly requests `"PNG"` format.

### Tests added

- **`lib/__tests__/format.test.ts`**: 4 test cases covering raw bytes, KB/MB/GB ranges, rollover at the 1024 boundary, and very large sizes staying in GB.
- **`lib/providers/__tests__/runware-image.test.ts`**: Added `outputFormat: "PNG"` assertion to the existing image generation test.

### Validation

- `npm test`: 101 files, 870 tests passing
- `npm run typecheck`: clean
- `npm run lint`: clean
- `npm run format:check`: clean
- `npm run build`: successful

### Open PR overlap check

Checked all 10 open PRs (#394, #395, #407, #408, #409, #410, #411, #412, #413, #414). None of the touched files (`lib/format.ts`, `lib/providers/image/runware.ts`, their test files) appear in any open PR's file list.