### PR TITLE
perf: nightly performance optimizations 2026-07-20

### DIFF
--- a/app/components/video/VideoPreview.tsx
+++ b/app/components/video/VideoPreview.tsx
@@ -53,6 +53,43 @@ const RemotionPlayer = dynamic(
 	{ ssr: false },
 );
 
+// Both of these track the playhead, so they stay siblings of the player rather
+// than hooks inside it: @remotion/player is not memoized, and a re-render of it
+// lands on the frame a transition is animating and the next asset is decoding.
+function ActiveSceneTracker({
+	player,
+	fps,
+}: {
+	player: PlayerRef | null;
+	fps: number;
+}) {
+	const segments = useSceneSegments();
+	const activeIndex = useActiveSegmentIndex(player, segments, fps);
+	useActiveSceneSync(player, segments, activeIndex);
+	return null;
+}
+
+function ClickToPlayOverlay({ player }: { player: PlayerRef | null }) {
+	const [flash, setFlash] = useState<{ key: number; playing: boolean } | null>(
+		null,
+	);
+	const toggleAndFlash = () => {
+		if (!player) return;
+		const willPlay = !player.isPlaying();
+		player.toggle();
+		setFlash((f) => ({ key: (f?.key ?? 0) + 1, playing: willPlay }));
+	};
+	return (
+		<>
+			<div
+				className="absolute inset-0 cursor-pointer"
+				onClick={toggleAndFlash}
+			/>
+			<PlayPauseFlash flash={flash} />
+		</>
+	);
+}
+
 type VideoPreviewProps = {
 	layout: VideoLayout;
 	restoreFrameRef: MutableRefObject<number | null>;
@@ -61,13 +98,7 @@ type VideoPreviewProps = {
 export function VideoPreview({ layout, restoreFrameRef }: VideoPreviewProps) {
 	const [player, setPlayer] = useState<PlayerRef | null>(null);
 	const [isFullscreen, setIsFullscreen] = useState(false);
-	const segments = useSceneSegments();
-	const activeIndex = useActiveSegmentIndex(player, segments, layout.fps);
-	useActiveSceneSync(player, segments, activeIndex);
 	const { registerPlayer } = usePlayerControl();
-	const [flash, setFlash] = useState<{ key: number; playing: boolean } | null>(
-		null,
-	);
 	useEffect(() => {
 		registerPlayer(player);
 		return () => registerPlayer(null);
@@ -80,12 +111,6 @@ export function VideoPreview({ layout, restoreFrameRef }: VideoPreviewProps) {
 		player.addEventListener("fullscreenchange", handler);
 		return () => player.removeEventListener("fullscreenchange", handler);
 	}, [player]);
-	const toggleAndFlash = () => {
-		if (!player) return;
-		const willPlay = !player.isPlaying();
-		player.toggle();
-		setFlash((f) => ({ key: (f?.key ?? 0) + 1, playing: willPlay }));
-	};
 	return (
 		<div className={`relative h-full w-full ${styles.player}`}>
 			<ToastErrorBoundary label="Player">
@@ -95,11 +120,8 @@ export function VideoPreview({ layout, restoreFrameRef }: VideoPreviewProps) {
 					controls={isFullscreen}
 				/>
 			</ToastErrorBoundary>
-			<div
-				className="absolute inset-0 cursor-pointer"
-				onClick={toggleAndFlash}
-			/>
-			<PlayPauseFlash flash={flash} />
+			<ActiveSceneTracker player={player} fps={layout.fps} />
+			<ClickToPlayOverlay player={player} />
 		</div>
 	);
 }

--- a/app/components/video/usePlayerState.ts
+++ b/app/components/video/usePlayerState.ts
@@ -1,5 +1,5 @@
 import type { PlayerRef } from "@remotion/player";
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback, useRef, useSyncExternalStore } from "react";
 
 type PlayerEvent =
 	| "frameupdate"
@@ -19,35 +19,65 @@ export function usePlayerValue<T>(
 	read: (p: PlayerRef) => T,
 	fallback: T,
 ): T {
+	// React calls getSnapshot on every render of every subscriber, plus a second
+	// time after commit to check for tearing. `read` can be O(scenes), so hold
+	// its result until either the player emits or the caller hands us a new
+	// reader — a reader that closes over changing data must still see it.
+	const cache = useRef<{
+		player: PlayerRef;
+		read: (p: PlayerRef) => T;
+		value: T;
+	} | null>(null);
+
 	const subscribe = useCallback(
 		(notify: () => void) => {
 			if (!player) return () => {};
-			for (const event of events) player.addEventListener(event, notify);
+			const handler = () => {
+				cache.current = null;
+				notify();
+			};
+			for (const event of events) player.addEventListener(event, handler);
 			return () => {
-				for (const event of events) player.removeEventListener(event, notify);
+				cache.current = null;
+				for (const event of events) player.removeEventListener(event, handler);
 			};
 		},
 		[player, events],
 	);
-	return useSyncExternalStore(
-		subscribe,
-		() => (player ? read(player) : fallback),
-		() => fallback,
-	);
+
+	const getSnapshot = () => {
+		if (!player) return fallback;
+		const cached = cache.current;
+		if (cached && cached.player === player && cached.read === read) {
+			return cached.value;
+		}
+		const value = read(player);
+		cache.current = { player, read, value };
+		return value;
+	};
+
+	return useSyncExternalStore(subscribe, getSnapshot, () => fallback);
 }
 
+// Module-level so the cache above survives re-renders of the subscriber: these
+// read straight off the player and can only change when it emits.
+const readFrame = (p: PlayerRef) => p.getCurrentFrame();
+const readPlaying = (p: PlayerRef) => p.isPlaying();
+const readVolume = (p: PlayerRef) => p.getVolume();
+const readMuted = (p: PlayerRef) => p.isMuted();
+
 export function usePlayerFrame(player: PlayerRef | null) {
-	return usePlayerValue(player, FRAME_EVENTS, (p) => p.getCurrentFrame(), 0);
+	return usePlayerValue(player, FRAME_EVENTS, readFrame, 0);
 }
 
 export function usePlayerPlaying(player: PlayerRef | null) {
-	return usePlayerValue(player, PLAY_EVENTS, (p) => p.isPlaying(), false);
+	return usePlayerValue(player, PLAY_EVENTS, readPlaying, false);
 }
 
 export function usePlayerVolume(player: PlayerRef | null) {
-	return usePlayerValue(player, VOLUME_EVENTS, (p) => p.getVolume(), 1);
+	return usePlayerValue(player, VOLUME_EVENTS, readVolume, 1);
 }
 
 export function usePlayerMuted(player: PlayerRef | null) {
-	return usePlayerValue(player, MUTE_EVENTS, (p) => p.isMuted(), false);
+	return usePlayerValue(player, MUTE_EVENTS, readMuted, false);
 }

--- a/remotion/components/Captions.tsx
+++ b/remotion/components/Captions.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 import sortedLastIndex from "lodash/sortedLastIndex";
 import { AbsoluteFill, useCurrentFrame, useVideoConfig } from "remotion";
 import type { TextTimestamp } from "@/lib/connectors/types";
@@ -72,6 +72,30 @@ function buildCaptionData(
 	return { startTimes, visibleByWordIndex };
 }
 
+// The word under the playhead changes a few times a second, but the parent
+// re-renders on every frame. Memoized so the 9-layer text shadow is only
+// reconciled at word boundaries.
+const CaptionLine = memo(function CaptionLine({
+	line,
+	fontSizePx,
+}: {
+	line: string;
+	fontSizePx: number;
+}) {
+	return (
+		<AbsoluteFill style={container}>
+			<div
+				style={{
+					width: `${MAX_LINE_WIDTH_RATIO * 100}%`,
+					fontSize: fontSizePx,
+				}}
+			>
+				<span style={text}>{line}</span>
+			</div>
+		</AbsoluteFill>
+	);
+});
+
 export function Captions({ timestamps }: { timestamps: TextTimestamp[] }) {
 	const frame = useCurrentFrame();
 	const { fps, width, height } = useVideoConfig();
@@ -96,16 +120,5 @@ export function Captions({ timestamps }: { timestamps: TextTimestamp[] }) {
 
 	const visible = visibleByWordIndex[wordIndex];
 
-	return (
-		<AbsoluteFill style={container}>
-			<div
-				style={{
-					width: `${MAX_LINE_WIDTH_RATIO * 100}%`,
-					fontSize: fontSizePx,
-				}}
-			>
-				<span style={text}>{visible}</span>
-			</div>
-		</AbsoluteFill>
-	);
+	return <CaptionLine line={visible} fontSizePx={fontSizePx} />;
 }


### PR DESCRIPTION
Runtime performance pass on the video preview playback path. No behavior changes.

## What was optimized

**`usePlayerValue` re-ran its reader several times per frame** (`app/components/video/usePlayerState.ts`)

`getSnapshot` was an uncached closure, so React re-ran the reader on every render of every subscriber and again after commit for the tear check. That is fine for `getCurrentFrame()`, but `useActiveSegmentIndex` reads through `findSegmentIndexAt`, a linear scan over every scene. Two components subscribe with that reader, so a 40-scene project was doing several full scans per frame to produce a number that changes once per scene.

The value is now held until the player emits or the caller passes a new reader. Keying on reader identity matters: a reader that closes over changing data (segments do change when the script is edited while paused) must still observe it, so this keeps the existing semantics rather than caching purely on events. The four closure-free readers moved to module scope, so for `usePlayerFrame`/`Playing`/`Volume`/`Muted` the cache also survives unrelated re-renders of the subscriber.

**Every scene boundary re-rendered the whole `<Player>`** (`app/components/video/VideoPreview.tsx`)

`VideoPreview` subscribed to the active segment index and owned the play/pause flash state, both above the `<Player>` it renders. `@remotion/player` is not `React.memo` and the `dynamic()` wrapper is not either, so each change re-rendered `PlayerFn` → `PlayerUI` → every `Sequence`. The deep subtree mostly bails out because `VideoComposition` memoizes its node arrays, but the work still lands on exactly the frame where a transition is animating and the next asset is decoding — the frame with the least headroom.

Active-scene tracking moved into a null-rendering sibling and the flash state into the overlay that owns it. `VideoPreview` now re-renders only when the player instance, fullscreen state, or layout changes.

**`Captions` reconciled its subtree every frame to render the same word** (`remotion/components/Captions.tsx`)

The binary-search lookup was already right, but the JSX and a fresh inline style object were rebuilt on every frame, so React diffed a 9-layer `textShadow` on full-width uppercase text at composition resolution 30-60 times a second to discover nothing had changed. The word under the playhead changes a few times a second. The presentational half is now memoized and bails between word boundaries. One `Captions` instance mounts per timestamped audio element, so this multiplies with concurrent narration.

## What was skipped

- **`sceneItems` identity churn in `useDragAndDrop.ts`.** The largest finding overall: `editor.children` is a new array per Slate op, so dnd-kit's `SortableContext` rebuilds its context every keystroke, re-rendering every scene and doing O(scenes²) work inside `useSortable`. Skipped as overlapping — PRs #433 and #431 both touch that file.
- **`findSegmentIndexAt` linear scan → binary search.** `useSceneSegments.ts` is covered by #435. The caching above removes most of the repeat cost without touching it.
- **`SegmentedSeekBar`/`ScrubBar` per-frame style-object churn.** Likely the single heaviest cost in the preview UI, but covered by #417 and #430.
- **`motionTransform` `toFixed` allocations.** Single-digit microseconds; below the bar.
- **`ViewModeContext` slicing, `useSceneIndex` O(scenes²), `ElementSettings` schema re-resolution.** Real, but either overlapping (#435) or only material once the dnd-kit churn above is fixed. Worth a follow-up night.

## Open PR overlap check

Considered open PRs #440, #439, #438, #435, #434, #433, #432, #431, #430, #429, #422, #421, #420, #419, #418, #417, #416. The three files here (`usePlayerState.ts`, `VideoPreview.tsx`, `Captions.tsx`) appear in none of them. The video-adjacent PRs (#435, #430, #417) touch `VideoPanel`, `useSceneSegments`, `useVideoLayout`, `VideoLayoutContext`, `useAssetPrefetch`, `PlayerControlContext`, `SegmentedSeekBar`, `ScrubBar`, `MotionLayer`, `startPlaybackAt`, `silenceMedia` — all disjoint from this diff.

## Validation

`lint`, `format:check`, `typecheck`, `knip`, `build`, and `test:run` (890 tests) all pass. Playwright smoke tests could not run locally — port 3000 was occupied by an unrelated process — so they are left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)