### PR TITLE
fix: nightly bug fixes 2026-07-23

### DIFF
--- a/lib/components/ImageWithShimmer.tsx
+++ b/lib/components/ImageWithShimmer.tsx
@@ -5,10 +5,17 @@ import Image, { type ImageProps } from "next/image";
 import { Skeleton } from "@/components/ui/skeleton";
 
 /**
- * `next/image` with a shimmer overlay that hides once the image loads.
+ * `next/image` with a shimmer overlay that hides once the image resolves.
+ * Clears on error too, so a broken/expired URL falls back to the image's
+ * own error state instead of shimmering forever.
  */
-export function ImageWithShimmer({ alt, onLoad, ...props }: ImageProps) {
-	const [loaded, setLoaded] = useState(false);
+export function ImageWithShimmer({
+	alt,
+	onLoad,
+	onError,
+	...props
+}: ImageProps) {
+	const [settled, setSettled] = useState(false);
 	return (
 		<>
 			<Image
@@ -16,10 +23,14 @@ export function ImageWithShimmer({ alt, onLoad, ...props }: ImageProps) {
 				alt={alt}
 				onLoad={(event: SyntheticEvent<HTMLImageElement>) => {
 					onLoad?.(event);
-					setLoaded(true);
+					setSettled(true);
+				}}
+				onError={(event: SyntheticEvent<HTMLImageElement>) => {
+					onError?.(event);
+					setSettled(true);
 				}}
 			/>
-			{!loaded && (
+			{!settled && (
 				<Skeleton className="absolute inset-0 animate-none shimmer-surface" />
 			)}
 		</>

--- a/lib/components/Waveform.tsx
+++ b/lib/components/Waveform.tsx
@@ -83,8 +83,8 @@ export function Waveform({
 	const [loadedSrc, setLoadedSrc] = useState<string | null>(() =>
 		peaksCache?.has(src) ? src : null,
 	);
-	const [metadataReadyFor, setMetadataReadyFor] = useState<string | null>(null);
-	const loading = loadedSrc !== src || metadataReadyFor !== src;
+	const [audioSettledFor, setAudioSettledFor] = useState<string | null>(null);
+	const loading = loadedSrc !== src || audioSettledFor !== src;
 
 	// Adjust state during render when src changes to a cached value
 	// (React-supported pattern for deriving state from props)
@@ -222,10 +222,11 @@ export function Waveform({
 					const a = audioRef.current;
 					if (!a) return;
 					if (Number.isFinite(a.duration) && a.duration > 0) {
-						setMetadataReadyFor(src);
+						setAudioSettledFor(src);
 					}
 					onTimeUpdate?.(0, a.duration || 0);
 				}}
+				onError={() => setAudioSettledFor(src)}
 				onPlay={onPlay}
 				onPause={onPause}
 				onEnded={onFinish}


### PR DESCRIPTION
## What

Two shimmer/skeleton overlays never cleared on asset **load failure** — only on success — so a broken or expired URL left an infinite loading state.

- **`ImageWithShimmer`** cleared `loaded` only in `onLoad`; there was no `onError`. A project whose `thumbnail_url` blob was deleted/expired/never-uploaded (rendered via `ProjectsList`) showed an eternally shimmering card instead of falling back to the image's own error state.
- **`Waveform`** gated `loading` on `metadataReadyFor === src`, set only in `<audio>`'s `onLoadedMetadata`. The `<audio>` had no `onError`, so a broken audio URL never fired metadata and the waveform skeleton stayed up forever. (The peaks fetch/decode path already recovers via its `.catch`; the audio-element path did not.)

Both are genuine runtime outcomes: generated and thumbnail assets live in external blob storage and can 404 or expire.

## How

- `ImageWithShimmer`: added an `onError` handler (passthrough + clear the overlay); renamed the state `loaded → settled` since it now means "resolved, success or error."
- `Waveform`: added `onError` on the `<audio>` element to close the loading gate; renamed `metadataReadyFor → audioSettledFor` to match its new meaning. Existing metadata/duration logic is unchanged.

No behavior change on the happy path — the shimmer still hides exactly when the asset loads.

## Tests

The repo's vitest setup is pure-logic only (no jsdom/testing-library, `coverage.include` is `lib/**` + `app/api/**`), so this UI-event wiring has no extractable pure seam to unit-test without introducing a DOM-render harness — disproportionate for a two-handler fix. Full existing gate is green instead: lint, prettier, `tsc --noEmit`, knip, 941 tests, production build.

## Open PR overlap check

Considered open PRs #463 (`feat/animated-image-still-reuse` — connectors + generation + `ElementContainer`) and #438 (`fix/dead-caret-element-chrome` — canvas plugins/hooks). This PR touches only `lib/components/ImageWithShimmer.tsx` and `lib/components/Waveform.tsx`; no file or theme overlap with either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)