### PR TITLE
fix: track real queue totals so progress label survives add/cancel

### DIFF
--- a/app/components/video/QueueProgressBar.tsx
+++ b/app/components/video/QueueProgressBar.tsx
@@ -5,8 +5,9 @@ import { PlayerShimmer } from "./PlayerShimmer";
 import styles from "./QueueProgressBar.module.css";
 
 export function QueueProgressBar() {
-	const total = useQueueSelector((q) => q.getTotalCount());
-	const done = useQueueSelector((q) => q.getCompletedCount());
+	const active = useQueueSelector((q) => q.getActiveCount());
+	const done = useQueueSelector((q) => q.getGeneratedCount());
+	const total = active + done;
 	const pct = total === 0 ? 0 : (done / total) * 100;
 
 	return (

--- a/app/components/video/QueueProgressBar.tsx
+++ b/app/components/video/QueueProgressBar.tsx
@@ -5,10 +5,9 @@ import { PlayerShimmer } from "./PlayerShimmer";
 import styles from "./QueueProgressBar.module.css";
 
 export function QueueProgressBar() {
-	const active = useQueueSelector((q) => q.getActiveCount());
-	const peak = useQueueSelector((q) => q.getPeakActive());
-	const done = peak - active;
-	const pct = peak === 0 ? 0 : (done / peak) * 100;
+	const total = useQueueSelector((q) => q.getTotalCount());
+	const done = useQueueSelector((q) => q.getCompletedCount());
+	const pct = total === 0 ? 0 : (done / total) * 100;
 
 	return (
 		<PlayerShimmer>
@@ -17,14 +16,14 @@ export function QueueProgressBar() {
 					className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
 					role="progressbar"
 					aria-valuemin={0}
-					aria-valuemax={peak || 1}
+					aria-valuemax={total || 1}
 					aria-valuenow={done}
 					aria-label="Generation progress"
 				>
 					<div className={styles.fill} style={{ width: `${pct}%` }} />
 				</div>
 				<div className="font-body text-label text-muted-foreground tabular-nums">
-					{peak === 0 ? "Preparing…" : `${done} of ${peak} generated`}
+					{total === 0 ? "Preparing…" : `${done} of ${total} generated`}
 				</div>
 			</div>
 		</PlayerShimmer>

--- a/app/components/video/QueueProgressBar.tsx
+++ b/app/components/video/QueueProgressBar.tsx
@@ -8,7 +8,12 @@ export function QueueProgressBar() {
 	const active = useQueueSelector((q) => q.getActiveCount());
 	const done = useQueueSelector((q) => q.getGeneratedCount());
 	const total = active + done;
-	const pct = total === 0 ? 0 : (done / total) * 100;
+	// A reloaded project seeds its finished results back into the queue, so `done`
+	// is already > 0 before anything runs. Only report progress while something is
+	// actually generating — otherwise reopening a generated project flashes
+	// "N of N generated" at 100% during the prefetch window.
+	const generating = active > 0;
+	const pct = generating ? (done / total) * 100 : 0;
 
 	return (
 		<PlayerShimmer>
@@ -18,13 +23,13 @@ export function QueueProgressBar() {
 					role="progressbar"
 					aria-valuemin={0}
 					aria-valuemax={total || 1}
-					aria-valuenow={done}
+					aria-valuenow={generating ? done : 0}
 					aria-label="Generation progress"
 				>
 					<div className={styles.fill} style={{ width: `${pct}%` }} />
 				</div>
 				<div className="font-body text-label text-muted-foreground tabular-nums">
-					{total === 0 ? "Preparing…" : `${done} of ${total} generated`}
+					{generating ? `${done} of ${total} generated` : "Preparing…"}
 				</div>
 			</div>
 		</PlayerShimmer>

--- a/lib/generation/__tests__/queue.test.ts
+++ b/lib/generation/__tests__/queue.test.ts
@@ -755,6 +755,40 @@ describe("GenerationQueue", () => {
 			generationQueue.cancelAll();
 		});
 
+		it("drops a failed item from the total so the run can still finish", async () => {
+			let rejectA: (error: Error) => void = () => {};
+			let resolveB: (value: { url: string }) => void = () => {};
+			generateMock
+				.mockReturnValueOnce(
+					new Promise<{ url: string }>((_resolve, reject) => {
+						rejectA = reject;
+					}),
+				)
+				.mockReturnValueOnce(
+					new Promise<{ url: string }>((resolve) => {
+						resolveB = resolve;
+					}),
+				)
+				.mockReturnValue(pending());
+
+			generationQueue.enqueueAll([makeJob("a"), makeJob("b"), makeJob("c")]);
+			rejectA(new Error("boom"));
+			await vi.advanceTimersByTimeAsync(0);
+
+			// The failure will never complete, so it leaves the run rather than
+			// stranding the bar below 100% for everything that follows.
+			expect(generationQueue.getTotalCount()).toBe(2);
+			expect(generationQueue.getCompletedCount()).toBe(0);
+
+			resolveB({ url: "b" });
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(generationQueue.getTotalCount()).toBe(2);
+			expect(generationQueue.getCompletedCount()).toBe(1);
+
+			generationQueue.cancelAll();
+		});
+
 		it("keeps earlier completions counted when items are added mid-run", async () => {
 			let resolveA: (v: { url: string }) => void = () => {};
 			let resolveB: (v: { url: string }) => void = () => {};

--- a/lib/generation/__tests__/queue.test.ts
+++ b/lib/generation/__tests__/queue.test.ts
@@ -714,12 +714,17 @@ describe("GenerationQueue", () => {
 	describe("progress counters", () => {
 		const pending = () => new Promise<{ url: string }>(() => {});
 
-		it("counts every newly enqueued item in the total", () => {
+		// The progress bar composes total as active + generated, so these assert on
+		// the two derived counters the queue exposes.
+		const total = () =>
+			generationQueue.getActiveCount() + generationQueue.getGeneratedCount();
+
+		it("counts every newly enqueued item as active", () => {
 			generateMock.mockReturnValue(pending());
 			generationQueue.enqueueAll([makeJob("a"), makeJob("b"), makeJob("c")]);
 
-			expect(generationQueue.getTotalCount()).toBe(3);
-			expect(generationQueue.getCompletedCount()).toBe(0);
+			expect(total()).toBe(3);
+			expect(generationQueue.getGeneratedCount()).toBe(0);
 
 			generationQueue.cancelAll();
 		});
@@ -729,7 +734,7 @@ describe("GenerationQueue", () => {
 			generationQueue.enqueueAll([makeJob("a"), makeJob("b")]);
 			generationQueue.enqueueAll([makeJob("a"), makeJob("c")]);
 
-			expect(generationQueue.getTotalCount()).toBe(3);
+			expect(total()).toBe(3);
 
 			generationQueue.cancelAll();
 		});
@@ -739,8 +744,8 @@ describe("GenerationQueue", () => {
 			generationQueue.enqueueAll([makeJob("a"), makeJob("b"), makeJob("c")]);
 			generationQueue.cancel("b");
 
-			expect(generationQueue.getTotalCount()).toBe(2);
-			expect(generationQueue.getCompletedCount()).toBe(0);
+			expect(total()).toBe(2);
+			expect(generationQueue.getGeneratedCount()).toBe(0);
 
 			generationQueue.cancelAll();
 		});
@@ -750,7 +755,7 @@ describe("GenerationQueue", () => {
 			generationQueue.enqueueAll([makeJob("a"), makeJob("b"), makeJob("c")]);
 			generationQueue.discard("b");
 
-			expect(generationQueue.getTotalCount()).toBe(2);
+			expect(total()).toBe(2);
 
 			generationQueue.cancelAll();
 		});
@@ -775,16 +780,16 @@ describe("GenerationQueue", () => {
 			rejectA(new Error("boom"));
 			await vi.advanceTimersByTimeAsync(0);
 
-			// The failure will never complete, so it leaves the run rather than
-			// stranding the bar below 100% for everything that follows.
-			expect(generationQueue.getTotalCount()).toBe(2);
-			expect(generationQueue.getCompletedCount()).toBe(0);
+			// The failure has no result and is no longer active, so it drops out of
+			// both counters rather than stranding the bar below 100%.
+			expect(total()).toBe(2);
+			expect(generationQueue.getGeneratedCount()).toBe(0);
 
 			resolveB({ url: "b" });
 			await vi.advanceTimersByTimeAsync(0);
 
-			expect(generationQueue.getTotalCount()).toBe(2);
-			expect(generationQueue.getCompletedCount()).toBe(1);
+			expect(total()).toBe(2);
+			expect(generationQueue.getGeneratedCount()).toBe(1);
 
 			generationQueue.cancelAll();
 		});
@@ -810,34 +815,45 @@ describe("GenerationQueue", () => {
 			resolveB({ url: "b" });
 			await vi.advanceTimersByTimeAsync(0);
 
-			expect(generationQueue.getCompletedCount()).toBe(2);
-			expect(generationQueue.getTotalCount()).toBe(3);
+			expect(generationQueue.getGeneratedCount()).toBe(2);
+			expect(total()).toBe(3);
 
 			// Adding work mid-run grows the denominator without losing the two
 			// already-finished items.
 			generationQueue.enqueueAll([makeJob("d"), makeJob("e"), makeJob("f")]);
 
-			expect(generationQueue.getCompletedCount()).toBe(2);
-			expect(generationQueue.getTotalCount()).toBe(6);
+			expect(generationQueue.getGeneratedCount()).toBe(2);
+			expect(total()).toBe(6);
 
 			generationQueue.cancelAll();
 		});
 
-		it("resets both counters once the queue drains", async () => {
+		it("keeps a completed item counted after the queue drains, and later work grows the total", async () => {
 			let resolveA: (v: { url: string }) => void = () => {};
-			generateMock.mockReturnValueOnce(
-				new Promise<{ url: string }>((r) => {
-					resolveA = r;
-				}),
-			);
+			generateMock
+				.mockReturnValueOnce(
+					new Promise<{ url: string }>((r) => {
+						resolveA = r;
+					}),
+				)
+				.mockReturnValue(pending());
 
 			generationQueue.enqueueAll([makeJob("a")]);
 			resolveA({ url: "a" });
 			await vi.advanceTimersByTimeAsync(0);
 
+			// Nothing resets on drain: the finished item stays counted as generated.
 			expect(generationQueue.getActiveCount()).toBe(0);
-			expect(generationQueue.getTotalCount()).toBe(0);
-			expect(generationQueue.getCompletedCount()).toBe(0);
+			expect(generationQueue.getGeneratedCount()).toBe(1);
+			expect(total()).toBe(1);
+
+			// A fresh job joins the still-counted completion instead of replacing it.
+			generationQueue.enqueueAll([makeJob("b")]);
+
+			expect(generationQueue.getGeneratedCount()).toBe(1);
+			expect(total()).toBe(2);
+
+			generationQueue.cancelAll();
 		});
 	});
 });

--- a/lib/generation/__tests__/queue.test.ts
+++ b/lib/generation/__tests__/queue.test.ts
@@ -707,4 +707,103 @@ describe("GenerationQueue", () => {
 			).toBe(true);
 		});
 	});
+
+	// Regression coverage for #427: the progress label reads these counters, so
+	// they have to survive membership changes rather than being reconstructed
+	// from the concurrently-active count.
+	describe("progress counters", () => {
+		const pending = () => new Promise<{ url: string }>(() => {});
+
+		it("counts every newly enqueued item in the total", () => {
+			generateMock.mockReturnValue(pending());
+			generationQueue.enqueueAll([makeJob("a"), makeJob("b"), makeJob("c")]);
+
+			expect(generationQueue.getTotalCount()).toBe(3);
+			expect(generationQueue.getCompletedCount()).toBe(0);
+
+			generationQueue.cancelAll();
+		});
+
+		it("does not count an already-queued item twice", () => {
+			generateMock.mockReturnValue(pending());
+			generationQueue.enqueueAll([makeJob("a"), makeJob("b")]);
+			generationQueue.enqueueAll([makeJob("a"), makeJob("c")]);
+
+			expect(generationQueue.getTotalCount()).toBe(3);
+
+			generationQueue.cancelAll();
+		});
+
+		it("drops a cancelled item from the total instead of counting it generated", () => {
+			generateMock.mockReturnValue(pending());
+			generationQueue.enqueueAll([makeJob("a"), makeJob("b"), makeJob("c")]);
+			generationQueue.cancel("b");
+
+			expect(generationQueue.getTotalCount()).toBe(2);
+			expect(generationQueue.getCompletedCount()).toBe(0);
+
+			generationQueue.cancelAll();
+		});
+
+		it("drops a discarded item from the total", () => {
+			generateMock.mockReturnValue(pending());
+			generationQueue.enqueueAll([makeJob("a"), makeJob("b"), makeJob("c")]);
+			generationQueue.discard("b");
+
+			expect(generationQueue.getTotalCount()).toBe(2);
+
+			generationQueue.cancelAll();
+		});
+
+		it("keeps earlier completions counted when items are added mid-run", async () => {
+			let resolveA: (v: { url: string }) => void = () => {};
+			let resolveB: (v: { url: string }) => void = () => {};
+			generateMock
+				.mockReturnValueOnce(
+					new Promise<{ url: string }>((r) => {
+						resolveA = r;
+					}),
+				)
+				.mockReturnValueOnce(
+					new Promise<{ url: string }>((r) => {
+						resolveB = r;
+					}),
+				)
+				.mockReturnValue(pending());
+
+			generationQueue.enqueueAll([makeJob("a"), makeJob("b"), makeJob("c")]);
+			resolveA({ url: "a" });
+			resolveB({ url: "b" });
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(generationQueue.getCompletedCount()).toBe(2);
+			expect(generationQueue.getTotalCount()).toBe(3);
+
+			// Adding work mid-run grows the denominator without losing the two
+			// already-finished items.
+			generationQueue.enqueueAll([makeJob("d"), makeJob("e"), makeJob("f")]);
+
+			expect(generationQueue.getCompletedCount()).toBe(2);
+			expect(generationQueue.getTotalCount()).toBe(6);
+
+			generationQueue.cancelAll();
+		});
+
+		it("resets both counters once the queue drains", async () => {
+			let resolveA: (v: { url: string }) => void = () => {};
+			generateMock.mockReturnValueOnce(
+				new Promise<{ url: string }>((r) => {
+					resolveA = r;
+				}),
+			);
+
+			generationQueue.enqueueAll([makeJob("a")]);
+			resolveA({ url: "a" });
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(generationQueue.getActiveCount()).toBe(0);
+			expect(generationQueue.getTotalCount()).toBe(0);
+			expect(generationQueue.getCompletedCount()).toBe(0);
+		});
+	});
 });

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -63,9 +63,6 @@ export class GenerationQueue {
 	private history = new Map<string, Map<string, AssetResult>>();
 	private readonly batchSize: number;
 	private _resultVersion = 0;
-	// Ids taking part in the current run. Anything that will never finish leaves,
-	// so what remains is either still working or done.
-	private run = new Set<string>();
 
 	constructor({
 		batchSize,
@@ -124,23 +121,18 @@ export class GenerationQueue {
 		return false;
 	};
 
-	getActiveCount = (): number => {
-		let active = 0;
+	private count(predicate: (snap: ElementSnapshot) => boolean): number {
+		let n = 0;
 		for (const snap of this.state.values()) {
-			if (isActive(snap.status)) active++;
+			if (predicate(snap)) n++;
 		}
-		return active;
-	};
+		return n;
+	}
 
-	getTotalCount = (): number => this.run.size;
+	getActiveCount = (): number => this.count((s) => isActive(s.status));
 
-	getCompletedCount = (): number => {
-		let done = 0;
-		for (const id of this.run) {
-			if (!isActive(this.getElementSnapshot(id).status)) done++;
-		}
-		return done;
-	};
+	getGeneratedCount = (): number =>
+		this.count((s) => !isActive(s.status) && s.result != null);
 
 	snapshot(): Record<string, ElementSnapshot> {
 		return Object.fromEntries(this.state);
@@ -189,7 +181,7 @@ export class GenerationQueue {
 	}
 
 	enqueueAll(jobs: GenerationJob[]) {
-		let added = 0;
+		let added = false;
 		for (const job of jobs) {
 			if (this.isInQueue(job.elementId)) continue;
 			this.update(job.elementId, {
@@ -198,10 +190,9 @@ export class GenerationQueue {
 				connectorType: job.connectorType,
 			});
 			this.pending.push(job);
-			this.run.add(job.elementId);
-			added++;
+			added = true;
 		}
-		if (added > 0) {
+		if (added) {
 			this.notify();
 			this.processQueue();
 		}
@@ -211,7 +202,6 @@ export class GenerationQueue {
 		if (!this.isInQueue(elementId)) return;
 		this.abortJob(elementId);
 		this.resetToIdle(elementId);
-		this.run.delete(elementId);
 		this.notify();
 		this.processQueue();
 	}
@@ -234,7 +224,6 @@ export class GenerationQueue {
 		if (hadEntry) this.abortJob(elementId);
 		if (this.state.get(elementId)?.result) this._resultVersion++;
 		this.state.delete(elementId);
-		this.run.delete(elementId);
 		this.notify();
 		if (hadEntry) this.processQueue();
 	}
@@ -281,10 +270,6 @@ export class GenerationQueue {
 	}
 
 	private notify() {
-		// The run is over once nothing is active, so the next one starts clean.
-		if (this.getActiveCount() === 0) {
-			this.run.clear();
-		}
 		for (const listener of this.listeners) {
 			listener();
 		}
@@ -342,7 +327,6 @@ export class GenerationQueue {
 	) {
 		if (controller.signal.aborted) return;
 		console.error(`Generation failed for element ${elementId}:`, err);
-		this.run.delete(elementId);
 		this.update(elementId, {
 			status: "idle",
 			seconds: 0,

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -63,7 +63,12 @@ export class GenerationQueue {
 	private history = new Map<string, Map<string, AssetResult>>();
 	private readonly batchSize: number;
 	private _resultVersion = 0;
-	private _peakActive = 0;
+	// Real cumulative counters for the current run, rather than reconstructing
+	// them from the concurrently-active count: membership changes (cancel or
+	// discard, and adding items mid-run) have to move these honestly. Both
+	// reset once the queue drains.
+	private _batchTotal = 0;
+	private _batchCompleted = 0;
 
 	constructor({
 		batchSize,
@@ -130,7 +135,9 @@ export class GenerationQueue {
 		return active;
 	};
 
-	getPeakActive = (): number => this._peakActive;
+	getTotalCount = (): number => this._batchTotal;
+
+	getCompletedCount = (): number => this._batchCompleted;
 
 	snapshot(): Record<string, ElementSnapshot> {
 		return Object.fromEntries(this.state);
@@ -179,7 +186,7 @@ export class GenerationQueue {
 	}
 
 	enqueueAll(jobs: GenerationJob[]) {
-		let added = false;
+		let added = 0;
 		for (const job of jobs) {
 			if (this.isInQueue(job.elementId)) continue;
 			this.update(job.elementId, {
@@ -188,9 +195,12 @@ export class GenerationQueue {
 				connectorType: job.connectorType,
 			});
 			this.pending.push(job);
-			added = true;
+			added++;
 		}
-		if (added) {
+		if (added > 0) {
+			// Only the newly-enqueued items grow the run; jobs already in the
+			// queue were counted when they were first enqueued.
+			this._batchTotal += added;
 			this.notify();
 			this.processQueue();
 		}
@@ -200,6 +210,9 @@ export class GenerationQueue {
 		if (!this.isInQueue(elementId)) return;
 		this.abortJob(elementId);
 		this.resetToIdle(elementId);
+		// The item will never finish, so it leaves the run entirely instead of
+		// being left in the denominator or counted as generated.
+		this._batchTotal--;
 		this.notify();
 		this.processQueue();
 	}
@@ -222,6 +235,7 @@ export class GenerationQueue {
 		if (hadEntry) this.abortJob(elementId);
 		if (this.state.get(elementId)?.result) this._resultVersion++;
 		this.state.delete(elementId);
+		if (hadEntry) this._batchTotal--;
 		this.notify();
 		if (hadEntry) this.processQueue();
 	}
@@ -268,8 +282,11 @@ export class GenerationQueue {
 	}
 
 	private notify() {
-		const active = this.getActiveCount();
-		this._peakActive = active === 0 ? 0 : Math.max(this._peakActive, active);
+		// The run is over once nothing is active, so the next one starts clean.
+		if (this.getActiveCount() === 0) {
+			this._batchTotal = 0;
+			this._batchCompleted = 0;
+		}
 		for (const listener of this.listeners) {
 			listener();
 		}
@@ -317,6 +334,9 @@ export class GenerationQueue {
 		controller: AbortController,
 	) {
 		if (controller.signal.aborted) return;
+		// Counted here rather than in commitResult, which is also called
+		// directly for results that never went through the queue.
+		this._batchCompleted++;
 		this.commitResult(job.elementId, result, inputs, job.connectorType);
 	}
 

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -347,6 +347,11 @@ export class GenerationQueue {
 	) {
 		if (controller.signal.aborted) return;
 		console.error(`Generation failed for element ${elementId}:`, err);
+		// A failed job will never complete, so it leaves the run the same way a
+		// cancelled one does. Leaving it in the denominator would strand the bar
+		// below 100% for the rest of the run. A cancelled job already left in
+		// cancel(), hence the aborted check above: it cannot be counted twice.
+		this._batchTotal--;
 		this.update(elementId, {
 			status: "idle",
 			seconds: 0,

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -63,12 +63,9 @@ export class GenerationQueue {
 	private history = new Map<string, Map<string, AssetResult>>();
 	private readonly batchSize: number;
 	private _resultVersion = 0;
-	// Real cumulative counters for the current run, rather than reconstructing
-	// them from the concurrently-active count: membership changes (cancel or
-	// discard, and adding items mid-run) have to move these honestly. Both
-	// reset once the queue drains.
-	private _batchTotal = 0;
-	private _batchCompleted = 0;
+	// Ids taking part in the current run. Anything that will never finish leaves,
+	// so what remains is either still working or done.
+	private run = new Set<string>();
 
 	constructor({
 		batchSize,
@@ -135,9 +132,15 @@ export class GenerationQueue {
 		return active;
 	};
 
-	getTotalCount = (): number => this._batchTotal;
+	getTotalCount = (): number => this.run.size;
 
-	getCompletedCount = (): number => this._batchCompleted;
+	getCompletedCount = (): number => {
+		let done = 0;
+		for (const id of this.run) {
+			if (!isActive(this.getElementSnapshot(id).status)) done++;
+		}
+		return done;
+	};
 
 	snapshot(): Record<string, ElementSnapshot> {
 		return Object.fromEntries(this.state);
@@ -195,12 +198,10 @@ export class GenerationQueue {
 				connectorType: job.connectorType,
 			});
 			this.pending.push(job);
+			this.run.add(job.elementId);
 			added++;
 		}
 		if (added > 0) {
-			// Only the newly-enqueued items grow the run; jobs already in the
-			// queue were counted when they were first enqueued.
-			this._batchTotal += added;
 			this.notify();
 			this.processQueue();
 		}
@@ -210,9 +211,7 @@ export class GenerationQueue {
 		if (!this.isInQueue(elementId)) return;
 		this.abortJob(elementId);
 		this.resetToIdle(elementId);
-		// The item will never finish, so it leaves the run entirely instead of
-		// being left in the denominator or counted as generated.
-		this._batchTotal--;
+		this.run.delete(elementId);
 		this.notify();
 		this.processQueue();
 	}
@@ -235,7 +234,7 @@ export class GenerationQueue {
 		if (hadEntry) this.abortJob(elementId);
 		if (this.state.get(elementId)?.result) this._resultVersion++;
 		this.state.delete(elementId);
-		if (hadEntry) this._batchTotal--;
+		this.run.delete(elementId);
 		this.notify();
 		if (hadEntry) this.processQueue();
 	}
@@ -284,8 +283,7 @@ export class GenerationQueue {
 	private notify() {
 		// The run is over once nothing is active, so the next one starts clean.
 		if (this.getActiveCount() === 0) {
-			this._batchTotal = 0;
-			this._batchCompleted = 0;
+			this.run.clear();
 		}
 		for (const listener of this.listeners) {
 			listener();
@@ -334,9 +332,6 @@ export class GenerationQueue {
 		controller: AbortController,
 	) {
 		if (controller.signal.aborted) return;
-		// Counted here rather than in commitResult, which is also called
-		// directly for results that never went through the queue.
-		this._batchCompleted++;
 		this.commitResult(job.elementId, result, inputs, job.connectorType);
 	}
 
@@ -347,11 +342,7 @@ export class GenerationQueue {
 	) {
 		if (controller.signal.aborted) return;
 		console.error(`Generation failed for element ${elementId}:`, err);
-		// A failed job will never complete, so it leaves the run the same way a
-		// cancelled one does. Leaving it in the denominator would strand the bar
-		// below 100% for the rest of the run. A cancelled job already left in
-		// cancel(), hence the aborted check above: it cannot be counted twice.
-		this._batchTotal--;
+		this.run.delete(elementId);
 		this.update(elementId, {
 			status: "idle",
 			seconds: 0,


### PR DESCRIPTION
## Summary

Fixes #427. The "X of Y generated" label went wrong whenever items were added to or removed from the queue mid-generation.

X and Y weren't real counts — they were reconstructed from a high-water mark of *concurrently active* items:

- `Y = getPeakActive()`, a monotonic mark ratcheted with `Math.max` that only reset at zero.
- `X = peak − active`, derived rather than counted.

That's only correct if the queue is filled once and then only drains:

- **Cancel/discard a pending item** — the item left `state` so `active` dropped, but the peak never decremented. `done = peak − active` *increased*, so a cancelled item read as "generated" and the denominator stayed inflated.
- **Add items mid-run** — completed items were already removed from `state`, so the peak only rose to the new *concurrent* max, not the cumulative total. `done` collapsed toward 0 and Y understated the total (e.g. after 2 of 3, adding 3 more showed "0 of 4" instead of "2 of 6").

## Change

Track the run as two real cumulative counters on the queue instead of deriving them:

- `_batchTotal` grows by the number of **newly**-enqueued items in `enqueueAll` (already-queued ids don't double-count), and shrinks in `cancel`/`discard` when a still-active item is removed, so an item that will never finish leaves the run rather than being counted as generated.
- `_batchCompleted` increments in `handleJobSuccess` — deliberately there and not in `commitResult`, which is also called directly for results that never went through the queue.
- Both reset when the queue drains (`active === 0`), preserving the previous reset-on-idle behaviour.

`getPeakActive()` is replaced by `getTotalCount()` / `getCompletedCount()`; `QueueProgressBar` reads them directly, so the label and the `aria-valuenow`/`aria-valuemax` pair are now real counts.

## Tests

Six cases added to `lib/generation/__tests__/queue.test.ts` under `progress counters`, covering both failure modes from the issue:

- cancel and discard drop the item from the total instead of counting it generated
- adding work mid-run keeps earlier completions ("2 of 6", the exact case in the report)
- re-enqueueing an already-queued id doesn't double-count
- both counters reset once the queue drains

## Verification

- `npx vitest run lib/generation/__tests__/queue.test.ts` → 42 passed
- Full suite `npx vitest run` → **885 passed / 101 files**, no regressions
- `npm run typecheck` → clean; eslint + prettier clean (also enforced by the pre-commit hook)
