### PR TITLE
refactor: nightly maintainability 2026-07-22

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,7 +39,7 @@ Every route that takes a JSON body or search params is built from a factory in `
 ## Editor state
 
 - `lib/generation/queue.ts` schedules generation jobs from the editor, caches results per element, and exposes status to the UI. UI dispatches jobs; it never calls connectors directly.
-- `lib/project/store.ts` holds per-project metadata in Zustand. Every mutation rule lives in a store action; components reach the store through `useProject(selector)` rather than `getProjectStore(projectId)`, which is reserved for non-React callers (connector plugins, queue workers).
+- `lib/project/store.ts` holds per-project metadata in Zustand. Every mutation rule lives in a store action. Components subscribe to reactive state through `useProject(selector)`; `getProjectStore(projectId)` is the escape hatch for imperative access that a render-time selector can't express — non-React callers (connector plugins, queue workers), plus hooks doing one-shot init, `.subscribe`, or reads outside render (`ProjectEditor`, `useAutosave`, `useGenerateAll`).
 - `lib/script/` provides script context and refinement utilities.
 
 ## Data

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,7 +39,7 @@ Every route that takes a JSON body or search params is built from a factory in `
 ## Editor state
 
 - `lib/generation/queue.ts` schedules generation jobs from the editor, caches results per element, and exposes status to the UI. UI dispatches jobs; it never calls connectors directly.
-- `lib/project/store.ts` holds per-project metadata in Zustand.
+- `lib/project/store.ts` holds per-project metadata in Zustand. Every mutation rule lives in a store action; components reach the store through `useProject(selector)` rather than `getProjectStore(projectId)`, which is reserved for non-React callers (connector plugins, queue workers).
 - `lib/script/` provides script context and refinement utilities.
 
 ## Data

--- a/app/components/canvas/elements/AssetTiles.tsx
+++ b/app/components/canvas/elements/AssetTiles.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Mic, Palette, User } from "@/components/ui/icon";
+import { characterAvatarElementId } from "@/lib/project/ensureCharacterAvatars";
+import { useProject } from "@/lib/project/useProject";
+import { AssetTile } from "./AssetTile";
+
+export function NarratorAssetTile({ onEdit }: { onEdit: () => void }) {
+	return (
+		<AssetTile name="Narrator" Icon={Mic} fallback="icon" onEdit={onEdit} />
+	);
+}
+
+export function CharacterAssetTiles({
+	onEdit,
+	onRemove,
+}: {
+	onEdit: (name: string) => void;
+	onRemove?: (name: string) => void;
+}) {
+	const characters = useProject((s) => s.metadata.characters);
+	return Object.entries(characters).map(([name, character]) => (
+		<AssetTile
+			key={`character:${name}`}
+			name={name}
+			previewUrl={character.avatarUrl}
+			Icon={User}
+			elementId={characterAvatarElementId(name)}
+			onEdit={() => onEdit(name)}
+			onRemove={onRemove && (() => onRemove(name))}
+			removeAffordance="corner"
+		/>
+	));
+}
+
+export function ReferenceAssetTiles() {
+	const referenceImages = useProject((s) => s.referenceImages);
+	const removeReferenceImage = useProject((s) => s.removeReferenceImage);
+	return referenceImages.map((url, index) => (
+		<AssetTile
+			key={`reference:${url}`}
+			name={`Reference ${index + 1}`}
+			previewUrl={url}
+			Icon={Palette}
+			onRemove={() => removeReferenceImage(index)}
+		/>
+	));
+}

--- a/app/components/canvas/elements/AssetsSection.tsx
+++ b/app/components/canvas/elements/AssetsSection.tsx
@@ -1,35 +1,28 @@
 "use client";
 
 import { memo, useState } from "react";
-import { ImagePlus, Mic, Palette, User, UserPlus } from "@/components/ui/icon";
-import { useConfig } from "@/lib/config/ConfigProvider";
-import { getProjectStore, useProjectStore } from "@/lib/project/store";
-import { characterAvatarElementId } from "@/lib/project/ensureCharacterAvatars";
+import { ImagePlus, UserPlus } from "@/components/ui/icon";
+import { useProject } from "@/lib/project/useProject";
 import { useImageUpload } from "@/lib/upload/useImageUpload";
 import { AddAssetTile } from "./AddAssetTile";
-import { AssetTile } from "./AssetTile";
+import {
+	CharacterAssetTiles,
+	NarratorAssetTile,
+	ReferenceAssetTiles,
+} from "./AssetTiles";
 import { useAssetEditDialogs } from "./character/useAssetEditDialogs";
 import { CollapsibleHeader } from "./CollapsibleHeader";
 
 function AssetsSectionComponent() {
-	const { projectId } = useConfig();
-	const hydrated = useProjectStore(projectId, (s) => s.hydrated);
-	const characters = useProjectStore(projectId, (s) => s.metadata.characters);
-	const referenceImages = useProjectStore(projectId, (s) => s.referenceImages);
-	const removeReferenceImage = useProjectStore(
-		projectId,
-		(s) => s.removeReferenceImage,
-	);
+	const hydrated = useProject((s) => s.hydrated);
+	const addReferenceImages = useProject((s) => s.addReferenceImages);
 	const [collapsed, setCollapsed] = useState(false);
 	const { openCreateCharacter, editCharacter, openNarrator, dialogs } =
 		useAssetEditDialogs();
 
 	const { openPicker, uploading, inputElement } = useImageUpload({
 		multiple: true,
-		onUpload: (urls) => {
-			const store = getProjectStore(projectId).getState();
-			store.setReferenceImages([...store.referenceImages, ...urls]);
-		},
+		onUpload: addReferenceImages,
 	});
 
 	if (!hydrated) return null;
@@ -44,37 +37,15 @@ function AssetsSectionComponent() {
 			/>
 			{!collapsed && (
 				<div className="flex flex-wrap gap-2">
-					<AssetTile
-						name="Narrator"
-						Icon={Mic}
-						fallback="icon"
-						onEdit={openNarrator}
-					/>
-					{Object.entries(characters).map(([name, ch]) => (
-						<AssetTile
-							key={`character:${name}`}
-							name={name}
-							previewUrl={ch.avatarUrl}
-							Icon={User}
-							elementId={characterAvatarElementId(name)}
-							onEdit={() => editCharacter(name)}
-						/>
-					))}
+					<NarratorAssetTile onEdit={openNarrator} />
+					<CharacterAssetTiles onEdit={editCharacter} />
 					<AddAssetTile
 						label="Character"
 						ariaLabel="Add character"
 						Icon={UserPlus}
 						onClick={openCreateCharacter}
 					/>
-					{referenceImages.map((url, i) => (
-						<AssetTile
-							key={`style:${url}`}
-							name={`Reference ${i + 1}`}
-							previewUrl={url}
-							Icon={Palette}
-							onRemove={() => removeReferenceImage(i)}
-						/>
-					))}
+					<ReferenceAssetTiles />
 					<AddAssetTile
 						label="Reference"
 						ariaLabel="Add reference image"

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -25,7 +25,7 @@ import {
 	characterAvatarElementId,
 } from "@/lib/project/ensureCharacterAvatars";
 import { deleteCharacter } from "@/lib/project/deleteCharacter";
-import { getProjectStore, useProjectStore } from "@/lib/project/store";
+import { useProject } from "@/lib/project/useProject";
 import type { MetadataCharacter } from "@/lib/project/types";
 import { UploadImageButton } from "@/lib/upload/UploadImageButton";
 import { GenerateButton, StaleIndicator } from "../GenerateButton";
@@ -65,9 +65,9 @@ function CharacterEditDialogBody({
 }) {
 	const { projectId, connectorConfig } = useConfig();
 	const queue = useGenerationQueue();
-	const metadata = useProjectStore(projectId, (s) => s.metadata);
+	const metadata = useProject((s) => s.metadata);
 	const character = metadata.characters[name];
-	const setCharacter = useProjectStore(projectId, (s) => s.setCharacter);
+	const updateCharacter = useProject((s) => s.updateCharacter);
 
 	const [confirmDelete, setConfirmDelete] = useState(false);
 	const [closeConfirm, setCloseConfirm] = useState(false);
@@ -80,12 +80,10 @@ function CharacterEditDialogBody({
 	if (!character) return null;
 
 	const update = (partial: Partial<MetadataCharacter>) =>
-		setCharacter(name, { ...character, ...partial });
+		updateCharacter(name, partial);
 
 	const regenerateAvatar = () => {
-		if (character.avatarUploaded) {
-			setCharacter(name, { ...character, avatarUploaded: false });
-		}
+		if (character.avatarUploaded) update({ avatarUploaded: false });
 		queue.enqueue(buildCharacterAvatarJob(projectId, name, connectorConfig));
 	};
 
@@ -194,14 +192,7 @@ function CharacterEditDialogBody({
 							className="absolute left-2 top-2 z-10 bg-card shadow-sm ring-1 ring-border"
 							onUpload={(url) => {
 								queue.discard(avatarElementId);
-								const store = getProjectStore(projectId).getState();
-								const current = store.metadata.characters[name];
-								if (!current) return;
-								store.setCharacter(name, {
-									...current,
-									avatarUrl: url,
-									avatarUploaded: true,
-								});
+								update({ avatarUrl: url, avatarUploaded: true });
 							}}
 						/>
 					</div>

--- a/app/components/canvas/hooks/useMetadataSync.ts
+++ b/app/components/canvas/hooks/useMetadataSync.ts
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
-import { useConfig } from "@/lib/config/ConfigProvider";
-import { getProjectStore } from "@/lib/project/store";
+import { useProject } from "@/lib/project/useProject";
 import type { DeepPartial, Metadata } from "@/lib/project/types";
 import { useScriptNodes } from "@/lib/script/ScriptProvider";
 import { METADATA_TAG_CONFIGS } from "../config/metadataTags";
@@ -8,7 +7,7 @@ import { getElementText } from "@/lib/canvas/osmlSerializer";
 
 export function useMetadataSync(): void {
 	const nodes = useScriptNodes();
-	const { projectId } = useConfig();
+	const updateMetadata = useProject((s) => s.updateMetadata);
 
 	useEffect(() => {
 		const partial: DeepPartial<Metadata> = {};
@@ -21,6 +20,6 @@ export function useMetadataSync(): void {
 				getElementText(node).trim(),
 			);
 		}
-		getProjectStore(projectId).getState().updateMetadata(partial);
-	}, [nodes, projectId]);
+		updateMetadata(partial);
+	}, [nodes, updateMetadata]);
 }

--- a/app/components/canvas/panel/PropertiesPanel.tsx
+++ b/app/components/canvas/panel/PropertiesPanel.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { SelectField } from "@/components/ui/select-field";
-import { useConfig } from "@/lib/config/ConfigProvider";
-import { getProjectStore } from "@/lib/project/store";
+import { useProject } from "@/lib/project/useProject";
 import { TRANSITION_TYPES, type TransitionType } from "@/lib/video/transitions";
 import { useTransitionType } from "@/lib/video/useTransitionType";
 import { PanelCard, PanelField } from "./PanelCard";
@@ -23,13 +22,11 @@ const OPTIONS = TRANSITION_TYPES.map((value) => ({
 }));
 
 export function PropertiesPanel() {
-	const { projectId } = useConfig();
 	const transitionType = useTransitionType();
+	const updateMetadata = useProject((s) => s.updateMetadata);
 
 	const setTransitionType = (value: TransitionType) =>
-		getProjectStore(projectId)
-			.getState()
-			.updateMetadata({ videoSettings: { transitionType: value } });
+		updateMetadata({ videoSettings: { transitionType: value } });
 
 	return (
 		<PanelCard title="Transition">

--- a/app/components/copilot/ComposerAssets.tsx
+++ b/app/components/copilot/ComposerAssets.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { Mic, Palette, User } from "@/components/ui/icon";
-import { AssetTile } from "@/app/components/canvas/elements/AssetTile";
+import {
+	CharacterAssetTiles,
+	NarratorAssetTile,
+	ReferenceAssetTiles,
+} from "@/app/components/canvas/elements/AssetTiles";
 import { ConfirmDeleteDialog } from "@/components/ui/confirm-delete-dialog";
-import { characterAvatarElementId } from "@/lib/project/ensureCharacterAvatars";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
 import { deleteCharacter } from "@/lib/project/deleteCharacter";
@@ -23,15 +25,11 @@ export function ComposerAssets({
 }: ComposerAssetsProps) {
 	const { projectId } = useConfig();
 	const queue = useGenerationQueue();
-	const referenceImages = useProject((s) => s.referenceImages);
-	const characters = useProject((s) => s.metadata.characters);
 	const narration = useProject((s) => s.metadata.narration);
-	const removeReferenceImage = useProject((s) => s.removeReferenceImage);
 
 	const [deletingName, setDeletingName] = useState<string>();
 
 	const hasNarration = Object.keys(narration).length > 0;
-	const characterEntries = Object.entries(characters);
 
 	const confirmDelete = () => {
 		if (deletingName) deleteCharacter(projectId, queue, deletingName);
@@ -40,35 +38,12 @@ export function ComposerAssets({
 
 	return (
 		<div className="flex flex-wrap gap-2 pb-2">
-			{hasNarration && (
-				<AssetTile
-					name="Narrator"
-					Icon={Mic}
-					fallback="icon"
-					onEdit={onEditNarrator}
-				/>
-			)}
-			{characterEntries.map(([name, ch]) => (
-				<AssetTile
-					key={`character:${name}`}
-					name={name}
-					previewUrl={ch.avatarUrl}
-					Icon={User}
-					elementId={characterAvatarElementId(name)}
-					onEdit={() => onEditCharacter(name)}
-					onRemove={() => setDeletingName(name)}
-					removeAffordance="corner"
-				/>
-			))}
-			{referenceImages.map((url, i) => (
-				<AssetTile
-					key={`ref:${url}`}
-					name={`Reference ${i + 1}`}
-					previewUrl={url}
-					Icon={Palette}
-					onRemove={() => removeReferenceImage(i)}
-				/>
-			))}
+			{hasNarration && <NarratorAssetTile onEdit={onEditNarrator} />}
+			<CharacterAssetTiles
+				onEdit={onEditCharacter}
+				onRemove={setDeletingName}
+			/>
+			<ReferenceAssetTiles />
 			{Array.from({ length: uploadingCount }).map((_, i) => (
 				<div
 					key={i}

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -22,7 +22,7 @@ import {
 	type Template,
 } from "@/lib/templates/templates";
 import { useConfig } from "@/lib/config/ConfigProvider";
-import { getProjectStore } from "@/lib/project/store";
+import { useProject } from "@/lib/project/useProject";
 import type { Mode } from "@/lib/project/types";
 import type { AspectRatio } from "@/lib/video/aspectRatio";
 import { useAspectRatio } from "@/lib/video/useAspectRatio";
@@ -172,20 +172,15 @@ export default function ComposerCopilot({
 	placeholder,
 	placeholderOverlay,
 }: ComposerCopilotProps) {
-	const { projectId, mode, setMode, selectedTemplateId, selectTemplate } =
-		useConfig();
+	const { mode, setMode, selectedTemplateId, selectTemplate } = useConfig();
 	const aspectRatio = useAspectRatio();
+	const updateMetadata = useProject((s) => s.updateMetadata);
+	const addReferenceImages = useProject((s) => s.addReferenceImages);
 	const { openCreateCharacter, editCharacter, openNarrator, dialogs } =
 		useAssetEditDialogs();
 
 	const { openPicker, uploading, uploadingCount, inputElement } =
-		useImageUpload({
-			multiple: true,
-			onUpload: (urls) => {
-				const store = getProjectStore(projectId).getState();
-				store.setReferenceImages([...store.referenceImages, ...urls]);
-			},
-		});
+		useImageUpload({ multiple: true, onUpload: addReferenceImages });
 	const isTemplateMode = mode === "template";
 	const hasText = value.trim().length > 0;
 	const selectedTemplate = getTemplate(selectedTemplateId);
@@ -256,11 +251,9 @@ export default function ComposerCopilot({
 						</SelectMenu>
 						<SelectMenu
 							value={aspectRatio}
-							onChange={(next: AspectRatio) => {
-								getProjectStore(projectId)
-									.getState()
-									.updateMetadata({ videoSettings: { aspectRatio: next } });
-							}}
+							onChange={(next: AspectRatio) =>
+								updateMetadata({ videoSettings: { aspectRatio: next } })
+							}
 							options={ASPECT_RATIO_OPTIONS}
 							itemClassName="rounded-lg text-label-xs"
 						>

--- a/lib/project/__tests__/store.test.ts
+++ b/lib/project/__tests__/store.test.ts
@@ -97,6 +97,39 @@ describe("project store updateMetadata", () => {
 		});
 	});
 
+	it("updateCharacter merges into the existing entry", () => {
+		const store = getProjectStore(PROJECT_ID);
+		store
+			.getState()
+			.setCharacter("Alice", { appearance: "A girl", accent: "british" });
+		store.getState().updateCharacter("Alice", { avatarUrl: "a.png" });
+
+		expect(store.getState().metadata.characters["Alice"]).toEqual({
+			appearance: "A girl",
+			accent: "british",
+			avatarUrl: "a.png",
+		});
+	});
+
+	it("updateCharacter throws for an unknown character", () => {
+		const store = getProjectStore(PROJECT_ID);
+		expect(() =>
+			store.getState().updateCharacter("Nobody", { avatarUrl: "a.png" }),
+		).toThrow(/Nobody/);
+	});
+
+	it("addReferenceImages appends to the existing images", () => {
+		const store = getProjectStore(PROJECT_ID);
+		store.getState().setReferenceImages(["a.png"]);
+		store.getState().addReferenceImages(["b.png", "c.png"]);
+
+		expect(store.getState().referenceImages).toEqual([
+			"a.png",
+			"b.png",
+			"c.png",
+		]);
+	});
+
 	it("removeReferenceImage drops only the image at the given index", () => {
 		const store = getProjectStore(PROJECT_ID);
 		store.getState().setReferenceImages(["a.png", "b.png", "c.png"]);

--- a/lib/project/store.ts
+++ b/lib/project/store.ts
@@ -15,9 +15,11 @@ export type ProjectContext = {
 	referenceImages: string[];
 	updateMetadata: (partial: DeepPartial<Metadata>) => void;
 	setCharacter: (name: string, character: MetadataCharacter) => void;
+	updateCharacter: (name: string, partial: Partial<MetadataCharacter>) => void;
 	removeCharacter: (name: string) => void;
 	setNarration: (narration: MetadataVoice) => void;
 	setReferenceImages: (urls: string[]) => void;
+	addReferenceImages: (urls: string[]) => void;
 	removeReferenceImage: (index: number) => void;
 	markHydrated: () => void;
 	reset: () => void;
@@ -47,6 +49,13 @@ export function getProjectStore(projectId: string): ProjectStore {
 					set((state) => {
 						state.metadata.characters[name] = character;
 					}),
+				updateCharacter: (name, partial) =>
+					set((state) => {
+						const character = state.metadata.characters[name];
+						if (!character)
+							throw new Error(`Cannot update unknown character "${name}"`);
+						Object.assign(character, partial);
+					}),
 				removeCharacter: (name) =>
 					set((state) => {
 						delete state.metadata.characters[name];
@@ -58,6 +67,10 @@ export function getProjectStore(projectId: string): ProjectStore {
 				setReferenceImages: (urls) =>
 					set((state) => {
 						state.referenceImages = urls;
+					}),
+				addReferenceImages: (urls) =>
+					set((state) => {
+						state.referenceImages.push(...urls);
 					}),
 				removeReferenceImage: (index) =>
 					set((state) => {

--- a/lib/script/ScriptProvider.tsx
+++ b/lib/script/ScriptProvider.tsx
@@ -14,7 +14,7 @@ import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { getDefaultConnector } from "@/lib/config/connectorUtils";
 import { createConnector } from "@/lib/connectors/factory";
-import { getProjectStore } from "@/lib/project/store";
+import { useProject } from "@/lib/project/useProject";
 import { useOSMLStreamParser } from "@/lib/canvas/useOSMLStreamParser";
 
 type ScriptControl = {
@@ -52,7 +52,8 @@ export function ScriptProvider({
 	initialScript?: string;
 	children: ReactNode;
 }) {
-	const { connectorConfig, projectId, mode } = useConfig();
+	const { connectorConfig, mode } = useConfig();
+	const updateMetadata = useProject((s) => s.updateMetadata);
 	const [hasContent, setHasContent] = useState(initialScript.length > 0);
 	const [loading, setLoading] = useState(false);
 	const abortRef = useRef<AbortController | null>(null);
@@ -77,9 +78,7 @@ export function ScriptProvider({
 
 			setHasContent(false);
 			setLoading(true);
-			getProjectStore(projectId)
-				.getState()
-				.updateMetadata({ lastMode: mode, lastPrompt: prompt });
+			updateMetadata({ lastMode: mode, lastPrompt: prompt });
 			try {
 				const connector = createConnector("llm", llmProvider, llmConfig);
 				for await (const chunk of connector.stream({ prompt })) {
@@ -95,7 +94,7 @@ export function ScriptProvider({
 				}
 			}
 		},
-		[llmProvider, llmConfig, appendChunk, projectId, mode],
+		[llmProvider, llmConfig, appendChunk, updateMetadata, mode],
 	);
 
 	const control = useMemo<ScriptControl>(


### PR DESCRIPTION
Makes the project store the single home for project-state mutation rules, and gives the two asset grids one shared implementation. No behavior changes.

## Architecture

**Store actions own the mutation rules.** Two knowledge items were living in components instead of `lib/project/store.ts`:

- `addReferenceImages(urls)` — the append rule (`setReferenceImages([...current, ...urls])`) was hand-rolled identically in `ComposerCopilot` and `AssetsSection`, each re-reading the store imperatively to do it.
- `updateCharacter(name, partial)` — partial character merges were spelled `setCharacter(name, { ...character, ...partial })` at three call sites in `CharacterEditModal`, one of which re-read the store, then **silently returned** if the character had vanished. The action now throws on an unknown name, so an impossible state surfaces instead of quietly dropping an avatar upload.

**`useProject` is the one way UI reads the store.** Seven call sites did `useConfig().projectId` + either `useProjectStore(projectId, …)` or `getProjectStore(projectId).getState()`. They now use `useProject(selector)`, which already existed as the canonical hook. `getProjectStore` is left to its real audience: non-React callers (connector plugins, queue workers, `applyTemplate`). Four components stop threading `projectId` entirely.

**One asset grid, not two.** `ComposerAssets` (composer) and `AssetsSection` (sidebar) duplicated the tile-rendering rules: narrator tile, character tiles wired to `characterAvatarElementId`, reference tiles labelled and removed by index. New `AssetTiles.tsx` holds `NarratorAssetTile` / `CharacterAssetTiles` / `ReferenceAssetTiles`; each reads what it needs from the store, so neither screen drills asset props. The two screens keep the trim that genuinely differs (add-tiles and the upload shimmers stay where they belong).

## Complexity delta

- 11 files, +45/−105 lines of app code excluding the new module and tests.
- `ComposerAssets` 90 → 65 lines, `AssetsSection` 95 → 66, `CharacterEditModal` 242 → 228.
- `getProjectStore` calls in `app/` + React providers: 9 → 3.
- Removed one silent-degradation early return and two hand-rolled read-modify-write blocks.
- Added 3 store tests (merge, unknown-name throw, append).

## Docs

One line in `ARCHITECTURE.md` recording the invariant this PR establishes: mutation rules live in store actions, components go through `useProject`, `getProjectStore` is for non-React callers.

## Skipped

- Extracting a `useCharacterAvatar` hook from `CharacterEditModal`. Its preview block overlaps the `MediaResult` helper added in #443, and the hook would have exactly one consumer.
- Deleting anything unreferenced. Nothing here was removed for being unused.

## Open PR overlap check

Considered #455, #453, #447, #446, #445, #444, #443, #442, #440, #438, #429 (file lists via `gh pr diff --name-only`). No file in this PR appears in any of them. Nearest neighbours: #440 touches `lib/project/storeSnapshot.ts` / `types.ts` (this PR touches `store.ts`), and #443 touches sibling files in `elements/` (this PR touches `AssetsSection.tsx` and adds `AssetTiles.tsx`).

## Validation

`npm run build`, `npm test` (911 passed), `npm run typecheck`, `npm run lint`, `prettier --check`, `knip` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)