### PR TITLE
feat: add explicit "Done" button to character and narration edit modals

### DIFF
--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -212,10 +212,15 @@ function CharacterEditDialogBody({
 					variant={confirmDelete ? "destructive" : "outline"}
 					size="sm"
 					onClick={handleDelete}
-					className={confirmDelete ? undefined : "text-muted-foreground"}
+					className={
+						confirmDelete ? "sm:mr-auto" : "text-muted-foreground sm:mr-auto"
+					}
 				>
 					<Trash2 />
 					{confirmDelete ? "Confirm delete" : "Delete"}
+				</Button>
+				<Button type="button" size="sm" onClick={requestClose}>
+					Done
 				</Button>
 			</DialogFooter>
 

--- a/app/components/canvas/elements/character/NarratorEditModal.tsx
+++ b/app/components/canvas/elements/character/NarratorEditModal.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { Button } from "@/components/ui/button";
 import {
 	DialogContent,
 	DialogDescription,
+	DialogFooter,
 	DialogHeader,
 	DialogTitle,
 	MountedDialog,
@@ -20,12 +22,12 @@ export function NarratorEditModal({
 }) {
 	return (
 		<MountedDialog open={open} onOpenChange={onOpenChange}>
-			<NarratorEditDialogBody />
+			<NarratorEditDialogBody onClose={() => onOpenChange(false)} />
 		</MountedDialog>
 	);
 }
 
-function NarratorEditDialogBody() {
+function NarratorEditDialogBody({ onClose }: { onClose: () => void }) {
 	const narration = useProject((s) => s.metadata.narration);
 	const setNarration = useProject((s) => s.setNarration);
 
@@ -42,6 +44,12 @@ function NarratorEditDialogBody() {
 			<div className="-mx-1 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-1">
 				<VoiceSection voice={narration} onChange={update} />
 			</div>
+
+			<DialogFooter className="shrink-0">
+				<Button type="button" size="sm" onClick={onClose}>
+					Done
+				</Button>
+			</DialogFooter>
 		</DialogContent>
 	);
 }


### PR DESCRIPTION
## Summary

The character and narration edit modals could only be dismissed via the corner X or by clicking outside — no affirmative "I'm finished" action. This adds an explicit **Done** button to the footer of both.

- `CharacterEditModal` — adds `Done` to the existing `DialogFooter`. It routes through the same `requestClose` handler as the X, so the stale-avatar confirmation dialog still intercepts a close when the appearance has changed without a regenerate. `Delete` gets `sm:mr-auto` so it stays pinned left instead of sitting adjacent to `Done` (avoids a destructive-action misclick).
- `NarratorEditModal` — adds a `DialogFooter` with `Done`; the body now takes an `onClose` prop.

Edits in both modals already save on change, so `Done` is a close action, not a commit action. No change to save semantics.

Uses the `default` `Button` variant at `size="sm"`, per `DESIGN.md` (`default` = in-tool actions; dimensions come from the `size` prop, never hand-sized).

## Selected issue and why it was safe/small

Issue #342 — `size: S`, `good first issue`, clear problem statement and an explicit suggested direction. Two files, additive, no logic or state changes beyond threading a close callback.

## Validation

| Command | Result |
| --- | --- |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm run knip` | pass |
| `npm run build` | pass |
| `npm run test:coverage` | pass — 101 files, 878 tests |
| `npm run test:e2e` | **skipped** — Playwright web server could not bind, port 3000 already in use in the runner environment. Not a code failure; these modals are not covered by the smoke suite. |

## Open-PR overlap check

Checked all 20 open PRs (#410–#435) via `gh pr diff --name-only`. Neither `CharacterEditModal.tsx` nor `NarratorEditModal.tsx` appears in any of them. No overlap.

## Skipped candidates

- **#424** (element title caret) — ambiguous. The issue itself asks to flag whether `ProjectTitle` is the intended surface, and the Slate chrome in `ElementContainer` / `CollapsibleHeader` already carries `select-none` + `contentEditable={false}`. No obvious minimal fix; needs browser repro and a Slate-void design decision.
- **#426, #427, #425** — already covered by open PRs #428, #429, #430.
- **#259** — gated on BYOK.
- Everything else open is `size: M`/`L`/`XL`, or product/design-direction work (pricing, moderation, i18n, community feed, provider strategy) — out of scope for this job.

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)