### PR TITLE
fix: nightly bug fixes 2026-07-22

### DIFF
--- a/lib/api/__tests__/sse.test.ts
+++ b/lib/api/__tests__/sse.test.ts
@@ -160,4 +160,24 @@ describe("readSSE", () => {
 		// If the lock had not been released, getReader() would throw.
 		expect(() => stream.getReader()).not.toThrow();
 	});
+
+	it("cancels a still-open source when the consumer breaks early", async () => {
+		const encoder = new TextEncoder();
+		let cancelled = false;
+		const stream = new ReadableStream({
+			start(controller) {
+				controller.enqueue(encoder.encode('data: {"a":1}\n\n'));
+			},
+			cancel() {
+				cancelled = true;
+			},
+		});
+
+		for await (const event of readSSE(stream)) {
+			expect(event).toEqual({ a: 1 });
+			break;
+		}
+
+		expect(cancelled).toBe(true);
+	});
 });

--- a/lib/api/sse.ts
+++ b/lib/api/sse.ts
@@ -87,6 +87,11 @@ export async function* readSSE<T>(body: ReadableStream): AsyncGenerator<T> {
 			}
 		}
 	} finally {
+		// Releasing the lock alone leaves the body open, so a consumer that breaks
+		// out of the loop (Stop) never tears down the upstream request.
+		await reader
+			.cancel()
+			.catch((err) => logger.warn({ err }, "SSE: reader cancel failed"));
 		reader.releaseLock();
 	}
 }

--- a/lib/canvas/__tests__/osmlStreamParser.test.ts
+++ b/lib/canvas/__tests__/osmlStreamParser.test.ts
@@ -64,13 +64,23 @@ describe("OSMLStreamParser", () => {
 		expect(getElementText(nodes[0])).toContain("Some long narration text here");
 	});
 
-	it("preserves raw tag name for unknown tags", () => {
+	it("keeps tags outside the OSML vocabulary as element text", () => {
 		const s = new OSMLStreamParser();
-		s.appendChunk("<unknowntag>content</unknowntag>", connectors);
+		s.appendChunk("<narration>He said <sigh> quietly</narration>", connectors);
 
 		const nodes = s.getNodes() as ParsedElement[];
 		expect(nodes).toHaveLength(1);
-		expect(nodes[0].type).toBe("unknowntag");
+		expect(nodes[0].type).toBe("narration");
+		expect(getElementText(nodes[0])).toContain("He said <sigh> quietly");
+	});
+
+	it("keeps an unmatched closing tag outside the vocabulary as text", () => {
+		const s = new OSMLStreamParser();
+		s.appendChunk("<narration>a </b> b</narration>", connectors);
+
+		const nodes = s.getNodes() as ParsedElement[];
+		expect(nodes).toHaveLength(1);
+		expect(getElementText(nodes[0])).toContain("a </b> b");
 	});
 
 	it("parses metadata_style metadata tag", () => {

--- a/lib/canvas/osmlSerializer.ts
+++ b/lib/canvas/osmlSerializer.ts
@@ -1,6 +1,7 @@
 import { Descendant } from "slate";
 import type { CanvasContentElement, ParsedElement } from "@/lib/canvas/types";
 import { getContentElements, isSceneElement } from "@/lib/canvas/scenes";
+import { ZERO_WIDTH_SPACE } from "./constants";
 
 export const SCENE_MARKER_PATTERN = /^---\s*Scene\s+\d+\s*---\s*$/m;
 const sceneMarker = (n: number) => `\n--- Scene ${n} ---\n`;
@@ -14,7 +15,10 @@ function serializeElement(element: CanvasContentElement): string {
 	const attrString = Object.entries({ id: element.id, ...attributes })
 		.map(([key, value]) => ` ${key}="${value}"`)
 		.join("");
-	return `<${element.type}${attrString}>${getElementText(element)}</${element.type}>\n`;
+	// The zero-width space is an editor-only caret anchor. It must not cross into
+	// OSML, or every save/reload cycle stacks another one onto the element text.
+	const body = getElementText(element).replaceAll(ZERO_WIDTH_SPACE, "");
+	return `<${element.type}${attrString}>${body}</${element.type}>\n`;
 }
 
 export function serializeOSML(descendants: Descendant[]): string {

--- a/lib/canvas/osmlStreamParser.ts
+++ b/lib/canvas/osmlStreamParser.ts
@@ -10,6 +10,15 @@ import { createCanvasNode } from "./createCanvasNode";
 
 const MIN_BUFFER_LENGTH = 5;
 const TAG_PATTERN = /<([^<>/][^<>]*?)>|<\/([^<>/][^<>]*?)>/g;
+const METADATA_TAG_PREFIX = "metadata_";
+
+/** OSML has a closed vocabulary. Anything else angle-bracketed is prose. */
+function isOSMLTag(tag: string): boolean {
+	return (
+		CANVAS_ELEMENT_TYPES.has(tag as CanvasElementType) ||
+		tag.startsWith(METADATA_TAG_PREFIX)
+	);
+}
 
 /**
  * Incrementally turns a stream of OSML text chunks into canvas nodes. Feed
@@ -43,18 +52,27 @@ export class OSMLStreamParser {
 		let updated = false;
 
 		while ((match = TAG_PATTERN.exec(this.buffer)) !== null) {
+			const [raw, openTag, closeTag] = match;
 			const text = this.buffer.slice(lastIndex, match.index);
+			lastIndex = match.index + raw.length;
+
 			if (text.trim()) {
 				this.updateCurrent(text);
 				updated = true;
 			}
 
-			const openTag = match[1];
 			if (openTag) {
 				const { tag, ...attributes } = parseXmlTag(openTag);
-				this.appendNext(tag, attributes, connectors);
+				if (isOSMLTag(tag)) {
+					this.appendNext(tag, attributes, connectors);
+					continue;
+				}
+			} else if (isOSMLTag(closeTag.trim())) {
+				continue;
 			}
-			lastIndex = match.index + match[0].length;
+
+			this.updateCurrent(raw);
+			updated = true;
 		}
 
 		this.buffer = this.buffer.slice(lastIndex);

--- a/lib/project/__tests__/serialize.test.ts
+++ b/lib/project/__tests__/serialize.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { Node } from "slate";
 import { serializeOSMLWithScenes } from "@/lib/canvas/osmlSerializer";
+import { createCanvasNode } from "@/lib/canvas/createCanvasNode";
+import { ZERO_WIDTH_SPACE } from "@/lib/canvas/constants";
 import type { ConnectorRegistry } from "@/lib/config/ConfigProvider";
 import {
 	SCENE_TYPE,
@@ -86,5 +89,52 @@ describe("deserializeWithScenes", () => {
 		const secondClip = scenes[1].children[0];
 		expect(secondClip.type).toBe("clip");
 		expect(secondClip.customAttributes?.url).toBe("https://cdn/b.mp4");
+	});
+});
+
+describe("save/reload round trip on real editor nodes", () => {
+	const editorScene = (...children: CanvasContentElement[]): SceneElement => ({
+		id: "scene-id",
+		type: SCENE_TYPE,
+		children,
+	});
+
+	const reload = (scenes: SceneElement[]) =>
+		deserializeWithScenes(serializeOSMLWithScenes(scenes), connectors);
+
+	it("keeps element text stable across repeated save/reload cycles", () => {
+		let scenes = [
+			editorScene(
+				createCanvasNode("narration", connectors, { id: "n1", text: "Hello" }),
+			),
+		];
+
+		for (let i = 0; i < 3; i++) scenes = reload(scenes);
+
+		expect(Node.string(scenes[0].children[0])).toBe(`${ZERO_WIDTH_SPACE}Hello`);
+	});
+
+	it("keeps an empty element empty so its placeholder still renders", () => {
+		const scenes = reload([
+			editorScene(createCanvasNode("image", connectors, { id: "i1" })),
+		]);
+
+		expect(Node.string(scenes[0].children[0])).toBe(ZERO_WIDTH_SPACE);
+	});
+
+	it("keeps angle-bracketed prose inside the element that owns it", () => {
+		const scenes = reload([
+			editorScene(
+				createCanvasNode("narration", connectors, {
+					id: "n1",
+					text: "He said <sigh> quietly",
+				}),
+			),
+		]);
+
+		expect(scenes[0].children).toHaveLength(1);
+		expect(Node.string(scenes[0].children[0])).toContain(
+			"He said <sigh> quietly",
+		);
 	});
 });


### PR DESCRIPTION
Three correctness fixes found by a nightly bug hunt, each verified end to end against the real code before and after.

## 1. Every save/reload cycle stacks another zero-width space onto every element

`createCanvasNode` gives each element two text children: a `ZERO_WIDTH_SPACE` caret anchor and the real text. `getElementText` joins **all** children, so `serializeElement` wrote that sentinel into the OSML body: `<narration id="n1">​Hello</narration>`. On reload, `parseOSML` → `appendNext` builds a *fresh* node (with a *fresh* anchor at `children[0]`), then `updateCurrent` appends the serialized body — old anchor included — onto `children[1]`. `String.prototype.trim()` does not strip U+200B, so the guard in `parseBuffer` doesn't drop it either.

Measured by running the real `serializeOSMLWithScenes` → `deserializeWithScenes` pair three times:

```
cycle 0 text: "​​Hello"
cycle 1 text: "​​​Hello"
cycle 2 text: "​​​​Hello"
```

An empty element round-trips to `"​​"`. That breaks `ElementContainer`'s `Node.string(element) === ZERO_WIDTH_SPACE` check, so after a single reload the "Write the narration…" placeholder never renders again for empty elements. It also grows the stored script by one invisible character per element per reload and puts phantom characters in front of the caret. Generation survives only because `getPromptText` strips the sentinel.

Fixed by stripping it at the one place it escapes — the serialization boundary. `getElementText` itself is left alone on purpose: `useScriptSync` compares its output against `Editor.string(...)`, which includes the editor's anchor, so those two must stay symmetric.

## 2. Angle-bracketed prose splits the element and mints an unrenderable node type

Element text is written raw into the tag body, and `TAG_PATTERN` matches *any* `<…>`. Type `He said <sigh> quietly` into a narration and the reload path parses `<sigh>` as an open tag, so `appendNext` takes the generic-node branch and everything after it is appended to *that* node:

```
[{ id: "n1", type: "narration", text: "​He said " },
 { id: "…",  type: "sigh",      text: " quietly" }]
```

`deserializeWithScenes` casts straight to `CanvasContentElement[]` and `withScenes` doesn't drop unknown child types, so the node reaches `renderElement`, where `ELEMENT_CONFIGS[element.type]` is `undefined` and `config.iconBgClass` throws. The user loses half their narration *and* the editor blows up on open — for that project, permanently, since the corruption is what got saved.

OSML has a closed vocabulary: the seven canvas element types plus `metadata_*` (the parser's own comment already said so). Anything else angle-bracketed is prose, so the parser now keeps it verbatim in the element that owns it. That also covers the streaming path, where a stray tag from the model previously vanished silently.

The existing `preserves raw tag name for unknown tags` test encoded the old fallback; it's replaced with two tests for the new contract.

## 3. Pressing Stop doesn't stop generation

`readSSE`'s `finally` called `reader.releaseLock()`, which detaches the reader but does **not** cancel the stream. Both consumers — `ScriptProvider` and `useRefineScript` — cancel purely by `break`ing out of the `for await` when the abort signal fires, and `OpenSlopClient` never passes an `AbortSignal` to `fetch`. So `break` → generator `.return()` → this `finally` was the only cancellation path there was.

Result: the response body stayed open and unread, the `/api/v1/llm` route kept pulling the upstream model stream to completion, and the user was billed for a completion they explicitly cancelled — once per Stop press, and once per re-submit, since both hooks abort before starting a new request.

`reader.cancel()` propagates cancellation to the body, which makes the route's `controller.enqueue` throw and unwind the provider generator. `cancel()` alone leaves the stream locked, so both calls are needed.

## Tests

- `lib/project/__tests__/serialize.test.ts` — new `save/reload round trip on real editor nodes` block driving `createCanvasNode` (the actual editor node shape, which the existing round-trip test's hand-built fixtures never had): text stable across three cycles, an empty element staying exactly one sentinel, and angle-bracketed prose staying in one element. All three fail on `master`.
- `lib/api/__tests__/sse.test.ts` — `cancels a still-open source when the consumer breaks early`, using a source stream that never closes (the production shape). Fails on `master`.
- `lib/canvas/__tests__/osmlStreamParser.test.ts` — unknown open tag and unmatched close tag both kept as element text.

Full suite: 106 files, 913 tests passing. Lint, format, typecheck, knip, and build all clean.

## Deliberately skipped

- **Avatar jobs don't gate the element jobs that depend on them.** Real: `scheduleGeneration` enqueues avatar jobs first and relies on queue *position*, but `processQueue` fills `batchSize` (2) concurrent slots, so the first image can start before its character's `avatarUrl` lands and gets generated with no character reference. Skipped because the only real fix is a completion barrier subscribed to the queue, which is a chunk of machinery for a case that already self-corrects via the stale badge — and it sits on top of `lib/generation/queue.ts`, which open PR #429 owns.
- **Refreshed Supabase cookies dropped on the auth-route redirect** in `lib/supabase/middleware.ts`. Still real, but this exact fix was already proposed in #431, which you closed. Not re-litigating it here.
- **Cartesia narration duration derived from the last word timestamp + 1s** rather than from the PCM buffer it already has, yielding `durationSec: 0` when no timestamp frames arrive. The `+ 1` was added deliberately in #108, so changing it shifts pacing in every existing video — a product call, not a nightly one.
- **`RunwareImage` ignores `params.format`** and always names/serves PNG. Either honour it or drop it from the route schema; either way it's an API-surface decision.
- **`<music length="…">` is inert** — the OSML prompt instructs the model to emit it, nothing maps `MusicLength` to `durationSeconds`. Same reason: product decision.
- **`durationSec` dropped for non-mock video jobs** — you called this intentional on #411.
- **`await ws.connect()` in `CartesiaTTS._generate` is redundant** (`client.tts.websocket()` already awaits it). Looked like a leak-on-connect-failure at first; checking the SDK showed it can't fail independently, so there's no bug and I left it alone.

## Open PR overlap check

Considered #453, #447, #446, #445, #444, #443, #442, #440, #438 and #429, building a file/theme list from `gh pr diff --name-only` on each.

No file here is touched by any of them. `lib/canvas/osmlSerializer.ts` and `osmlStreamParser.ts` are distinct from #444's `nodeUtils.ts`/`withNodeId.ts` and #442's `withScenes.ts`; `lib/api/sse.ts` is distinct from #447's `lib/clients/**`; `lib/project/__tests__/serialize.test.ts` is distinct from #440's `storeSnapshot.test.ts`. Thematically distinct too — #438 also touches the caret sentinel but from the render side (`CompactElement`'s dead caret), not serialization. The two findings that would have collided with #429 and #431 were dropped rather than reworked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
