### PR TITLE
refactor: nightly maintainability 2026-07-17

### DIFF
--- a/app/api/v1/__tests__/routes.test.ts
+++ b/app/api/v1/__tests__/routes.test.ts
@@ -47,6 +47,51 @@ function makeRequest(
 	});
 }
 
+type RoutePost = (req: NextRequest) => Promise<Response>;
+
+// Every asset route that accepts `referenceImages` shares the same field
+// contract (see optionalReferenceImages), so its validation coverage is
+// identical. Register the suite once per route instead of duplicating it.
+function referenceImagesSuite(
+	routePath: string,
+	loadPost: () => Promise<{ POST: RoutePost }>,
+) {
+	const post = (body: Record<string, unknown>) =>
+		loadPost().then(({ POST }) =>
+			POST(makeRequest(routePath, { prompt: "a", ...body })),
+		);
+
+	it("accepts requests without referenceImages", async () => {
+		expect((await post({})).status).toBe(200);
+	});
+
+	it("returns 400 for non-array referenceImages", async () => {
+		const res = await post({ referenceImages: "not-an-array" });
+		expect(res.status).toBe(400);
+		expect((await res.json()).error).toContain("expected array");
+	});
+
+	it("returns 400 for invalid referenceImages entry", async () => {
+		const res = await post({ referenceImages: ["not-a-data-uri"] });
+		expect(res.status).toBe(400);
+		expect((await res.json()).error).toContain("data URI or an HTTP");
+	});
+
+	it("accepts valid referenceImages data URIs", async () => {
+		const res = await post({
+			referenceImages: ["data:image/png;base64,iVBORw0KGgo"],
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it("accepts valid referenceImages URLs", async () => {
+		const res = await post({
+			referenceImages: ["https://example.com/image.png"],
+		});
+		expect(res.status).toBe(200);
+	});
+}
+
 describe("API routes", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -129,57 +174,10 @@ describe("API routes", () => {
 			expect(res.status).toBe(500);
 		});
 
-		it("accepts requests without referenceImages", async () => {
-			const { POST } = await import("@/app/api/v1/image/route");
-			const res = await POST(makeRequest("/api/v1/image", { prompt: "cat" }));
-			expect(res.status).toBe(200);
-		});
-
-		it("returns 400 for non-array referenceImages", async () => {
-			const { POST } = await import("@/app/api/v1/image/route");
-			const res = await POST(
-				makeRequest("/api/v1/image", {
-					prompt: "cat",
-					referenceImages: "not-an-array",
-				}),
-			);
-			expect(res.status).toBe(400);
-			expect((await res.json()).error).toContain("expected array");
-		});
-
-		it("returns 400 for invalid referenceImages entry", async () => {
-			const { POST } = await import("@/app/api/v1/image/route");
-			const res = await POST(
-				makeRequest("/api/v1/image", {
-					prompt: "cat",
-					referenceImages: ["not-a-data-uri"],
-				}),
-			);
-			expect(res.status).toBe(400);
-			expect((await res.json()).error).toContain("data URI or an HTTP");
-		});
-
-		it("accepts valid referenceImages data URIs", async () => {
-			const { POST } = await import("@/app/api/v1/image/route");
-			const res = await POST(
-				makeRequest("/api/v1/image", {
-					prompt: "cat",
-					referenceImages: ["data:image/png;base64,iVBORw0KGgo"],
-				}),
-			);
-			expect(res.status).toBe(200);
-		});
-
-		it("accepts valid referenceImages URLs", async () => {
-			const { POST } = await import("@/app/api/v1/image/route");
-			const res = await POST(
-				makeRequest("/api/v1/image", {
-					prompt: "cat",
-					referenceImages: ["https://example.com/image.png"],
-				}),
-			);
-			expect(res.status).toBe(200);
-		});
+		referenceImagesSuite(
+			"/api/v1/image",
+			() => import("@/app/api/v1/image/route"),
+		);
 
 		it("returns 400 for blank dimension strings", async () => {
 			const { POST } = await import("@/app/api/v1/image/route");
@@ -204,59 +202,10 @@ describe("API routes", () => {
 			expect(mockEnqueueJob).toHaveBeenCalledWith("job-abc", "video");
 		});
 
-		it("accepts requests without referenceImages", async () => {
-			const { POST } = await import("@/app/api/v1/video/route");
-			const res = await POST(
-				makeRequest("/api/v1/video", { prompt: "sunset" }),
-			);
-			expect(res.status).toBe(200);
-		});
-
-		it("returns 400 for non-array referenceImages", async () => {
-			const { POST } = await import("@/app/api/v1/video/route");
-			const res = await POST(
-				makeRequest("/api/v1/video", {
-					prompt: "test",
-					referenceImages: "not-an-array",
-				}),
-			);
-			expect(res.status).toBe(400);
-			expect((await res.json()).error).toContain("expected array");
-		});
-
-		it("returns 400 for invalid referenceImages entry", async () => {
-			const { POST } = await import("@/app/api/v1/video/route");
-			const res = await POST(
-				makeRequest("/api/v1/video", {
-					prompt: "test",
-					referenceImages: ["not-a-data-uri"],
-				}),
-			);
-			expect(res.status).toBe(400);
-			expect((await res.json()).error).toContain("data URI or an HTTP");
-		});
-
-		it("accepts valid referenceImages data URIs", async () => {
-			const { POST } = await import("@/app/api/v1/video/route");
-			const res = await POST(
-				makeRequest("/api/v1/video", {
-					prompt: "animate",
-					referenceImages: ["data:image/png;base64,iVBORw0KGgo"],
-				}),
-			);
-			expect(res.status).toBe(200);
-		});
-
-		it("accepts valid referenceImages URLs", async () => {
-			const { POST } = await import("@/app/api/v1/video/route");
-			const res = await POST(
-				makeRequest("/api/v1/video", {
-					prompt: "animate",
-					referenceImages: ["https://example.com/image.png"],
-				}),
-			);
-			expect(res.status).toBe(200);
-		});
+		referenceImagesSuite(
+			"/api/v1/video",
+			() => import("@/app/api/v1/video/route"),
+		);
 
 		it("returns 400 for missing prompt", async () => {
 			const { POST } = await import("@/app/api/v1/video/route");


### PR DESCRIPTION
## Summary

Nightly maintainability + docs pass. No behavior changes. Net **−51 lines** in one file (removes **104 lines** of verbatim test duplication).

The product code is exceptionally well-factored — the `lib/api/*` handlers, route wiring (`bodySchema` + `createAssetRouteHandlers`/`createApiRouteHandler`), contexts, and provider layer are already consolidated behind narrow interfaces. Nearly every substantial target was under an existing open PR (see overlap check), so this pass landed the one clean, non-overlapping win.

## Maintainability change

**Deduplicate `referenceImages` validation coverage** (`app/api/v1/__tests__/routes.test.ts`). Every asset route that accepts `referenceImages` shares one field contract (`optionalReferenceImages`), so the `POST /api/v1/image` and `POST /api/v1/video` suites carried the **same five tests verbatim** — differing only in the route path and prompt string:

- accepts requests without referenceImages
- returns 400 for non-array referenceImages
- returns 400 for invalid referenceImages entry
- accepts valid referenceImages data URIs
- accepts valid referenceImages URLs

Extracted a reusable `referenceImagesSuite(routePath, loadPost)` that registers the coverage once per route. Adding the suite to another asset route is now a one-liner, and the assertions can't drift apart between routes.

## Complexity delta

- Files changed: 1 (−51 net: +53 / −104)
- Removed 104 lines of verbatim duplication (10 duplicated `it` blocks → 2 suite calls)
- Test count unchanged (866 passing); same assertions, registered once

## Validation

- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run typecheck` ✅
- `npm run knip` ✅
- `npm run build` ✅
- `npm run test:run` ✅ (866 passing)

## Open PR overlap check

Reviewed all 13 open PRs: #421, #420, #419, #418, #417, #416, #415, #414, #413, #412, #410, #395, #394. They collectively cover `lib/providers/*`, `components/ui/*`, `lib/gateway/*`, `lib/connectors/*`, most of `lib/api/*`, `lib/canvas/*`, `lib/video/*`, `lib/generation/*`, `app/components/video/*`, `app/components/canvas/*`, and several top-level `app/components` files. The one file changed here — `app/api/v1/__tests__/routes.test.ts` — is touched by **none** of them. Non-overlapping.

## Skipped (with reasons)

- **Per-type asset-connector class boilerplate** (`lib/connectors/{image,music,sfx,video}/connector.ts`, identical `sfx`/`music` `attributes.ts`): real product duplication, but a clean factory would reach into `asset-base.ts` / `factory.ts` / `lib/gateway/*` — all under open PRs #414/#416/#420. Deferred to avoid theme overlap.
- **`GET` search-param route boilerplate** (`tts/voices`, `tts/voices/preview`): only 2 call sites, and a shared helper belongs in the `lib/api/*` layer that PRs #419/#418/#414/#412 are actively reworking. Marginal + contested; skipped.
- **`AccessCodeInput` hand-rolled fetch vs `OpenSlopClient`**: converging them would change the redirect-vs-error control flow (behavior risk); left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)