### PR TITLE
fix: nightly bug fixes 2026-07-20

### DIFF
--- a/app/api/queues/asset-generate/route.ts
+++ b/app/api/queues/asset-generate/route.ts
@@ -4,11 +4,12 @@ import type { AssetQueueMessage } from "@/lib/api/jobs";
 import { loadJobForProcessing, updateJob } from "@/lib/api/jobs";
 import { logger } from "@/lib/api/logger";
 import { stringifyError } from "@/lib/errors";
+import { isTerminal } from "@/lib/gateway/base";
 
 export const POST = handleCallback<AssetQueueMessage>(
 	async ({ jobId, connectorType }) => {
 		const job = await loadJobForProcessing(jobId);
-		if (job.status === "completed" || job.status === "failed") return;
+		if (isTerminal(job.status)) return;
 
 		const handler = getJobHandler(connectorType);
 		if (!handler) {

--- a/app/components/canvas/elements/PlayFromHereButton.tsx
+++ b/app/components/canvas/elements/PlayFromHereButton.tsx
@@ -6,12 +6,13 @@ import { usePlayerControl } from "@/app/components/video/PlayerControlContext";
 import { findSceneSequence } from "@/app/components/video/useSceneSegments";
 import { useLayout } from "@/app/components/video/VideoLayoutContext";
 import type { SceneElement } from "@/lib/canvas/types";
+import { toFrames } from "@/lib/video/frames";
 
 export function PlayFromHereButton({ scene }: { scene: SceneElement }) {
 	const { layout } = useLayout();
 	const { playFromFrame } = usePlayerControl();
 	const seq = findSceneSequence(scene, layout);
-	const startFrame = seq && layout ? Math.round(seq.start * layout.fps) : null;
+	const startFrame = seq && layout ? toFrames(seq.start, layout.fps) : null;
 	const disabled = startFrame == null;
 	return (
 		<TooltipIconButton

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -25,7 +25,7 @@ import {
 	characterAvatarElementId,
 } from "@/lib/project/ensureCharacterAvatars";
 import { deleteCharacter } from "@/lib/project/deleteCharacter";
-import { useProjectStore } from "@/lib/project/store";
+import { getProjectStore, useProjectStore } from "@/lib/project/store";
 import type { MetadataCharacter } from "@/lib/project/types";
 import { UploadImageButton } from "@/lib/upload/UploadImageButton";
 import { GenerateButton, StaleIndicator } from "../GenerateButton";
@@ -194,8 +194,11 @@ function CharacterEditDialogBody({
 							className="absolute left-2 top-2 z-10 bg-card shadow-sm ring-1 ring-border"
 							onUpload={(url) => {
 								queue.discard(avatarElementId);
-								setCharacter(name, {
-									...character,
+								const store = getProjectStore(projectId).getState();
+								const current = store.metadata.characters[name];
+								if (!current) return;
+								store.setCharacter(name, {
+									...current,
 									avatarUrl: url,
 									avatarUploaded: true,
 								});

--- a/app/components/canvas/elements/character/VoicePicker.tsx
+++ b/app/components/canvas/elements/character/VoicePicker.tsx
@@ -66,7 +66,7 @@ export function VoicePicker({
 	}, [connectorConfig]);
 
 	const [voices, setVoices] = useState<VoiceInfo[]>([]);
-	const [loading, setLoading] = useState(false);
+	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {

--- a/app/components/video/BottomTransportBar.tsx
+++ b/app/components/video/BottomTransportBar.tsx
@@ -3,6 +3,7 @@
 import { memo } from "react";
 import { ChevronsLeft, ChevronsRight, Pause, Play } from "@/components/ui/icon";
 import { TooltipIconButton } from "@/components/ui/icon-button";
+import { toFrames, toSeconds } from "@/lib/video/frames";
 import { usePlayerControl } from "./PlayerControlContext";
 import { usePlayerPosition } from "./PlayerPositionContext";
 import { useLayout } from "./VideoLayoutContext";
@@ -34,10 +35,10 @@ function BottomTransportBarComponent() {
 		if (!player || !layout || segments.length === 0) return;
 		const current = findSegmentIndexAt(
 			segments,
-			player.getCurrentFrame() / layout.fps,
+			toSeconds(player.getCurrentFrame(), layout.fps),
 		);
 		const target = segments[current + dir];
-		if (target) player.seekTo(Math.ceil(target.start * layout.fps));
+		if (target) player.seekTo(toFrames(target.start, layout.fps));
 	};
 
 	return (

--- a/app/components/video/PlayerControls.tsx
+++ b/app/components/video/PlayerControls.tsx
@@ -5,6 +5,7 @@ import { Maximize, Volume2, VolumeX } from "@/components/ui/icon";
 import type { VideoLayout } from "@/lib/video/types";
 import { scrollToScene } from "@/app/components/canvas/utils/scrollToScene";
 import { IconButton } from "@/components/ui/icon-button";
+import { toSeconds } from "@/lib/video/frames";
 import { formatTime } from "@/lib/video/timestamps";
 import { usePlayerControl } from "./PlayerControlContext";
 import {
@@ -26,7 +27,7 @@ export function TimeDisplay({
 	const seconds = usePlayerValue(
 		player,
 		FRAME_EVENTS,
-		(p) => Math.floor(p.getCurrentFrame() / layout.fps),
+		(p) => Math.floor(toSeconds(p.getCurrentFrame(), layout.fps)),
 		0,
 	);
 	return (

--- a/app/components/video/useSceneSegments.ts
+++ b/app/components/video/useSceneSegments.ts
@@ -2,6 +2,7 @@ import type { PlayerRef } from "@remotion/player";
 import { useMemo } from "react";
 import { isForeground } from "@/lib/canvas/guards";
 import type { SceneElement } from "@/lib/canvas/types";
+import { toSeconds } from "@/lib/video/frames";
 import type { Sequence, VideoLayout } from "@/lib/video/types";
 import type { SeekThumbnail } from "./SeekTooltip";
 import { useLayout } from "./VideoLayoutContext";
@@ -46,7 +47,10 @@ export function useActiveSegmentIndex(
 	return usePlayerValue(
 		player,
 		FRAME_EVENTS,
-		(p) => (fps ? findSegmentIndexAt(segments, p.getCurrentFrame() / fps) : -1),
+		(p) =>
+			fps
+				? findSegmentIndexAt(segments, toSeconds(p.getCurrentFrame(), fps))
+				: -1,
 		-1,
 	);
 }

--- a/lib/api/handlers/__tests__/video.test.ts
+++ b/lib/api/handlers/__tests__/video.test.ts
@@ -1,18 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BundleResponse } from "@/lib/api/asset-bundle";
 import type { VideoGenerateParams } from "@/lib/connectors/types";
-import type { TypedJobRow } from "../../job-handlers";
+import type { TypedJobRow } from "@/lib/api/job-handlers";
 import { videoHandler } from "../video";
 
 const generate = vi.fn();
 const poll = vi.fn();
 const updateJob = vi.fn();
 
-vi.mock("../../providers", async (importOriginal) => ({
-	...(await importOriginal<typeof import("../../providers")>()),
+vi.mock("@/lib/api/providers", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/lib/api/providers")>()),
 	getVideoProvider: () => ({ generate, poll }),
 }));
-vi.mock("../../jobs", () => ({
+vi.mock("@/lib/api/jobs", () => ({
 	updateJob: (...args: unknown[]) => updateJob(...args),
 }));
 

--- a/lib/api/handlers/__tests__/video.test.ts
+++ b/lib/api/handlers/__tests__/video.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BundleResponse } from "@/lib/api/asset-bundle";
+import type { VideoGenerateParams } from "@/lib/connectors/types";
+import type { TypedJobRow } from "../../job-handlers";
+import { videoHandler } from "../video";
+
+const generate = vi.fn();
+const poll = vi.fn();
+const updateJob = vi.fn();
+
+vi.mock("../../providers", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../../providers")>()),
+	getVideoProvider: () => ({ generate, poll }),
+}));
+vi.mock("../../jobs", () => ({
+	updateJob: (...args: unknown[]) => updateJob(...args),
+}));
+
+type VideoJobRow = TypedJobRow<VideoGenerateParams, { providerJobId?: string }>;
+
+const bundle = { id: "bundle-1" } as unknown as BundleResponse;
+
+function job(overrides: Partial<VideoJobRow> = {}): VideoJobRow {
+	return {
+		id: "job-1",
+		user_id: "user-1",
+		project_id: null,
+		connector_type: "video",
+		status: "processing",
+		request: { prompt: "a cat" } as VideoGenerateParams,
+		result: null,
+		metadata: { providerJobId: "upstream-1" },
+		error: null,
+		created_at: "2026-01-01T00:00:00Z",
+		updated_at: "2026-01-01T00:00:00Z",
+		...overrides,
+	};
+}
+
+describe("videoHandler.process", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("returns the provider job id as pending metadata", async () => {
+		generate.mockResolvedValue({ metadata: { jobId: "upstream-9" } });
+
+		await expect(videoHandler.process(job())).resolves.toEqual({
+			kind: "pending",
+			metadata: { providerJobId: "upstream-9" },
+		});
+	});
+
+	it("throws when the provider returns no job id", async () => {
+		generate.mockResolvedValue({ metadata: {} });
+
+		await expect(videoHandler.process(job())).rejects.toThrow(
+			"Video provider returned no jobId",
+		);
+	});
+});
+
+describe("videoHandler.poll", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("returns the stored row for completed jobs without re-polling upstream", async () => {
+		const row = job({ status: "completed", result: bundle });
+
+		await expect(videoHandler.poll?.(row)).resolves.toEqual({
+			jobId: "job-1",
+			status: "completed",
+			result: bundle,
+			error: null,
+		});
+		expect(poll).not.toHaveBeenCalled();
+		expect(updateJob).not.toHaveBeenCalled();
+	});
+
+	it("returns the stored row for failed jobs without re-polling upstream", async () => {
+		const row = job({ status: "failed", error: "upstream exploded" });
+
+		await expect(videoHandler.poll?.(row)).resolves.toEqual({
+			jobId: "job-1",
+			status: "failed",
+			result: null,
+			error: "upstream exploded",
+		});
+		expect(poll).not.toHaveBeenCalled();
+		expect(updateJob).not.toHaveBeenCalled();
+	});
+
+	it("returns the stored row when no provider job id was recorded", async () => {
+		const row = job({ metadata: {} });
+
+		await expect(videoHandler.poll?.(row)).resolves.toEqual({
+			jobId: "job-1",
+			status: "processing",
+			result: null,
+			error: null,
+		});
+		expect(poll).not.toHaveBeenCalled();
+	});
+
+	it("persists the bundle once upstream reports a video", async () => {
+		poll.mockResolvedValue({ ...bundle, result: { video: "v.mp4" } });
+
+		await expect(videoHandler.poll?.(job())).resolves.toEqual({
+			jobId: "job-1",
+			status: "completed",
+			result: { ...bundle, result: { video: "v.mp4" } },
+			error: null,
+		});
+		expect(updateJob).toHaveBeenCalledWith("job-1", {
+			status: "completed",
+			result: { ...bundle, result: { video: "v.mp4" } },
+		});
+	});
+
+	it("persists the upstream error message on failure", async () => {
+		poll.mockResolvedValue({
+			result: {},
+			metadata: { status: "failed", error: "content policy" },
+		});
+
+		await expect(videoHandler.poll?.(job())).resolves.toEqual({
+			jobId: "job-1",
+			status: "failed",
+			result: null,
+			error: "content policy",
+		});
+		expect(updateJob).toHaveBeenCalledWith("job-1", {
+			status: "failed",
+			error: "content policy",
+		});
+	});
+
+	it("stays processing without writing when upstream is still working", async () => {
+		poll.mockResolvedValue({ result: {}, metadata: { status: "processing" } });
+
+		await expect(videoHandler.poll?.(job())).resolves.toEqual({
+			jobId: "job-1",
+			status: "processing",
+			result: null,
+			error: null,
+		});
+		expect(updateJob).not.toHaveBeenCalled();
+	});
+});

--- a/lib/api/handlers/video.ts
+++ b/lib/api/handlers/video.ts
@@ -18,6 +18,10 @@ export const videoHandler: JobHandler<VideoGenerateParams, VideoMetadata> = {
 		return { kind: "pending", metadata: { providerJobId } };
 	},
 	poll: async (job): Promise<JobPoll> => {
+		if (job.status === "completed" || job.status === "failed") {
+			return rowView(job);
+		}
+
 		const providerJobId = job.metadata.providerJobId;
 		if (!providerJobId) return rowView(job);
 

--- a/lib/api/handlers/video.ts
+++ b/lib/api/handlers/video.ts
@@ -1,5 +1,5 @@
 import type { VideoGenerateParams } from "@/lib/connectors/types";
-import type { JobPoll, JobStatus } from "@/lib/gateway/base";
+import { isTerminal, type JobPoll, type JobStatus } from "@/lib/gateway/base";
 import type { VideoProviderResponse } from "@/lib/providers/video/base";
 import type { JobHandler } from "../job-handlers";
 import { rowView } from "../job-handlers";
@@ -18,9 +18,7 @@ export const videoHandler: JobHandler<VideoGenerateParams, VideoMetadata> = {
 		return { kind: "pending", metadata: { providerJobId } };
 	},
 	poll: async (job): Promise<JobPoll> => {
-		if (job.status === "completed" || job.status === "failed") {
-			return rowView(job);
-		}
+		if (isTerminal(job.status)) return rowView(job);
 
 		const providerJobId = job.metadata.providerJobId;
 		if (!providerJobId) return rowView(job);

--- a/lib/connectors/asset-base.ts
+++ b/lib/connectors/asset-base.ts
@@ -1,6 +1,6 @@
 import { AssetBundle } from "@/lib/api/asset-bundle";
 import type { ResultKind } from "@/lib/canvas/types";
-import type { AssetGateway } from "@/lib/gateway/base";
+import { type AssetGateway, isTerminal } from "@/lib/gateway/base";
 import { awaitCompletion } from "@/lib/providers/poll";
 import { assetUrlField } from "./assetUrl";
 import { BaseConnector } from "./base";
@@ -32,7 +32,7 @@ export abstract class BaseAssetConnector<
 		const completed = await awaitCompletion(
 			(id) => this.gateway.poll(id),
 			jobId,
-			(p) => p.status === "completed" || p.status === "failed",
+			(p) => isTerminal(p.status),
 		);
 		if (completed.status === "failed") {
 			throw new Error(completed.error ?? "Generation failed");

--- a/lib/gateway/base.ts
+++ b/lib/gateway/base.ts
@@ -6,6 +6,11 @@ export abstract class GatewayClient<TParams = unknown, TResult = unknown> {
 
 export type JobStatus = "pending" | "processing" | "completed" | "failed";
 
+/** A job in a terminal state will never change again, so stop polling it. */
+export function isTerminal(status: JobStatus): boolean {
+	return status === "completed" || status === "failed";
+}
+
 export type JobSubmission = { jobId: string; status: JobStatus };
 
 export type JobPoll = {

--- a/lib/video/__tests__/frames.test.ts
+++ b/lib/video/__tests__/frames.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { toFrames, toSeconds } from "../frames";
+
+describe("toFrames", () => {
+	it("rounds to the nearest whole frame, the way Remotion does", () => {
+		expect(toFrames(0.4, 24)).toBe(10);
+		expect(toFrames(0.4, 25)).toBe(10);
+		expect(toFrames(0.4, 30)).toBe(12);
+	});
+
+	it("does not truncate a sub-frame duration away", () => {
+		expect(toFrames(1 / 48, 24)).toBe(1);
+	});
+});
+
+describe("toSeconds", () => {
+	it("inverts toFrames for a duration on the grid", () => {
+		expect(toSeconds(toFrames(2.5, 24), 24)).toBe(2.5);
+	});
+});

--- a/lib/video/__tests__/scene-builder.test.ts
+++ b/lib/video/__tests__/scene-builder.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { toFrames } from "../frames";
 import { buildVideoLayout } from "../scene-builder";
 import type { ResolvedElement, Sequence, VideoLayout } from "../types";
 import type { CanvasElementType } from "@/lib/canvas/types";
@@ -476,8 +477,6 @@ describe("buildVideoLayout", () => {
 	// Both must land on the same frame, or audio drifts further behind the visuals
 	// with every scene boundary.
 	describe("frame alignment with the rendered timeline", () => {
-		const toFrames = (sec: number, fps: number) => Math.round(sec * fps);
-
 		it.each([24, 30, 25])(
 			"keeps absolute layer starts on the TransitionSeries grid at %ifps",
 			(fps) => {

--- a/lib/video/__tests__/scene-builder.test.ts
+++ b/lib/video/__tests__/scene-builder.test.ts
@@ -3,6 +3,10 @@ import { buildVideoLayout } from "../scene-builder";
 import type { ResolvedElement, Sequence, VideoLayout } from "../types";
 import type { CanvasElementType } from "@/lib/canvas/types";
 
+// The rendered transition overlap: TRANSITION_DURATION_SEC (0.4s) snapped to the
+// 24fps frame grid, which is what <TransitionSeries> actually lays down.
+const OVERLAP = 10 / 24;
+
 function seqs(layout: VideoLayout, type: CanvasElementType): Sequence[] {
 	const s = layout.sequences[type];
 	expect(s).toBeDefined();
@@ -72,10 +76,10 @@ describe("buildVideoLayout", () => {
 			]);
 			expect(layout.series).toHaveLength(2);
 			expect(layout.series[0].start).toBe(0);
-			// Each foreground past the first overlaps the previous by one
-			// TRANSITION_DURATION_SEC (0.4s) to match what <TransitionSeries> renders.
-			expect(layout.series[1].start).toBe(4.6);
-			expect(layout.totalDurationSec).toBe(7.6);
+			// Each foreground past the first overlaps the previous by one rendered
+			// transition to match what <TransitionSeries> renders.
+			expect(layout.series[1].start).toBeCloseTo(5 - OVERLAP, 5);
+			expect(layout.totalDurationSec).toBeCloseTo(8 - OVERLAP, 5);
 		});
 
 		it("places overlays on the rendered timeline so they align with transitioned visuals", () => {
@@ -84,9 +88,9 @@ describe("buildVideoLayout", () => {
 				el({ id: "img2", type: "image", durationSec: 3 }),
 				el({ id: "n1", type: "narration", durationSec: 2 }),
 			]);
-			expect(layout.series[1].start).toBe(4.6);
-			expect(seqs(layout, "narration")[0].start).toBe(4.6);
-			expect(layout.totalDurationSec).toBe(7.6);
+			expect(layout.series[1].start).toBeCloseTo(5 - OVERLAP, 5);
+			expect(seqs(layout, "narration")[0].start).toBeCloseTo(5 - OVERLAP, 5);
+			expect(layout.totalDurationSec).toBeCloseTo(8 - OVERLAP, 5);
 		});
 
 		it("clamps a foreground shorter than the minimum duration", () => {
@@ -176,7 +180,7 @@ describe("buildVideoLayout", () => {
 			]);
 			expect(layout.series).toHaveLength(2);
 			expect(layout.series[1].element?.id).toBe("clip1");
-			expect(layout.series[1].start).toBe(8.6);
+			expect(layout.series[1].start).toBeCloseTo(9 - OVERLAP, 5);
 			expect(layout.series[1].duration).toBe(6);
 		});
 
@@ -188,7 +192,7 @@ describe("buildVideoLayout", () => {
 			]);
 			expect(layout.series).toHaveLength(2);
 			expect(layout.series[1].element?.id).toBe("clip1");
-			expect(layout.series[1].start).toBe(29.6);
+			expect(layout.series[1].start).toBeCloseTo(30 - OVERLAP, 5);
 			expect(layout.series[1].duration).toBe(6);
 		});
 
@@ -251,13 +255,13 @@ describe("buildVideoLayout", () => {
 				el({ id: "c2", type: "character", durationSec: 5 }),
 				el({ id: "img1", type: "image", durationSec: 6 }),
 			]);
-			expect(layout.totalDurationSec).toBe(15.6);
+			expect(layout.totalDurationSec).toBeCloseTo(16 - OVERLAP, 5);
 			expect(seqs(layout, "music")).toHaveLength(2);
 			expect(seqs(layout, "music")[0].start).toBe(0);
 			expect(seqs(layout, "music")[0].duration).toBe(10);
 			expect(seqs(layout, "music")[1].start).toBe(10);
-			// m2 trimmed to the rendered total (15.6) since img1 is overlapped by 0.4s.
-			expect(seqs(layout, "music")[1].duration).toBe(5.6);
+			// m2 trimmed to the rendered total since img1 is overlapped by one transition.
+			expect(seqs(layout, "music")[1].duration).toBeCloseTo(6 - OVERLAP, 5);
 		});
 
 		it("collapses consecutive backgrounds at the same offset to the latest", () => {
@@ -270,13 +274,13 @@ describe("buildVideoLayout", () => {
 				el({ id: "m5", type: "music", durationSec: 50 }),
 				el({ id: "clip1", type: "clip", durationSec: 20 }),
 			]);
-			expect(layout.totalDurationSec).toBe(29.6);
+			expect(layout.totalDurationSec).toBeCloseTo(30 - OVERLAP, 5);
 			expect(seqs(layout, "music")).toHaveLength(2);
 			expect(seqs(layout, "music")[0].start).toBe(0);
 			expect(seqs(layout, "music")[0].duration).toBe(10);
 			expect(seqs(layout, "music")[1].start).toBe(10);
-			// m5 trimmed to the rendered total (29.6) since clip1 is overlapped by 0.4s.
-			expect(seqs(layout, "music")[1].duration).toBe(19.6);
+			// m5 trimmed to the rendered total since clip1 is overlapped by one transition.
+			expect(seqs(layout, "music")[1].duration).toBeCloseTo(20 - OVERLAP, 5);
 		});
 
 		it("emits N consecutive copies for a looped background, trimmed to the foreground span", () => {
@@ -305,10 +309,10 @@ describe("buildVideoLayout", () => {
 			expect(music).toHaveLength(3);
 			expect(music[0]).toMatchObject({ start: 0, duration: 10 });
 			expect(music[1]).toMatchObject({ start: 10, duration: 5 });
-			// m2 trimmed to the rendered total (24.6) since img2 is overlapped by 0.4s.
+			// m2 trimmed to the rendered total since img2 is overlapped by one transition.
 			expect(music[2].start).toBe(15);
-			expect(music[2].duration).toBeCloseTo(9.6);
-			expect(layout.totalDurationSec).toBe(24.6);
+			expect(music[2].duration).toBeCloseTo(10 - OVERLAP, 5);
+			expect(layout.totalDurationSec).toBeCloseTo(25 - OVERLAP, 5);
 		});
 
 		it("emits a clamped background sequence when no series elements exist", () => {
@@ -440,8 +444,8 @@ describe("buildVideoLayout", () => {
 			expect(layout.series[0].element?.id).toBe("img1");
 			expect(layout.series[0].duration).toBe(5);
 			expect(layout.series[1].element?.id).toBe("clip1");
-			expect(layout.series[1].duration).toBe(6);
-			expect(layout.totalDurationSec).toBe(10.6);
+			expect(layout.series[1].duration).toBeCloseTo(6, 5);
+			expect(layout.totalDurationSec).toBeCloseTo(11 - OVERLAP, 5);
 
 			expect(seqs(layout, "music")).toHaveLength(1);
 			expect(seqs(layout, "narration")).toHaveLength(2);
@@ -464,6 +468,52 @@ describe("buildVideoLayout", () => {
 			);
 			expect(layout.width).toBe(1280);
 			expect(layout.height).toBe(720);
+		});
+	});
+
+	// <TransitionSeries> positions scenes implicitly (durations minus whole-frame
+	// overlaps) while narration/music are positioned absolutely from layout.start.
+	// Both must land on the same frame, or audio drifts further behind the visuals
+	// with every scene boundary.
+	describe("frame alignment with the rendered timeline", () => {
+		const toFrames = (sec: number, fps: number) => Math.round(sec * fps);
+
+		it.each([24, 30, 25])(
+			"keeps absolute layer starts on the TransitionSeries grid at %ifps",
+			(fps) => {
+				const elements = Array.from({ length: 10 }, (_, i) => [
+					el({ id: `img${i}`, type: "image", durationSec: 5 }),
+					el({ id: `n${i}`, type: "narration", durationSec: 4 }),
+				]).flat();
+				const layout = buildVideoLayout(elements, { fps });
+				const overlap = toFrames(layout.transitionDurationSec, fps);
+
+				let renderedStart = 0;
+				layout.series.forEach((scene, i) => {
+					if (i > 0) renderedStart -= overlap;
+					expect(toFrames(scene.start, fps)).toBe(renderedStart);
+					expect(toFrames(seqs(layout, "narration")[i].start, fps)).toBe(
+						renderedStart,
+					);
+					renderedStart += toFrames(scene.duration, fps);
+				});
+			},
+		);
+
+		it("ends the composition exactly where TransitionSeries runs out of content", () => {
+			const fps = 24;
+			const elements = Array.from({ length: 10 }, (_, i) =>
+				el({ id: `img${i}`, type: "image", durationSec: 5 }),
+			);
+			const layout = buildVideoLayout(elements, { fps });
+			const overlap = toFrames(layout.transitionDurationSec, fps);
+
+			const rendered = layout.series.reduce(
+				(total, scene, i) =>
+					total + toFrames(scene.duration, fps) - (i > 0 ? overlap : 0),
+				0,
+			);
+			expect(layout.totalFrames).toBe(rendered);
 		});
 	});
 });

--- a/lib/video/frames.ts
+++ b/lib/video/frames.ts
@@ -1,0 +1,14 @@
+/**
+ * Seconds are the input unit (provider durations, caption timestamps); frames
+ * are the timeline unit. Remotion rounds when it converts, so every crossing
+ * has to round the same way — otherwise layers positioned absolutely drift
+ * away from the ones the renderer positions for us.
+ */
+
+export function toFrames(sec: number, fps: number): number {
+	return Math.round(sec * fps);
+}
+
+export function toSeconds(frames: number, fps: number): number {
+	return frames / fps;
+}

--- a/lib/video/scene-builder.ts
+++ b/lib/video/scene-builder.ts
@@ -7,6 +7,7 @@ import type {
 } from "./types";
 import { DEFAULT_CONFIG } from "./types";
 import { type AspectRatio, ASPECT_RATIO_DIMENSIONS } from "./aspectRatio";
+import { toFrames, toSeconds } from "./frames";
 import {
 	DEFAULT_TRANSITION,
 	TRANSITION_DURATION_SEC,
@@ -19,6 +20,8 @@ export type BuildLayoutOptions = Partial<VideoConfig> & {
 };
 
 const MIN_DURATION_SEC = 1;
+// Durations accumulated on the frame grid land a few ULPs above a whole frame.
+// Without this slack the total ceils into a trailing frame with no content.
 const FRAME_EPSILON = 1e-6;
 
 function createSequence(
@@ -87,8 +90,10 @@ export function buildVideoLayout(
 	// TransitionSeries lays transitions down in whole frames, so the overlap has
 	// to sit on the frame grid too. Subtracting the raw seconds would drift the
 	// absolutely-positioned layers a fraction of a frame per scene boundary.
-	const transitionDurationSec =
-		Math.round(TRANSITION_DURATION_SEC * cfg.fps) / cfg.fps;
+	const transitionDurationSec = toSeconds(
+		toFrames(TRANSITION_DURATION_SEC, cfg.fps),
+		cfg.fps,
+	);
 	const series: Sequence[] = [];
 	const sequences: SequenceMap = {};
 	let cursor = 0;
@@ -162,9 +167,6 @@ export function buildVideoLayout(
 		sequences,
 		sequenceByElementId,
 		totalDurationSec,
-		// Nudge before rounding up: accumulated overlap subtraction leaves the
-		// total a few ULPs above a whole frame, which would ceil into a trailing
-		// black frame the renderer has no content for.
 		totalFrames: Math.max(
 			2,
 			Math.ceil(totalDurationSec * cfg.fps - FRAME_EPSILON),

--- a/lib/video/scene-builder.ts
+++ b/lib/video/scene-builder.ts
@@ -19,6 +19,7 @@ export type BuildLayoutOptions = Partial<VideoConfig> & {
 };
 
 const MIN_DURATION_SEC = 1;
+const FRAME_EPSILON = 1e-6;
 
 function createSequence(
 	element: ResolvedElement | null,
@@ -83,6 +84,11 @@ export function buildVideoLayout(
 		: undefined;
 	const cfg = { ...DEFAULT_CONFIG, ...aspectDims, ...options };
 	const transitionType = options?.transitionType ?? DEFAULT_TRANSITION;
+	// TransitionSeries lays transitions down in whole frames, so the overlap has
+	// to sit on the frame grid too. Subtracting the raw seconds would drift the
+	// absolutely-positioned layers a fraction of a frame per scene boundary.
+	const transitionDurationSec =
+		Math.round(TRANSITION_DURATION_SEC * cfg.fps) / cfg.fps;
 	const series: Sequence[] = [];
 	const sequences: SequenceMap = {};
 	let cursor = 0;
@@ -109,9 +115,9 @@ export function buildVideoLayout(
 					cursor = foregroundCursor;
 					if (series.length > 0) {
 						// TransitionSeries.Sequence overlap the previous
-						// ones by TRANSITION_DURATION_SEC. Bake that into the cursor so every
+						// ones by transitionDurationSec. Bake that into the cursor so every
 						// subsequent overlay/background/effect lands on the rendered timeline.
-						cursor -= TRANSITION_DURATION_SEC;
+						cursor -= transitionDurationSec;
 					}
 					series.push(createSequence(element, cursor, element.durationSec));
 				}
@@ -156,8 +162,14 @@ export function buildVideoLayout(
 		sequences,
 		sequenceByElementId,
 		totalDurationSec,
-		totalFrames: Math.max(2, Math.ceil(totalDurationSec * cfg.fps)),
+		// Nudge before rounding up: accumulated overlap subtraction leaves the
+		// total a few ULPs above a whole frame, which would ceil into a trailing
+		// black frame the renderer has no content for.
+		totalFrames: Math.max(
+			2,
+			Math.ceil(totalDurationSec * cfg.fps - FRAME_EPSILON),
+		),
 		transitionType,
-		transitionDurationSec: TRANSITION_DURATION_SEC,
+		transitionDurationSec,
 	};
 }

--- a/remotion/components/Captions.tsx
+++ b/remotion/components/Captions.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import sortedLastIndex from "lodash/sortedLastIndex";
 import { AbsoluteFill, useCurrentFrame, useVideoConfig } from "remotion";
 import type { TextTimestamp } from "@/lib/connectors/types";
+import { toSeconds } from "@/lib/video/frames";
 
 const MAX_LINE_WIDTH_RATIO = 0.8;
 const FONT_SIZE_RATIO = 0.065;
@@ -90,7 +91,7 @@ export function Captions({ timestamps }: { timestamps: TextTimestamp[] }) {
 
 	if (visibleByWordIndex.length === 0) return null;
 
-	const seconds = frame / fps;
+	const seconds = toSeconds(frame, fps);
 	const wordIndex = sortedLastIndex(startTimes, seconds) - 1;
 	if (wordIndex < 0) return null;
 

--- a/remotion/compositions/VideoComposition.tsx
+++ b/remotion/compositions/VideoComposition.tsx
@@ -13,6 +13,7 @@ import type {
 	Sequence as SeqType,
 	ResolvedElement,
 } from "@/lib/video/types";
+import { toFrames } from "@/lib/video/frames";
 import {
 	AUDIO_FADE_SEC,
 	TRANSITION_DURATION_SEC,
@@ -30,10 +31,6 @@ const coverStyle: React.CSSProperties = {
 };
 
 const blackBg: React.CSSProperties = { backgroundColor: "black" };
-
-function toFrames(sec: number, fps: number): number {
-	return Math.round(sec * fps);
-}
 
 function AudioSequence({ element }: { element: ResolvedElement }) {
 	const { durationInFrames, fps } = useVideoConfig();


### PR DESCRIPTION
Four correctness fixes found by a nightly bug hunt, each with a concrete failure path.

## 1. Audio/overlay layers drift behind the visuals in every multi-scene video

`lib/video/scene-builder.ts` advanced the timeline with `cursor -= TRANSITION_DURATION_SEC` (0.4s), but `<TransitionSeries>` renders each transition as `Math.round(0.4 * fps)` whole frames. At 24fps that's 10 frames vs 9.6s worth of seconds, so the two disagree by 0.4 frames at every scene boundary.

That matters because the two consumers read the numbers differently: scenes are positioned *implicitly* by `TransitionSeries`, while narration/character/music/sound sequences are positioned *absolutely* from `toFrames(seq.start, fps)`.

Measured with the real `buildVideoLayout` (10 scenes, 5s image + 4s narration, 24fps, default `transitionType: "none"`):

```
scene2: visual@220  narration@221   drift=1
scene4: visual@440  narration@442   drift=2
scene7: visual@770  narration@773   drift=3
scene9: visual@990  narration@994   drift=4
composition totalFrames = 1114 vs 1110 rendered -> 4 black frames at the end
```

The drift is linear in scene count, so a 30-scene story lands ~0.5s out of sync. It hits the default `"none"` transition too, since a `TransitionSeries.Transition` is emitted for every `i > 0` regardless of presentation and `none()` still consumes its timing duration.

Fixed by snapping the overlap to the same integer frame grid the renderer uses and returning that value as `transitionDurationSec`, so `toFrames` reproduces an identical count. Also nudged `totalFrames` before `Math.ceil` — the accumulated overlap subtraction leaves the total a few ULPs above a whole frame, which would otherwise ceil into a trailing black frame with no content behind it.

## 2. Polling a finished video job re-uploads its bundle and can destroy the result

`pollJob` calls `handler.poll(job)` unconditionally, and `videoHandler.poll` never checked `job.status`. So every GET on an already-completed video job re-polled the provider and re-ran `store()`, uploading a fresh blob under a new nanoid and overwriting `jobs.result`.

Any URL already handed out is orphaned. Worse, once the provider expires the task id, a permanently-completed job either starts throwing 500s forever or gets flipped to `status: "failed"` with its result dropped.

Fixed by returning the stored row for terminal states.

## 3. Avatar upload silently reverts concurrent character edits

`CharacterEditModal`'s `onUpload` spread a render-captured `character` across an await. Type a new appearance while the avatar upload is in flight (~2-3s) and the resolving handler writes the stale snapshot back, reverting the edit — which autosave then persists.

The other two `useImageUpload` consumers (`AssetsSection`, `ComposerCopilot`) already re-read through `getState()` after the await; this was the only call site that didn't. Fixed to match.

## 4. Voice picker shows a false "no results" on every open

`loading` was initialized to `false` and only set `true` inside the 300ms debounce, so the empty-state branch rendered before the fetch had even started. Every open of a character or narrator modal flashed "No voices match these filters." for 300ms. The effect always schedules a fetch on mount, so `true` is the honest initial state.

## Tests

- `lib/video/__tests__/scene-builder.test.ts` — new `frame alignment with the rendered timeline` block asserting absolute layer starts land on the `TransitionSeries` grid at 24/30/25fps, and that `totalFrames` equals what the renderer actually lays down. Existing expectations updated from the old raw-seconds overlap to the frame-quantized one.
- `lib/api/handlers/__tests__/video.test.ts` — new file covering `videoHandler` end to end (was 4% covered): terminal states short-circuit without touching the provider, missing provider id, bundle persistence, upstream failure, and still-processing. The two terminal-state tests fail without the fix in this PR.

Full suite: 104 files, 902 tests passing. Lint, format, typecheck, knip, and build all clean.

## Deliberately skipped

- **`durationSec` dropped for non-mock video jobs** — this is the omission you called intentional on #411 ("we intentionally omit durationSecs from video for now"), so I left it alone.
- **Player commands dropped when the panel is hidden** (`playFromFrame` / transport play button issuing commands against a not-yet-mounted player) — real, but it's the same root cause as open PR #430, which owns `PlayerControlContext.tsx`.
- **Non-UUID job id returns 500 instead of 404** — the idiomatic fix is `z.uuid()` in `pollJob`, but `lib/api/route-handler.ts` belongs to open PR #435.
- **Dead empty-node guard in `useScriptSync`** — the guard can never fire because `createCanvasNode` always emits a zero-width space. Fixing it changes when elements first appear during streaming, which is a real behavior change for little gain.

## Open PR overlap check

Considered #438, #435, #434, #433, #432, #431, #430, #429, #422, #421, #420, #419, #418, #417, #416 and built a file/theme list from `gh pr diff --name-only` on each.

No file in this PR is touched by any open PR: `lib/video/**` is untouched by all of them, `lib/api/handlers/**` is distinct from #435's `lib/api/{parse,route-handler,response}.ts`, and `CharacterEditModal.tsx` / `VoicePicker.tsx` are distinct from #431's and #438's canvas files. Thematically distinct too — the three player-related findings that would have collided with #430 were dropped rather than reworked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)