### PR TITLE
refactor: nightly conventions 2026-07-17

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,10 +21,11 @@ export default async function Home() {
 	} = await supabase.auth.getUser();
 
 	if (user) {
-		const { data: projects } = await supabase
+		const { data: projects, error } = await supabase
 			.from("projects")
 			.select("id, name, thumbnail_url, updated_at")
 			.order("updated_at", { ascending: false });
+		if (error) throw error;
 		return (
 			<UserProvider user={user}>
 				<ProjectsList initialProjects={projects ?? []} />

--- a/lib/video/transitions.ts
+++ b/lib/video/transitions.ts
@@ -32,25 +32,25 @@ type Dimensions = { width: number; height: number };
 
 // Each presentation has its own prop type — TransitionPresentation is invariant
 // in its generic, so we widen with `any` at the boundary.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Presentation = TransitionPresentation<any>;
+
+const PRESENTATIONS: Record<
+	TransitionType,
+	(dims: Dimensions) => Presentation
+> = {
+	none: () => none(),
+	fade: () => fade(),
+	slide: () => slide(),
+	wipe: () => wipe(),
+	flip: () => flip(),
+	clockWipe: ({ width, height }) => clockWipe({ width, height }),
+	iris: ({ width, height }) => iris({ width, height }),
+};
+
 export function getPresentation(
 	name: TransitionType,
-	{ width, height }: Dimensions,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-): TransitionPresentation<any> {
-	switch (name) {
-		case "none":
-			return none();
-		case "fade":
-			return fade();
-		case "slide":
-			return slide();
-		case "wipe":
-			return wipe();
-		case "flip":
-			return flip();
-		case "clockWipe":
-			return clockWipe({ width, height });
-		case "iris":
-			return iris({ width, height });
-	}
+	dims: Dimensions,
+): Presentation {
+	return PRESENTATIONS[name](dims);
 }


### PR DESCRIPTION
Nightly CONVENTIONS.md compliance audit. Two safe, no-behavior-change fixes.

## Fixed

**`app/page.tsx` — fail loudly (hard rule)**
The logged-in home route discarded the Supabase `error` from the project-list query. On a query failure (RLS, network) `projects` came back `null` and the page silently rendered the empty "No projects yet" state instead of surfacing the failure. Now destructures `error` and throws, matching the convention used everywhere else in the codebase (`lib/project/api.ts`, `app/projects/[id]/page.tsx`).

**`lib/video/transitions.ts` — registry over type-switch / declarative reads like config**
`getPresentation` hand-rolled a `switch (name)` over the `TransitionType` discriminant. Replaced with a `Record<TransitionType, ...>` lookup table, matching its own sibling `motionEffects.ts` (`SPECS`). The `Record` key preserves the same compile-time exhaustiveness the `switch` provided; the caller signature is unchanged.

## Audit scope

Full `lib/` + `app/` sweep for all seven CONVENTIONS.md rules (define-errors-out-of-existence, no special-case wiring, policy/mechanism split, dumb units, one canonical way, fail loudly, declarative-as-config). Files touched by the 14 open PRs were excluded. No other genuine violations surfaced — the connector/gateway/provider layering and the app UI layer remain clean per prior audits.

## Checks

`npm run lint`, `typecheck`, `format:check`, and `test:run` (866 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)