### PR TITLE
fix: remove embedded indentation from forbidden() error message

### DIFF
--- a/lib/api/response.ts
+++ b/lib/api/response.ts
@@ -15,8 +15,8 @@ export function unauthorized() {
 export function forbidden() {
 	return NextResponse.json(
 		{
-			error: `Forbidden, your API access has been revoked.
-		Please contact hi@openslop.ai or post on our Discord server for help.`,
+			error:
+				"Forbidden, your API access has been revoked. Please contact hi@openslop.ai or post on our Discord server for help.",
 		},
 		{ status: 403 },
 	);


### PR DESCRIPTION
## Summary

Nightly CONVENTIONS.md compliance audit for 2026-07-16. Full-codebase sweep against all seven audited rules (define errors out of existence, no special-case wiring, policy vs mechanism, dumb units, one canonical way, fail loudly, declarative-as-config). Files covered by the 11 open PRs were excluded.

One defect found and fixed:

- `lib/api/response.ts` `forbidden()` used a multi-line template literal, so the wire error string contained a literal newline plus tab indentation in the middle of the message. Collapsed to a single clean string. No other behavior change.

## Flagged for human review (no change made)

- `lib/script/refine/parseOps.ts:25-30`: malformed refine-op lines from the LLM stream are silently dropped (`catch` -> `[]`, failed `safeParse` -> `[]`). This is explicitly pinned by the test "skips malformed JSON lines", so it is intentional LLM-noise tolerance, but it sits in tension with the fail-loudly rule: a refine request can partially no-op with zero signal. Consider a `console.warn` on dropped lines if that ever bites.

## Audit verdict

The rest of the codebase is genuinely compliant: job handlers, connectors, mode plugins, motion effects, and element presentation all use registries/lookup tables; routes are declarative configs over shared factories (`createAssetRouteHandlers`, `withSession`/`withApiAccess`, `parseBody`); no error-string pattern-matching anywhere; all catches either rethrow, return typed results, or log and surface to the user.

## Checks

- lint, typecheck, format:check: pass
- test:run: 866/866 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)