### PR TITLE
refactor: nightly CONVENTIONS.md compliance 2026-07-21

### DIFF
--- a/app/components/AccessCodeInput.tsx
+++ b/app/components/AccessCodeInput.tsx
@@ -35,7 +35,8 @@ export default function AccessCodeInput() {
 				} else {
 					resetWithError(data.error || "Invalid access code");
 				}
-			} catch {
+			} catch (err) {
+				console.error("Access code validation failed", err);
 				resetWithError("Something went wrong. Please try again.");
 			} finally {
 				setLoading(false);

--- a/app/components/AuthForm.tsx
+++ b/app/components/AuthForm.tsx
@@ -71,7 +71,6 @@ export default function AuthForm({
 	if (sent) {
 		return (
 			<EmailSentCard
-				email={email}
 				subtitle={`We sent a ${sentKind} link to ${email}`}
 				resendLabel={`Send another ${sentKind} link`}
 				loading={loading}

--- a/app/components/EmailSentCard.tsx
+++ b/app/components/EmailSentCard.tsx
@@ -20,9 +20,8 @@ const EnvelopeIcon = (
 );
 
 interface EmailSentCardProps {
-	email: string;
-	subtitle?: string;
-	resendLabel?: string;
+	subtitle: string;
+	resendLabel: string;
 	loading: boolean;
 	error: string;
 	onResend: () => void;
@@ -30,7 +29,6 @@ interface EmailSentCardProps {
 }
 
 export default function EmailSentCard({
-	email,
 	subtitle,
 	resendLabel,
 	loading,
@@ -41,7 +39,7 @@ export default function EmailSentCard({
 	return (
 		<OnboardingCard
 			heading="Email sent!"
-			subtitle={subtitle ?? `We sent a login link to ${email}`}
+			subtitle={subtitle}
 			icon={EnvelopeIcon}
 			footer={
 				<button
@@ -60,7 +58,7 @@ export default function EmailSentCard({
 				disabled={loading}
 				className="h-11 w-full"
 			>
-				{loading ? "Sending…" : (resendLabel ?? "Send another login link")}
+				{loading ? "Sending…" : resendLabel}
 			</Button>
 			{error && (
 				<p className="text-center text-body text-destructive">{error}</p>

--- a/lib/generation/buildGenerationJob.ts
+++ b/lib/generation/buildGenerationJob.ts
@@ -11,8 +11,12 @@ export function buildGenerationJob(
 ): GenerationJob {
 	const customAttributes = element.customAttributes ?? {};
 	const connectorType = ELEMENT_TYPES[element.type].connector;
-	const provider = (customAttributes.provider as ProviderKey) ?? "openslop";
-	const { config } = getDefaultConnector(connectorConfig, connectorType);
+	const { provider: defaultProvider, config } = getDefaultConnector(
+		connectorConfig,
+		connectorType,
+	);
+	const provider =
+		(customAttributes.provider as ProviderKey) ?? defaultProvider;
 
 	return {
 		elementId: element.id,

--- a/lib/providers/__tests__/cache.test.ts
+++ b/lib/providers/__tests__/cache.test.ts
@@ -138,7 +138,6 @@ describe("pineconeCache", () => {
 		const { pineconeCache } = await loadCache();
 		mockQuery.mockRejectedValue(new Error("pinecone down"));
 		mockUpsert.mockResolvedValue(undefined);
-		const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
 		const inner = vi.fn().mockResolvedValue("fresh");
 		const wrapped = pineconeCache<[string], string>(inner, {
@@ -151,13 +150,8 @@ describe("pineconeCache", () => {
 		const result = await wrapped("q");
 		expect(result).toBe("fresh");
 		expect(inner).toHaveBeenCalledWith("q");
-		expect(errSpy).toHaveBeenCalledWith(
-			"[pinecone-cache] read failed; falling through",
-			expect.any(Error),
-		);
 		// vector embedded successfully, so write is still attempted
 		expect(mockUpsert).toHaveBeenCalled();
-		errSpy.mockRestore();
 	});
 
 	it("swallows index-not-found errors and falls through", async () => {
@@ -168,7 +162,6 @@ describe("pineconeCache", () => {
 			}),
 		);
 		mockUpsert.mockRejectedValue(new Error("index missing"));
-		const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
 		const inner = vi.fn().mockResolvedValue("fresh");
 		const wrapped = pineconeCache<[string], string>(inner, {
@@ -181,13 +174,11 @@ describe("pineconeCache", () => {
 		const result = await wrapped("q");
 		expect(result).toBe("fresh");
 		expect(inner).toHaveBeenCalled();
-		errSpy.mockRestore();
 	});
 
 	it("swallows embed errors and skips write entirely", async () => {
 		const { pineconeCache } = await loadCache();
 		mockEmbed.mockRejectedValue(new Error("openai down"));
-		const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
 		const inner = vi.fn().mockResolvedValue("fresh");
 		const wrapped = pineconeCache<[string], string>(inner, {
@@ -202,14 +193,12 @@ describe("pineconeCache", () => {
 		expect(inner).toHaveBeenCalled();
 		expect(mockQuery).not.toHaveBeenCalled();
 		expect(mockUpsert).not.toHaveBeenCalled();
-		errSpy.mockRestore();
 	});
 
 	it("logs but does not throw on write failure", async () => {
 		const { pineconeCache } = await loadCache();
 		mockQuery.mockResolvedValue({ matches: [] });
 		mockUpsert.mockRejectedValue(new Error("upsert failed"));
-		const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
 		const inner = vi.fn().mockResolvedValue("fresh");
 		const wrapped = pineconeCache<[string], string>(inner, {
@@ -221,11 +210,7 @@ describe("pineconeCache", () => {
 
 		const result = await wrapped("q");
 		expect(result).toBe("fresh");
-		expect(errSpy).toHaveBeenCalledWith(
-			"[pinecone-cache] write failed",
-			expect.any(Error),
-		);
-		errSpy.mockRestore();
+		expect(mockUpsert).toHaveBeenCalled();
 	});
 
 	it("default threshold is 0.8", async () => {

--- a/lib/providers/cache.ts
+++ b/lib/providers/cache.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { Pinecone } from "@pinecone-database/pinecone";
 import { AssetBundle, type BundleResponse } from "@/lib/api/asset-bundle";
+import { logger } from "@/lib/api/logger";
 import { embedText } from "./embed";
 
 type Metadata = Record<string, string | number | boolean>;
@@ -64,7 +65,7 @@ export function pineconeCache<Args extends unknown[], Result, This = unknown>(
 				if (cached !== undefined) return cached;
 			}
 		} catch (err) {
-			console.error("[pinecone-cache] read failed; falling through", err);
+			logger.error(err, "[pinecone-cache] read failed; falling through");
 		}
 
 		const result = await method.call(this, ...args);
@@ -80,7 +81,7 @@ export function pineconeCache<Args extends unknown[], Result, This = unknown>(
 					],
 				});
 			} catch (err) {
-				console.error("[pinecone-cache] write failed", err);
+				logger.error(err, "[pinecone-cache] write failed");
 			}
 		}
 		return result;

--- a/lib/video/elementAttributes.ts
+++ b/lib/video/elementAttributes.ts
@@ -18,6 +18,11 @@ const VOLUME_MIN = 0;
 const VOLUME_MAX = 10;
 const DEFAULT_VOLUME = VOLUME_MAX;
 
+/** Converts the 0–10 authoring scale to the 0–1 gain players expect. */
+export function volumeToGain(volume: number): number {
+	return volume / VOLUME_MAX;
+}
+
 /** Volume coerced to a finite number clamped to [0, 10], defaulting to 10. */
 export function getVolume(element: CanvasContentElement): number {
 	const raw = Number(element.customAttributes?.volume);

--- a/remotion/compositions/VideoComposition.tsx
+++ b/remotion/compositions/VideoComposition.tsx
@@ -20,6 +20,8 @@ import {
 	getPresentation,
 } from "@/lib/video/transitions";
 import { audioVolume } from "@/lib/video/audioVolume";
+import { volumeToGain } from "@/lib/video/elementAttributes";
+import { ELEMENT_TYPES } from "@/lib/canvas/types";
 import { Captions } from "../components/Captions";
 import { MotionLayer } from "../components/MotionLayer";
 
@@ -37,7 +39,7 @@ function toFrames(sec: number, fps: number): number {
 
 function AudioSequence({ element }: { element: ResolvedElement }) {
 	const { durationInFrames, fps } = useVideoConfig();
-	const gain = element.volume / 10;
+	const gain = volumeToGain(element.volume);
 	const hasFadeEnvelope = element.role === "background";
 	const fadeFrames = hasFadeEnvelope ? toFrames(AUDIO_FADE_SEC, fps) : 0;
 	const volume = useMemo(
@@ -66,13 +68,13 @@ function SequenceContent({ element }: { element: ResolvedElement }) {
 		case "visual":
 			return (
 				<MotionLayer effect={element.motion}>
-					{element.type === "image" ? (
+					{ELEMENT_TYPES[element.type].outputKind === "image" ? (
 						<Img src={element.url} crossOrigin="anonymous" style={coverStyle} />
 					) : (
 						<OffthreadVideo
 							src={element.url}
 							style={coverStyle}
-							volume={element.volume / 10}
+							volume={volumeToGain(element.volume)}
 						/>
 					)}
 				</MotionLayer>


### PR DESCRIPTION
Nightly CONVENTIONS.md audit. Files owned by the 11 open PRs were excluded from both the audit and the fixes.

## Applied (behavior-preserving)

**`app/components/EmailSentCard.tsx` — "define errors out of existence" + "one canonical way"**
`subtitle` and `resendLabel` were optional with `??` fallbacks, but `AuthForm` is the only caller and always passes both, so neither branch was reachable. `email` was referenced *only* inside the dead default, making it an entirely unused prop. The "login link" wording lived in three places (`AuthForm`'s `sentKind` default plus both fallbacks) and would drift silently. Props are now required, the fallbacks and the `email` prop are gone.

**`app/components/AccessCodeInput.tsx:38` — "fail loudly"**
The only bare `catch {` in the components tree, on the gate that controls beta access. A malformed-JSON response, a network failure, and a thrown navigation were indistinguishable and left zero diagnostics. Now binds and logs the error, matching `ProjectsList` and `useAutosave`.

**`remotion/compositions/VideoComposition.tsx:69` — "almost no special-case wiring"**
Picked `Img` vs `OffthreadVideo` by hardcoding `element.type === "image"`, one member of the `CanvasElementType` union. The authoritative fact already exists as `ELEMENT_TYPES[type].outputKind`. Now reads the registry — exactly equivalent today (`image`→image, `animated_image`/`clip`→video), but a new visual element type routes off the registry instead of silently falling into the video branch.

**`lib/video/elementAttributes.ts` — "one canonical way"**
The 0–10 volume scale was defined as an unexported `VOLUME_MAX` and re-implemented as a bare `/ 10` twice in the composition. Changing the scale would have mis-scaled rendered audio in one place and not the other. Exported `volumeToGain` is now the one home.

**`lib/providers/cache.ts:67,83` — "one canonical way"**
Logged via `console.error` while the rest of the server layer (e.g. `tts/cartesia.ts`) uses the pino `logger`, so Pinecone read/write failures never reached structured logs. The fall-through-on-miss behavior is unchanged and still correct. Its two tests asserted on the exact `console.error` call — testing the logging channel, not behavior — so they now assert the fall-through and the attempted write instead.

**`lib/generation/buildGenerationJob.ts:14` — "almost no special-case wiring"**
Hardcoded `"openslop"` as the fallback provider while discarding the `provider` that `getDefaultConnector` already returns on the very next line. Identical today (openslop is the only registered provider), but the literal is gone.

## Flagged, not applied

Each needs a judgement call:

1. **`lib/api/providers.ts:23`** — a missing or typo'd API key silently swaps in the mock provider. Users get fake assets with no error on server or client. Still the worst silent failure in the repo; flagged in #442 and unfixed. Mocking should be explicit opt-in with a throw when a real provider is expected.
2. **Floating `refineScript` promises** — `EditorToolbar.tsx:34` and `AnimateButton.tsx:23` call it unawaited, and `useRefineScript` has a `finally` but no `catch`. An LLM error stops the spinner and shows the user nothing. Best fixed once inside the hook. Flagged in #434 and #442, still unfixed.
3. **Three mechanisms for composing `systemPrompt`** — `osml.ts:145` sets-if-absent, `refine.ts:62` clobbers, and `script-mode`/`story-mode`/`template-mode`/`project-metadata` all use the canonical `prependSystemPrompt`. The osml guard never fires only because of unenforced plugin ordering; a caller-supplied `systemPrompt` (an optional field on the public LLM API schema) would silently erase the entire OSML format contract. Not auto-fixed because `osml.test.ts:14` explicitly pins the set-if-absent behavior, so this is a deliberate decision to revisit rather than a slip.
4. **`BaseVideoProvider.poll`** (`lib/providers/video/base.ts:35`) returns a fake `BundleResponse` with `id: ""` and `result: {}` for pending jobs, forcing `mapVideoStatus` to re-derive state by sniffing fields — while `ProcessOutcome` in `job-handlers.ts:19` already models pending-vs-completed as a proper discriminated union. Two representations of the same state. Also `video/runware.ts:16` casts an arbitrary upstream string straight into `VideoJobStatus`. Touches `lib/api/handlers/video.ts`, owned by #439.
5. **`ResolvedElement` still omits `outputKind`** — the composition now reads it from the registry, but `resolve.ts:24` computes `spec.outputKind` and throws it away. Putting it on the type is the cleaner fix; deferred because it breaks the `ResolvedElement` literals in `scene-builder.test.ts`, owned by #439.
6. **`createCanvasNode` silently overwrites caller-supplied `model`/`provider`** (`lib/canvas/createCanvasNode.ts:33`), contradicting its own "caller attrs win" contract asserted in its tests. Reloading a project discards each element's stored model in favour of the current default. Should land with the connector-snapshot work the `osmlStreamParser.ts:105` TODO refers to.
7. **`FIELD_CLS` is a parallel form-field style** — `character/fields.tsx:12` reimplements the design system's `Input`/`Textarea` (`bg-card` vs `bg-input`, `text-label` vs `text-body`, different focus ring), and `TextAttributePopover.tsx:101` copy-pastes it with `rounded-lg` instead of `rounded-md`. Already drifted. Unifying is a visible restyle.
8. **Two contracts for a client-supplied duration** — `request-schema-fields.ts:18` (`optionalDurationSeconds`, music/sfx) rejects `"10"`; `:22` (`optionalVideoDuration`, video) coerces it. Four lines apart in the same file. Reconciling changes the public API surface.
9. **`serializeOSML` vs `serializeOSMLWithScenes`** (`lib/canvas/osmlSerializer.ts:20`) — two exported ways to serialize the same editor value. Every production caller uses the scenes variant; the plain one is referenced only by its own test and silently collapses scene structure for whoever picks the shorter name. Left in place rather than deleted, per the standing "unused is not dead" rule.

## Checked clean

No provider-sniffing (`isX` / `=== "anthropic"`) anywhere. The three `switch` statements in the repo are each single-site exhaustive switches over a discriminated union. No duplicate fetch or error-response helpers. `ELEMENT_TYPES`, `PRESERVED_ATTRIBUTE_TYPES`, `PANELS`, `METADATA_TAG_CONFIGS`, `THEME_MODES`, `icon.tsx` are all proper data tables. `with-auth.ts` is a single canonical route wrapper. All 26 `components/ui/` files are clean off-the-shelf wrappers. `lib/supabase/server.ts:18`'s empty catch is the vendor-documented SSR pattern; `RefineOpParser`'s line-drop is deliberate and tested.

lint, typecheck, format:check clean. 892 tests across 104 files passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)