### PR TITLE
perf: nightly performance optimizations 2026-07-22

### DIFF
--- a/app/components/canvas/dnd/useDragAndDrop.ts
+++ b/app/components/canvas/dnd/useDragAndDrop.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import {
 	DragEndEvent,
 	DragOverEvent,
@@ -12,6 +12,7 @@ import {
 import { Descendant, Editor, Element, Path, Transforms } from "slate";
 import { isSceneElement } from "@/lib/canvas/scenes";
 import type { DragTransfer } from "./DragTransferContext";
+import { useSortableIds } from "./useSortableIds";
 
 export function useDragAndDrop(editor: Editor, value: Descendant[]) {
 	const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
@@ -19,9 +20,8 @@ export function useDragAndDrop(editor: Editor, value: Descendant[]) {
 
 	const sensors = useSensors(useSensor(PointerSensor), useSensor(TouchSensor));
 
-	const sceneItems = useMemo<string[]>(
-		() => value.filter(isSceneElement).map((s) => s.id),
-		[value],
+	const sceneItems = useSortableIds(
+		value.filter(isSceneElement).map((s) => s.id),
 	);
 
 	const handleDragStart = useCallback((event: DragStartEvent) => {

--- a/app/components/canvas/dnd/useSortableIds.ts
+++ b/app/components/canvas/dnd/useSortableIds.ts
@@ -1,0 +1,15 @@
+import { useMemo } from "react";
+
+/** Safe because node ids are nanoids, whose alphabet is `A-Za-z0-9_-`. */
+const SEPARATOR = ",";
+
+/**
+ * dnd-kit keys its sortable context value on the identity of `items`, and a
+ * context change re-renders every `useSortable` consumer under it — straight
+ * through slate-react's memoized elements. Slate replaces the children array on
+ * every operation, so derive identity from the ids rather than the array.
+ */
+export function useSortableIds(ids: string[]): string[] {
+	const key = ids.join(SEPARATOR);
+	return useMemo(() => (key ? key.split(SEPARATOR) : []), [key]);
+}

--- a/app/components/canvas/elements/SceneContainer.tsx
+++ b/app/components/canvas/elements/SceneContainer.tsx
@@ -9,6 +9,7 @@ import { findSceneSequence } from "@/app/components/video/useSceneSegments";
 import { useLayout } from "@/app/components/video/VideoLayoutContext";
 import { isForeground } from "@/lib/canvas/guards";
 import { useDragTransfer } from "../dnd/DragTransferContext";
+import { useSortableIds } from "../dnd/useSortableIds";
 import { useSceneIndex } from "../hooks/useSceneIndex";
 import { useViewMode } from "../ViewModeContext";
 import { CollapsibleHeader } from "./CollapsibleHeader";
@@ -28,10 +29,7 @@ interface SceneProps {
 }
 
 function useSceneState(element: SceneElement) {
-	const childIds = useMemo(
-		() => element.children.map((c) => c.id),
-		[element.children],
-	);
+	const childIds = useSortableIds(element.children.map((c) => c.id));
 
 	const transfer = useDragTransfer();
 	const isDropTarget =


### PR DESCRIPTION
Canvas render-path pass. No behavior changes.

## What was optimized

**Every Slate operation invalidated both sortable contexts, re-rendering the whole document.**

`slate-react` memoizes elements on `prev.element === next.element` (`MemoizedElement`), which is what lets a large script stay editable — editing one element should re-render only that element. `@dnd-kit/sortable` was punching straight through it:

```js
// @dnd-kit/sortable SortableContext
const items = useMemo(() => userDefinedItems.map(...), [userDefinedItems]);
const contextValue = useMemo(() => ({ ..., items, sortedRects: getSortedRects(items, droppableRects) }), [..., items, ...]);
```

The context value is keyed on the **identity** of `items`. Both canvas sortable contexts were handed arrays rebuilt on every op:

- `useDragAndDrop` derived `sceneItems` from `value`
- `SceneContainer` derived `childIds` from `element.children`

Slate replaces those arrays on every operation, so both `useMemo` deps changed on every keystroke. Context propagation ignores `React.memo`, so there is no bailout: one character re-rendered **every scene shell in the document** plus **every element in the edited scene**. Each of those re-renders drags in `useSortable`'s transform work and droppable re-registration, `sceneIndexOf`'s O(scenes) scan (O(scenes²) across the document), `findSceneSequence`, `SortableActions`, `CollapsibleHeader`, and — for content elements — `resolveAttributeSchema` and three `useGenerate` subscriptions apiece.

`useSortableIds` pins the id array's identity to the ids themselves. That is also exactly when the dependent render output changes: sortable order, the "Scene N" label and the drop-gap padding all derive from the id list, so the invalidation key now matches the real dependency instead of over-approximating it with "any Slate op". Typing re-renders the edited element; insert, delete and reorder still repaint the affected scenes.

This is the case the [Slate performance walkthrough](https://docs.slatejs.org/walkthroughs/09-performance) calls out directly — custom contexts holding non-primitive values defeat element memoization.

## What was skipped

- **`getLayoutKey(getContentElements(value), …)` in `PostPromptView`** rebuilds a signature string over every content element per keystroke. Real, but tens of microseconds against render work an order of magnitude larger, and `lib/video/elementAttributes.ts` is covered by #446. Below the bar on its own.
- **`sceneIndexOf`'s O(scenes²) total scan** (`useSceneIndex`). Only material when every scene re-renders, which this PR stops. Not worth an index map on its own.
- **Playback-path micro-optimizations** (per-frame `cn()`, `usePlayerValue` snapshot caching, Remotion frame components). Previously measured as no-ops in #417/#441; not revisited.
- **No new test.** The change is React memoization semantics across renders; the repo has no hook/render-count test harness (no `@testing-library/react`, node test env), and adding one is out of scope for a perf pass.

## Open PR overlap check

Considered open PRs #456, #455, #453, #447, #446, #445, #444, #443, #442, #440, #438, #429.

- `useSortableIds.ts` (new) and `SceneContainer.tsx` are untouched by any open PR.
- `useDragAndDrop.ts` is also edited by #445, but in disjoint regions — that PR extracts `handleDragOver`/`handleDragEnd` into `lib/canvas/dragOps`; this PR only replaces the `sceneItems` memo, which has no other home. Different theme (maintainability extraction vs. render-path perf).
- Deliberately avoided as overlapping: `ElementContainer` and the element preview path (#443), `AssetsSection`/`PropertiesPanel` (#456), `VideoComposition`/`elementAttributes` (#446, #440), the render/upload clients (#447), `lib/generation/queue` (#429).

## Validation

`lint`, `format:check`, `typecheck`, `knip`, `build`, `test:run` (908 tests) all pass locally. Playwright smoke tests left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)