### PR TITLE
fix: stop the collapsed element label from catching a dead caret

### DIFF
--- a/app/components/canvas/dnd/SortableContent.tsx
+++ b/app/components/canvas/dnd/SortableContent.tsx
@@ -71,6 +71,7 @@ export function SortableContent({
 			insertOptions={INSERT_OPTIONS}
 			onInsert={handleInsert}
 			disabled={collapsed}
+			readOnly={collapsed}
 			attributes={attributes}
 			element={element}
 		>

--- a/app/components/canvas/dnd/SortableItem.tsx
+++ b/app/components/canvas/dnd/SortableItem.tsx
@@ -15,6 +15,7 @@ interface SortableItemProps {
 	insertOptions?: InsertOption<CanvasElementType>[];
 	onInsert?: (type: CanvasElementType) => void;
 	disabled?: boolean;
+	readOnly?: boolean;
 	attributes: RenderElementProps["attributes"];
 	element: CanvasElement;
 	children: React.ReactNode;
@@ -28,6 +29,7 @@ export function SortableItem({
 	insertOptions,
 	onInsert,
 	disabled,
+	readOnly,
 	attributes,
 	element,
 	children,
@@ -77,7 +79,9 @@ export function SortableItem({
 							/>
 						</div>
 					)}
-					<div>{renderCanvasElement({ attributes, children, element })}</div>
+					<div contentEditable={readOnly ? false : undefined}>
+						{renderCanvasElement({ attributes, children, element })}
+					</div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Closes #424

## Root cause

A collapsed element card renders inside the editable Slate tree. Clicking its read-only label therefore dropped a blinking caret into text that can never accept input — the card is `contentEditable={false}` and shows a `Node.string` snapshot, so there is nothing to type into.

## Fix

Wrap the rendered element in a plain, non-Slate `contentEditable={false}` div while its scene is collapsed. `SortableContent` already computes `collapsed`, so this threads straight through with no new state:

```tsx
// SortableItem.tsx
<div contentEditable={readOnly ? false : undefined}>
  {renderCanvasElement({ attributes, children, element })}
</div>
```

```tsx
// SortableContent.tsx
<SortableItem disabled={collapsed} readOnly={collapsed} ... />
```

Six lines across two files.

## Rebased and reworked

This branch has been rebased onto current master and squashed. Both earlier approaches are reverted, so the diff is now just the fix above:

- the `select-none` + `onMouseDown` `preventDefault` pass on `CompactElement`;
- the `withCollapsedVoids` `isVoid` plugin, along with `CollapsedVoidSync`, its test, the `setCollapsedElementIds` editor type, and the `useEditorSetup` wiring.

The `isVoid` route was dropped because `Transforms.insertText` bails on a void unless callers pass `{ voids: true }`, which would have silently gagged our own programmatic writes (script streaming via `useScriptSync`, refine `set` ops) until every call site in `lib/canvas/editorOps.ts` was updated. The DOM-level fix leaves those paths untouched.

## Verification

`lint`, `format:check`, `typecheck`, `knip`, `build`, and the full suite (994 tests) pass on current master.
