### PR TITLE
refactor: nightly maintainability 2026-07-21

### DIFF
--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, KeyboardEvent } from "react";
-import { Descendant, Editor, Element } from "slate";
+import { Descendant, Editor } from "slate";
 import { Slate, Editable, RenderElementProps } from "slate-react";
 import { DndContext, DragOverlay, pointerWithin } from "@dnd-kit/core";
 import {
@@ -11,6 +11,7 @@ import {
 import { useDragAndDrop } from "./dnd/useDragAndDrop";
 import { DragTransferContext } from "./dnd/DragTransferContext";
 import type { CanvasContentElement } from "@/lib/canvas/types";
+import { findElementById } from "@/lib/canvas/editorOps";
 import { isSceneElement } from "@/lib/canvas/scenes";
 import { SortableScene } from "./dnd/SortableScene";
 import { SortableContent } from "./dnd/SortableContent";
@@ -57,16 +58,13 @@ export default function Canvas({
 		);
 	}, []);
 
-	const activeElement = useMemo(() => {
-		if (!activeId) {
-			return null;
-		}
-		const [entry] = Editor.nodes(editor, {
-			at: [],
-			match: (n) => Element.isElement(n) && n.id === activeId,
-		});
-		return entry?.[0] as Descendant;
-	}, [editor, activeId]);
+	const activeElement = useMemo(
+		() =>
+			activeId
+				? (findElementById(editor, String(activeId))?.[0] ?? null)
+				: null,
+		[editor, activeId],
+	);
 
 	return (
 		<DragTransferContext value={dragTransfer}>

--- a/app/components/canvas/dnd/SortableActions.tsx
+++ b/app/components/canvas/dnd/SortableActions.tsx
@@ -25,7 +25,7 @@ export function SortableActions<K extends string>({
 }: SortableActionsProps<K>) {
 	return (
 		<>
-			{options?.length && onInsert && (
+			{onInsert && options && options.length > 0 && (
 				<ActionMenu
 					items={options.map((option) => ({
 						key: option.key,

--- a/app/components/canvas/dnd/SortableContent.tsx
+++ b/app/components/canvas/dnd/SortableContent.tsx
@@ -68,8 +68,8 @@ export function SortableContent({
 			sceneId={sceneId}
 			sortableType="content"
 			wrapperStyle={wrapperStyle}
-			insertOptions={collapsed ? undefined : INSERT_OPTIONS}
-			onInsert={collapsed ? undefined : handleInsert}
+			insertOptions={INSERT_OPTIONS}
+			onInsert={handleInsert}
 			disabled={collapsed}
 			attributes={attributes}
 			element={element}

--- a/app/components/canvas/dnd/useDragAndDrop.ts
+++ b/app/components/canvas/dnd/useDragAndDrop.ts
@@ -9,7 +9,9 @@ import {
 	useSensor,
 	useSensors,
 } from "@dnd-kit/core";
-import { Descendant, Editor, Element, Path, Transforms } from "slate";
+import { Descendant, Editor } from "slate";
+import { moveDraggedElement } from "@/lib/canvas/dragOps";
+import { findElementById } from "@/lib/canvas/editorOps";
 import { isSceneElement } from "@/lib/canvas/scenes";
 import type { DragTransfer } from "./DragTransferContext";
 
@@ -44,10 +46,7 @@ export function useDragAndDrop(editor: Editor, value: Descendant[]) {
 				return;
 			}
 
-			const [overEntry] = Editor.nodes(editor, {
-				at: [],
-				match: (n) => Element.isElement(n) && n.id === over.id,
-			});
+			const overEntry = findElementById(editor, String(over.id));
 			if (!overEntry) return;
 
 			const [overNode, overPath] = overEntry;
@@ -72,38 +71,7 @@ export function useDragAndDrop(editor: Editor, value: Descendant[]) {
 
 			if (!over?.id || active.id === over.id) return;
 
-			const [activeEntry] = Editor.nodes(editor, {
-				at: [],
-				match: (n) => Element.isElement(n) && n.id === active.id,
-			});
-			const [overEntry] = Editor.nodes(editor, {
-				at: [],
-				match: (n) => Element.isElement(n) && n.id === over.id,
-			});
-			if (!activeEntry || !overEntry) return;
-
-			const [activeNode, activePath] = activeEntry;
-			const [overNode, overPath] = overEntry;
-
-			if (isSceneElement(activeNode)) {
-				const targetPath = isSceneElement(overNode)
-					? overPath
-					: Path.parent(overPath);
-				if (!Path.equals(activePath, targetPath)) {
-					Transforms.moveNodes(editor, { at: activePath, to: targetPath });
-				}
-				return;
-			}
-
-			if (isSceneElement(overNode)) {
-				Transforms.moveNodes(editor, {
-					at: activePath,
-					to: [...overPath, overNode.children.length],
-				});
-				return;
-			}
-
-			Transforms.moveNodes(editor, { at: activePath, to: overPath });
+			moveDraggedElement(editor, String(active.id), String(over.id));
 		},
 		[editor],
 	);

--- a/lib/canvas/__tests__/dragOps.test.ts
+++ b/lib/canvas/__tests__/dragOps.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { createEditor } from "slate";
+import type { CanvasContentElement, SceneElement } from "@/lib/canvas/types";
+import { moveDraggedElement } from "../dragOps";
+
+function content(id: string): CanvasContentElement {
+	return {
+		id,
+		type: "narration",
+		children: [{ id: `${id}-t`, type: "narration", text: "" }],
+	};
+}
+
+function scene(id: string, children: CanvasContentElement[]): SceneElement {
+	return { id, type: "scene", children };
+}
+
+function makeEditor(scenes: SceneElement[]) {
+	const editor = createEditor();
+	editor.children = scenes;
+	return editor;
+}
+
+const layout = (editor: ReturnType<typeof makeEditor>) =>
+	(editor.children as SceneElement[]).map((s) => [
+		s.id,
+		s.children.map((c) => c.id),
+	]);
+
+describe("moveDraggedElement", () => {
+	it("reorders content within a scene", () => {
+		const editor = makeEditor([scene("s1", [content("a"), content("b")])]);
+		moveDraggedElement(editor, "b", "a");
+		expect(layout(editor)).toEqual([["s1", ["b", "a"]]]);
+	});
+
+	it("appends content dropped onto another scene", () => {
+		const editor = makeEditor([
+			scene("s1", [content("a"), content("b")]),
+			scene("s2", [content("c")]),
+		]);
+		moveDraggedElement(editor, "a", "s2");
+		expect(layout(editor)).toEqual([
+			["s1", ["b"]],
+			["s2", ["c", "a"]],
+		]);
+	});
+
+	it("moves content into the target's slot in another scene", () => {
+		const editor = makeEditor([
+			scene("s1", [content("a"), content("z")]),
+			scene("s2", [content("b"), content("c")]),
+		]);
+		moveDraggedElement(editor, "a", "c");
+		expect(layout(editor)).toEqual([
+			["s1", ["z"]],
+			["s2", ["b", "a", "c"]],
+		]);
+	});
+
+	it("reorders scenes", () => {
+		const editor = makeEditor([
+			scene("s1", [content("a")]),
+			scene("s2", [content("b")]),
+		]);
+		moveDraggedElement(editor, "s2", "s1");
+		expect(layout(editor)).toEqual([
+			["s2", ["b"]],
+			["s1", ["a"]],
+		]);
+	});
+
+	it("targets the parent scene when a scene is dropped on content", () => {
+		const editor = makeEditor([
+			scene("s1", [content("a")]),
+			scene("s2", [content("b")]),
+		]);
+		moveDraggedElement(editor, "s2", "a");
+		expect(layout(editor)).toEqual([
+			["s2", ["b"]],
+			["s1", ["a"]],
+		]);
+	});
+
+	it("no-ops when a scene is dropped on its own content", () => {
+		const editor = makeEditor([
+			scene("s1", [content("a")]),
+			scene("s2", [content("b")]),
+		]);
+		moveDraggedElement(editor, "s1", "a");
+		expect(layout(editor)).toEqual([
+			["s1", ["a"]],
+			["s2", ["b"]],
+		]);
+	});
+
+	it("no-ops when either id is missing", () => {
+		const editor = makeEditor([scene("s1", [content("a")])]);
+		moveDraggedElement(editor, "a", "gone");
+		moveDraggedElement(editor, "gone", "a");
+		expect(layout(editor)).toEqual([["s1", ["a"]]]);
+	});
+});

--- a/lib/canvas/__tests__/editorOps.test.ts
+++ b/lib/canvas/__tests__/editorOps.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { createEditor, Editor } from "slate";
 import type { CanvasContentElement, SceneElement } from "@/lib/canvas/types";
-import { findNodeById, updateNodeText, setNodeAttrs } from "../editorOps";
+import {
+	findElementById,
+	findNodeById,
+	updateNodeText,
+	setNodeAttrs,
+} from "../editorOps";
 
 function content(
 	type: CanvasContentElement["type"],
@@ -47,6 +52,33 @@ describe("findNodeById", () => {
 	it("does not match scene elements", () => {
 		const editor = makeEditor([scene([content("narration", "n1")], "s1")]);
 		expect(findNodeById(editor, "s1")).toBeNull();
+	});
+});
+
+describe("findElementById", () => {
+	it("finds a content element by id", () => {
+		const editor = makeEditor([
+			scene([content("narration", "n1"), content("image", "img1")]),
+		]);
+		expect(findElementById(editor, "img1")?.[1]).toEqual([0, 1]);
+	});
+
+	it("finds a scene by id", () => {
+		const editor = makeEditor([
+			scene([content("narration", "n1")], "s1"),
+			scene([content("image", "img1")], "s2"),
+		]);
+		expect(findElementById(editor, "s2")?.[1]).toEqual([1]);
+	});
+
+	it("does not match text leaves", () => {
+		const editor = makeEditor([scene([content("narration", "n1")])]);
+		expect(findElementById(editor, "n1-t")).toBeNull();
+	});
+
+	it("returns null for nonexistent id", () => {
+		const editor = makeEditor([scene([content("narration", "n1")])]);
+		expect(findElementById(editor, "nope")).toBeNull();
 	});
 });
 

--- a/lib/canvas/dragOps.ts
+++ b/lib/canvas/dragOps.ts
@@ -1,0 +1,34 @@
+import { Editor, Path, Transforms } from "slate";
+import { findElementById } from "./editorOps";
+import { isSceneElement } from "./scenes";
+
+/**
+ * Where a dragged element lands when dropped on `overId`. Scenes reorder among
+ * scenes (dropping on content targets its parent scene); content dropped on a
+ * scene appends to that scene, and content dropped on content takes its slot.
+ * No-ops when either id is gone or a scene is already in the target slot.
+ */
+export function moveDraggedElement(
+	editor: Editor,
+	activeId: string,
+	overId: string,
+): void {
+	const activeEntry = findElementById(editor, activeId);
+	const overEntry = findElementById(editor, overId);
+	if (!activeEntry || !overEntry) return;
+
+	const [activeNode, activePath] = activeEntry;
+	const [overNode, overPath] = overEntry;
+
+	if (isSceneElement(activeNode)) {
+		const to = isSceneElement(overNode) ? overPath : Path.parent(overPath);
+		if (Path.equals(activePath, to)) return;
+		Transforms.moveNodes(editor, { at: activePath, to });
+		return;
+	}
+
+	const to = isSceneElement(overNode)
+		? [...overPath, overNode.children.length]
+		: overPath;
+	Transforms.moveNodes(editor, { at: activePath, to });
+}

--- a/lib/canvas/editorOps.ts
+++ b/lib/canvas/editorOps.ts
@@ -1,6 +1,18 @@
-import { Editor, type NodeEntry, type Path, Transforms } from "slate";
-import type { CanvasContentElement } from "@/lib/canvas/types";
+import { Editor, Element, type NodeEntry, type Path, Transforms } from "slate";
+import type { CanvasContentElement, CanvasElement } from "@/lib/canvas/types";
 import { isContentElement } from "./guards";
+
+/** Any canvas element by id — scenes included. Use {@link findNodeById} when only content will do. */
+export function findElementById(
+	editor: Editor,
+	id: string,
+): NodeEntry<CanvasElement> | null {
+	const [entry] = Editor.nodes<CanvasElement>(editor, {
+		at: [],
+		match: (n) => Element.isElement(n) && n.id === id,
+	});
+	return entry ?? null;
+}
 
 export function findNodeById(
 	editor: Editor,


### PR DESCRIPTION
Gives the canvas drag/drop seam a tested home in the domain layer. No behavior change.

## Architecture

- **`lib/canvas/editorOps.ts` — new `findElementById`.** "Find a canvas element by id (scenes included)" was hand-rolled four times in the UI layer as `Editor.nodes(editor, { at: [], match: (n) => Element.isElement(n) && n.id === id })` — once in `Canvas.tsx` and three times in `useDragAndDrop.ts`. One knowledge, one home, next to the existing content-only `findNodeById`.
- **`lib/canvas/dragOps.ts` — new sister module** holding `moveDraggedElement`, the drop policy lifted verbatim out of `handleDragEnd`. Drop rules (scenes reorder among scenes; content dropped on a scene appends; content dropped on content takes its slot) are domain knowledge, not React state, and were previously untestable inside a `useCallback`.

## Maintainability

- `useDragAndDrop` is now React state wiring only. `handleDragEnd` goes from four branches and two inline node lookups to one call; `slate`'s `Element`, `Path`, and `Transforms` imports drop out of the hook entirely.
- `SortableContent`: dropped the redundant `collapsed ? undefined :` guards on `insertOptions`/`onInsert`. `SortableItem` already renders `SortableActions` only when `!disabled`, and `disabled={collapsed}` carries the same fact — three props encoded one boolean.
- `SortableActions`: `{options?.length && onInsert && …}` renders a literal `0` into the DOM when `options` is `[]`. Guarded on a boolean instead.

## Tests

New `lib/canvas/__tests__/dragOps.test.ts` covers all seven drop outcomes (intra-scene reorder, append to another scene, cross-scene slot insert, scene reorder, scene dropped on content, the same-parent no-op, and missing ids). Four `findElementById` cases added to `editorOps.test.ts`, including that it does not match text leaves.

## Complexity delta

| | before | after |
| --- | --- | --- |
| by-id lookup implementations | 4 | 1 |
| `handleDragEnd` branches | 4 | 1 |
| drag-policy test coverage | none | 7 cases |

## Open PR overlap check

Considered open PRs #429, #432, #435, #438, #439, #440, #441, #442, #443, #444. None touches `Canvas.tsx`, `app/components/canvas/dnd/**`, or `lib/canvas/editorOps.ts`. Nearest neighbours: #444 touches `lib/canvas/nodeUtils.ts` and `plugins/withNodeId.ts`, #442 touches `plugins/withScenes.ts`, #443 touches `elements/**` — all distinct files and distinct themes. No open PR covers drag and drop.

## Skipped for a human call

- `ScriptProvider.submitPrompt` and `useRefineScript.refineScript` duplicate the abortable-stream lifecycle, including the subtle `abortRef.current === controller` ownership check. Only two sites, so left alone under the rule of three.
- `NewCharacterDialog` and `StaleAvatarCloseDialog` use one-off Tailwind buttons where the design-system `Button` exists. That is CONVENTIONS/DESIGN territory and overlaps the conventions nightly (#442).
- `AssetTile` carries eight props including two string-variant switches (`removeAffordance`, `fallback`). A compound-component split would be a real interface change, not a behavior-preserving refactor.

## Validation

`npm run lint`, `format:check`, `typecheck`, `knip`, `build` all clean. 903 tests pass across 105 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)