### PR TITLE
fix: make scene duration badge match the displayed time range

### DIFF
--- a/app/components/canvas/elements/SceneTimestamp.tsx
+++ b/app/components/canvas/elements/SceneTimestamp.tsx
@@ -1,4 +1,4 @@
-import { formatDuration, formatTimeRange } from "@/lib/video/timestamps";
+import { formatRangeDuration, formatTimeRange } from "@/lib/video/timestamps";
 
 export function SceneTimestamp({
 	start,
@@ -13,7 +13,7 @@ export function SceneTimestamp({
 				{formatTimeRange(start, duration)}
 			</span>
 			<span className="rounded bg-muted px-1.5 py-px text-muted-foreground">
-				{formatDuration(duration)}
+				{formatRangeDuration(start, duration)}
 			</span>
 		</span>
 	);

--- a/lib/video/__tests__/timestamps.test.ts
+++ b/lib/video/__tests__/timestamps.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { formatDuration, formatTime, formatTimeRange } from "../timestamps";
+import {
+	formatRangeDuration,
+	formatTime,
+	formatTimeRange,
+} from "../timestamps";
 
 describe("formatTime", () => {
 	it("formats seconds as m:ss", () => {
@@ -25,14 +29,25 @@ describe("formatTimeRange", () => {
 	});
 });
 
-describe("formatDuration", () => {
-	it("rounds to integer seconds", () => {
-		expect(formatDuration(14)).toBe("14s");
-		expect(formatDuration(6.7)).toBe("7s");
-		expect(formatDuration(6.3)).toBe("6s");
+describe("formatRangeDuration", () => {
+	it("equals the length of the floored start–end range", () => {
+		expect(formatRangeDuration(0, 14)).toBe("14s");
+		expect(formatRangeDuration(60, 65)).toBe("65s");
+	});
+
+	// Regression for #426: the badge must match the range, not round(duration).
+	it("stays consistent with the range on non-integer input", () => {
+		// round(duration) would show 13s while the range reads 0:00–0:12.
+		expect(formatTimeRange(0, 12.6)).toBe("0:00–0:12");
+		expect(formatRangeDuration(0, 12.6)).toBe("12s");
+
+		// Independent flooring of both endpoints: range reads 0:05–0:09 (4s),
+		// while round(duration) would show 3s.
+		expect(formatTimeRange(5.6, 3.4)).toBe("0:05–0:09");
+		expect(formatRangeDuration(5.6, 3.4)).toBe("4s");
 	});
 
 	it("clamps negatives to zero", () => {
-		expect(formatDuration(-1)).toBe("0s");
+		expect(formatRangeDuration(-1, 0)).toBe("0s");
 	});
 });

--- a/lib/video/timestamps.ts
+++ b/lib/video/timestamps.ts
@@ -1,7 +1,11 @@
+function floorSeconds(seconds: number): number {
+	return Math.floor(Math.max(0, seconds));
+}
+
 export function formatTime(seconds: number): string {
-	const safe = Math.max(0, seconds);
-	const m = Math.floor(safe / 60);
-	const s = Math.floor(safe % 60);
+	const total = floorSeconds(seconds);
+	const m = Math.floor(total / 60);
+	const s = total % 60;
 	return `${m}:${s.toString().padStart(2, "0")}`;
 }
 
@@ -9,6 +13,9 @@ export function formatTimeRange(start: number, duration: number): string {
 	return `${formatTime(start)}–${formatTime(start + duration)}`;
 }
 
-export function formatDuration(seconds: number): string {
-	return `${Math.round(Math.max(0, seconds))}s`;
+// Derive the badge from the same floored endpoints the start–end range shows,
+// so the two can never disagree (#426). Rounding the raw length instead diverges
+// from the floored range whenever start/duration are non-integer.
+export function formatRangeDuration(start: number, duration: number): string {
+	return `${floorSeconds(start + duration) - floorSeconds(start)}s`;
 }


### PR DESCRIPTION
## Summary

Fixes #426. The scene-header duration badge could disagree with the start–end range shown right next to it — e.g. the range reads `0:00–0:12` while the badge reads `13s`.

Both labels are fed the **same** fractional-seconds `duration`, so the data is fine; the divergence was purely two different rounding strategies in the formatters:

- `formatTimeRange(start, duration)` **floors** each endpoint.
- `formatDuration(duration)` **rounded** the raw length.

Since scene `start`/`duration` are routinely non-integer, the two disagreed in two independent ways:

1. Round-vs-floor of the length: `start=0, duration=12.6` → range `0:00–0:12` but badge `13s`.
2. Independent flooring of both endpoints: `start=5.6, duration=3.4` → range `0:05–0:09` (implies 4s) but badge `3s`.

## Change

Make the displayed range the single source of truth for the badge. `formatDuration` is replaced by `formatRangeDuration(start, duration)`, which derives the badge from the *same* floored endpoints the range uses:

```
floor(start + duration) − floor(start)
```

So the badge is, by construction, always equal to the length the range shows. The shared `floorSeconds` helper is used by both `formatTime` and the new function so they can't drift apart. `formatDuration` had no other callers, so it's removed.

- `lib/video/timestamps.ts` — add `formatRangeDuration`, factor out `floorSeconds`, drop `formatDuration`
- `app/components/canvas/elements/SceneTimestamp.tsx` — badge now uses `formatRangeDuration(start, duration)`

## Tests

`lib/video/__tests__/timestamps.test.ts` — replaced the `formatDuration` block with `formatRangeDuration` coverage, including both `#426` repro cases asserted against `formatTimeRange` so the badge/range consistency is locked in.

## Verification

- `npx vitest run lib/video/__tests__/timestamps.test.ts` → 7 passed
- `npm run typecheck` → clean
- `npx eslint` on the changed files → clean; `prettier --check` → clean (also enforced by the pre-commit hook)
- `npm run knip` could not complete locally (the oxc parser hit a native `ArrayBuffer` OOM on my machine, unrelated to this diff); the change removes one export and adds one that's imported by `SceneTimestamp.tsx`, so it introduces no unused export.
