### PR TITLE
refactor: nightly maintainability 2026-07-18

### DIFF
--- a/app/components/ComposerHero.tsx
+++ b/app/components/ComposerHero.tsx
@@ -22,7 +22,7 @@ And in that garden… lived a little rabbit named Lumi…`;
 
 export default function ComposerHero() {
 	const { submitPrompt } = useScriptControl();
-	const { mode, applyTemplate, setMode } = useConfig();
+	const { mode, selectTemplate } = useConfig();
 	const [value, setValue] = useState("");
 
 	return (
@@ -47,8 +47,7 @@ export default function ComposerHero() {
 
 			<TemplateGallery
 				onSelect={(templateId, examplePrompt) => {
-					applyTemplate(templateId);
-					setMode("template");
+					selectTemplate(templateId);
 					setValue(examplePrompt);
 				}}
 			/>

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -16,7 +16,11 @@ import { ActionMenu, type ActionMenuItem } from "@/components/ui/action-menu";
 import { SelectMenu, type SelectMenuOption } from "@/components/ui/select-menu";
 import { cn } from "@/lib/utils";
 import { useAssetEditDialogs } from "@/app/components/canvas/elements/character/useAssetEditDialogs";
-import { TEMPLATES, getTemplateById } from "@/lib/templates/templates";
+import {
+	TEMPLATES,
+	getTemplate,
+	type Template,
+} from "@/lib/templates/templates";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getProjectStore } from "@/lib/project/store";
 import type { Mode } from "@/lib/project/types";
@@ -129,15 +133,12 @@ function AttachMenu({
 }
 
 function TemplatePill({
-	templateId,
+	template,
 	onRemove,
 }: {
-	templateId: string;
+	template: Template;
 	onRemove: () => void;
 }) {
-	const template = getTemplateById(templateId);
-	if (!template) return null;
-
 	return (
 		<span
 			className=" relative inline-flex self-start shrink-0 items-center gap-1 overflow-hidden rounded-full py-0.5 pl-1 pr-2 font-body text-body text-foreground whitespace-nowrap sm:mt-px sm:self-auto"
@@ -171,7 +172,7 @@ export default function ComposerCopilot({
 	placeholder,
 	placeholderOverlay,
 }: ComposerCopilotProps) {
-	const { projectId, mode, setMode, selectedTemplateId, applyTemplate } =
+	const { projectId, mode, setMode, selectedTemplateId, selectTemplate } =
 		useConfig();
 	const aspectRatio = useAspectRatio();
 	const { openCreateCharacter, editCharacter, openNarrator, dialogs } =
@@ -185,11 +186,9 @@ export default function ComposerCopilot({
 				store.setReferenceImages([...store.referenceImages, ...urls]);
 			},
 		});
-	const showPill = mode === "template" && selectedTemplateId !== undefined;
+	const isTemplateMode = mode === "template";
 	const hasText = value.trim().length > 0;
-	const selectedTemplate = selectedTemplateId
-		? getTemplateById(selectedTemplateId)
-		: undefined;
+	const selectedTemplate = getTemplate(selectedTemplateId);
 
 	const handleSubmit = () => {
 		if (hasText) onSubmit();
@@ -204,9 +203,9 @@ export default function ComposerCopilot({
 					onEditNarrator={openNarrator}
 				/>
 				<div className="flex flex-col gap-1 sm:flex-row sm:items-baseline">
-					{showPill && (
+					{isTemplateMode && (
 						<TemplatePill
-							templateId={selectedTemplateId}
+							template={selectedTemplate}
 							onRemove={() => setMode("story")}
 						/>
 					)}
@@ -224,7 +223,7 @@ export default function ComposerCopilot({
 							style={{ fieldSizing: "content" }}
 							className=" w-full resize-none bg-transparent font-body text-body text-foreground caret-accent placeholder:text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:rounded-sm"
 						/>
-						{!hasText && !showPill && placeholderOverlay && (
+						{!hasText && !isTemplateMode && placeholderOverlay && (
 							<div className="pointer-events-none overflow-hidden font-body text-body">
 								{placeholderOverlay}
 							</div>
@@ -242,12 +241,11 @@ export default function ComposerCopilot({
 						/>
 						<SelectMenu
 							value={mode}
-							onChange={(mode: Mode) => {
-								setMode(mode);
-								if (mode === "template" && selectedTemplateId) {
-									applyTemplate(selectedTemplateId);
-								}
-							}}
+							onChange={(next: Mode) =>
+								next === "template"
+									? selectTemplate(selectedTemplateId)
+									: setMode(next)
+							}
 							options={MODE_OPTIONS}
 							itemClassName="rounded-lg text-label-xs"
 						>
@@ -272,21 +270,18 @@ export default function ComposerCopilot({
 								label={aspectRatio}
 							/>
 						</SelectMenu>
-						{mode === "template" && selectedTemplateId && (
+						{isTemplateMode && (
 							<SelectMenu
 								value={selectedTemplateId}
-								onChange={(templateId: string) => {
-									setMode("template");
-									applyTemplate(templateId);
-								}}
+								onChange={selectTemplate}
 								options={TEMPLATE_OPTIONS}
 								itemClassName="rounded-lg text-label-xs"
 							>
 								<PillTrigger
 									aria-label="Select template"
 									className="relative overflow-hidden"
-									style={{ backgroundColor: selectedTemplate?.color }}
-									label={selectedTemplate?.name}
+									style={{ backgroundColor: selectedTemplate.color }}
+									label={selectedTemplate.name}
 								/>
 							</SelectMenu>
 						)}

--- a/lib/config/ConfigProvider.tsx
+++ b/lib/config/ConfigProvider.tsx
@@ -28,23 +28,16 @@ import { createTemplateModePlugin } from "../connectors/llm/plugins/template-mod
 import { createProjectMetadataPlugin } from "../connectors/llm/plugins/project-metadata";
 import { createReferenceStylePlugin } from "../connectors/llm/plugins/reference-style";
 import { createCharacterAvatarStylePlugin } from "../connectors/llm/plugins/character-avatar-style";
-import { TEMPLATES } from "@/lib/templates/templates";
-import * as template from "@/lib/templates/applyTemplate";
+import { DEFAULT_TEMPLATE_ID } from "@/lib/templates/templates";
+import { applyTemplate as applyTemplateToProject } from "@/lib/templates/applyTemplate";
 import { withRegistry } from "./connectorUtils";
 
 import type { Mode } from "@/lib/project/types";
 
-interface ModeContext {
-	projectId: string;
-	templateId?: string;
-}
-
-type ModePluginFactory = (ctx: ModeContext) => LLMPlugin;
-
-const MODE_PLUGIN_FACTORIES: Record<Mode, ModePluginFactory> = {
+const MODE_PLUGIN_FACTORIES: Record<Mode, (templateId: string) => LLMPlugin> = {
 	story: () => storyModePlugin,
 	script: () => scriptModePlugin,
-	template: ({ templateId }) => createTemplateModePlugin(templateId),
+	template: (templateId) => createTemplateModePlugin(templateId),
 };
 
 export type ConnectorRegistry = Record<
@@ -81,8 +74,8 @@ type ConfigContextValue = {
 	connectorConfig: ConnectorRegistry;
 	mode: Mode;
 	setMode: (mode: Mode) => void;
-	selectedTemplateId: string | undefined;
-	applyTemplate: (templateId: string) => void;
+	selectedTemplateId: string;
+	selectTemplate: (templateId: string) => void;
 };
 
 const [ConfigContext, useConfig] =
@@ -96,26 +89,22 @@ export function ConfigProvider({
 	projectId: string;
 	children: ReactNode;
 }) {
-	const [connectorConfig] = useState<ConnectorRegistry>(initialConnectorConfig);
 	const [mode, setMode] = useState<Mode>("story");
-	const [selectedTemplateId, setSelectedTemplateId] = useState<
-		string | undefined
-	>(TEMPLATES[0]?.id);
+	const [selectedTemplateId, setSelectedTemplateId] =
+		useState<string>(DEFAULT_TEMPLATE_ID);
 
-	const applyTemplate = useCallback(
+	const selectTemplate = useCallback(
 		(templateId: string) => {
 			setSelectedTemplateId(templateId);
-			template.applyTemplate(projectId, templateId);
+			applyTemplateToProject(projectId, templateId);
+			setMode("template");
 		},
 		[projectId],
 	);
 
 	const configWithPlugins = useMemo<ConnectorRegistry>(() => {
-		const modePlugin = MODE_PLUGIN_FACTORIES[mode]({
-			projectId,
-			templateId: selectedTemplateId,
-		});
-		const base = withRegistry(connectorConfig)
+		const modePlugin = MODE_PLUGIN_FACTORIES[mode](selectedTemplateId);
+		const base = withRegistry(initialConnectorConfig)
 			.appendPlugins(
 				"llm",
 				createProjectMetadataPlugin(projectId),
@@ -135,7 +124,7 @@ export function ConfigProvider({
 				...buildAnimatedImagePlugins(projectId, base),
 			)
 			.build();
-	}, [connectorConfig, mode, selectedTemplateId, projectId]);
+	}, [mode, selectedTemplateId, projectId]);
 
 	const value = useMemo<ConfigContextValue>(
 		() => ({
@@ -144,7 +133,7 @@ export function ConfigProvider({
 			mode,
 			setMode,
 			selectedTemplateId,
-			applyTemplate,
+			selectTemplate,
 		}),
 		[
 			projectId,
@@ -152,7 +141,7 @@ export function ConfigProvider({
 			mode,
 			setMode,
 			selectedTemplateId,
-			applyTemplate,
+			selectTemplate,
 		],
 	);
 

--- a/lib/project/__tests__/applyTemplate.test.ts
+++ b/lib/project/__tests__/applyTemplate.test.ts
@@ -53,6 +53,12 @@ describe("applyTemplate", () => {
 		);
 	});
 
+	it("throws on an unknown template id instead of silently no-opping", () => {
+		expect(() => applyTemplate(PROJECT_ID, "does-not-exist")).toThrow(
+			/Unknown template id/,
+		);
+	});
+
 	it("wipes user-set narration before applying", () => {
 		getProjectStore(PROJECT_ID)
 			.getState()

--- a/lib/templates/applyTemplate.ts
+++ b/lib/templates/applyTemplate.ts
@@ -1,9 +1,8 @@
 import { getProjectStore } from "@/lib/project/store";
-import { getTemplateById } from "./templates";
+import { getTemplate } from "./templates";
 
 export function applyTemplate(projectId: string, templateId: string) {
-	const template = getTemplateById(templateId);
-	if (!template) return;
+	const template = getTemplate(templateId);
 	const project = getProjectStore(projectId).getState();
 	project.reset();
 	project.setReferenceImages(template.referenceImages);

--- a/lib/templates/templates.ts
+++ b/lib/templates/templates.ts
@@ -1241,6 +1241,19 @@ Wrap up with the aftermath — arrest, trial, sentence, ironic twist, or grim en
 
 const TEMPLATE_MAP = new Map(TEMPLATES.map((t) => [t.id, t]));
 
+/** Optional lookup for ids from outside the app (persisted state, plugin params). */
 export function getTemplateById(id: string): Template | undefined {
 	return TEMPLATE_MAP.get(id);
 }
+
+/** Lookup for ids sourced from `TEMPLATES`, where a miss is a programming error. */
+export function getTemplate(id: string): Template {
+	const template = TEMPLATE_MAP.get(id);
+	if (!template) throw new Error(`Unknown template id "${id}"`);
+	return template;
+}
+
+const [firstTemplate] = TEMPLATES;
+if (!firstTemplate) throw new Error("TEMPLATES must not be empty");
+
+export const DEFAULT_TEMPLATE_ID = firstTemplate.id;


### PR DESCRIPTION
Make template selection one operation with an honest contract. No behavior changes.

## Architecture

**Template selection was a two-step choreography, open-coded three times in two different orders.**

| Call site | Before |
|---|---|
| `ComposerHero` gallery | `applyTemplate(id)` then `setMode("template")` |
| `ComposerCopilot` template menu | `setMode("template")` then `applyTemplate(id)` |
| `ComposerCopilot` mode menu | `setMode(m)` then `if (m === "template" && id) applyTemplate(id)` |

All three now call a single provider-owned `selectTemplate(id)` that sets the id, applies the template, and switches mode. `applyTemplate` is no longer exposed on the context, so the two steps can't drift apart again.

I deliberately did **not** fold this into `setMode`, even though it would have removed the last conditional. `applyTemplate` calls `project.reset()`, and hiding a destructive reset behind a plain mode setter is worse than one explicit ternary at the one call site where the user actually picks "template".

## Type honesty

`selectedTemplateId` was `string | undefined`, but it is seeded from `TEMPLATES[0]?.id` and the only setter always assigns a real id. Three guards and two optional chains were unreachable:

- `mode === "template" && selectedTemplateId !== undefined` → `mode === "template"`
- `mode === "template" && selectedTemplateId && (...)` → same dead clause
- `selectedTemplate?.color` / `?.name` → rendered `undefined` background and empty label in a branch that can't be reached
- `TemplatePill`'s `if (!template) return null` → takes a `Template` instead of doing its own lookup

Narrowed to `string`, backed by `DEFAULT_TEMPLATE_ID`, which throws at import time if `TEMPLATES` is empty rather than putting the app in a broken template mode.

## Fail loudly

`applyTemplate` silently returned on an unknown id — but `setSelectedTemplateId` had already run, so the UI showed a template selected while the project store was never reset. It now uses `getTemplate`, which throws. Covered by a new test.

`getTemplateById` is unchanged and kept for the plugin boundary: `lib/connectors/__tests__/template-mode.test.ts` explicitly asserts that unknown ids degrade to a pass-through there, so the two lookups genuinely have different contracts and the doc comments say which is which.

## Incidental

- `useState` wrapping the module constant `initialConnectorConfig` had no setter and could never change; dropped, along with its dead `useMemo` dep.
- `ModeContext.projectId` was passed but read by no factory; the wrapper object is gone.
- `import * as template` (a namespace import dodging a name collision) → named import.

## Open PR overlap check

Considered all 16 open PRs (#410, #412–#422, #428–#431) and built a file/theme map from `gh pr diff --name-only`. This PR touches 6 files, none of which appear in any of them.

Three findings from the audit were **dropped for overlap** rather than implemented:
- Consolidating the `resolveAttributeSchema` fallback shared by `ElementSettings` / `ModelBadge` / `createCanvasNode` — `ModelBadge.tsx` (#412), `createCanvasNode.ts` (#418), `factory.test.ts` (#414).
- Deduplicating `ComposerAssets` / `AssetsSection` — `AssetsSection.tsx` (#413).
- Moving `systemPrompt`/`exampleText` out of `templates.ts` to drop ~60 KB of prompt prose from the client bundle (the single highest-value change available) — requires editing `template-mode.ts` (#416).

Also dropped as **behavior changes**, which this pass excludes — these are bug-fix material, not refactors:
- `ProjectsList` optimistic-delete rollback resurrects a concurrently-deleted project.
- `normalizeCharacterName` doesn't strip commas, but names are comma-joined into one attribute, so `"Bob, Jr"` round-trips as two phantom characters.
- `VoicePicker` initializes `loading` to `false`, flashing "No voices match these filters." for 300 ms on mount.
- `CharacterEditModal`'s `confirmDelete` never resets, leaving the delete button armed for the modal's lifetime.
- `Waveform` marks a failed decode as loaded, rendering a solid bar instead of an error.

Two audit findings were reported as dead code and turned out **not** to be — `getDefaultConnector`'s first-provider fallback and `getTemplateById`'s undefined return are both covered by explicit tests. I reverted both after the suite caught them.

## Validation

`lint`, `format:check`, `typecheck`, `knip`, `build` all clean. Tests 879 passed / 879 (up one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)