### PR TITLE
fix: nightly bug fixes 2026-07-16

### DIFF
--- a/app/components/AuthForm.tsx
+++ b/app/components/AuthForm.tsx
@@ -60,12 +60,14 @@ export default function AuthForm({
 	};
 
 	const handleGoogleAuth = async () => {
-		await supabase.auth.signInWithOAuth({
+		setError("");
+		const { error } = await supabase.auth.signInWithOAuth({
 			provider: "google",
 			options: {
 				redirectTo: `${window.location.origin}/auth/callback`,
 			},
 		});
+		if (error) setError(error.message);
 	};
 
 	if (sent) {

--- a/lib/api/__tests__/sse.test.ts
+++ b/lib/api/__tests__/sse.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { formatSSE, createSSEResponse, readSSE } from "../sse";
+import {
+	formatSSE,
+	createSSEResponse,
+	createSSEStreamResponse,
+	readSSE,
+} from "../sse";
 
 function makeSSEStream(chunks: string[]): ReadableStream {
 	const encoder = new TextEncoder();
@@ -159,5 +164,87 @@ describe("readSSE", () => {
 		}
 		// If the lock had not been released, getReader() would throw.
 		expect(() => stream.getReader()).not.toThrow();
+	});
+
+	it("cancels the underlying stream when the consumer breaks early", async () => {
+		let cancelled = false;
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream({
+			start(controller) {
+				controller.enqueue(encoder.encode('data: {"a":1}\n\n'));
+				controller.enqueue(encoder.encode('data: {"b":2}\n\n'));
+			},
+			cancel() {
+				cancelled = true;
+			},
+		});
+
+		for await (const event of readSSE(stream)) {
+			expect(event).toEqual({ a: 1 });
+			break;
+		}
+
+		expect(cancelled).toBe(true);
+	});
+
+	it("throws when the stream carries an error frame", async () => {
+		const stream = makeSSEStream([
+			'data: {"text":"partial"}\n\n',
+			'data: {"type":"error","message":"provider overloaded"}\n\n',
+		]);
+		const results: unknown[] = [];
+
+		await expect(async () => {
+			for await (const event of readSSE(stream)) {
+				results.push(event);
+			}
+		}).rejects.toThrow("provider overloaded");
+		expect(results).toEqual([{ text: "partial" }]);
+	});
+});
+
+describe("createSSEStreamResponse", () => {
+	it("streams chunks from the iterable and closes", async () => {
+		async function* iter() {
+			yield { text: "a" };
+			yield { text: "b", done: true };
+		}
+
+		const response = createSSEStreamResponse(iter(), "test");
+		const text = await response.text();
+		expect(text).toBe(
+			'data: {"text":"a"}\n\ndata: {"text":"b","done":true}\n\n',
+		);
+	});
+
+	it("delivers an in-band error frame when the iterable throws mid-stream", async () => {
+		async function* iter() {
+			yield { text: "partial" };
+			throw new Error("provider exploded");
+		}
+
+		const response = createSSEStreamResponse(iter(), "test");
+		const text = await response.text();
+		expect(text).toContain('"text":"partial"');
+		expect(text).toContain('"type":"error"');
+		expect(text).toContain("provider exploded");
+	});
+
+	it("round-trips a mid-stream error through readSSE as a thrown Error", async () => {
+		async function* iter() {
+			yield { text: "partial" };
+			throw new Error("rate limited");
+		}
+
+		const response = createSSEStreamResponse(iter(), "test");
+		if (!response.body) throw new Error("expected response body");
+
+		const results: unknown[] = [];
+		await expect(async () => {
+			for await (const event of readSSE(response.body as ReadableStream)) {
+				results.push(event);
+			}
+		}).rejects.toThrow("rate limited");
+		expect(results).toEqual([{ text: "partial" }]);
 	});
 });

--- a/lib/api/sse.ts
+++ b/lib/api/sse.ts
@@ -1,5 +1,16 @@
-import { stringifyError } from "../errors";
+import { errorMessage, stringifyError } from "../errors";
 import { logger } from "./logger";
+
+type SSEErrorFrame = { type: "error"; message: string };
+
+function isErrorFrame(event: unknown): event is SSEErrorFrame {
+	return (
+		typeof event === "object" &&
+		event !== null &&
+		(event as SSEErrorFrame).type === "error" &&
+		typeof (event as SSEErrorFrame).message === "string"
+	);
+}
 
 export function formatSSE(data: unknown): string {
 	return `data: ${JSON.stringify(data)}\n\n`;
@@ -56,7 +67,18 @@ export function createSSEStreamResponse<T>(
 				controller.close();
 			} catch (error) {
 				logger.error(error, `${label} stream error`);
-				controller.error(error);
+				// The response already streams with status 200, so the failure is
+				// surfaced as an in-band error frame that readSSE rethrows.
+				try {
+					controller.enqueue(
+						encoder.encode(
+							formatSSE({ type: "error", message: errorMessage(error) }),
+						),
+					);
+					controller.close();
+				} catch {
+					// Client already cancelled the stream; nothing left to deliver.
+				}
 			}
 		},
 	});
@@ -79,14 +101,22 @@ export async function* readSSE<T>(body: ReadableStream): AsyncGenerator<T> {
 
 			for (const part of parts) {
 				if (!part.startsWith("data: ")) continue;
+				let event: unknown;
 				try {
-					yield JSON.parse(part.slice(6)) as T;
+					event = JSON.parse(part.slice(6));
 				} catch (err) {
 					logger.warn({ err }, "SSE: skipping malformed event");
+					continue;
 				}
+				if (isErrorFrame(event)) throw new Error(event.message);
+				yield event as T;
 			}
 		}
 	} finally {
+		// Cancel (not just release) so abandoning the stream mid-read aborts
+		// the upstream request. cancel() may echo an error already propagating
+		// from read(), hence the catch.
+		await reader.cancel().catch(() => undefined);
 		reader.releaseLock();
 	}
 }

--- a/lib/canvas/__tests__/createCanvasNode.test.ts
+++ b/lib/canvas/__tests__/createCanvasNode.test.ts
@@ -79,6 +79,13 @@ describe("createCanvasNode", () => {
 		const node = createCanvasNode("narration", connectors);
 		expect(node.children[1].text).toBe("");
 	});
+
+	it("strips zero-width spaces leaked into saved text by older serializers", () => {
+		const node = createCanvasNode("narration", connectors, {
+			text: `${ZWSP}${ZWSP}hello`,
+		});
+		expect(node.children[1].text).toBe("hello");
+	});
 });
 
 describe("createCanvasNode — no default model configured", () => {

--- a/lib/canvas/__tests__/osmlSerializer.test.ts
+++ b/lib/canvas/__tests__/osmlSerializer.test.ts
@@ -35,6 +35,21 @@ describe("serializeOSML", () => {
 		expect(result).toBe('<narration id="e1">Hello world</narration>');
 	});
 
+	it("strips zero-width space caret artifacts from editor nodes", () => {
+		// Real editor nodes carry a leading ZWSP leaf (see createCanvasNode);
+		// serializing it would grow the text by one ZWSP per save/load cycle.
+		const element: CanvasContentElement = {
+			id: "e1",
+			type: "narration",
+			children: [
+				{ id: "z1", type: "narration", text: "​" },
+				{ id: "t1", type: "narration", text: "​Hello" },
+			],
+		};
+		const result = serializeOSML([wrap(element)]);
+		expect(result).toBe('<narration id="e1">Hello</narration>');
+	});
+
 	it("serializes tagged elements with id", () => {
 		const result = serializeOSML([wrap(el("image", "a sunset"))]);
 		expect(result).toBe('<image id="e1">a sunset</image>');

--- a/lib/canvas/createCanvasNode.ts
+++ b/lib/canvas/createCanvasNode.ts
@@ -44,7 +44,12 @@ export function createCanvasNode(
 		customAttributes,
 		children: [
 			{ id: makeNodeId(), type, text: ZERO_WIDTH_SPACE },
-			{ id: makeNodeId(), type, text: (opts.text ?? "").trim() },
+			{
+				id: makeNodeId(),
+				type,
+				// Strip ZWSPs that older serializer versions leaked into saved text.
+				text: (opts.text ?? "").replaceAll(ZERO_WIDTH_SPACE, "").trim(),
+			},
 		],
 	};
 }

--- a/lib/canvas/osmlSerializer.ts
+++ b/lib/canvas/osmlSerializer.ts
@@ -1,6 +1,7 @@
 import { Descendant } from "slate";
 import type { CanvasContentElement, ParsedElement } from "@/lib/canvas/types";
 import { getContentElements, isSceneElement } from "@/lib/canvas/scenes";
+import { ZERO_WIDTH_SPACE } from "./constants";
 
 export const SCENE_MARKER_PATTERN = /^---\s*Scene\s+\d+\s*---\s*$/m;
 const sceneMarker = (n: number) => `\n--- Scene ${n} ---\n`;
@@ -14,7 +15,10 @@ function serializeElement(element: CanvasContentElement): string {
 	const attrString = Object.entries({ id: element.id, ...attributes })
 		.map(([key, value]) => ` ${key}="${value}"`)
 		.join("");
-	return `<${element.type}${attrString}>${getElementText(element)}</${element.type}>\n`;
+	// The ZWSP is a Slate caret artifact; serializing it would add one more
+	// ZWSP to the text on every parse/serialize round trip.
+	const text = getElementText(element).replaceAll(ZERO_WIDTH_SPACE, "");
+	return `<${element.type}${attrString}>${text}</${element.type}>\n`;
 }
 
 export function serializeOSML(descendants: Descendant[]): string {

--- a/lib/script/refine/__tests__/applyOps.test.ts
+++ b/lib/script/refine/__tests__/applyOps.test.ts
@@ -217,6 +217,46 @@ describe("applyRefineOp — insert", () => {
 		expect(texts).toEqual(["first", "A", "B", "C"]);
 	});
 
+	it("stacks consecutive before-inserts at the same anchor in stream order", () => {
+		const editor = makeEditor([scene([content("narration", "n1", "first")])]);
+		const anchorMap: Record<string, string> = {};
+
+		for (const text of ["A", "B", "C"]) {
+			applyRefineOp(
+				editor,
+				{
+					op: "insert",
+					anchor_id: "n1",
+					position: "before",
+					type: "sound",
+					text,
+				},
+				anchorMap,
+				connectors,
+			);
+		}
+
+		const texts = getContentTexts(editor);
+		expect(texts).toEqual(["A", "B", "C", "first"]);
+	});
+
+	it("stacks consecutive no-anchor prepends in stream order", () => {
+		const editor = makeEditor([scene([content("narration", "n1", "first")])]);
+		const anchorMap: Record<string, string> = {};
+
+		for (const text of ["A", "B"]) {
+			applyRefineOp(
+				editor,
+				{ op: "insert", position: "before", type: "sound", text },
+				anchorMap,
+				connectors,
+			);
+		}
+
+		const texts = getContentTexts(editor);
+		expect(texts).toEqual(["A", "B", "first"]);
+	});
+
 	it("falls back to append when anchor_id not found", () => {
 		const editor = makeEditor([scene([content("narration", "n1", "hello")])]);
 		const anchorMap: Record<string, string> = {};

--- a/lib/script/refine/applyOps.ts
+++ b/lib/script/refine/applyOps.ts
@@ -31,21 +31,35 @@ export function applyRefineOp(
 	});
 }
 
+// Chains consecutive no-anchor prepends so they land in stream order.
+const PREPEND_ANCHOR = "";
+
+// "after" inserts chain the anchorMap to the last inserted id. "before"
+// inserts stack naturally by targeting the anchor's current path, so
+// chaining them would reverse stream order.
 function resolveInsertPath(
 	editor: Editor,
 	op: Extract<RefineOp, { op: "insert" }>,
 	anchorMap: Record<string, string>,
 ): Path {
-	if (!op.anchor_id) {
-		return op.position === "before" ? [0, 0] : [editor.children.length];
+	if (op.position === "before") {
+		if (op.anchor_id) {
+			const entry = findNodeById(editor, op.anchor_id);
+			return entry ? entry[1] : [editor.children.length];
+		}
+		const lastPrepended = anchorMap[PREPEND_ANCHOR];
+		const entry = lastPrepended ? findNodeById(editor, lastPrepended) : null;
+		return entry ? Path.next(entry[1]) : [0, 0];
 	}
+
+	if (!op.anchor_id) return [editor.children.length];
 
 	const resolvedId = anchorMap[op.anchor_id] ?? op.anchor_id;
 	const entry =
 		findNodeById(editor, resolvedId) ?? findNodeById(editor, op.anchor_id);
 	if (!entry) return [editor.children.length];
 
-	return op.position === "before" ? entry[1] : Path.next(entry[1]);
+	return Path.next(entry[1]);
 }
 
 function applyInsert(
@@ -60,7 +74,9 @@ function applyInsert(
 		text: op.text,
 	});
 
-	if (op.anchor_id) {
+	if (op.position === "before") {
+		if (!op.anchor_id) anchorMap[PREPEND_ANCHOR] = id;
+	} else if (op.anchor_id) {
 		anchorMap[op.anchor_id] = id;
 	}
 }


### PR DESCRIPTION
## Summary

Nightly correctness bug hunt and test pass. Four real bugs fixed, each with a concrete user-facing failure.

## Bugs fixed

### 1. Refine: "before" inserts land in reverse order (`lib/script/refine/applyOps.ts`)

The anchorMap chaining that keeps consecutive "after" inserts in stream order inverts the order for `position: "before"`. Asking refine to "add two sound effects before the final narration" produced `B, A, narration` instead of `A, B, narration`. Same inversion for no-anchor prepends, which all targeted `[0, 0]`. Verified by test before the fix: 3 before-inserts at one anchor produced `C, B, A, anchor`.

Fix: before-inserts now target the anchor's current path directly (it shifts down as inserts land, so they stack naturally) and no longer chain the map. No-anchor prepends chain through a sentinel key so they land in stream order.

### 2. Zero-width spaces accumulate in element text on every save/load cycle (`lib/canvas/osmlSerializer.ts`, `createCanvasNode.ts`)

Serialize/parse was not idempotent. `createCanvasNode` prepends a ZWSP caret leaf; the serializer emitted it into the OSML text; the next parse prepended a fresh one. Each open + autosave added one ZWSP per element (observed 1 -> 2 -> 3 -> 4 across cycles). After the first reload, empty elements no longer matched the `Node.string(element) === ZERO_WIDTH_SPACE` check, so their placeholder text disappeared, and the invisible characters leaked into the script sent to the refine LLM.

Fix: the serializer strips ZWSPs (caret artifacts are editor-internal), and `createCanvasNode` strips ZWSPs from incoming text so previously corrupted saves heal on load.

### 3. Streaming LLM errors never reach the client; abandoned streams never cancel (`lib/api/sse.ts`)

Two defects in the only production SSE path:

- On a mid-stream provider error (Anthropic 429/529 are routine), `createSSEStreamResponse` called `controller.error()`, which just aborts the already-200 body. The script stops mid-sentence with no error shown anywhere; the real reason existed only in server logs. The non-stream path returns a proper 500 for the same failure. Now the route emits an in-band `{type: "error", message}` frame (the same convention `createSSEResponse` already uses) and `readSSE` rethrows it on the consumer side, where the existing unhandled-rejection toaster surfaces it.
- `readSSE`'s finally block only released the reader lock. Clicking Stop during generation abandoned the iterator but the HTTP connection and the upstream Anthropic generation ran to completion (full token cost). Now the reader is cancelled, which aborts the fetch, cancels the route's ReadableStream, and closes the provider stream up the chain.

### 4. Google OAuth failures are silent (`app/components/AuthForm.tsx`)

`signInWithOAuth` returns `{error}` rather than throwing, and the result was discarded. Clicking "Continue with Google" while the auth endpoint is unreachable did nothing, with no feedback. The error is now rendered through the same state the magic-link path already uses.

## Tests added

- `lib/script/refine/__tests__/applyOps.test.ts`: before-inserts stack in stream order at an anchor; no-anchor prepends stack in stream order.
- `lib/canvas/__tests__/osmlSerializer.test.ts`: serializing editor-shaped nodes (ZWSP leaf + ZWSP-prefixed text) emits clean OSML.
- `lib/canvas/__tests__/createCanvasNode.test.ts`: ZWSPs stripped from incoming saved text.
- `lib/api/__tests__/sse.test.ts`: `createSSEStreamResponse` happy path and mid-stream error frame; `readSSE` throws on error frames and cancels the underlying stream on early exit; full server-to-client error round trip.

## Validation

| Check | Result |
|-------|--------|
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm run knip` | pass |
| `npm test` | 100 files, 875 tests, all passing |
| `npm run build` | pass |

## Open PR overlap check

Considered open PRs #417, #416, #415, #414, #413, #412, #411, #410, #395, #394 (full file lists inspected). This PR touches `applyOps.ts`, `osmlSerializer.ts`, `createCanvasNode.ts`, `sse.ts`, `AuthForm.tsx`, and their test files. Zero file overlap with any open PR. Adjacent files were deliberately avoided: `lib/providers/llm/anthropic.ts` (#414), `useRefineScript.ts` (#413), `lib/canvas/guards.ts`/`keyboardGuards.ts` (#394/#395). Nothing here repeats fixes from closed PRs #399/#402/#407.

## Skipped items and rationale

- Middleware redirect cookie propagation and OSML attribute escaping: both were already proposed in closed PR #407 and not accepted; not re-proposing.
- `useOSMLStreamParser` MAX_NODES_TO_SYNC=3 can drop elements when 4+ complete in one render (timing-dependent permanent loss), and the per-project store cache is never invalidated so a second tab can silently overwrite newer saves: both real but need design decisions, flagging instead of patching.
- `/login?error=auth_callback_failed` is produced by the auth callback but nothing renders it, so a failed cross-device magic link is silent. Left out to keep this PR tight; needs a copy decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)