### PR TITLE
refactor: nightly CONVENTIONS.md compliance 2026-07-20

### DIFF
--- a/app/components/canvas/plugins/withScenes.ts
+++ b/app/components/canvas/plugins/withScenes.ts
@@ -1,73 +1,91 @@
-import { Transforms, Path, Node } from "slate";
+import { Transforms, Path, Node, NodeEntry } from "slate";
 import { CanvasEditor, SceneElement, SCENE_TYPE } from "@/lib/canvas/types";
 import { isSceneElement } from "@/lib/canvas/scenes";
 import { isContentElement, isForeground } from "@/lib/canvas/guards";
 import { makeNodeId } from "@/lib/canvas/nodeUtils";
 
+/** Returns true when the rule applied a transform and normalization should restart. */
+type SceneRule = (editor: CanvasEditor, entry: NodeEntry) => boolean;
+
+const adoptIntoPreviousScene: SceneRule = (editor, [node, path]) => {
+	if (!isContentElement(node) || !Path.hasPrevious(path)) return false;
+	const prevPath = Path.previous(path);
+	const prevNode = Node.getIf(editor, prevPath);
+	if (!isSceneElement(prevNode)) return false;
+	Transforms.moveNodes(editor, {
+		at: path,
+		to: [...prevPath, prevNode.children.length],
+	});
+	return true;
+};
+
+const wrapOrphanContent: SceneRule = (editor, [node, path]) => {
+	if (!isContentElement(node)) return false;
+	const wrapper: SceneElement = {
+		id: makeNodeId(),
+		type: SCENE_TYPE,
+		children: [],
+	};
+	Transforms.wrapNodes(editor, wrapper, { at: path });
+	return true;
+};
+
+// Must precede Slate's default normalizer, which would otherwise insert a text
+// child into the empty scene and violate SceneElement.children.
+const removeEmptyScene: SceneRule = (editor, [node, path]) => {
+	if (!isSceneElement(node) || node.children.length > 0) return false;
+	Transforms.removeNodes(editor, { at: path });
+	return true;
+};
+
+const splitExtraForeground: SceneRule = (editor, [node, path]) => {
+	if (!isSceneElement(node)) return false;
+	const first = node.children.findIndex(isForeground);
+	if (first === -1) return false;
+	const second = node.children.findIndex(
+		(child, i) => i > first && isForeground(child),
+	);
+	if (second === -1) return false;
+	Transforms.splitNodes(editor, {
+		at: [...path, second],
+		match: isSceneElement,
+	});
+	return true;
+};
+
+const mergeForegroundlessScene: SceneRule = (editor, [node, path]) => {
+	if (!isSceneElement(node) || node.children.some(isForeground)) return false;
+	if (
+		Path.hasPrevious(path) &&
+		isSceneElement(Node.getIf(editor, Path.previous(path)))
+	) {
+		Transforms.mergeNodes(editor, { at: path });
+		return true;
+	}
+	const nextPath = Path.next(path);
+	if (isSceneElement(Node.getIf(editor, nextPath))) {
+		Transforms.mergeNodes(editor, { at: nextPath });
+		return true;
+	}
+	return false;
+};
+
+// Order is load-bearing: each rule assumes the ones above it did not apply.
+const SCENE_RULES: readonly SceneRule[] = [
+	adoptIntoPreviousScene,
+	wrapOrphanContent,
+	removeEmptyScene,
+	splitExtraForeground,
+	mergeForegroundlessScene,
+];
+
 export const withScenes = (editor: CanvasEditor): CanvasEditor => {
 	const { normalizeNode } = editor;
 
 	editor.normalizeNode = (entry) => {
-		const [node, path] = entry;
-
-		if (path.length === 1) {
-			if (isContentElement(node)) {
-				if (Path.hasPrevious(path)) {
-					const prevPath = Path.previous(path);
-					const prevNode = Node.getIf(editor, prevPath);
-					if (isSceneElement(prevNode)) {
-						Transforms.moveNodes(editor, {
-							at: path,
-							to: [...prevPath, prevNode.children.length],
-						});
-						return;
-					}
-				}
-				const wrapper: SceneElement = {
-					id: makeNodeId(),
-					type: SCENE_TYPE,
-					children: [],
-				};
-				Transforms.wrapNodes(editor, wrapper, { at: path });
-				return;
-			}
-
-			if (isSceneElement(node)) {
-				// Remove empty scenes first — otherwise Slate's default normalizer
-				// would insert a text child, violating SceneElement.children.
-				if (node.children.length === 0) {
-					Transforms.removeNodes(editor, { at: path });
-					return;
-				}
-
-				let foregroundCount = 0;
-				for (let i = 0; i < node.children.length; i++) {
-					if (isForeground(node.children[i])) {
-						foregroundCount++;
-						if (foregroundCount > 1) {
-							Transforms.splitNodes(editor, {
-								at: [...path, i],
-								match: isSceneElement,
-							});
-							return;
-						}
-					}
-				}
-
-				if (foregroundCount === 0) {
-					if (
-						Path.hasPrevious(path) &&
-						isSceneElement(Node.getIf(editor, Path.previous(path)))
-					) {
-						Transforms.mergeNodes(editor, { at: path });
-						return;
-					}
-					const nextPath = Path.next(path);
-					if (isSceneElement(Node.getIf(editor, nextPath))) {
-						Transforms.mergeNodes(editor, { at: nextPath });
-						return;
-					}
-				}
+		if (entry[1].length === 1) {
+			for (const rule of SCENE_RULES) {
+				if (rule(editor, entry)) return;
 			}
 		}
 

--- a/lib/connectors/factory.ts
+++ b/lib/connectors/factory.ts
@@ -51,15 +51,22 @@ export function isKnownProvider(
 	return Object.hasOwn(PROVIDERS[type], provider);
 }
 
+function providerCtor(
+	type: ConnectorType,
+	provider: ProviderKey,
+): ProviderConstructor {
+	const Ctor = PROVIDERS[type][provider];
+	if (!Ctor)
+		throw new Error(`Unknown provider "${provider}" for type "${type}"`);
+	return Ctor;
+}
+
 export function createConnector<T extends ConnectorType>(
 	type: T,
 	provider: ProviderKey,
 	config: ConnectorConfig,
 ): ConnectorTypeMap[T] {
-	const Ctor = PROVIDERS[type][provider];
-	if (!Ctor)
-		throw new Error(`Unknown provider "${provider}" for type "${type}"`);
-	return new Ctor(config) as ConnectorTypeMap[T];
+	return new (providerCtor(type, provider))(config) as ConnectorTypeMap[T];
 }
 
 /** Resolve the attribute schema for a (connectorType, provider, model), via the same class hierarchy `createConnector` instantiates. */
@@ -68,8 +75,5 @@ export function resolveAttributeSchema(
 	provider: ProviderKey,
 	model?: string,
 ): AttributeSchema {
-	const Ctor = PROVIDERS[type][provider];
-	if (!Ctor)
-		throw new Error(`Unknown provider "${provider}" for type "${type}"`);
-	return Ctor.attributesFor(model);
+	return providerCtor(type, provider).attributesFor(model);
 }


### PR DESCRIPTION
Nightly CONVENTIONS.md audit. Files owned by the 18 open PRs were excluded from scope.

## Applied (behavior-preserving)

**`withScenes.ts` — "units stay dumb and simple" / "declarative reads like config"**
The normalizer held five distinct scene rules in one 65-line closure nested four deep, with six return-to-restart exits threaded through it. Nothing told a reader there were five rules; you had to trace the branch tree to enumerate them. Each rule is now a named `SceneRule` owning its own guard and reporting whether it applied, run from an ordered list. Ordering is load-bearing and is now stated rather than implied by nesting. The 24 existing invariant tests pass unchanged.

**`lib/connectors/factory.ts` — "one canonical way"**
`createConnector` and `resolveAttributeSchema` each carried a character-identical provider lookup and throw, so the error message lived in two places. Extracted `providerCtor`.

## Flagged, not applied

Design-level, each needs a judgement call:

1. **`lib/api/providers.ts:23`** — a missing or typo'd API key silently swaps in the mock provider. Users get fake assets with no error anywhere, on server or client. Mocking should be explicit opt-in (`OPENSLOP_MOCK=1`) with a throw when a real provider is expected. Worst silent failure found.
2. **`lib/generation/buildGenerationJob.ts:93`** — calls `getDefaultConnector`, discards its `provider`, hardcodes `"openslop"`, then pairs that with the other provider's `config`. Correct today only because openslop is the sole provider; breaks the moment a second one lands. Also an unchecked `as ProviderKey` cast on user input despite `isKnownProvider` existing.
3. **Floating promises** — `EditorToolbar.tsx:34` and `AnimateButton.tsx:23` call `refineScript` unawaited, and `useRefineScript` has a `finally` but no `catch`. An LLM error stops the spinner and shows the user nothing. Best fixed once inside the hook. Same bug exists in `ComposerHero.tsx:39`, which PR #441 owns.
4. **`"image" | "animated_image"` re-encoded in five places** (`preservedAttributes.ts:9`, `ElementCharacters.tsx:21`, `thumbnail.ts:10`, `AnimateButton.tsx:12`, `ElementContainer.tsx:151`) instead of capability flags on the existing `ELEMENT_TYPES` registry.
5. **`VideoComposition.tsx:69`** re-derives output kind via `element.type === "image"` because `ResolvedElement` drops the registry's `outputKind`. A new visual type silently falls into the video branch. Fix is mechanical but requires editing `scene-builder.test.ts`, which PR #441 owns — left for after that merges.
6. **Provider adapters bake in model/resolution policy** — `image/runware.ts:38-40` (`bytedance:seedream@5.0-lite`, 2848x1600, diverging from `ASPECT_RATIO_DIMENSIONS`), `llm/anthropic.ts:75`, `music/elevenlabs.ts:60`. Model ids now live in two files that must be bumped together.
7. **`FIELD_CLS` vs the design system** — `character/fields.tsx:12` is a parallel form-field style, and `TextAttributePopover.tsx:101` copy-pastes it with `rounded-lg` instead of `rounded-md`. Already drifted.
8. **`useRendering.ts:24` hand-rolls `postJSON`**, duplicating `OpenSlopClient.post` with different error extraction, so render failures surface differently from every other API call.
9. **`request-schema-fields.ts:17,21`** — two contracts for a client-supplied duration; music/sfx reject `"10"`, video coerces it.
10. **`parseOps.ts:25`** silently drops malformed ops twice over. Streaming refine applies fewer ops than the model emitted with no signal.

Deliberately not touched: `lib/supabase/server.ts:18`'s empty catch is the vendor-documented SSR pattern. Several "add an options param" suggestions were rejected as YAGNI.

Checked clean: connector/gateway/provider layering, `job-handlers`, `transitions`, `assetUrl`, `elementConfigs`, the `app/api/v1` routes. The three `switch` statements in the repo are each single-site exhaustive switches over a discriminated union.

lint, typecheck, format:check, knip, build, 890 tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)