### PR TITLE
refactor: rethink openslop architecture 2026-07-21

### DIFF
--- a/app/api/render/progress/route.ts
+++ b/app/api/render/progress/route.ts
@@ -1,21 +1,14 @@
 import { getRenderProgress } from "@remotion/lambda/client";
 import { NextResponse } from "next/server";
-import { z } from "zod";
 import { createSessionRouteHandler } from "@/lib/api/route-handler";
 import { getFunctionName, REGION } from "@/lib/video/lambda-config";
-
-const ProgressRequest = z.object({
-	renderId: z.string(),
-	bucketName: z.string(),
-});
-
-export type ProgressResponse =
-	| { type: "progress"; progress: number }
-	| { type: "done"; url: string; size: number }
-	| { type: "error"; message: string };
+import {
+	RenderHandleRequest,
+	type RenderProgress,
+} from "@/lib/video/render-api";
 
 export const POST = createSessionRouteHandler({
-	schema: ProgressRequest,
+	schema: RenderHandleRequest,
 	label: "render/progress",
 	handle: async ({ body }) => {
 		const progress = await getRenderProgress({
@@ -26,7 +19,7 @@ export const POST = createSessionRouteHandler({
 		});
 
 		if (progress.fatalErrorEncountered) {
-			return NextResponse.json<ProgressResponse>({
+			return NextResponse.json<RenderProgress>({
 				type: "error",
 				message: progress.errors[0]?.message ?? "Render failed",
 			});
@@ -35,13 +28,13 @@ export const POST = createSessionRouteHandler({
 			if (progress.outputFile == null || progress.outputSizeInBytes == null) {
 				throw new Error("Render reported done without an output file");
 			}
-			return NextResponse.json<ProgressResponse>({
+			return NextResponse.json<RenderProgress>({
 				type: "done",
 				url: progress.outputFile,
 				size: progress.outputSizeInBytes,
 			});
 		}
-		return NextResponse.json<ProgressResponse>({
+		return NextResponse.json<RenderProgress>({
 			type: "progress",
 			progress: progress.overallProgress,
 		});

--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -1,18 +1,13 @@
 import { renderMediaOnLambda } from "@remotion/lambda/client";
 import { NextResponse } from "next/server";
-import { z } from "zod";
 import { createSessionRouteHandler } from "@/lib/api/route-handler";
 import {
 	getFunctionName,
 	getSiteName,
 	REGION,
 } from "@/lib/video/lambda-config";
+import { RenderRequest, type RenderHandle } from "@/lib/video/render-api";
 import { COMPOSITION_ID } from "@/lib/video/types";
-
-const RenderRequest = z.object({
-	inputProps: z.record(z.string(), z.unknown()),
-	scale: z.number().positive().optional(),
-});
 
 export const POST = createSessionRouteHandler({
 	schema: RenderRequest,
@@ -29,6 +24,6 @@ export const POST = createSessionRouteHandler({
 			downloadBehavior: { type: "download", fileName: "video.mp4" },
 		});
 
-		return NextResponse.json({ renderId, bucketName });
+		return NextResponse.json<RenderHandle>({ renderId, bucketName });
 	},
 });

--- a/app/components/video/useRendering.ts
+++ b/app/components/video/useRendering.ts
@@ -1,19 +1,15 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import type { ProgressResponse } from "@/app/api/render/progress/route";
-import { stringifyError } from "@/lib/errors";
+import { apiJson } from "@/lib/clients/http";
+import { errorMessage } from "@/lib/errors";
+import type { RenderHandle, RenderProgress } from "@/lib/video/render-api";
 import type { VideoLayout } from "@/lib/video/types";
 
 type RenderState =
 	| { status: "idle" }
 	| { status: "invoking" }
-	| {
-			status: "rendering";
-			renderId: string;
-			bucketName: string;
-			progress: number;
-	  }
+	| ({ status: "rendering"; progress: number } & RenderHandle)
 	| { status: "done"; url: string; size: number }
 	| { status: "error"; message: string };
 
@@ -21,34 +17,24 @@ const POLL_INTERVAL_MS = 5000;
 
 const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
-async function postJSON<T>(url: string, body: unknown): Promise<T> {
-	const res = await fetch(url, {
-		method: "POST",
-		headers: { "content-type": "application/json" },
-		body: JSON.stringify(body),
-	});
-	if (!res.ok) throw new Error(await res.text());
-	return res.json() as Promise<T>;
-}
-
 export function useRendering() {
 	const [state, setState] = useState<RenderState>({ status: "idle" });
 
 	const render = useCallback(async (layout: VideoLayout, scale?: number) => {
 		setState({ status: "invoking" });
 		try {
-			const { renderId, bucketName } = await postJSON<{
-				renderId: string;
-				bucketName: string;
-			}>("/api/render", { inputProps: layout, scale });
+			const handle = await apiJson<RenderHandle>("/api/render", {
+				method: "POST",
+				body: { inputProps: layout, scale },
+			});
 
-			setState({ status: "rendering", renderId, bucketName, progress: 0 });
+			setState({ status: "rendering", ...handle, progress: 0 });
 
 			for (;;) {
-				const result = await postJSON<ProgressResponse>(
-					"/api/render/progress",
-					{ renderId, bucketName },
-				);
+				const result = await apiJson<RenderProgress>("/api/render/progress", {
+					method: "POST",
+					body: handle,
+				});
 
 				if (result.type === "error") {
 					setState({ status: "error", message: result.message });
@@ -60,14 +46,13 @@ export function useRendering() {
 				}
 				setState({
 					status: "rendering",
-					renderId,
-					bucketName,
+					...handle,
 					progress: result.progress,
 				});
 				await wait(POLL_INTERVAL_MS);
 			}
 		} catch (err) {
-			setState({ status: "error", message: stringifyError(err) });
+			setState({ status: "error", message: errorMessage(err) });
 		}
 	}, []);
 

--- a/lib/clients/__tests__/http.test.ts
+++ b/lib/clients/__tests__/http.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { apiFetch, apiJson } from "../http";
+
+describe("apiFetch", () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+	});
+
+	it("defaults to GET without a body", async () => {
+		fetchMock.mockResolvedValue({ ok: true });
+
+		await apiFetch("/api/render");
+
+		expect(fetchMock).toHaveBeenCalledWith("/api/render", { method: "GET" });
+	});
+
+	it("JSON-encodes plain object bodies", async () => {
+		fetchMock.mockResolvedValue({ ok: true });
+
+		await apiFetch("/api/render", { method: "POST", body: { scale: 2 } });
+
+		expect(fetchMock).toHaveBeenCalledWith("/api/render", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ scale: 2 }),
+		});
+	});
+
+	it("passes FormData through so the browser sets the boundary", async () => {
+		fetchMock.mockResolvedValue({ ok: true });
+		const body = new FormData();
+
+		await apiFetch("/api/upload/image", { method: "POST", body });
+
+		expect(fetchMock).toHaveBeenCalledWith("/api/upload/image", {
+			method: "POST",
+			body,
+		});
+	});
+
+	it("throws the route's error message", async () => {
+		fetchMock.mockResolvedValue({
+			ok: false,
+			status: 400,
+			statusText: "Bad Request",
+			json: () => Promise.resolve({ error: "File must be under 10 MB" }),
+		});
+
+		await expect(apiFetch("/api/upload/image")).rejects.toThrow(
+			"File must be under 10 MB",
+		);
+	});
+
+	it("falls back to the status line when there is no error message", async () => {
+		fetchMock.mockResolvedValue({
+			ok: false,
+			status: 500,
+			statusText: "Internal Server Error",
+			json: () => Promise.reject(new Error("not json")),
+		});
+
+		await expect(apiFetch("/api/render")).rejects.toThrow(
+			"500 Internal Server Error",
+		);
+	});
+});
+
+describe("apiJson", () => {
+	it("returns the parsed body", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: () => Promise.resolve({ url: "https://blob/img.png" }),
+			}),
+		);
+
+		await expect(apiJson("/api/upload/image")).resolves.toEqual({
+			url: "https://blob/img.png",
+		});
+	});
+});
+
+describe("query params", () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn().mockResolvedValue({ ok: true });
+		vi.stubGlobal("fetch", fetchMock);
+	});
+
+	it("appends encoded params", async () => {
+		await apiFetch("/api/v1/tts/voices", { params: { gender: "feminine" } });
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/v1/tts/voices?gender=feminine",
+			expect.anything(),
+		);
+	});
+
+	it("drops undefined values and an empty query string", async () => {
+		const params = { age: undefined } as unknown as Record<string, string>;
+
+		await apiFetch("/api/v1/tts/voices", { params });
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/v1/tts/voices",
+			expect.anything(),
+		);
+	});
+});

--- a/lib/clients/http.ts
+++ b/lib/clients/http.ts
@@ -1,0 +1,54 @@
+type RequestOptions = {
+	method?: string;
+	body?: unknown;
+	params?: Record<string, string>;
+};
+
+/** Every internal route answers failures with `{ error }` (see `lib/api/response.ts`). */
+async function readErrorMessage(res: Response): Promise<string> {
+	const fallback = `${res.status} ${res.statusText}`;
+	const detail = await res.json().then(
+		(body: unknown) =>
+			typeof body === "object" && body !== null && "error" in body
+				? body.error
+				: undefined,
+		() => undefined,
+	);
+	return (typeof detail === "string" && detail) || fallback;
+}
+
+function buildInit(method: string, body: unknown): RequestInit {
+	if (body === undefined) return { method };
+	if (body instanceof FormData) return { method, body };
+	return {
+		method,
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	};
+}
+
+function buildUrl(url: string, params?: Record<string, string>): string {
+	if (!params) return url;
+	const qs = new URLSearchParams(
+		Object.entries(params).filter(([, value]) => value !== undefined),
+	).toString();
+	return qs ? `${url}?${qs}` : url;
+}
+
+/** Calls one of our own API routes, surfacing its error envelope as a thrown `Error`. */
+export async function apiFetch(
+	url: string,
+	{ method = "GET", body, params }: RequestOptions = {},
+): Promise<Response> {
+	const res = await fetch(buildUrl(url, params), buildInit(method, body));
+	if (!res.ok) throw new Error(await readErrorMessage(res));
+	return res;
+}
+
+export async function apiJson<T>(
+	url: string,
+	options?: RequestOptions,
+): Promise<T> {
+	const res = await apiFetch(url, options);
+	return res.json() as Promise<T>;
+}

--- a/lib/clients/openslop.ts
+++ b/lib/clients/openslop.ts
@@ -1,3 +1,5 @@
+import { apiFetch, apiJson } from "./http";
+
 export class OpenSlopClient {
 	private baseUrl: string;
 
@@ -5,45 +7,15 @@ export class OpenSlopClient {
 		this.baseUrl = baseUrl || "";
 	}
 
-	private async request(
-		method: string,
-		url: string,
-		body?: unknown,
-	): Promise<Response> {
-		const res = await fetch(url, {
-			method,
-			headers: { "content-type": "application/json" },
-			...(body !== undefined && { body: JSON.stringify(body) }),
-		});
-		if (!res.ok) {
-			const fallback = `${res.status} ${res.statusText}`;
-			const message = await res.json().then(
-				(b) => (b && typeof b === "object" && b.error) || fallback,
-				() => fallback,
-			);
-			throw new Error(message);
-		}
-		return res;
-	}
-
 	async post<T>(path: string, body: unknown): Promise<T> {
-		const res = await this.request("POST", `${this.baseUrl}${path}`, body);
-		return res.json() as Promise<T>;
+		return apiJson<T>(`${this.baseUrl}${path}`, { method: "POST", body });
 	}
 
 	async get<T>(path: string, params?: Record<string, string>): Promise<T> {
-		let url = `${this.baseUrl}${path}`;
-		if (params) {
-			const qs = new URLSearchParams(
-				Object.entries(params).filter(([, v]) => v !== undefined),
-			).toString();
-			if (qs) url += `?${qs}`;
-		}
-		const res = await this.request("GET", url);
-		return res.json() as Promise<T>;
+		return apiJson<T>(`${this.baseUrl}${path}`, { params });
 	}
 
 	async postStream(path: string, body: unknown): Promise<Response> {
-		return this.request("POST", `${this.baseUrl}${path}`, body);
+		return apiFetch(`${this.baseUrl}${path}`, { method: "POST", body });
 	}
 }

--- a/lib/upload/__tests__/uploadImage.test.ts
+++ b/lib/upload/__tests__/uploadImage.test.ts
@@ -24,15 +24,24 @@ describe("uploadImage", () => {
 		await expect(uploadImage(file)).resolves.toBe("https://blob/x.png");
 	});
 
-	it("throws status and body when response is not ok", async () => {
+	it("throws the route's error message when the response is not ok", async () => {
 		fetchMock.mockResolvedValue({
 			ok: false,
 			status: 400,
-			text: async () => "File must be under 10 MB",
+			statusText: "Bad Request",
+			json: async () => ({ error: "File must be under 10 MB" }),
 		});
-		await expect(uploadImage(file)).rejects.toThrow(
-			"400 File must be under 10 MB",
-		);
+		await expect(uploadImage(file)).rejects.toThrow("File must be under 10 MB");
+	});
+
+	it("falls back to the status line when the body has no error", async () => {
+		fetchMock.mockResolvedValue({
+			ok: false,
+			status: 502,
+			statusText: "Bad Gateway",
+			json: async () => ({}),
+		});
+		await expect(uploadImage(file)).rejects.toThrow("502 Bad Gateway");
 	});
 
 	it("propagates network failures", async () => {

--- a/lib/upload/uploadImage.ts
+++ b/lib/upload/uploadImage.ts
@@ -1,14 +1,12 @@
+import { apiJson } from "@/lib/clients/http";
+
 export async function uploadImage(file: File): Promise<string> {
 	const formData = new FormData();
 	formData.append("file", file);
 
-	const res = await fetch("/api/upload/image", {
+	const { url } = await apiJson<{ url: string }>("/api/upload/image", {
 		method: "POST",
 		body: formData,
 	});
-
-	if (!res.ok) throw new Error(`${res.status} ${await res.text()}`);
-
-	const { url } = (await res.json()) as { url: string };
 	return url;
 }

--- a/lib/upload/useImageUpload.tsx
+++ b/lib/upload/useImageUpload.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useState } from "react";
 import { toast } from "sonner";
-import { stringifyError } from "@/lib/errors";
+import { errorMessage } from "@/lib/errors";
 import { uploadImage } from "@/lib/upload/uploadImage";
 
 export function useImageUpload({
@@ -24,7 +24,7 @@ export function useImageUpload({
 			const urls: string[] = [];
 			for (const r of results) {
 				if (r.status === "fulfilled") urls.push(r.value);
-				else toast.error(stringifyError(r.reason));
+				else toast.error(errorMessage(r.reason));
 			}
 			if (urls.length > 0) onUpload(urls);
 		} finally {

--- a/lib/video/render-api.ts
+++ b/lib/video/render-api.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+/** Wire contract for `/api/render` and `/api/render/progress`. */
+export const RenderRequest = z.object({
+	inputProps: z.record(z.string(), z.unknown()),
+	scale: z.number().positive().optional(),
+});
+
+export const RenderHandleRequest = z.object({
+	renderId: z.string(),
+	bucketName: z.string(),
+});
+
+/** Identifies an in-flight Lambda render: returned by `/api/render`, polled by progress. */
+export type RenderHandle = z.infer<typeof RenderHandleRequest>;
+
+export type RenderProgress =
+	| { type: "progress"; progress: number }
+	| { type: "done"; url: string; size: number }
+	| { type: "error"; message: string };


### PR DESCRIPTION
## App understanding

OpenSlop turns a prompt into a rendered video. The LLM connector streams OSML into a Slate canvas; stale elements are queued and generated through connector → gateway → provider into Vercel Blob; project state persists to Supabase; Remotion Lambda renders the final MP4. `lib/` is the domain layer, `app/` is UI, and dependencies point one way.

## From-scratch architecture

Rebuilt today, the browser would talk to our own API through **one** client that knows the `{ error }` envelope every route returns, and every route's request/response shape would have **one** home that both the route and its caller import. Nothing in `app/` would import from `app/api/`.

The current code was close, but the "talk to our API" knowledge had drifted into four places, and the render contract lived inside the route file that produced it.

## Implemented simplifications

**One internal HTTP client (`lib/clients/http.ts`).** `apiFetch`/`apiJson` own the request shape (JSON bodies, FormData passthrough, query params) and the `{ error }` envelope that `lib/api/response.ts` emits. Three hand-rolled copies now delegate to it:

- `OpenSlopClient` loses its private `request` and URL-building (`lib/clients/openslop.ts`: 50 → 22 lines).
- `useRendering`'s local `postJSON` is gone.
- `uploadImage`'s raw fetch is gone.

Side effect: the two non-gateway callers used to surface `throw new Error(await res.text())`, so a failed export or upload showed the user raw JSON (`{"error":"File must be under 10 MB"}`) or a `stringifyError` blob. They now show the route's actual message.

**One home for the render contract (`lib/video/render-api.ts`).** The zod schemas and the `RenderHandle` / `RenderProgress` types are shared by `app/api/render/route.ts`, `app/api/render/progress/route.ts`, and `useRendering`. This removes the repo's only `app/ → app/api/` route-module import, and the client no longer re-declares `{ renderId, bucketName }` inline. `useRendering` imports types only, so no zod reaches the client bundle.

**Consistent error formatting.** `useImageUpload` and `useRendering` now use `errorMessage` (the established convention for user-facing text, as in `VoicePicker` and `queue.ts`) instead of `stringifyError`, which stays on logging/serialization boundaries.

Net: −97/+49 in the touched files, plus the two new shared modules and their tests.

## Validation

| Check | Result |
| --- | --- |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm run knip` | pass |
| `npm run build` | pass |
| `npm run test:run` | 901 passed / 105 files |
| `npm run test:e2e` | 3 passed |

New tests cover `apiFetch`/`apiJson` (method defaulting, JSON vs FormData bodies, error envelope, status-line fallback, query params). `uploadImage`'s error test was updated to the envelope the route actually returns — it previously mocked a `text()` body the route never sends.

## Open PR overlap check

Considered #429, #432, #435, #438, #439, #440, #441, #442, #443, #444, #445, #446. This PR touches none of their files or themes: the video PRs (#441, #435, #429) are player state, layout context, and queue progress; #446 is providers/conventions; #435 owns `lib/api/parse.ts` and `route-handler.ts`, which are untouched here.

## Skipped

- `AccessCodeInput` also hand-rolls a fetch against `/api/validate-code` and would fold into `apiJson` cleanly, but it is owned by open PR #446. Worth a follow-up once that lands.
- `lib/api/asset-bundle.ts`'s `fetchJson` stays as-is: it fetches public blob URLs, not our routes, so it has no error envelope to read.
- `GlobalErrorToaster` / `ToastErrorBoundary` keep `stringifyError`; full serialization looks deliberate for unexpected top-level failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)