### PR TITLE
fix: nightly bug fixes 2026-07-21

### DIFF
--- a/app/components/canvas/__tests__/withNodeId.test.ts
+++ b/app/components/canvas/__tests__/withNodeId.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { createEditor, Transforms, Element, Editor } from "slate";
 import { withReact } from "slate-react";
+import { HistoryEditor, withHistory } from "slate-history";
 import { withNodeId } from "../plugins/withNodeId";
+import type { CanvasEditor } from "@/lib/canvas/types";
 
 function makeEditor() {
 	const editor = withNodeId(withReact(createEditor()));
@@ -59,6 +61,34 @@ describe("withNodeId", () => {
 			expect(first.id).toBeDefined();
 			expect(second.id).toBeDefined();
 			expect(first.id).not.toBe(second.id);
+		});
+	});
+
+	describe("undo of a merge", () => {
+		it("restores the merged-away element's original ID", () => {
+			const editor = withNodeId(
+				withReact(withHistory(createEditor())),
+			) as CanvasEditor & HistoryEditor;
+			editor.children = [
+				{
+					id: "a",
+					type: "narration",
+					children: [{ id: "at", type: "narration", text: "first" }],
+				},
+				{
+					id: "b",
+					type: "image",
+					customAttributes: { url: "https://cdn/b.png" },
+					children: [{ id: "bt", type: "image", text: "second" }],
+				},
+			] as unknown as Element[];
+
+			// Backspace at the start of "b" merges it into "a".
+			Transforms.select(editor, { path: [1, 0], offset: 0 });
+			editor.deleteBackward("character");
+			HistoryEditor.undo(editor);
+
+			expect(editor.children.map((n) => (n as Element).id)).toEqual(["a", "b"]);
 		});
 	});
 

--- a/app/components/canvas/plugins/withNodeId.ts
+++ b/app/components/canvas/plugins/withNodeId.ts
@@ -2,6 +2,7 @@ import { ReactEditor } from "slate-react";
 import type { CanvasEditor } from "@/lib/canvas/types";
 import {
 	assignIdRecursively,
+	isNodeIdTaken,
 	makeNodeId,
 	stripIds,
 } from "@/lib/canvas/nodeUtils";
@@ -19,8 +20,15 @@ export const withNodeId = (editor: ReactEditor): CanvasEditor => {
 			return apply(operation);
 		}
 
+		// A split copies the original node's properties onto the new half, so it
+		// needs a fresh id. History replays the inverse of a merge as a split
+		// carrying the merged-away node's id, which is free again — reusing it
+		// keeps the element's generated assets attached across undo.
 		if (operation.type === "split_node") {
-			operation.properties.id = makeNodeId();
+			const { id } = operation.properties;
+			if (typeof id !== "string" || isNodeIdTaken(editor, id)) {
+				operation.properties.id = makeNodeId();
+			}
 			return apply(operation);
 		}
 

--- a/lib/canvas/nodeUtils.ts
+++ b/lib/canvas/nodeUtils.ts
@@ -1,7 +1,16 @@
-import { Element, Node } from "slate";
+import { Editor, Element, Node } from "slate";
 import { nanoid } from "nanoid";
 
 export const makeNodeId = () => nanoid(16);
+
+/** Whether any node in the document — element or text — already claims `id`. */
+export const isNodeIdTaken = (editor: Editor, id: string): boolean => {
+	const [match] = Editor.nodes(editor, {
+		at: [],
+		match: (n) => !Editor.isEditor(n) && (n as { id?: string }).id === id,
+	});
+	return match !== undefined;
+};
 
 export const stripIds = (node: Node): Node => {
 	if (Element.isElement(node)) {

--- a/lib/providers/__tests__/anthropic-llm.test.ts
+++ b/lib/providers/__tests__/anthropic-llm.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 const mockCreate = vi.fn();
 const mockStream = vi.fn();
+const mockConstruct = vi.fn();
 
 vi.mock("@anthropic-ai/sdk", () => ({
 	default: class {
 		messages = { create: mockCreate, stream: mockStream };
+		constructor(options: unknown) {
+			mockConstruct(options);
+		}
 	},
 }));
 
@@ -150,6 +154,45 @@ describe("AnthropicLLM", () => {
 				}),
 			).rejects.toThrow(/media type "image\/svg\+xml" is not supported/);
 			expect(mockCreate).not.toHaveBeenCalled();
+		});
+
+		// The SDK refuses non-streaming calls whose max_tokens implies a >10min
+		// completion unless the client sets an explicit timeout, and it throws
+		// locally before any request. Replay our real client options and request
+		// body through the real SDK so raising max_tokens (or dropping the
+		// timeout) fails here rather than 500ing every non-streaming call.
+		it("builds a non-streaming request the real SDK will actually send", async () => {
+			mockCreate.mockResolvedValue({
+				content: [{ type: "text", text: "ok" }],
+				model: "claude-opus-4-8",
+				usage: { input_tokens: 1, output_tokens: 1 },
+			});
+			await new AnthropicLLM("test-key").generate({ prompt: "hi" });
+
+			const { default: RealAnthropic } =
+				await vi.importActual<typeof import("@anthropic-ai/sdk")>(
+					"@anthropic-ai/sdk",
+				);
+			const fetch = vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							content: [{ type: "text", text: "ok" }],
+							model: "claude-opus-4-8",
+							usage: { input_tokens: 1, output_tokens: 1 },
+						}),
+						{ headers: { "content-type": "application/json" } },
+					),
+			);
+			const client = new RealAnthropic({
+				...mockConstruct.mock.calls[0][0],
+				fetch,
+			});
+
+			await expect(
+				client.messages.create(mockCreate.mock.calls[0][0]),
+			).resolves.toBeDefined();
+			expect(fetch).toHaveBeenCalled();
 		});
 
 		it("concatenates multiple text blocks", async () => {

--- a/lib/providers/llm/anthropic.ts
+++ b/lib/providers/llm/anthropic.ts
@@ -15,6 +15,8 @@ const SUPPORTED_IMAGE_MEDIA_TYPES = [
 
 type SupportedImageMediaType = (typeof SUPPORTED_IMAGE_MEDIA_TYPES)[number];
 
+const NON_STREAMING_TIMEOUT_MS = 10 * 60 * 1000;
+
 function isSupportedMediaType(value: string): value is SupportedImageMediaType {
 	return (SUPPORTED_IMAGE_MEDIA_TYPES as readonly string[]).includes(value);
 }
@@ -54,7 +56,10 @@ export class AnthropicLLM extends BaseProvider<
 
 	constructor(apiKey: string) {
 		super();
-		this.client = new Anthropic({ apiKey });
+		// Without an explicit timeout the SDK derives one from `max_tokens` for
+		// non-streaming calls and throws outright above ~21k tokens, which our
+		// default exceeds. Opt in to its 10-minute ceiling instead.
+		this.client = new Anthropic({ apiKey, timeout: NON_STREAMING_TIMEOUT_MS });
 	}
 
 	protected toFiles() {

--- a/lib/script/refine/__tests__/applyOps.test.ts
+++ b/lib/script/refine/__tests__/applyOps.test.ts
@@ -217,6 +217,59 @@ describe("applyRefineOp — insert", () => {
 		expect(texts).toEqual(["first", "A", "B", "C"]);
 	});
 
+	it("stacks consecutive before-inserts at the same anchor in order", () => {
+		const editor = makeEditor([scene([content("narration", "n1", "first")])]);
+		const anchorMap: Record<string, string> = {};
+
+		for (const text of ["A", "B", "C"]) {
+			applyRefineOp(
+				editor,
+				{
+					op: "insert",
+					anchor_id: "n1",
+					position: "before",
+					type: "sound",
+					text,
+				},
+				anchorMap,
+				connectors,
+			);
+		}
+
+		const texts = getContentTexts(editor);
+		expect(texts).toEqual(["A", "B", "C", "first"]);
+	});
+
+	it("keeps each side of an anchor independent when mixing before and after", () => {
+		const editor = makeEditor([scene([content("narration", "n1", "first")])]);
+		const anchorMap: Record<string, string> = {};
+
+		const ops = [
+			{ position: "before", text: "before-1" },
+			{ position: "after", text: "after-1" },
+			{ position: "before", text: "before-2" },
+			{ position: "after", text: "after-2" },
+		] as const;
+
+		for (const { position, text } of ops) {
+			applyRefineOp(
+				editor,
+				{ op: "insert", anchor_id: "n1", position, type: "sound", text },
+				anchorMap,
+				connectors,
+			);
+		}
+
+		const texts = getContentTexts(editor);
+		expect(texts).toEqual([
+			"before-1",
+			"before-2",
+			"first",
+			"after-1",
+			"after-2",
+		]);
+	});
+
 	it("falls back to append when anchor_id not found", () => {
 		const editor = makeEditor([scene([content("narration", "n1", "hello")])]);
 		const anchorMap: Record<string, string> = {};
@@ -552,8 +605,8 @@ describe("applyRefineOp — mixed operations", () => {
 			anchorMap,
 			connectors,
 		);
-		// Remove the inserted node — anchorMap["n1"] is now stale
-		const insertedId = anchorMap["n1"];
+		// Remove the inserted node — the "after n1" cursor is now stale
+		const insertedId = anchorMap["after:n1"];
 		applyRefineOp(
 			editor,
 			{ op: "remove", id: insertedId },
@@ -582,7 +635,7 @@ describe("applyRefineOp — mixed operations", () => {
 			anchorMap,
 			connectors,
 		);
-		const staleId = anchorMap["n1"];
+		const staleId = anchorMap["after:n1"];
 		applyRefineOp(editor, { op: "remove", id: staleId }, anchorMap, connectors);
 		// After fallback, the stale mapping should be cleared
 		applyRefineOp(

--- a/lib/script/refine/applyOps.ts
+++ b/lib/script/refine/applyOps.ts
@@ -31,6 +31,13 @@ export function applyRefineOp(
 	});
 }
 
+// Consecutive inserts stack in stream order, so each one lands just after the
+// one before it. The cursor is per side of the anchor: an "after" insert must
+// not shift where a later "before" insert on the same anchor goes, or the
+// element ends up on the wrong side of it.
+const stackKey = (op: Extract<RefineOp, { op: "insert" }>) =>
+	`${op.position ?? "after"}:${op.anchor_id}`;
+
 function resolveInsertPath(
 	editor: Editor,
 	op: Extract<RefineOp, { op: "insert" }>,
@@ -40,9 +47,11 @@ function resolveInsertPath(
 		return op.position === "before" ? [0, 0] : [editor.children.length];
 	}
 
-	const resolvedId = anchorMap[op.anchor_id] ?? op.anchor_id;
-	const entry =
-		findNodeById(editor, resolvedId) ?? findNodeById(editor, op.anchor_id);
+	const stackedId = anchorMap[stackKey(op)];
+	const stacked = stackedId ? findNodeById(editor, stackedId) : null;
+	if (stacked) return Path.next(stacked[1]);
+
+	const entry = findNodeById(editor, op.anchor_id);
 	if (!entry) return [editor.children.length];
 
 	return op.position === "before" ? entry[1] : Path.next(entry[1]);
@@ -61,7 +70,7 @@ function applyInsert(
 	});
 
 	if (op.anchor_id) {
-		anchorMap[op.anchor_id] = id;
+		anchorMap[stackKey(op)] = id;
 	}
 }
 


### PR DESCRIPTION
Three verified correctness bugs. Each fix ships with a regression test that fails without it (confirmed by stashing the fix and re-running).

## 1. Refine inserts ignored `position` when stacking

`lib/script/refine/applyOps.ts`

The anchor cursor that makes consecutive inserts stack in stream order was keyed by anchor id alone, but consumed for both directions. An `after` insert therefore moved where a later `before` insert on the same anchor landed, and vice versa.

Reproduced against real Slate, doc `scene[ n1("first") ]`, both ops anchored on `n1`:

| ops | before fix | expected |
|---|---|---|
| `before A`, `before B` | `["B", "A", "first"]` | `["A", "B", "first"]` |
| `before A`, `after B` | `["A", "B", "first"]` — **B ends up before n1** | `["A", "first", "B"]` |
| `after A`, `before B` | `["first", "B", "A"]` — **B ends up after n1** | `["B", "first", "A"]` |

Rows 2 and 3 are the bad ones: the op says "after n1" and the element lands on the other side of `n1`.

Reachable because the refine system prompt documents `position` as `before|after` and explicitly tells the model to "emit all operations for a given location consecutively" — a sound before and a narration after the same anchor is the encouraged output shape.

Fix: key the cursor per side of the anchor, so the two directions stop interfering.

## 2. Undoing a merge minted a new element id, orphaning its generated asset

`app/components/canvas/plugins/withNodeId.ts`

Slate replays the inverse of a `merge_node` as a `split_node` carrying the merged-away node's original properties, including its id. The plugin overwrote `properties.id` unconditionally, so undo restored the element under a brand-new id.

Generation state is keyed strictly by element id, so: generate an image on an element, put the caret at its start, press Backspace, then Ctrl+Z. The element returns with its queue snapshot orphaned and the generated preview gone — and autosave then persists `generation` under the dead id, so the loss survives reload. Cycling undo/redo mints another id each pass.

Fix: the real invariant is id uniqueness, not "splits always mint". Mint only when the incoming id is still taken — a forward split collides (the first half keeps it) and gets a fresh id as before; an undone merge does not collide and keeps its identity.

## 3. Every non-streaming LLM call failed with a 500

`lib/providers/llm/anthropic.ts`

`@anthropic-ai/sdk` derives a timeout from `max_tokens` for non-streaming calls when the client sets none, and throws locally above ~21,333 tokens. Our default is `65536`, so the request never reached the network.

Verified against the pinned SDK in `node_modules`:

```
$ node -e "new Anthropic({apiKey:'sk-test'}).messages.create({model:'claude-opus-4-8',max_tokens:65536,...})"
Error: Streaming is required for operations that may take longer than 10 minutes.
    at Anthropic.calculateNonstreamingTimeout (client.js:434:19)
```

So `POST /api/v1/llm` without `stream` always 500'd. The existing test replaced the whole SDK with a stub, so the guard never ran. Streaming was unaffected.

Fix: set an explicit client timeout, opting in to the SDK's own 10-minute ceiling. The new test replays the provider's real client options and real request body through the **real** SDK with a stubbed `fetch`, so raising `max_tokens` or dropping the timeout fails here rather than in production.

## Checks

`npm test` (896 passed, 104 files), `npm run build`, `tsc --noEmit`, `eslint`, `prettier --check` — all clean.

## Open PR overlap check

Considered open PRs #443, #442, #441, #440, #439, #438, #435, #432, #429. Built their combined file list via `gh pr diff --name-only`; intersection with this PR's files is empty.

Deliberately skipped several other candidates that would have overlapped or repeated rejected work: the ZWSP serialization and autosave-on-open findings land in files already covered by closed PRs #418/#431, and the Runware video handler is covered by open #439.