### PR TITLE
add dev-only user impersonation to the account menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,12 @@ Follow @CONVENTIONS.md, the canonical coding style for this repo.
 ## Workflow
 
 - After each change, run the checks from `.github/workflows/ci.yml` (lint, format, typecheck, tests) and fix all failures.
-- After completing code changes, run the following to review against best practices:
+- After each round of code changes, run the following to review against best practices:
   - `/simplify`
   - `/vercel-composition-patterns`
   - `/web-design-guidelines`
   - `/vercel-react-best-practices`
+  - Check against @CONVENTIONS.md
 
 ## Project structure
 

--- a/app/api/dev/impersonate/route.ts
+++ b/app/api/dev/impersonate/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { parseSearchParams } from "@/lib/api/parse";
+import { withPublic } from "@/lib/api/with-auth";
+import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/service";
+
+const ImpersonateRequest = z.object({
+	email: z.email({ error: "A valid email query param is required" }),
+});
+
+// Signs the caller in as an existing user with no email delivery, against
+// whichever Supabase project the environment points at — production included.
+export async function GET(request: NextRequest) {
+	if (process.env.NODE_ENV === "production")
+		return new NextResponse(null, { status: 404 });
+
+	return withPublic("impersonate", async () => {
+		const parsed = parseSearchParams(
+			request,
+			ImpersonateRequest,
+			"impersonate",
+		);
+		if (!parsed.ok) return parsed.response;
+
+		const { data, error } = await createServiceClient().auth.admin.generateLink(
+			{
+				type: "magiclink",
+				email: parsed.data.email,
+			},
+		);
+		if (error) throw error;
+
+		const supabase = await createClient();
+		const { error: verifyError } = await supabase.auth.verifyOtp({
+			token_hash: data.properties.hashed_token,
+			type: "magiclink",
+		});
+		if (verifyError) throw verifyError;
+
+		return NextResponse.redirect(new URL("/", request.url));
+	});
+}

--- a/app/api/dev/impersonate/route.ts
+++ b/app/api/dev/impersonate/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { parseSearchParams } from "@/lib/api/parse";
+import { badRequest } from "@/lib/api/response";
 import { withPublic } from "@/lib/api/with-auth";
 import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/service";
@@ -23,18 +24,26 @@ export async function GET(request: NextRequest) {
 		);
 		if (!parsed.ok) return parsed.response;
 
+		// `recovery` targets an existing user and errors when the email is
+		// unknown; `magiclink` would silently create a junk account instead.
 		const { data, error } = await createServiceClient().auth.admin.generateLink(
 			{
-				type: "magiclink",
+				type: "recovery",
 				email: parsed.data.email,
 			},
 		);
-		if (error) throw error;
+		if (error) {
+			if (error.status && error.status < 500)
+				return badRequest(
+					`Cannot impersonate ${parsed.data.email}: ${error.message}`,
+				);
+			throw error;
+		}
 
 		const supabase = await createClient();
 		const { error: verifyError } = await supabase.auth.verifyOtp({
 			token_hash: data.properties.hashed_token,
-			type: "magiclink",
+			type: "recovery",
 		});
 		if (verifyError) throw verifyError;
 

--- a/app/components/ImpersonateDialog.tsx
+++ b/app/components/ImpersonateDialog.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from "react";
+import {
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	MountedDialog,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { AlertCircle } from "@/components/ui/icon";
+import { errorMessage } from "@/lib/errors";
+
+export default function ImpersonateDialog({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	return (
+		<MountedDialog open={open} onOpenChange={onOpenChange}>
+			<ImpersonateDialogBody />
+		</MountedDialog>
+	);
+}
+
+function ImpersonateDialogBody() {
+	const [email, setEmail] = useState("");
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState("");
+
+	const handleSubmit = async (event: React.FormEvent) => {
+		event.preventDefault();
+		setLoading(true);
+		setError("");
+
+		try {
+			const response = await fetch(
+				`/api/dev/impersonate?email=${encodeURIComponent(email)}`,
+			);
+			if (response.ok) {
+				window.location.assign("/");
+				return;
+			}
+			const body = await response.json();
+			setError(body.error ?? `Impersonation failed (${response.status})`);
+		} catch (cause) {
+			setError(errorMessage(cause));
+		}
+		setLoading(false);
+	};
+
+	return (
+		<DialogContent className="max-w-sm">
+			<form onSubmit={handleSubmit} className="flex flex-col gap-3">
+				<DialogHeader>
+					<DialogTitle className="flex items-center gap-2">
+						Impersonate user
+						<Badge variant="caution">Dev only</Badge>
+					</DialogTitle>
+					<DialogDescription>
+						Signs you in as this user on the live Supabase project.
+					</DialogDescription>
+				</DialogHeader>
+
+				<p className="flex gap-2 rounded-lg border border-caution/40 bg-caution/10 p-3 text-label-xs text-foreground">
+					<AlertCircle className="mt-0.5 shrink-0" />
+					<span>
+						Any changes you make as this user are written to production.
+					</span>
+				</p>
+
+				<Input
+					type="email"
+					autoFocus
+					required
+					value={email}
+					onChange={(e) => setEmail(e.target.value)}
+					placeholder="user@example.com"
+					aria-label="User email"
+				/>
+
+				{error && (
+					<span role="alert" className="text-label-xs text-destructive">
+						{error}
+					</span>
+				)}
+
+				<DialogFooter>
+					<Button type="submit" variant="accent" disabled={loading || !email}>
+						{loading ? "Signing in…" : "Impersonate"}
+					</Button>
+				</DialogFooter>
+			</form>
+		</DialogContent>
+	);
+}

--- a/app/components/UserProfile.tsx
+++ b/app/components/UserProfile.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { memo } from "react";
+import { memo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { useUser } from "@/lib/user/UserProvider";
 import { useTheme } from "next-themes";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -16,7 +17,10 @@ import {
 	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Check, Contrast, LogOut } from "@/components/ui/icon";
+import { Check, Contrast, LogOut, User } from "@/components/ui/icon";
+import ImpersonateDialog from "./ImpersonateDialog";
+
+const IS_DEV = process.env.NODE_ENV !== "production";
 
 const THEME_MODES = [
 	{ value: "light", label: "Light" },
@@ -27,6 +31,7 @@ const THEME_MODES = [
 function UserProfile() {
 	const router = useRouter();
 	const { theme, setTheme } = useTheme();
+	const [impersonateOpen, setImpersonateOpen] = useState(false);
 	const user = useUser();
 	const email = user.email ?? "";
 	const avatarUrl: string | undefined = user.user_metadata?.avatar_url;
@@ -92,6 +97,18 @@ function UserProfile() {
 								))}
 							</DropdownMenuSubContent>
 						</DropdownMenuSub>
+						{IS_DEV && (
+							<DropdownMenuItem
+								onClick={() => setImpersonateOpen(true)}
+								className="my-1 cursor-pointer rounded-xl py-2"
+							>
+								<User className="mr-2 h-4 w-4" />
+								Impersonate user
+								<Badge variant="caution" className="ml-auto">
+									Dev
+								</Badge>
+							</DropdownMenuItem>
+						)}
 						<DropdownMenuItem
 							onClick={handleLogout}
 							className="my-1 cursor-pointer rounded-xl py-2"
@@ -102,6 +119,12 @@ function UserProfile() {
 					</div>
 				</DropdownMenuContent>
 			</DropdownMenu>
+			{IS_DEV && (
+				<ImpersonateDialog
+					open={impersonateOpen}
+					onOpenChange={setImpersonateOpen}
+				/>
+			)}
 		</div>
 	);
 }

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -13,6 +13,7 @@ const badgeVariants = cva(
 				outline: "border-border text-foreground",
 				accent: "border-transparent bg-accent text-accent-foreground",
 				success: "border-transparent bg-success text-success-foreground",
+				caution: "border-transparent bg-caution text-caution-foreground",
 				destructive:
 					"border-transparent bg-destructive text-destructive-foreground",
 				new: "border-transparent bg-accent-soft text-accent",


### PR DESCRIPTION
## Summary
- Adds `GET /api/dev/impersonate?email=...`, which mints a session for an existing user via `auth.admin.generateLink` + `verifyOtp`, no email round trip. Useful for reproducing a reported bug against the real account.
- Adds an "Impersonate user" item to the account menu (dev builds only) opening a small dialog with an email field.
- Adds a `caution` variant to `Badge`, filling the gap next to `success` / `destructive` against the existing `--caution` token.
- Unrelated `AGENTS.md` tweak folded in: review skills run each round of changes, and `CONVENTIONS.md` gets checked explicitly.

## Gating
The route returns 404 unless `NODE_ENV !== "production"`, and `createServiceClient()` throws without `SUPABASE_SECRET_KEY`. The menu item and dialog compile out of production bundles.

Worth being explicit, since this repo is public: there is **no per-caller auth and no audit log**. On a dev server that is reachable by anyone (`-H 0.0.0.0`, a tunnel, a public Codespace port), this endpoint is an unauthenticated account-takeover. It is safe on localhost and inert in production, and it is not currently safe to make functional in production.

Impersonated sessions are indistinguishable from the user's own, so anything done while impersonating is written to prod under their id.

Not included, discussed and deferred: an `IMPERSONATION_ENABLED` opt-in env flag as a fail-closed second gate, an `app_metadata.admin` check, an audit table, and a "viewing as X" banner with exit.

## Test plan
- [ ] `npm run dev`, open the account menu, confirm the "Impersonate user" item with the Dev badge appears
- [ ] Enter a known user's email, submit, confirm you land on `/` signed in as them
- [ ] Enter a malformed email, confirm the inline zod error rather than a 500
- [ ] `npm run build && npm start`, confirm `/api/dev/impersonate?email=...` returns 404 and the menu item is absent

CI covers lint, format, typecheck, knip, build, 892 unit tests, and the Playwright smoke suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
