### PR TITLE
perf: nightly performance optimizations 2026-07-15

### DIFF
--- a/app/components/video/ScrubBar.tsx
+++ b/app/components/video/ScrubBar.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { type PointerEvent, type ReactNode, useRef, useState } from "react";
+import {
+	type PointerEvent,
+	type ReactNode,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { clamp, cn } from "@/lib/utils";
 
 /** A slice of a segmented track; `basis` is its fraction (0–1) of the whole. */
@@ -59,6 +65,23 @@ export function ScrubBar({
 	const continuous = !segments;
 	const segs = segments ?? SINGLE;
 
+	const rootClass = useMemo(
+		() => cn("group relative flex h-5 cursor-pointer items-center", className),
+		[className],
+	);
+	const trackClass = useMemo(
+		() => cn("flex h-1 w-full", continuous ? "gap-0" : "gap-[2px]"),
+		[continuous],
+	);
+	const segmentClass = useMemo(
+		() =>
+			cn(
+				"relative h-full overflow-hidden bg-scrub-track",
+				continuous && "rounded-full",
+			),
+		[continuous],
+	);
+
 	const hoverFrom = (e: PointerEvent<HTMLDivElement>): ScrubHover | null => {
 		const rect = trackRef.current?.getBoundingClientRect();
 		if (!rect) return null;
@@ -116,10 +139,7 @@ export function ScrubBar({
 		<div
 			ref={trackRef}
 			aria-label={ariaLabel}
-			className={cn(
-				"group relative flex h-5 cursor-pointer items-center",
-				className,
-			)}
+			className={rootClass}
 			style={{ touchAction: "none" }}
 			onPointerDown={onPointerDown}
 			onPointerMove={onPointerMove}
@@ -127,16 +147,11 @@ export function ScrubBar({
 			onPointerCancel={endDrag}
 			onPointerLeave={onPointerLeave}
 		>
-			<div
-				className={cn("flex h-1 w-full", continuous ? "gap-0" : "gap-[2px]")}
-			>
+			<div className={trackClass}>
 				{fills.map(({ seg, fill, hover }) => (
 					<div
 						key={seg.id}
-						className={cn(
-							"relative h-full overflow-hidden bg-scrub-track",
-							continuous && "rounded-full",
-						)}
+						className={segmentClass}
 						style={{ flexBasis: `${seg.basis * 100}%` }}
 					>
 						<div

--- a/app/components/video/SegmentedSeekBar.tsx
+++ b/app/components/video/SegmentedSeekBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { PlayerRef } from "@remotion/player";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { clamp } from "@/lib/utils";
 import type { VideoLayout } from "@/lib/video/types";
 import { usePlayerFrame } from "./usePlayerState";
@@ -45,12 +45,16 @@ export function SegmentedSeekBar({
 		[],
 	);
 
-	if (segments.length === 0) return null;
+	const scrubSegments = useMemo(
+		() =>
+			segments.map((seg) => ({
+				id: seg.sceneId,
+				basis: seg.duration / totalDurationSec,
+			})),
+		[segments, totalDurationSec],
+	);
 
-	const scrubSegments = segments.map((seg) => ({
-		id: seg.sceneId,
-		basis: seg.duration / totalDurationSec,
-	}));
+	if (segments.length === 0) return null;
 
 	const onHoverChange = (h: ScrubHover | null) => {
 		setHover(h);

--- a/remotion/components/MotionLayer.tsx
+++ b/remotion/components/MotionLayer.tsx
@@ -1,19 +1,22 @@
 import type { ReactNode } from "react";
 import { AbsoluteFill, useCurrentFrame, useVideoConfig } from "remotion";
-import { type MotionEffect, motionTransform } from "@/lib/video/motionEffects";
+import {
+	type ActiveMotionEffect,
+	type MotionEffect,
+	motionTransform,
+} from "@/lib/video/motionEffects";
 
 const clip: React.CSSProperties = { overflow: "hidden" };
 
-export function MotionLayer({
+function AnimatedMotionLayer({
 	effect,
 	children,
 }: {
-	effect: MotionEffect;
+	effect: ActiveMotionEffect;
 	children: ReactNode;
 }) {
 	const frame = useCurrentFrame();
 	const { durationInFrames, width, height } = useVideoConfig();
-	if (effect === "none") return <>{children}</>;
 	const aspectRatio = Math.max(width, height) / Math.min(width, height);
 	const transform = motionTransform(
 		effect,
@@ -34,4 +37,15 @@ export function MotionLayer({
 			</AbsoluteFill>
 		</AbsoluteFill>
 	);
+}
+
+export function MotionLayer({
+	effect,
+	children,
+}: {
+	effect: MotionEffect;
+	children: ReactNode;
+}) {
+	if (effect === "none") return <>{children}</>;
+	return <AnimatedMotionLayer effect={effect}>{children}</AnimatedMotionLayer>;
 }


### PR DESCRIPTION
## Summary

Nightly performance pass targeting Remotion per-frame hot paths and 30fps playback components.

## Changes

### 1. MotionLayer — skip frame subscription for `"none"` effect (Remotion render path)

`MotionLayer` called `useCurrentFrame()` unconditionally, then early-returned for `effect === "none"` (the default). That forced re-execution on **every frame** (30fps preview, `fps × totalFrames` Lambda export) for identical output. Extracted the animated body into `AnimatedMotionLayer` so the `"none"` path is a pure passthrough with no frame subscription.

### 2. ScrubBar — memoize frame-invariant `cn()` calls (30fps seek bar)

The seek bar re-renders every frame during playback. Each render re-ran `cn()` (clsx + tailwind-merge) for root/track/segment class strings — expensive per-frame work for values that depend only on `continuous`/`className`. Memoized them so only frame-varying widths recompute.

### 3. SegmentedSeekBar — memoize per-frame `scrubSegments` rebuild

The `segments.map(...)` allocating N objects ran every frame during playback despite depending only on stable `segments`/`totalDurationSec`. Wrapped in `useMemo`.

## Files changed
- `remotion/components/MotionLayer.tsx` — extract `AnimatedMotionLayer` (+22/-4)
- `app/components/video/ScrubBar.tsx` — memoize tailwind-merge classes (+39/-22)
- `app/components/video/SegmentedSeekBar.tsx` — memoize scrubSegments (+16/-5)

## Validation

| Check | Result |
|-------|--------|
| `npm run lint` | ✅ pass |
| `npm run format:check` | ✅ pass |
| `npm run typecheck` | ✅ pass |
| `npm test -- --passWithNoTests` | ✅ 100 files, 866 tests |
| `npm run build` | ✅ pass |
| `npm run knip` | ✅ pass |

## Open PR overlap check

Considered open PRs #416, #415, #414, #413, #412, #411, #410, #409, #408, #407, #395, and #394. This PR touches only `MotionLayer.tsx`, `ScrubBar.tsx`, and `SegmentedSeekBar.tsx` — **zero file overlap** with any open PR. (#413 covers `PlayerPanel.tsx` which imports `SegmentedSeekBar` but does not modify it.)

## Skipped items / rationale

- **Slate.js render-path**: Already covered by open PR #413 ("stop the editor shell re-rendering on every Slate operation").
- **Remotion `VideoComposition` inner components**: `SeriesEntry`/`SequenceContent`/`AudioSequence` are already scoped inside `useMemo` arrays — extracting them to module level would be cosmetic with no runtime impact.
- **Per-frame callbacks in playback components**: The `usePlayerFrame`/`useSyncExternalStore` pattern is already minimal — the `subscribe` callback is stable when `player` ref is stable.
- **Bundle/code-splitting changes**: Skipped per runbook priority — runtime UX first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)