### PR TITLE
fix: nightly bug fixes 2026-07-17

### DIFF
--- a/lib/providers/__tests__/cartesia-tts.test.ts
+++ b/lib/providers/__tests__/cartesia-tts.test.ts
@@ -61,8 +61,8 @@ const makeVoices = (count: number, offset = 0) =>
 		preview_file_url: null,
 	}));
 
-function makePage(data: object[], more = false) {
-	return { data, has_more: more, next_page: more ? "cursor" : null };
+function makePage(data: object[]) {
+	return { data };
 }
 
 const stubClient = { get: mockGet } as unknown as Cartesia;
@@ -72,7 +72,7 @@ describe("collectVoices", () => {
 		vi.clearAllMocks();
 	});
 
-	it("returns a single short page when has_more is false", async () => {
+	it("returns a single short page and stops", async () => {
 		mockGet.mockResolvedValue(makePage(makeVoices(30)));
 
 		const voices = await collectVoices(stubClient, {}, 250);
@@ -81,23 +81,11 @@ describe("collectVoices", () => {
 		expect(mockGet).toHaveBeenCalledTimes(1);
 	});
 
-	it("paginates past 100 using next_page cursor", async () => {
+	it("paginates past 100 using the last voice id as the cursor", async () => {
 		mockGet
-			.mockResolvedValueOnce({
-				data: makeVoices(100),
-				has_more: true,
-				next_page: "cur1",
-			})
-			.mockResolvedValueOnce({
-				data: makeVoices(100, 100),
-				has_more: true,
-				next_page: "cur2",
-			})
-			.mockResolvedValueOnce({
-				data: makeVoices(50, 200),
-				has_more: false,
-				next_page: null,
-			});
+			.mockResolvedValueOnce(makePage(makeVoices(100)))
+			.mockResolvedValueOnce(makePage(makeVoices(100, 100)))
+			.mockResolvedValueOnce(makePage(makeVoices(50, 200)));
 
 		const voices = await collectVoices(stubClient, {}, 250);
 
@@ -109,24 +97,20 @@ describe("collectVoices", () => {
 			2,
 			"/voices",
 			expect.objectContaining({
-				query: expect.objectContaining({ starting_after: "cur1" }),
+				query: expect.objectContaining({ starting_after: "v99" }),
 			}),
 		);
 		expect(mockGet).toHaveBeenNthCalledWith(
 			3,
 			"/voices",
 			expect.objectContaining({
-				query: expect.objectContaining({ starting_after: "cur2" }),
+				query: expect.objectContaining({ starting_after: "v199" }),
 			}),
 		);
 	});
 
-	it("stops at the limit even when has_more is true", async () => {
-		mockGet.mockResolvedValue({
-			data: makeVoices(100),
-			has_more: true,
-			next_page: "cur1",
-		});
+	it("stops at the limit even when a full page comes back", async () => {
+		mockGet.mockResolvedValue(makePage(makeVoices(100)));
 
 		const voices = await collectVoices(stubClient, {}, 100);
 
@@ -134,18 +118,10 @@ describe("collectVoices", () => {
 		expect(mockGet).toHaveBeenCalledTimes(1);
 	});
 
-	it("stops when has_more becomes false mid-pagination", async () => {
+	it("stops on the first short page mid-pagination", async () => {
 		mockGet
-			.mockResolvedValueOnce({
-				data: makeVoices(100),
-				has_more: true,
-				next_page: "cur1",
-			})
-			.mockResolvedValueOnce({
-				data: makeVoices(40, 100),
-				has_more: false,
-				next_page: null,
-			});
+			.mockResolvedValueOnce(makePage(makeVoices(100)))
+			.mockResolvedValueOnce(makePage(makeVoices(40, 100)));
 
 		const voices = await collectVoices(stubClient, {}, 250);
 
@@ -155,16 +131,8 @@ describe("collectVoices", () => {
 
 	it("passes filter params through on every page request", async () => {
 		mockGet
-			.mockResolvedValueOnce({
-				data: makeVoices(100),
-				has_more: true,
-				next_page: "cur1",
-			})
-			.mockResolvedValueOnce({
-				data: makeVoices(10, 100),
-				has_more: false,
-				next_page: null,
-			});
+			.mockResolvedValueOnce(makePage(makeVoices(100)))
+			.mockResolvedValueOnce(makePage(makeVoices(10, 100)));
 
 		const params = {
 			q: "warm",
@@ -358,16 +326,8 @@ describe("CartesiaTTS", () => {
 
 		it("aggregates voices across multiple pages", async () => {
 			mockGet
-				.mockResolvedValueOnce({
-					data: makeVoices(100),
-					has_more: true,
-					next_page: "cur1",
-				})
-				.mockResolvedValueOnce({
-					data: makeVoices(50, 100),
-					has_more: false,
-					next_page: null,
-				});
+				.mockResolvedValueOnce(makePage(makeVoices(100)))
+				.mockResolvedValueOnce(makePage(makeVoices(50, 100)));
 
 			const provider = new CartesiaTTS("test-key");
 			const voices = await provider.search({});

--- a/lib/providers/tts/cartesia.ts
+++ b/lib/providers/tts/cartesia.ts
@@ -77,8 +77,6 @@ const MAX_VOICES = 1000;
 
 type VoiceListPage = {
 	data: Voice[];
-	has_more: boolean;
-	next_page: string | null;
 };
 
 type VoiceQueryParams = Omit<
@@ -100,8 +98,9 @@ export async function collectVoices(
 			query: { ...params, limit: PAGE_SIZE, starting_after: cursor },
 		});
 		voices.push(...page.data);
-		if (!page.has_more || !page.next_page) break;
-		cursor = page.next_page;
+		if (page.data.length < PAGE_SIZE) break;
+		cursor = page.data[page.data.length - 1]?.id;
+		if (!cursor) break;
 	}
 	return voices;
 }


### PR DESCRIPTION
## Bug fixed

**Cartesia voice search silently truncated to the first 100 voices.**

`collectVoices()` (`lib/providers/tts/cartesia.ts`) drove pagination off `page.has_more` / `page.next_page`. But Cartesia's `/voices` endpoint is a **CursorIDPage** — its raw JSON body is only `{ data: [...] }` (verified against `@cartesia/cartesia-js/core/pagination`: `CursorIDPageResponse<Item>` = `{ data: Array<Item> }`, and `nextPageRequestOptions()` paginates via `starting_after` = the last item's `id`). There is no `has_more` and no `next_page` field.

Consequences:
- `page.has_more` read `undefined`, so `!page.has_more` was always `true` and the loop **broke after the first page**.
- `MAX_VOICES = 1000` / `PAGE_SIZE = 100` was unreachable; at most 100 voices were ever fetched.
- Voice similarity ranking and the user's `limit` (up to 250) ran over a truncated pool, so voices sorting past index 100 were silently unreachable.

### Fix
Paginate using Cartesia's real cursor contract: pass the last voice `id` as `starting_after`, and stop on a short page (`data.length < PAGE_SIZE`).

### Tests
The existing `cartesia-tts` tests encoded the fictional `has_more`/`next_page` contract, so they validated the bug. Rewrote the page stub and the `collectVoices` cases to match the real API shape (cursor-by-id, short-page termination). The "paginates past 100" test now guards the exact regression. Full suite: 866 passing.

## Validation
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run knip` ✅
- `npm run test:run` ✅ (866 passing)
- `npm run build` ✅

## Open PR overlap check
Reviewed open PRs #420, #419, #418, #417, #416, #415, #414, #413, #412, #410, #395, #394. Several touch `lib/providers/*` (#415 image/runware, #414 llm/anthropic, #412 cache + music/elevenlabs) but none touch `lib/providers/tts/cartesia.ts` or its test. This PR is non-overlapping.