### PR TITLE
refactor: nightly CONVENTIONS.md compliance 2026-07-22

### DIFF
--- a/app/components/EditorToolbar.tsx
+++ b/app/components/EditorToolbar.tsx
@@ -5,7 +5,7 @@ import type { Editor } from "slate";
 import { Sparkles, X } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
-import { SimpleTooltip } from "@/components/ui/tooltip";
+import { TooltipIconButton } from "@/components/ui/icon-button";
 import { useScriptControl } from "@/lib/script/ScriptProvider";
 import {
 	useGenerationQueue,
@@ -83,16 +83,13 @@ function EditorToolbarComponent({ editor }: { editor: Editor }) {
 					</Button>
 					<ExportButton />
 					{generating && (
-						<SimpleTooltip label="Cancel generation">
-							<button
-								type="button"
-								onClick={() => queue.cancelAll()}
-								aria-label="Cancel generation"
-								className="relative flex h-7 w-7 shrink-0 items-center justify-center self-center rounded-md bg-muted text-muted-foreground transition-colors hover:bg-button-hover hover:text-foreground"
-							>
-								<X className="h-3 w-3" aria-hidden="true" />
-							</button>
-						</SimpleTooltip>
+						<TooltipIconButton
+							label="Cancel generation"
+							className="self-center bg-muted text-muted-foreground hover:text-foreground"
+							onClick={() => queue.cancelAll()}
+						>
+							<X className="h-3 w-3" aria-hidden="true" />
+						</TooltipIconButton>
 					)}
 				</div>
 			</div>

--- a/lib/connectors/__tests__/template-mode.test.ts
+++ b/lib/connectors/__tests__/template-mode.test.ts
@@ -33,16 +33,11 @@ describe("createTemplateModePlugin", () => {
 			);
 		});
 
-		it("returns params unchanged when templateId is null", () => {
-			const { beforeGenerate } = createTemplateModePlugin(undefined);
-			const params = { prompt: "hi", systemPrompt: "keep me" };
-			expect(beforeGenerate?.(params)).toBe(params);
-		});
-
-		it("returns params unchanged when templateId is unknown", () => {
+		it("throws when templateId is unknown", () => {
 			const { beforeGenerate } = createTemplateModePlugin("does-not-exist");
-			const params = { prompt: "hi" };
-			expect(beforeGenerate?.(params)).toBe(params);
+			expect(() => beforeGenerate?.({ prompt: "hi" })).toThrow(
+				'Unknown template id "does-not-exist"',
+			);
 		});
 
 		it("preserves other params", () => {
@@ -71,16 +66,11 @@ describe("createTemplateModePlugin", () => {
 			expect(result).toContain(realTemplate.exampleText.slice(0, 64));
 		});
 
-		it("returns prompt unchanged when templateId is null", async () => {
-			const { transformPrompt } = createTemplateModePlugin(undefined);
-			const result = await transformPrompt?.("anything", fakeCtx);
-			expect(result).toBe("anything");
-		});
-
-		it("returns prompt unchanged when templateId is unknown", async () => {
+		it("rejects when templateId is unknown", async () => {
 			const { transformPrompt } = createTemplateModePlugin("does-not-exist");
-			const result = await transformPrompt?.("anything", fakeCtx);
-			expect(result).toBe("anything");
+			await expect(transformPrompt?.("anything", fakeCtx)).rejects.toThrow(
+				'Unknown template id "does-not-exist"',
+			);
 		});
 	});
 });

--- a/lib/connectors/llm/plugins/template-mode.ts
+++ b/lib/connectors/llm/plugins/template-mode.ts
@@ -1,25 +1,18 @@
 import dedent from "dedent";
 import type { LLMPlugin } from "@/lib/connectors/types";
-import { getTemplateById } from "@/lib/templates/templates";
+import { getTemplate } from "@/lib/templates/templates";
 import { prependSystemPrompt } from "./system-prompt";
 
-export function createTemplateModePlugin(
-	templateId: string | undefined,
-): LLMPlugin {
-	const template = templateId ? getTemplateById(templateId) : undefined;
-
+export function createTemplateModePlugin(templateId: string): LLMPlugin {
 	return {
 		name: "templateMode",
 		beforeGenerate(params) {
-			if (!template) return params;
-			return prependSystemPrompt(params, template.systemPrompt);
+			return prependSystemPrompt(params, getTemplate(templateId).systemPrompt);
 		},
 		async transformPrompt(prompt: string) {
-			if (!template) return prompt;
-
 			return dedent`Pastiche this story format (with tone, language, pacing, imagery, plot techniques, story beats, structure, etc.) and reframe it to be about ${prompt}.
 
-				Example story: ${template.exampleText}`;
+				Example story: ${getTemplate(templateId).exampleText}`;
 		},
 	};
 }


### PR DESCRIPTION
Nightly audit of the codebase against `CONVENTIONS.md`. Two violations fixed; the rest of the sweep is flagged below rather than changed.

## Fixed

### Fail loudly + define errors out of existence — `lib/connectors/llm/plugins/template-mode.ts`

```ts
export function createTemplateModePlugin(templateId: string | undefined): LLMPlugin {
	const template = templateId ? getTemplateById(templateId) : undefined;
	return {
		beforeGenerate(params) {
			if (!template) return params;   // silent no-op
			...
		},
		async transformPrompt(prompt) {
			if (!template) return prompt;   // silent no-op
			...
		},
	};
}
```

A missing or unknown template id silently disabled the plugin, so a user who picked a template would get a generic story with no error anywhere. That's a swallow on a critical path (hard rule: *"Never swallow an error on a critical path to keep going"*).

Neither case is actually reachable — `ConfigProvider` seeds `selectedTemplateId` with `DEFAULT_TEMPLATE_ID` and only reassigns it from `selectTemplate`, and `ComposerCopilot` already calls the throwing `getTemplate` on the same value. So the edge case is designed out rather than handled: the parameter is now `string`, and the lookup uses the canonical throwing `getTemplate` instead of the lenient `getTemplateById`. Resolving lazily inside the hooks keeps the throw on the generation path (where the connector's `onError` + toast surface it) instead of during render.

Two tests that asserted the silent no-op now assert the throw.

### One canonical way — `app/components/EditorToolbar.tsx`

The cancel-generation control hand-rolled `SimpleTooltip` + a raw `<button>` whose classes restated `IconButton`'s base (`flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors hover:bg-button-hover`). Replaced with the shared `TooltipIconButton`, keeping only the genuinely local `self-center bg-muted text-muted-foreground`. Also picks up the design system's `focus-ring` and disabled styles, which the hand-rolled version was missing.

## Flagged, not fixed

- **`lib/connectors/llm/plugins/refine.ts:36-42`** — the refine system prompt hand-maintains a per-element-type attribute list (`narration: emotion, captions`, `image: overlays, motion`, …) that already exists declaratively in `lib/connectors/*/attributes.ts` as `AttributeSchema` definitions, reachable via `ELEMENT_TYPES[type].connector`. Two homes for one piece of knowledge, so the prompt silently drifts whenever an attribute is added. `osml.ts` has the same shape. Deriving the prompt text from the schemas changes what we send the model, so it needs a deliberate prompt-quality review rather than a nightly refactor.
- **`app/components/canvas/elements/CharactersPicker.tsx:116`** duplicates the exact one-off Tailwind string at **`ElementContainer.tsx:67`** verbatim (a 6x6 ghost icon button). `ElementContainer.tsx` is owned by open PR #443, so I left both alone; worth folding into a shared variant once that lands.
- **Three ways to set an LLM system prompt**: `prependSystemPrompt` (story/script/template/project-metadata), `if (!params.systemPrompt)` guard (`osml.ts`), and direct assignment (`refine.ts`). Each is correct for its own plugin ordering, but the vocabulary is inconsistent enough to be worth one deliberate pass.

## Checks

`npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run test:run` (906 passed), `npm run build` — all green.

Files touched by open PRs (#429, #438, #440, #442-447, #453, #455, #456, #457) were excluded from the sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)