### PR TITLE
refactor: rethink openslop architecture 2026-07-20

### DIFF
--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -19,6 +19,7 @@ import { SceneContainer } from "./SceneContainer";
 import { ElementCharacters } from "./ElementCharacters";
 import { AttributeBadge } from "./AttributeBadge";
 import { ElementGenerateButton, ElementStaleIndicator } from "./GenerateButton";
+import { ElementGenerationProvider } from "./ElementGenerationContext";
 import { AnimateButton } from "./AnimateButton";
 import { ElementUploadButton } from "./ElementUploadButton";
 import { ModelBadge } from "./ModelBadge";
@@ -105,75 +106,80 @@ export function ElementContainer({
 	const isEmpty = Node.string(element) === ZERO_WIDTH_SPACE;
 
 	return (
-		<div className="flex items-stretch mb-1.5 animate-fadeInUp" {...attributes}>
-			{/* Left: element card */}
-			<div className="group/card @container relative min-w-0 flex-1 overflow-hidden rounded-2xl border border-border bg-element-card p-3">
-				<div className="relative z-10 min-w-0">
-					<div
-						className="mb-2 flex items-start gap-1.5 select-none"
-						contentEditable={false}
-					>
-						<div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
-							<span
-								className={`flex h-6 w-6 @sm:w-auto shrink-0 items-center justify-center @sm:justify-start gap-1.5 rounded-md @sm:px-2 ${config.iconBgClass} ${config.colorClass}`}
-							>
-								{config.icon}
-								<span className="hidden font-body text-label-xs @sm:inline">
-									{config.label}
+		<ElementGenerationProvider element={element}>
+			<div
+				className="flex items-stretch mb-1.5 animate-fadeInUp"
+				{...attributes}
+			>
+				{/* Left: element card */}
+				<div className="group/card @container relative min-w-0 flex-1 overflow-hidden rounded-2xl border border-border bg-element-card p-3">
+					<div className="relative z-10 min-w-0">
+						<div
+							className="mb-2 flex items-start gap-1.5 select-none"
+							contentEditable={false}
+						>
+							<div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+								<span
+									className={`flex h-6 w-6 @sm:w-auto shrink-0 items-center justify-center @sm:justify-start gap-1.5 rounded-md @sm:px-2 ${config.iconBgClass} ${config.colorClass}`}
+								>
+									{config.icon}
+									<span className="hidden font-body text-label-xs @sm:inline">
+										{config.label}
+									</span>
 								</span>
-							</span>
-							<ElementCharacters element={element} />
-							<ModelBadge element={element} />
-							<ElementSettings element={element} config={config} />
-						</div>
-						<div className="shrink-0 opacity-0 pointer-events-none transition-opacity duration-200 group-hover/card:opacity-100 group-hover/card:pointer-events-auto">
-							<DeleteButton element={element} />
-						</div>
-					</div>
-					<div className="relative min-w-0 rounded-xl border border-transparent bg-element-input px-3 py-2.5 transition-colors hover:border-element-input-border-hover focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/30">
-						{isEmpty && (
-							<div
-								style={{ userSelect: "none" }}
-								className="pointer-events-none absolute top-2.5 left-3 text-left text-label text-muted-foreground"
-							>
-								{config.placeholder}
+								<ElementCharacters element={element} />
+								<ModelBadge element={element} />
+								<ElementSettings element={element} config={config} />
 							</div>
-						)}
-						<div className="overflow-hidden text-left text-label leading-relaxed text-foreground transition-[max-height,opacity] duration-200">
-							{children}
+							<div className="shrink-0 opacity-0 pointer-events-none transition-opacity duration-200 group-hover/card:opacity-100 group-hover/card:pointer-events-auto">
+								<DeleteButton element={element} />
+							</div>
 						</div>
-					</div>
-					<div
-						className="mt-2 flex items-center justify-end gap-2 select-none"
-						contentEditable={false}
-					>
-						<ElementStaleIndicator element={element} />
-						{element.type === "image" && (
-							<ElementUploadButton element={element} />
-						)}
-						<AnimateButton element={element} />
-						<ElementGenerateButton element={element} />
+						<div className="relative min-w-0 rounded-xl border border-transparent bg-element-input px-3 py-2.5 transition-colors hover:border-element-input-border-hover focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/30">
+							{isEmpty && (
+								<div
+									style={{ userSelect: "none" }}
+									className="pointer-events-none absolute top-2.5 left-3 text-left text-label text-muted-foreground"
+								>
+									{config.placeholder}
+								</div>
+							)}
+							<div className="overflow-hidden text-left text-label leading-relaxed text-foreground transition-[max-height,opacity] duration-200">
+								{children}
+							</div>
+						</div>
+						<div
+							className="mt-2 flex items-center justify-end gap-2 select-none"
+							contentEditable={false}
+						>
+							<ElementStaleIndicator />
+							{element.type === "image" && (
+								<ElementUploadButton element={element} />
+							)}
+							<AnimateButton element={element} />
+							<ElementGenerateButton />
+						</div>
 					</div>
 				</div>
-			</div>
 
-			{/* Center divider */}
-			<div
-				className="flex shrink-0 items-stretch px-3 select-none sm:px-4"
-				contentEditable={false}
-				aria-hidden="true"
-			>
-				<div className="w-px self-stretch bg-border" />
-			</div>
+				{/* Center divider */}
+				<div
+					className="flex shrink-0 items-stretch px-3 select-none sm:px-4"
+					contentEditable={false}
+					aria-hidden="true"
+				>
+					<div className="w-px self-stretch bg-border" />
+				</div>
 
-			{/* Right: preview */}
-			<div
-				className="flex-1 min-w-0 flex items-center select-none"
-				contentEditable={false}
-			>
-				<OutputPreview element={element} />
+				{/* Right: preview */}
+				<div
+					className="flex-1 min-w-0 flex items-center select-none"
+					contentEditable={false}
+				>
+					<OutputPreview element={element} />
+				</div>
 			</div>
-		</div>
+		</ElementGenerationProvider>
 	);
 }
 

--- a/app/components/canvas/elements/ElementGenerationContext.tsx
+++ b/app/components/canvas/elements/ElementGenerationContext.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { createRequiredContext } from "@/lib/components/createRequiredContext";
+import type { CanvasContentElement } from "@/lib/canvas/types";
+import { useGenerate } from "../hooks/useGenerate";
+
+type ElementGeneration = ReturnType<typeof useGenerate>;
+
+const [ElementGenerationContext, useElementGeneration] =
+	createRequiredContext<ElementGeneration>("ElementGenerationContext");
+export { useElementGeneration };
+
+// One subscription, one staleness check and one restore effect per element card.
+// Children are passed through untouched, so a queue tick re-renders only the
+// consumers below, not the Slate-managed subtree.
+export function ElementGenerationProvider({
+	element,
+	children,
+}: {
+	element: CanvasContentElement;
+	children: ReactNode;
+}) {
+	const generation = useGenerate(element);
+	return (
+		<ElementGenerationContext value={generation}>
+			{children}
+		</ElementGenerationContext>
+	);
+}

--- a/app/components/canvas/elements/ElementUploadButton.tsx
+++ b/app/components/canvas/elements/ElementUploadButton.tsx
@@ -1,27 +1,18 @@
 "use client";
 
-import { useConfig } from "@/lib/config/ConfigProvider";
-import {
-	useGenerationQueue,
-	useQueueSelector,
-} from "@/lib/generation/GenerationQueueProvider";
-import { getGenerationInputs } from "@/lib/generation/getGenerationInputs";
-import { useProjectStore } from "@/lib/project/store";
+import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
 import { UploadImageButton } from "@/lib/upload/UploadImageButton";
 import { ELEMENT_CONFIGS } from "@/lib/canvas/elementConfigs";
 import type { CanvasContentElement } from "@/lib/canvas/types";
+import { useElementGeneration } from "./ElementGenerationContext";
 
 export function ElementUploadButton({
 	element,
 }: {
 	element: CanvasContentElement;
 }) {
-	const { projectId } = useConfig();
 	const queue = useGenerationQueue();
-	const status = useQueueSelector(
-		(q) => q.getElementSnapshot(element.id).status,
-	);
-	const metadata = useProjectStore(projectId, (s) => s.metadata);
+	const { status, inputs } = useElementGeneration();
 	const busy = status === "generating" || status === "queued";
 
 	return (
@@ -34,7 +25,7 @@ export function ElementUploadButton({
 				queue.commitResult(
 					element.id,
 					{ imageUrl: url, durationSec: 0 },
-					getGenerationInputs(element, metadata),
+					inputs,
 					ELEMENT_CONFIGS[element.type].connector,
 				);
 			}}

--- a/app/components/canvas/elements/GenerateButton.tsx
+++ b/app/components/canvas/elements/GenerateButton.tsx
@@ -4,9 +4,8 @@ import { AlertCircle, Hourglass, Sparkles } from "@/components/ui/icon";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
-import type { CanvasContentElement } from "@/lib/canvas/types";
 import type { GenerationStatus } from "@/lib/generation/queue";
-import { useGenerate } from "../hooks/useGenerate";
+import { useElementGeneration } from "./ElementGenerationContext";
 
 export function StaleIndicator() {
 	return (
@@ -19,12 +18,8 @@ export function StaleIndicator() {
 	);
 }
 
-export function ElementStaleIndicator({
-	element,
-}: {
-	element: CanvasContentElement;
-}) {
-	const { stale } = useGenerate(element);
+export function ElementStaleIndicator() {
+	const { stale } = useElementGeneration();
 	if (!stale) return null;
 	return <StaleIndicator />;
 }
@@ -71,12 +66,8 @@ export function GenerateButton({
 	);
 }
 
-export function ElementGenerateButton({
-	element,
-}: {
-	element: CanvasContentElement;
-}) {
-	const { hasPrompt, hasResult, status, generate } = useGenerate(element);
+export function ElementGenerateButton() {
+	const { hasPrompt, hasResult, status, generate } = useElementGeneration();
 	return (
 		<GenerateButton
 			status={status}

--- a/app/components/canvas/elements/OutputPreview.tsx
+++ b/app/components/canvas/elements/OutputPreview.tsx
@@ -1,14 +1,9 @@
 import { memo } from "react";
 import { ELEMENT_TYPES, type CanvasContentElement } from "@/lib/canvas/types";
-import { useGenerate } from "../hooks/useGenerate";
 import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
-import {
-	AudioResult,
-	AudioPlaceholder,
-	MediaPreview,
-	MediaPlaceholder,
-} from "./preview/results";
+import { AudioResult, AudioPlaceholder, MediaResult } from "./preview/results";
 import { AnimatedImagePreview } from "./preview/AnimatedImagePreview";
+import { useElementGeneration } from "./ElementGenerationContext";
 
 function OutputPreviewComponent({
 	element,
@@ -17,7 +12,8 @@ function OutputPreviewComponent({
 }) {
 	const type = element.type;
 	const { outputKind } = ELEMENT_TYPES[type];
-	const { status, seconds, result, error, discard } = useGenerate(element);
+	const { status, seconds, result, error, discard } = useElementGeneration();
+	const state = { status, seconds, error, onDiscard: discard };
 
 	if (outputKind === "audio") {
 		if (result?.audioUrl) {
@@ -25,48 +21,24 @@ function OutputPreviewComponent({
 				<AudioResult src={result.audioUrl} status={status} seconds={seconds} />
 			);
 		}
-		return (
-			<AudioPlaceholder
-				status={status}
-				seconds={seconds}
-				error={error}
-				onDiscard={discard}
-			/>
-		);
+		return <AudioPlaceholder {...state} />;
 	}
 
 	if (type === "animated_image") {
 		return (
 			<AnimatedImagePreview
+				{...state}
 				imageUrl={result?.imageUrl}
 				videoUrl={result?.videoUrl}
-				status={status}
-				seconds={seconds}
-				error={error}
-				onDiscard={discard}
-			/>
-		);
-	}
-
-	const url = getPrimaryUrl(result, outputKind);
-	if (url) {
-		return (
-			<MediaPreview
-				key={url}
-				url={url}
-				outputKind={outputKind}
-				status={status}
-				seconds={seconds}
 			/>
 		);
 	}
 
 	return (
-		<MediaPlaceholder
-			status={status}
-			seconds={seconds}
-			error={error}
-			onDiscard={discard}
+		<MediaResult
+			{...state}
+			url={getPrimaryUrl(result, outputKind)}
+			outputKind={outputKind}
 		/>
 	);
 }

--- a/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
+++ b/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Image as ImageIcon, Video } from "@/components/ui/icon";
 import { MediaToggle } from "@/components/ui/media-toggle";
-import { MediaPreview, MediaPlaceholder } from "./results";
+import { MediaResult } from "./results";
 import type { PlaceholderProps } from "./status";
 
 type AnimatedImagePreviewProps = PlaceholderProps & {
@@ -14,33 +14,18 @@ type AnimatedImagePreviewProps = PlaceholderProps & {
 export function AnimatedImagePreview({
 	imageUrl,
 	videoUrl,
-	status,
-	seconds,
-	error,
-	onDiscard,
+	...state
 }: AnimatedImagePreviewProps) {
 	const [mode, setMode] = useState<"animated" | "still">("animated");
-	const url = mode === "animated" ? videoUrl : imageUrl;
 
 	return (
 		<div className="relative w-full">
-			{url ? (
-				<MediaPreview
-					key={url}
-					url={url}
-					outputKind={mode === "animated" ? "video" : "image"}
-					status={status}
-					seconds={seconds}
-				/>
-			) : (
-				<MediaPlaceholder
-					status={status}
-					seconds={seconds}
-					error={error}
-					onDiscard={onDiscard}
-					cancelClassName="top-10"
-				/>
-			)}
+			<MediaResult
+				{...state}
+				url={mode === "animated" ? videoUrl : imageUrl}
+				outputKind={mode === "animated" ? "video" : "image"}
+				cancelClassName="top-10"
+			/>
 			<MediaToggle
 				className="absolute top-2 right-2 z-10 shadow-sm"
 				value={mode}

--- a/app/components/canvas/elements/preview/__tests__/cancelClassName.test.tsx
+++ b/app/components/canvas/elements/preview/__tests__/cancelClassName.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AnimatedImagePreview } from "../AnimatedImagePreview";
-import { MediaPlaceholder } from "../results";
+import { MediaResult } from "../results";
 
 const withTooltip = (node: React.ReactNode) =>
 	renderToStaticMarkup(<TooltipProvider>{node}</TooltipProvider>);
@@ -15,10 +15,12 @@ const cancelButtonClass = (html: string) => {
 	return match[1];
 };
 
-describe("MediaPlaceholder cancelClassName forwarding", () => {
+describe("MediaResult cancelClassName forwarding", () => {
 	it("defaults to top-2 when cancelClassName is unset", () => {
 		const html = withTooltip(
-			<MediaPlaceholder
+			<MediaResult
+				url={undefined}
+				outputKind="image"
 				status="generating"
 				seconds={1}
 				error={null}
@@ -30,7 +32,9 @@ describe("MediaPlaceholder cancelClassName forwarding", () => {
 
 	it("forwards cancelClassName through to the cancel button", () => {
 		const html = withTooltip(
-			<MediaPlaceholder
+			<MediaResult
+				url={undefined}
+				outputKind="image"
 				status="generating"
 				seconds={1}
 				error={null}
@@ -39,6 +43,21 @@ describe("MediaPlaceholder cancelClassName forwarding", () => {
 			/>,
 		);
 		expect(cancelButtonClass(html)).toContain("top-10");
+	});
+
+	it("renders the media instead of the placeholder once a url arrives", () => {
+		const html = withTooltip(
+			<MediaResult
+				url="https://cdn.example.com/a.png"
+				outputKind="image"
+				status="idle"
+				seconds={0}
+				error={null}
+				onDiscard={() => {}}
+			/>,
+		);
+		expect(html).not.toContain('aria-label="Cancel generation"');
+		expect(html).toContain("https://cdn.example.com/a.png");
 	});
 });
 

--- a/app/components/canvas/elements/preview/results.tsx
+++ b/app/components/canvas/elements/preview/results.tsx
@@ -74,6 +74,30 @@ export function MediaPlaceholder(
 	);
 }
 
+export function MediaResult({
+	url,
+	outputKind,
+	cancelClassName,
+	...state
+}: PlaceholderProps & {
+	url: string | undefined;
+	outputKind: "image" | "video";
+	cancelClassName?: string;
+}) {
+	if (!url) {
+		return <MediaPlaceholder {...state} cancelClassName={cancelClassName} />;
+	}
+	return (
+		<MediaPreview
+			key={url}
+			url={url}
+			outputKind={outputKind}
+			status={state.status}
+			seconds={state.seconds}
+		/>
+	);
+}
+
 export function MediaPreview({
 	url,
 	outputKind,

--- a/app/components/canvas/hooks/useGenerate.ts
+++ b/app/components/canvas/hooks/useGenerate.ts
@@ -46,6 +46,7 @@ export function useGenerate(element: CanvasContentElement) {
 		result: snapshot.result,
 		error: snapshot.error,
 		stale,
+		inputs: currentInputs,
 		hasPrompt: Boolean(currentInputs.prompt),
 		hasResult: Boolean(snapshot.result),
 		generate,


### PR DESCRIPTION
## App understanding

OpenSlop turns a prompt into a rendered video. An LLM streams OSML into a SlateJS canvas; each element (image, video, tts, music, sfx) is generated client-side through a **connector → gateway → provider** pipeline, results land in Vercel Blob, and the composition renders via Remotion Lambda. Project state (script + store + generation snapshots) persists to a Supabase `projects` row.

The canvas is the heart of the app: `renderCanvasElement` → `ElementContainer` draws each element card with its prompt editor on the left and its generated output preview on the right, plus a footer row of generate / upload / animate / stale controls.

## From-scratch architecture

An element card has exactly one piece of live state: *what is the generation queue currently saying about this element?* A rebuild would establish that once at the card boundary and let every control read it. It would also express "show the media, or show a placeholder" once, not once per call site.

The current code did the opposite. `useGenerate(element)` was called **three separate times** inside a single element card (`OutputPreview`, `ElementStaleIndicator`, `ElementGenerateButton`), with `ElementUploadButton` maintaining a fourth, independent queue subscription. Each call independently rebuilt `getGenerationInputs`, re-ran the `isStaleResult` deep-equal, and mounted its own `restoreResult` effect — four subscriptions and three duplicate effects per element, multiplied by every element on the canvas.

## Implemented simplifications

**1. One generation state per element card.** New `ElementGenerationProvider` calls `useGenerate` once at the card boundary and exposes it via `useElementGeneration`. `OutputPreview`, `ElementStaleIndicator`, `ElementGenerateButton` and `ElementUploadButton` now read from it.

- 4 queue subscriptions → 1
- 3 `restoreResult` effects → 1
- 3 `getGenerationInputs` memos + `isStaleResult` deep-equals → 1
- `ElementUploadButton` drops its duplicate `useConfig`/`useProjectStore`/`getGenerationInputs` wiring and reuses the memoized inputs
- `ElementStaleIndicator` / `ElementGenerateButton` no longer need an `element` prop at all

The provider passes `children` through untouched, so a queue tick re-renders only the consumers below it, never the Slate-managed subtree. This preserves the editor-shell render isolation landed in #413.

**2. One place that decides media-vs-placeholder.** `url ? <MediaPreview> : <MediaPlaceholder>` existed verbatim in both `OutputPreview` and `AnimatedImagePreview`. Both now render `MediaResult`, which owns that branch (including the `key={url}` remount and `cancelClassName` forwarding). `OutputPreview` shrinks from a 4-branch prop-spelling exercise to a 3-line dispatch on `outputKind`.

Net: −152 / +171 lines, most of the additions being the new provider module and an added test.

## Validation

| Check | Result |
| --- | --- |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm run knip` | pass |
| `npm run build` | pass |
| `npm run test:run` | 891 passed / 103 files |
| `npm run test:e2e` | **not run** — port 3000 held by an unrelated dev server on the runner |

The Playwright smoke suite covers app copy and routes; this change touches neither. Test coverage was extended: `cancelClassName.test.tsx` now targets `MediaResult` (the real surface) and adds a case asserting the placeholder gives way to media once a url arrives.

## Open PR overlap check

Reviewed all 19 open PRs (#416, #417, #418, #419, #420, #421, #422, #429, #430, #431, #432, #433, #434, #435, #438, #439, #440, #441, #442) and their file lists.

This PR is non-overlapping — **zero** files in common with any open PR. Two candidate targets were deliberately dropped for overlap:

- The `lib/generation` input-pipeline consolidation (`getGenerationInputs.ts` / `getPromptText.ts` / `scheduleGeneration.ts` merge) would have touched `lib/generation/queue.ts`, owned by #429 and #433.
- `MediaPreview` / `MediaPlaceholder` were kept exported rather than made private, because their only remaining external consumer is `CharacterEditModal.tsx`, owned by #439.

## Skipped items / risks

- **`cancelClassName` is still drilled 4 levels** (`AnimatedImagePreview` → `MediaResult` → `MediaPlaceholder` → `PlaceholderOverlay` → `CancelButton`). Removing it properly means a `<Placeholder variant>` compound component; deferred as it is a layout concern with its own test surface, not an architectural one.
- **Status predicates are still inlined** (`status !== "idle"` in 6 places, `=== "generating"` in 7). `queue.ts` already has a private `isActive`, but that file is owned by open PRs — worth revisiting once #429/#433 land.
- `ForegroundPreview` keeps its own `useGenerate` call. It renders scene-level previews outside `ElementContainer`, so it has no provider to read from and its chrome genuinely differs.
- The `ElementContainer.tsx` diff looks larger than it is: most of it is re-indentation from the new provider wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)