### PR TITLE
fix: nightly bug fixes 2026-07-18

### DIFF
--- a/app/components/canvas/__tests__/resolveDragTransfer.test.ts
+++ b/app/components/canvas/__tests__/resolveDragTransfer.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { createEditor, type Editor } from "slate";
+import type { DragOverEvent } from "@dnd-kit/core";
+import { resolveDragTransfer } from "../dnd/useDragAndDrop";
+
+function makeEditor(): Editor {
+	const editor = createEditor();
+	editor.children = [
+		{
+			id: "scene-1",
+			type: "scene",
+			children: [
+				{ id: "a", type: "narration", children: [{ text: "" }] },
+				{ id: "b", type: "narration", children: [{ text: "" }] },
+			],
+		},
+		{
+			id: "scene-2",
+			type: "scene",
+			children: [{ id: "c", type: "narration", children: [{ text: "" }] }],
+		},
+	] as unknown as Editor["children"];
+	return editor;
+}
+
+const dragOver = (
+	activeId: string,
+	activeSceneId: string | undefined,
+	over: { id: string; sceneId?: string } | null,
+) =>
+	({
+		active: { id: activeId, data: { current: { sceneId: activeSceneId } } },
+		over: over && {
+			id: over.id,
+			data: { current: { sceneId: over.sceneId } },
+		},
+	}) as unknown as DragOverEvent;
+
+describe("resolveDragTransfer", () => {
+	it("proposes a transfer at the hovered element's index in the target scene", () => {
+		expect(
+			resolveDragTransfer(
+				makeEditor(),
+				dragOver("a", "scene-1", { id: "c", sceneId: "scene-2" }),
+			),
+		).toEqual({
+			itemId: "a",
+			fromSceneId: "scene-1",
+			toSceneId: "scene-2",
+			atIndex: 0,
+		});
+	});
+
+	it("clears the transfer once the pointer leaves every droppable", () => {
+		expect(
+			resolveDragTransfer(makeEditor(), dragOver("a", "scene-1", null)),
+		).toBe(null);
+	});
+
+	it("clears the transfer when the hover target is missing a scene id", () => {
+		expect(
+			resolveDragTransfer(
+				makeEditor(),
+				dragOver("a", "scene-1", { id: "c", sceneId: undefined }),
+			),
+		).toBe(null);
+	});
+
+	it("clears the transfer when the hovered element is unknown to the editor", () => {
+		expect(
+			resolveDragTransfer(
+				makeEditor(),
+				dragOver("a", "scene-1", { id: "ghost", sceneId: "scene-2" }),
+			),
+		).toBe(null);
+	});
+
+	it("returns null for a same-scene reorder", () => {
+		expect(
+			resolveDragTransfer(
+				makeEditor(),
+				dragOver("a", "scene-1", { id: "b", sceneId: "scene-1" }),
+			),
+		).toBe(null);
+	});
+
+	it("appends to the end when hovering the target scene itself", () => {
+		const event = {
+			active: { id: "a", data: { current: { sceneId: "scene-1" } } },
+			over: { id: "scene-2", data: { current: { sceneId: "scene-2" } } },
+		} as unknown as DragOverEvent;
+
+		expect(resolveDragTransfer(makeEditor(), event)).toMatchObject({
+			toSceneId: "scene-2",
+			atIndex: 1,
+		});
+	});
+});

--- a/app/components/canvas/dnd/useDragAndDrop.ts
+++ b/app/components/canvas/dnd/useDragAndDrop.ts
@@ -13,6 +13,41 @@ import { Descendant, Editor, Element, Path, Transforms } from "slate";
 import { isSceneElement } from "@/lib/canvas/scenes";
 import type { DragTransfer } from "./DragTransferContext";
 
+/**
+ * Resolves the cross-scene transfer a drag is currently proposing, or `null`
+ * when there is none. Every caller assigns the result unconditionally: bailing
+ * out early would leave the previous target's insert gap wedged open once the
+ * pointer moves off it.
+ */
+export function resolveDragTransfer(
+	editor: Editor,
+	event: DragOverEvent,
+): DragTransfer {
+	const { active, over } = event;
+	if (!over?.id || active.id === over.id) return null;
+	if (active.data.current?.type === "scene") return null;
+
+	const fromSceneId = active.data.current?.sceneId;
+	const toSceneId = over.data.current?.sceneId;
+	if (!fromSceneId || !toSceneId || fromSceneId === toSceneId) return null;
+
+	const [overEntry] = Editor.nodes(editor, {
+		at: [],
+		match: (n) => Element.isElement(n) && n.id === over.id,
+	});
+	if (!overEntry) return null;
+
+	const [overNode, overPath] = overEntry;
+	return {
+		itemId: active.id as string,
+		fromSceneId,
+		toSceneId,
+		atIndex: isSceneElement(overNode)
+			? overNode.children.length
+			: overPath[overPath.length - 1],
+	};
+}
+
 export function useDragAndDrop(editor: Editor, value: Descendant[]) {
 	const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
 	const [dragTransfer, setDragTransfer] = useState<DragTransfer>(null);
@@ -29,38 +64,8 @@ export function useDragAndDrop(editor: Editor, value: Descendant[]) {
 	}, []);
 
 	const handleDragOver = useCallback(
-		(event: DragOverEvent) => {
-			const { active, over } = event;
-			if (!over?.id || active.id === over.id) return;
-			if (active.data.current?.type === "scene") return;
-
-			const fromSceneId = active.data.current?.sceneId;
-			const toSceneId = over.data.current?.sceneId;
-
-			if (!fromSceneId || !toSceneId) return;
-
-			if (fromSceneId === toSceneId) {
-				setDragTransfer(null);
-				return;
-			}
-
-			const [overEntry] = Editor.nodes(editor, {
-				at: [],
-				match: (n) => Element.isElement(n) && n.id === over.id,
-			});
-			if (!overEntry) return;
-
-			const [overNode, overPath] = overEntry;
-			const atIndex = isSceneElement(overNode)
-				? overNode.children.length
-				: overPath[overPath.length - 1];
-			setDragTransfer({
-				itemId: active.id as string,
-				fromSceneId,
-				toSceneId,
-				atIndex,
-			});
-		},
+		(event: DragOverEvent) =>
+			setDragTransfer(resolveDragTransfer(editor, event)),
 		[editor],
 	);
 

--- a/app/components/canvas/elements/MediaWithSkeleton.tsx
+++ b/app/components/canvas/elements/MediaWithSkeleton.tsx
@@ -18,7 +18,7 @@ export function MediaWithSkeleton({
 	videoInteractive = false,
 	objectFit = "cover",
 }: MediaWithSkeletonProps) {
-	const [videoLoaded, setVideoLoaded] = useState(false);
+	const [loadedVideoSrc, setLoadedVideoSrc] = useState<string | null>(null);
 	const fitClass = objectFit === "contain" ? "object-contain" : "object-cover";
 
 	if (outputKind === "image") {
@@ -38,9 +38,9 @@ export function MediaWithSkeleton({
 				src={src}
 				controls={videoInteractive}
 				className={`w-full h-full ${fitClass} ${videoInteractive ? "" : "pointer-events-none"}`}
-				onLoadedData={() => setVideoLoaded(true)}
+				onLoadedData={() => setLoadedVideoSrc(src)}
 			/>
-			{!videoLoaded && (
+			{loadedVideoSrc !== src && (
 				<Skeleton className="absolute inset-0 animate-none shimmer-surface" />
 			)}
 		</>

--- a/app/components/canvas/hooks/useAutosave.ts
+++ b/app/components/canvas/hooks/useAutosave.ts
@@ -71,7 +71,11 @@ export function useAutosave(projectId: string, value: Descendant[]): void {
 
 	const schedule = useCallback(() => debouncedRef.current?.(), []);
 
+	// The editor mounts empty and is filled a render later by rehydration, so
+	// "skip the first change" has to mean the first *content*, not the first
+	// effect run — otherwise loading a project saves it straight back.
 	useEffect(() => {
+		if (value.length === 0) return;
 		if (skipNextRef.current) {
 			skipNextRef.current = false;
 			return;

--- a/lib/canvas/__tests__/osmlStreamParser.test.ts
+++ b/lib/canvas/__tests__/osmlStreamParser.test.ts
@@ -198,6 +198,29 @@ describe("OSMLStreamParser", () => {
 			provider: "openslop",
 		});
 	});
+	it("drops prior nodes on reset so a second stream starts empty", () => {
+		const s = new OSMLStreamParser();
+		s.appendChunk("<narration>a rabbit named Lumi</narration>", connectors);
+		s.reset();
+		s.appendChunk("<narration>a dog named Rex</narration>", connectors);
+
+		const nodes = s.getNodes() as ParsedElement[];
+		expect(nodes).toHaveLength(1);
+		expect(getElementText(nodes[0])).toContain("a dog named Rex");
+		expect(getElementText(nodes[0])).not.toContain("Lumi");
+	});
+
+	it("drops a partial tag on reset instead of fusing it into the next stream", () => {
+		const s = new OSMLStreamParser();
+		s.appendChunk("<narration>the end<imag", connectors);
+		s.reset();
+		s.appendChunk("<narration>a fresh start</narration>", connectors);
+
+		const nodes = s.getNodes() as ParsedElement[];
+		expect(nodes).toHaveLength(1);
+		expect(nodes[0].type).toBe("narration");
+		expect(getElementText(nodes[0])).toContain("a fresh start");
+	});
 });
 
 describe("parseOSML", () => {

--- a/lib/canvas/osmlStreamParser.ts
+++ b/lib/canvas/osmlStreamParser.ts
@@ -29,6 +29,12 @@ export class OSMLStreamParser {
 		return this.nodes;
 	}
 
+	/** Drops accumulated nodes and any partial tag so the next stream starts clean. */
+	reset(): void {
+		this.buffer = "";
+		this.nodes = [];
+	}
+
 	private parseBuffer(connectors: ConnectorRegistry): boolean {
 		TAG_PATTERN.lastIndex = 0;
 

--- a/lib/canvas/useOSMLStreamParser.ts
+++ b/lib/canvas/useOSMLStreamParser.ts
@@ -24,5 +24,10 @@ export function useOSMLStreamParser() {
 		[connectorConfig],
 	);
 
-	return { nodes, appendChunk };
+	const reset = useCallback(() => {
+		parserRef.current.reset();
+		setNodes([]);
+	}, []);
+
+	return { nodes, appendChunk, reset };
 }

--- a/lib/components/ImageWithShimmer.tsx
+++ b/lib/components/ImageWithShimmer.tsx
@@ -8,7 +8,7 @@ import { Skeleton } from "@/components/ui/skeleton";
  * `next/image` with a shimmer overlay that hides once the image loads.
  */
 export function ImageWithShimmer({ alt, onLoad, ...props }: ImageProps) {
-	const [loaded, setLoaded] = useState(false);
+	const [loadedSrc, setLoadedSrc] = useState<ImageProps["src"] | null>(null);
 	return (
 		<>
 			<Image
@@ -16,10 +16,10 @@ export function ImageWithShimmer({ alt, onLoad, ...props }: ImageProps) {
 				alt={alt}
 				onLoad={(event: SyntheticEvent<HTMLImageElement>) => {
 					onLoad?.(event);
-					setLoaded(true);
+					setLoadedSrc(props.src);
 				}}
 			/>
-			{!loaded && (
+			{loadedSrc !== props.src && (
 				<Skeleton className="absolute inset-0 animate-none shimmer-surface" />
 			)}
 		</>

--- a/lib/providers/__tests__/runware-video.test.ts
+++ b/lib/providers/__tests__/runware-video.test.ts
@@ -173,6 +173,60 @@ describe("RunwareVideo", () => {
 			expect(result.result).toEqual({});
 		});
 
+		it('maps Runware\'s "error" status to failed so the job stops polling', async () => {
+			mockGetResponse.mockResolvedValue([
+				{
+					taskUUID: "job-1",
+					status: "error",
+					errorMessage: "content filter rejected the prompt",
+				},
+			]);
+
+			const provider = new RunwareVideo("test-key");
+			const result = await provider.poll("job-1");
+
+			expect(result.metadata?.status).toBe("failed");
+			expect(result.metadata?.error).toBe("content filter rejected the prompt");
+		});
+
+		it("falls back to a task-scoped message when a failure carries none", async () => {
+			mockGetResponse.mockResolvedValue([
+				{ taskUUID: "job-9", status: "error" },
+			]);
+
+			const provider = new RunwareVideo("test-key");
+			const result = await provider.poll("job-9");
+
+			expect(result.metadata?.error).toBe("Runware video task failed: job-9");
+		});
+
+		it('maps Runware\'s "success" status to completed', async () => {
+			mockGetResponse.mockResolvedValue([
+				{
+					taskUUID: "job-1",
+					status: "success",
+					videoURL: "https://result.mp4",
+				},
+			]);
+
+			const provider = new RunwareVideo("test-key");
+			const result = await provider.poll("job-1");
+
+			expect(result.result.video).toBe("https://result.mp4");
+		});
+
+		it("treats an unrecognized status as still processing", async () => {
+			mockGetResponse.mockResolvedValue([
+				{ taskUUID: "job-1", status: "queued-upstream" },
+			]);
+
+			const provider = new RunwareVideo("test-key");
+			const result = await provider.poll("job-1");
+
+			expect(result.metadata?.status).toBe("processing");
+			expect(result.metadata?.error).toBeUndefined();
+		});
+
 		it("throws when job not found", async () => {
 			mockGetResponse.mockResolvedValue([]);
 

--- a/lib/providers/__tests__/voicePreview.test.ts
+++ b/lib/providers/__tests__/voicePreview.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { fetchAllowedVoicePreview } from "../tts/voicePreview";
+
+const ALLOWED_HOST = "api.cartesia.ai";
+
+describe("fetchAllowedVoicePreview", () => {
+	beforeEach(() => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response("ok")),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("rejects a URL whose origin is not the provider's", () => {
+		expect(() =>
+			fetchAllowedVoicePreview(
+				"https://evil.example.com/preview.mp3",
+				ALLOWED_HOST,
+			),
+		).toThrow("Voice preview origin not allowed");
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("rejects plaintext HTTP on the allowed host", () => {
+		expect(() =>
+			fetchAllowedVoicePreview(
+				`http://${ALLOWED_HOST}/preview.mp3`,
+				ALLOWED_HOST,
+			),
+		).toThrow("Voice preview origin not allowed");
+	});
+
+	it("keeps redirect:manual even when init tries to override it", async () => {
+		await fetchAllowedVoicePreview(
+			`https://${ALLOWED_HOST}/preview.mp3`,
+			ALLOWED_HOST,
+			{
+				redirect: "follow",
+				headers: { Authorization: "Bearer secret" },
+			},
+		);
+
+		expect(fetch).toHaveBeenCalledWith(
+			`https://${ALLOWED_HOST}/preview.mp3`,
+			expect.objectContaining({
+				redirect: "manual",
+				headers: { Authorization: "Bearer secret" },
+			}),
+		);
+	});
+});

--- a/lib/providers/tts/voicePreview.ts
+++ b/lib/providers/tts/voicePreview.ts
@@ -15,5 +15,5 @@ export function fetchAllowedVoicePreview(
 	if (new URL(url).origin !== allowedOrigin) {
 		throw new Error(`Voice preview origin not allowed: ${url}`);
 	}
-	return fetch(url, { redirect: "manual", ...init });
+	return fetch(url, { ...init, redirect: "manual" });
 }

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -3,16 +3,31 @@ import type { VideoJob, VideoJobStatus } from "./base";
 import { BaseVideoProvider } from "./base";
 import { withRunware } from "../runware";
 
-function toVideoJob(video: {
+type RunwareVideoResult = {
 	taskUUID: string;
 	status: string;
 	videoURL?: string;
-}): VideoJob {
+	errorMessage?: string;
+};
+
+// Runware reports terminal states as "success"/"error"; anything else is a
+// state the task can still move out of, so it maps to "processing".
+const TERMINAL_STATUS: Record<string, VideoJobStatus> = {
+	success: "completed",
+	error: "failed",
+};
+
+function toVideoJob(video: RunwareVideoResult): VideoJob {
+	const status = TERMINAL_STATUS[video.status] ?? "processing";
 	return {
 		url: video.videoURL,
 		metadata: {
 			jobId: video.taskUUID,
-			status: video.status as VideoJobStatus,
+			status,
+			...(status === "failed" && {
+				error:
+					video.errorMessage ?? `Runware video task failed: ${video.taskUUID}`,
+			}),
 		},
 	};
 }
@@ -65,11 +80,9 @@ export class RunwareVideo extends BaseVideoProvider {
 
 	protected async _poll(jobId: string): Promise<VideoJob> {
 		return withRunware(this.apiKey, async (runware) => {
-			const results = await runware.getResponse<{
-				taskUUID: string;
-				status: string;
-				videoURL?: string;
-			}>({ taskUUID: jobId });
+			const results = await runware.getResponse<RunwareVideoResult>({
+				taskUUID: jobId,
+			});
 
 			const video = results?.[0];
 			if (!video) throw new Error("Job not found");

--- a/lib/script/ScriptProvider.tsx
+++ b/lib/script/ScriptProvider.tsx
@@ -9,7 +9,9 @@ import {
 	useState,
 	type ReactNode,
 } from "react";
+import { toast } from "sonner";
 import type { ParsedElement } from "@/lib/canvas/types";
+import { errorMessage } from "@/lib/errors";
 import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
@@ -56,7 +58,7 @@ export function ScriptProvider({
 	const [hasContent, setHasContent] = useState(initialScript.length > 0);
 	const [loading, setLoading] = useState(false);
 	const abortRef = useRef<AbortController | null>(null);
-	const { nodes, appendChunk } = useOSMLStreamParser();
+	const { nodes, appendChunk, reset } = useOSMLStreamParser();
 
 	const stopGeneration = useCallback(() => {
 		abortRef.current?.abort();
@@ -75,6 +77,7 @@ export function ScriptProvider({
 			const controller = new AbortController();
 			abortRef.current = controller;
 
+			reset();
 			setHasContent(false);
 			setLoading(true);
 			getProjectStore(projectId)
@@ -88,6 +91,8 @@ export function ScriptProvider({
 					setHasContent(true);
 					appendChunk(chunk.text);
 				}
+			} catch (error) {
+				toast.error(`Script generation failed: ${errorMessage(error)}`);
 			} finally {
 				if (abortRef.current === controller) {
 					abortRef.current = null;
@@ -95,7 +100,7 @@ export function ScriptProvider({
 				}
 			}
 		},
-		[llmProvider, llmConfig, appendChunk, projectId, mode],
+		[llmProvider, llmConfig, appendChunk, reset, projectId, mode],
 	);
 
 	const control = useMemo<ScriptControl>(

--- a/lib/supabase/__tests__/middleware.test.ts
+++ b/lib/supabase/__tests__/middleware.test.ts
@@ -2,11 +2,21 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
 const mockGetUser = vi.fn();
+let capturedCookies: {
+	setAll: (c: { name: string; value: string; options?: object }[]) => void;
+} | null = null;
 
 vi.mock("@supabase/ssr", () => ({
-	createServerClient: vi.fn(() => ({
-		auth: { getUser: mockGetUser },
-	})),
+	createServerClient: vi.fn(
+		(
+			_url: string,
+			_key: string,
+			options: { cookies: typeof capturedCookies },
+		) => {
+			capturedCookies = options.cookies;
+			return { auth: { getUser: mockGetUser } };
+		},
+	),
 }));
 
 import { updateSession } from "../middleware";
@@ -18,6 +28,7 @@ function makeRequest(path: string) {
 describe("middleware - session refresh", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		capturedCookies = null;
 		process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
 		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
 	});
@@ -58,6 +69,22 @@ describe("middleware - session refresh", () => {
 
 		const res = await updateSession(makeRequest("/signup"));
 		expect(res.status).toBe(307);
+	});
+
+	it("carries refreshed session cookies onto the auth-route redirect", async () => {
+		mockGetUser.mockImplementation(async () => {
+			capturedCookies?.setAll([
+				{ name: "sb-access-token", value: "rotated-access", options: {} },
+				{ name: "sb-refresh-token", value: "rotated-refresh", options: {} },
+			]);
+			return { data: { user: { id: "user-1" } }, error: null };
+		});
+
+		const res = await updateSession(makeRequest("/login"));
+
+		expect(res.status).toBe(307);
+		expect(res.cookies.get("sb-access-token")?.value).toBe("rotated-access");
+		expect(res.cookies.get("sb-refresh-token")?.value).toBe("rotated-refresh");
 	});
 
 	it("does not redirect unauthenticated user from /login", async () => {

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -30,7 +30,14 @@ export async function updateSession(request: NextRequest) {
 	} = await supabase.auth.getUser();
 
 	if (user && AUTH_ROUTES.includes(request.nextUrl.pathname)) {
-		return NextResponse.redirect(new URL("/", request.url));
+		const redirect = NextResponse.redirect(new URL("/", request.url));
+		// getUser() may have rotated the session onto supabaseResponse. A fresh
+		// redirect response would drop those Set-Cookie headers, leaving the
+		// browser holding a refresh token Supabase has already consumed.
+		for (const cookie of supabaseResponse.cookies.getAll()) {
+			redirect.cookies.set(cookie);
+		}
+		return redirect;
 	}
 
 	return supabaseResponse;


### PR DESCRIPTION
Correctness pass over areas not already covered by open PRs. Behavior is unchanged except where it was wrong.

## Bugs fixed

**1. Auth redirect dropped refreshed session cookies, logging users out** (`lib/supabase/middleware.ts`)

`supabase.auth.getUser()` can rotate the session, and the `setAll` callback writes the new tokens onto `supabaseResponse`. The auth-route redirect built a brand-new response, so those `Set-Cookie` headers were discarded. A logged-in user with an expired access token who hits `/login` had their refresh token consumed server-side but never received the replacement, so the next request failed auth and bounced them back to `/login` — a loop. Cookies are now copied onto the redirect.

**2. Stream parser was never reset, so a second generation fused onto the first** (`lib/canvas/osmlStreamParser.ts`, `lib/canvas/useOSMLStreamParser.ts`, `lib/script/ScriptProvider.tsx`)

`useOSMLStreamParser` holds one `OSMLStreamParser` for the provider's lifetime, and the class had no way to clear itself. Submitting a second prompt appended onto the first script's nodes, and any leftover partial tag in `this.buffer` was string-concatenated onto the new stream's first chunk. Because the hook syncs `.slice(-3)`, the first three renders of the "new" script actually showed the tail of the old one. `submitPrompt` now resets the parser before streaming.

**3. Script generation failures were silent** (`lib/script/ScriptProvider.tsx`)

`submitPrompt` had a `try`/`finally` with no `catch`, and `ComposerHero` calls it fire-and-forget. Offline, a bad API key, or any non-2xx left the composer looking like the click never registered, plus an `unhandledrejection`. Failures now surface as a toast.

**4. Runware video failures hung for the full 10-minute poll timeout** (`lib/providers/video/runware.ts`)

`VideoJobStatus` is `queued|processing|completed|failed`, but Runware emits `success`/`error`. The unchecked `as VideoJobStatus` cast meant `mapVideoStatus` in `lib/api/handlers/video.ts` never saw `"failed"`, so a content-filter rejection was reported as `"processing"` until `awaitCompletion` gave up after 600s and threw a bogus timeout. The real provider message was discarded too. Replaced the cast with an explicit terminal-status map and threaded `errorMessage` into `metadata.error`.

**5. Opening a project immediately saved it back** (`app/components/canvas/hooks/useAutosave.ts`)

The editor mounts with `initialValue: []` and is filled a render later by `useProjectRehydrate`, so the `skipNextRef` guard was burned on the empty value and the real content — arriving next render — scheduled a save. Opening any project and touching nothing wrote the full round-tripped script and store snapshot back, bumped `updated_at`, and toasted "Saved". The guard now keys off the first *content*, not the first effect run.

**6. Drag insert-gap stayed wedged open after leaving all droppables** (`app/components/canvas/dnd/useDragAndDrop.ts`)

`handleDragOver` had four early returns that left the previous `dragTransfer` in context, including the `!over?.id` path dnd-kit fires when you drag into empty space. The gap kept pointing at a target that was no longer active. Extracted the branching into a pure `resolveDragTransfer` that always returns a value, so the caller assigns unconditionally.

**7. Regenerated media showed no loading affordance** (`lib/components/ImageWithShimmer.tsx`, `app/components/canvas/elements/MediaWithSkeleton.tsx`)

Both components latched a one-way `loaded` boolean, so a new `src` on the same instance suppressed the skeleton and left the stale image/frozen video on screen until the new file decoded. Most call sites papered over this with a remount `key`; `ForegroundPreview` doesn't. Both now derive loading from `loadedSrc === src`, matching the pattern already approved in #399.

**8. `redirect: "manual"` was overridable by the caller** (`lib/providers/tts/voicePreview.ts`)

`fetch(url, { redirect: "manual", ...init })` spreads `init` last, so a caller-supplied `redirect` wins — defeating the guarantee the doc comment above it makes. The one credentialed caller attaches `Authorization: Bearer <key>`. Moved the security-relevant option after the spread.

## Tests

+16 tests, 894 passing.

- `middleware.test.ts` — rotated cookies survive the auth-route redirect
- `osmlStreamParser.test.ts` — reset drops prior nodes and a partial tag instead of fusing them into the next stream
- `runware-video.test.ts` — `error` maps to failed and carries the provider message, a failure with no message gets a task-scoped fallback, `success` maps to completed, unknown statuses stay processing
- `resolveDragTransfer.test.ts` (new) — every clearing path returns null; hovering an element vs. the scene itself resolves the right index
- `voicePreview.test.ts` (new) — cross-origin and plaintext-HTTP rejection, and `redirect: "manual"` survives an init override

## Skipped (open-PR overlap)

- **`manifest.json` filename collision in `AssetBundle.upload`** — uploading a file named `manifest.json` overwrites it with the bundle manifest, silently returning a 200 with corrupt data. The knowledge home is `lib/api/asset-bundle.ts`, which #414 touches.
- **Abort signal never reaches the connector** — `stopGeneration` aborts a controller whose signal is never passed to `connector.stream`, so cancellation is cooperative and the HTTP stream stays open. Plumbing it through requires `lib/connectors/types.ts`, which #416 touches.
- **Transition frame-rounding drift** — at the default fps=24, `round(0.4 × 24) = 10` frames while the layout assumed 0.4s, accumulating ~0.5s of audio/visual desync over 30 scenes. The fix spans `lib/video/scene-builder.ts`, which #412 touches.
- **Non-atomic job claim in `app/api/queues/asset-generate`** — read-then-write with no compare-and-swap, so at-least-once delivery can double-bill a generation. Non-overlapping, but a guarded update is a bigger change than a nightly pass should land unreviewed.
- `ImageWithShimmer` / `MediaWithSkeleton` / `useAutosave` have no unit tests — the repo has no jsdom or testing-library, and `renderToStaticMarkup` never fires `onLoad`, so any test I could write would pass against the old code too.

## Open PR overlap check

Considered #410, #412–#422, #428, #429, #430 and diffed each with `gh pr diff --name-only`. None of the 15 files here appears in any of them. Nearest neighbors: #415 touches `lib/providers/image/runware.ts` (this PR touches `video/runware.ts`), #421 touches `lib/providers/tts/cartesia.ts` (this touches `tts/voicePreview.ts`), and #418 touches `lib/canvas/osmlSerializer.ts` and `createCanvasNode.ts` (this touches `osmlStreamParser.ts`).

CI: lint, format:check, typecheck, knip, build, and test:coverage all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)