### PR TITLE
fix: nightly CONVENTIONS.md compliance 2026-07-18

### DIFF
--- a/app/api/upload/image/route.ts
+++ b/app/api/upload/image/route.ts
@@ -3,7 +3,7 @@ import { AssetBundle } from "@/lib/api/asset-bundle";
 import { badRequest } from "@/lib/api/response";
 import { withSession } from "@/lib/api/with-auth";
 
-const MAX_SIZE = 10 * 1024 * 1024; // 10 MB
+const MAX_SIZE = 10 * 1024 * 1024;
 
 function sanitizeFilename(name: string): string {
 	const base = name.split(/[\\/]/).pop() ?? "";

--- a/app/components/AccessCodeInput.tsx
+++ b/app/components/AccessCodeInput.tsx
@@ -13,6 +13,12 @@ export default function AccessCodeInput() {
 	const [loading, setLoading] = useState(false);
 	const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
 
+	const resetWithError = useCallback((message: string) => {
+		setError(message);
+		setValues(EMPTY_CODE());
+		inputRefs.current[0]?.focus();
+	}, []);
+
 	const submitCode = useCallback(
 		async (code: string) => {
 			setLoading(true);
@@ -27,19 +33,15 @@ export default function AccessCodeInput() {
 				if (res.ok && data.redirect) {
 					router.push(data.redirect);
 				} else {
-					setError(data.error || "Invalid access code");
-					setValues(EMPTY_CODE());
-					inputRefs.current[0]?.focus();
+					resetWithError(data.error || "Invalid access code");
 				}
 			} catch {
-				setError("Something went wrong. Please try again.");
-				setValues(EMPTY_CODE());
-				inputRefs.current[0]?.focus();
+				resetWithError("Something went wrong. Please try again.");
 			} finally {
 				setLoading(false);
 			}
 		},
-		[router],
+		[router, resetWithError],
 	);
 
 	const handleChange = (index: number, value: string) => {
@@ -82,10 +84,7 @@ export default function AccessCodeInput() {
 
 		if (!pasted) return;
 
-		const next = EMPTY_CODE();
-		for (let i = 0; i < pasted.length; i++) {
-			next[i] = pasted[i];
-		}
+		const next = EMPTY_CODE().map((_, i) => pasted[i] ?? "");
 		setValues(next);
 		setError("");
 

--- a/app/components/canvas/utils/nodeOps.ts
+++ b/app/components/canvas/utils/nodeOps.ts
@@ -12,7 +12,6 @@ export function updateElementAttrs(
 	setNodeAttrs(editor, ReactEditor.findPath(editor, element), element, attrs);
 }
 
-/** Remove a live element from the canvas. */
 export function removeElement(editor: Editor, element: CanvasElement): void {
 	Transforms.removeNodes(editor, { at: ReactEditor.findPath(editor, element) });
 }

--- a/app/projects/[id]/loading.tsx
+++ b/app/projects/[id]/loading.tsx
@@ -1,9 +1,5 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
-/**
- * Editor placeholder that mirrors the real canvas
- */
-
 const SCENES = [3, 2, 4];
 
 function RailItemSkeleton() {

--- a/lib/canvas/editorOps.ts
+++ b/lib/canvas/editorOps.ts
@@ -2,7 +2,6 @@ import { Editor, type NodeEntry, type Path, Transforms } from "slate";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { isContentElement } from "./guards";
 
-/** Find a content element by ID. Returns [node, path] or null. */
 export function findNodeById(
 	editor: Editor,
 	id: string,

--- a/lib/components/Waveform.tsx
+++ b/lib/components/Waveform.tsx
@@ -127,7 +127,10 @@ export function Waveform({
 
 		let cancelled = false;
 		fetch(src, { mode: "cors" })
-			.then((r) => r.arrayBuffer())
+			.then((r) => {
+				if (!r.ok) throw new Error(`Failed to fetch audio: ${r.status}`);
+				return r.arrayBuffer();
+			})
 			.then((buf) => getAudioCtx().decodeAudioData(buf))
 			.then((ab) => {
 				if (cancelled) return;

--- a/lib/connectors/llm/plugins/project-metadata.ts
+++ b/lib/connectors/llm/plugins/project-metadata.ts
@@ -39,7 +39,7 @@ function buildPreamble(metadata: Metadata): string {
 	const sections: string[] = [];
 
 	if (metadata.style) {
-		sections.push(`
+		sections.push(dedent`
 			# Art Style
 
 			Below is the exact art style description for the story. Do not change it.

--- a/lib/connectors/tts/enums.ts
+++ b/lib/connectors/tts/enums.ts
@@ -1,7 +1,3 @@
-/**
- * TTS attribute enums
- * These enums are used for text-to-speech (TTS) generation
- */
 export const TTS_GENDERS = ["masculine", "feminine"] as const;
 export type TTSGender = (typeof TTS_GENDERS)[number];
 

--- a/lib/project/deleteCharacter.ts
+++ b/lib/project/deleteCharacter.ts
@@ -2,7 +2,6 @@ import type { GenerationQueue } from "@/lib/generation/queue";
 import { characterAvatarElementId } from "./ensureCharacterAvatars";
 import { getProjectStore } from "./store";
 
-/** Remove a character and discard its pending avatar generation. */
 export function deleteCharacter(
 	projectId: string,
 	queue: GenerationQueue,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -32,7 +32,6 @@ export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
 
-/** Constrain `n` to the inclusive range [min, max]. */
 export function clamp(n: number, min: number, max: number) {
 	return Math.max(min, Math.min(max, n));
 }


### PR DESCRIPTION
Nightly audit of `lib/`, `app/`, `remotion/`, `components/` against CONVENTIONS.md. Files covered by the 18 currently-open PRs were excluded from both the audit and the fixes.

## Applied (safe, no behavior change)

**`lib/connectors/llm/plugins/project-metadata.ts:42`** — real bug. The "Art Style" section used a plain template literal while its two siblings use `dedent`, so the source file's leading tabs were baked into the LLM system prompt. Now `dedent`.

**`lib/components/Waveform.tsx:130`** — *fail loudly*. `fetch(...).then(r => r.arrayBuffer())` had no `res.ok` check, so a 404 HTML body flowed into `decodeAudioData` and failed there instead of at the real cause. Every other fetch site in the repo checks `res.ok`.

**`app/components/AccessCodeInput.tsx`** — *declarative reads like config* + *one canonical way*. Paste handler's index loop became a `map`; the setError/reset/refocus triple existed in three places, now one `resetWithError` helper.

**Comment narration pass** (7 files) — removed JSDoc and inline comments that restate the signature or expression directly below: `lib/utils.ts` clamp, `lib/canvas/editorOps.ts` findNodeById, `app/components/canvas/utils/nodeOps.ts` removeElement, `lib/project/deleteCharacter.ts`, `lib/connectors/tts/enums.ts` header, `app/projects/[id]/loading.tsx` (JSDoc attached to nothing), `app/api/upload/image/route.ts` `// 10 MB`.

## Flagged, not fixed (design-level)

- **Provider default-model literals shadow the model registry** — `lib/providers/{image,video}/runware.ts`, `llm/anthropic.ts`, `tts/cartesia.ts`, `music/elevenlabs.ts` each hardcode a default that already lives in `lib/connectors/*/openslop/models.ts`. `sfx/elevenlabs.ts` proves the drift: it passes no model, so its registry entry reaches nothing. Also `runware.ts` defaults to 2848x1600, matching no `ASPECT_RATIO_DIMENSIONS` entry.
- **Unresolvable refine anchors reposition rather than reject** — `lib/script/refine/applyOps.ts:46` falls back to appending at the end of the document, so a bad LLM anchor produces visibly wrong output silently. (Also `lib/script/refine/parseOps.ts:25` `catch { return [] }` drops ops with no trace.) Rule: *define errors out of existence*.
- **`.catch(undefined)` defeats the parse boundary** — `lib/project/types.ts:12-18,37`. Makes the `badRequest` branch in `app/api/v1/tts/voices/route.ts` unreachable: `?gender=blah&limit=-5` returns 200 instead of 400.
- **`ResolvedElement` omits `outputKind`** — three consumers re-derive it via `type === "image"` (`remotion/compositions/VideoComposition.tsx:69`, `app/components/video/useSceneSegments.ts:78`, `OutputPreview.tsx:38`). A new still-image type would silently render as `<video>`.
- **Element attribute knowledge has three homes** — `AttributeSchema` registry vs prose copies in `llm/plugins/refine.ts:35` and `osml.ts:36`, already out of sync (refine omits `speed`/`volume`, advertises a nonexistent `overlays`).
- **`withScenes.ts:10`** — the repo's one genuine complexity hotspot: 4 nesting levels, 8 decision points in one `normalizeNode`. Body is four independent rules that would flatten to an ordered rule array. Left alone because Slate normalizer changes carry real behavior risk.
- **Three hand-rolled `postJSON` wrappers** duplicating `lib/clients/openslop.ts` with worse error handling; **`createSSEResponse`** is dead code with a swallow that would be a live bug if wired up.

## Checks

lint, typecheck, format:check clean. 878 tests across 101 files passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)