### PR TITLE
refactor: nightly maintainability 2026-07-23

### DIFF
--- a/app/components/video/BottomTransportBar.tsx
+++ b/app/components/video/BottomTransportBar.tsx
@@ -7,11 +7,7 @@ import { toFrames, toSeconds } from "@/lib/video/frames";
 import { usePlayerControl } from "./PlayerControlContext";
 import { usePlayerPosition } from "./PlayerPositionContext";
 import { useLayout } from "./VideoLayoutContext";
-import {
-	findSegmentIndexAt,
-	useActiveSegmentIndex,
-	useSceneSegments,
-} from "./useSceneSegments";
+import { findSegmentIndexAt, useActiveSegmentIndex } from "./useSceneSegments";
 import { usePlayerPlaying } from "./usePlayerState";
 import { SegmentedSeekBar } from "./SegmentedSeekBar";
 import {
@@ -24,8 +20,7 @@ import {
 function BottomTransportBarComponent() {
 	const { player } = usePlayerControl();
 	const { showPlayer } = usePlayerPosition();
-	const { layout } = useLayout();
-	const segments = useSceneSegments();
+	const { layout, segments } = useLayout();
 	const playing = usePlayerPlaying(player);
 	const activeIndex = useActiveSegmentIndex(player, segments, layout.fps);
 

--- a/app/components/video/VideoLayoutContext.tsx
+++ b/app/components/video/VideoLayoutContext.tsx
@@ -2,18 +2,18 @@
 
 import { useMemo, type ReactNode } from "react";
 import type { Editor } from "slate";
-import type { SceneElement } from "@/lib/canvas/types";
 import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
 import type { VideoLayout } from "@/lib/video/types";
 import { useAssetPrefetch } from "./useAssetPrefetch";
+import { buildSceneSegments, type SceneSegment } from "./useSceneSegments";
 import { useVideoLayout } from "./useVideoLayout";
 
 type VideoLayoutValue = {
 	layout: VideoLayout;
 	ready: boolean;
 	playerKey: string;
-	scenes: SceneElement[];
+	segments: SceneSegment[];
 };
 
 const [VideoLayoutContext, useLayout] =
@@ -33,9 +33,13 @@ export function VideoLayoutProvider({
 	const prefetched = useAssetPrefetch(layout);
 	const busy = useQueueSelector((q) => q.isBusy());
 	const ready = prefetched && !busy;
+	const segments = useMemo(
+		() => buildSceneSegments(scenes, layout),
+		[scenes, layout],
+	);
 	const value = useMemo(
-		() => ({ layout, ready, playerKey, scenes }),
-		[layout, ready, playerKey, scenes],
+		() => ({ layout, ready, playerKey, segments }),
+		[layout, ready, playerKey, segments],
 	);
 	return <VideoLayoutContext value={value}>{children}</VideoLayoutContext>;
 }

--- a/app/components/video/VideoPreview.tsx
+++ b/app/components/video/VideoPreview.tsx
@@ -9,7 +9,8 @@ import { usePlayerControl } from "./PlayerControlContext";
 import { PlayPauseFlash } from "./PlayPauseFlash";
 import { useActiveSceneSync } from "./useActiveSceneSync";
 import { usePreservedPlayhead } from "./usePreservedPlayhead";
-import { useActiveSegmentIndex, useSceneSegments } from "./useSceneSegments";
+import { useActiveSegmentIndex } from "./useSceneSegments";
+import { useLayout } from "./VideoLayoutContext";
 import styles from "./VideoPlayer.module.css";
 
 const fullSizeStyle = { width: "100%", height: "100%" };
@@ -61,7 +62,7 @@ type VideoPreviewProps = {
 export function VideoPreview({ layout, restoreFrameRef }: VideoPreviewProps) {
 	const [player, setPlayer] = useState<PlayerRef | null>(null);
 	const [isFullscreen, setIsFullscreen] = useState(false);
-	const segments = useSceneSegments();
+	const { segments } = useLayout();
 	const activeIndex = useActiveSegmentIndex(player, segments, layout.fps);
 	useActiveSceneSync(player, segments, activeIndex);
 	const { registerPlayer } = usePlayerControl();

--- a/app/components/video/__tests__/useSceneSegments.test.ts
+++ b/app/components/video/__tests__/useSceneSegments.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { findSegmentIndexAt, type SceneSegment } from "../useSceneSegments";
+import type { SceneElement } from "@/lib/canvas/types";
+import type { ResolvedElement, Sequence, VideoLayout } from "@/lib/video/types";
+import {
+	buildSceneSegments,
+	findSegmentIndexAt,
+	type SceneSegment,
+} from "../useSceneSegments";
 
 const seg = (
 	sceneId: string,
@@ -51,5 +57,106 @@ describe("findSegmentIndexAt", () => {
 		expect(findSegmentIndexAt(one, 0)).toBe(0);
 		expect(findSegmentIndexAt(one, 5)).toBe(0);
 		expect(findSegmentIndexAt(one, 100)).toBe(0);
+	});
+});
+
+const resolved = (url: string): ResolvedElement => ({
+	id: `${url}-el`,
+	type: "image",
+	role: "foreground",
+	layer: "visual",
+	url,
+	durationSec: 0,
+	loops: 1,
+	volume: 10,
+	motion: "none",
+});
+
+const sequence = (
+	start: number,
+	duration: number,
+	element: ResolvedElement | null,
+): Sequence => ({ element, start, duration });
+
+const scene = (id: string, foregroundId: string | null): SceneElement => ({
+	id,
+	type: "scene",
+	children: foregroundId
+		? [
+				{
+					id: foregroundId,
+					type: "image",
+					children: [{ id: `${foregroundId}-t`, type: "image", text: "" }],
+				},
+			]
+		: [],
+});
+
+const layout = (
+	entries: Record<string, Sequence>,
+	transitionDurationSec = 0,
+): VideoLayout => ({
+	series: [],
+	sequences: {},
+	sequenceByElementId: new Map(Object.entries(entries)),
+	fps: 24,
+	width: 1920,
+	height: 1080,
+	totalDurationSec: 0,
+	totalFrames: 0,
+	transitionType: "none",
+	transitionDurationSec,
+});
+
+describe("buildSceneSegments", () => {
+	it("returns an empty array when there are no scenes", () => {
+		expect(buildSceneSegments([], layout({}))).toEqual([]);
+	});
+
+	it("maps each scene's foreground sequence to a segment", () => {
+		const segments = buildSceneSegments(
+			[scene("s1", "fg1")],
+			layout({ fg1: sequence(0, 2, resolved("a.png")) }),
+		);
+		expect(segments).toEqual([
+			{
+				sceneId: "s1",
+				sceneIndex: 1,
+				start: 0,
+				duration: 2,
+				label: "Scene 1",
+				thumbnail: { url: "a.png", kind: "image" },
+			},
+		]);
+	});
+
+	it("trims the previous segment by the transition overlap", () => {
+		const segments = buildSceneSegments(
+			[scene("s1", "fg1"), scene("s2", "fg2")],
+			layout(
+				{
+					fg1: sequence(0, 2, resolved("a.png")),
+					fg2: sequence(2, 3, resolved("b.png")),
+				},
+				0.5,
+			),
+		);
+		expect(segments.map((s) => s.duration)).toEqual([1.5, 3]);
+	});
+
+	it("skips scenes with no foreground or no resolved sequence", () => {
+		const segments = buildSceneSegments(
+			[scene("s1", null), scene("s2", "missing"), scene("s3", "fg3")],
+			layout({ fg3: sequence(0, 4, resolved("c.png")) }),
+		);
+		expect(segments.map((s) => s.sceneId)).toEqual(["s3"]);
+	});
+
+	it("emits a null thumbnail when the sequence has no element", () => {
+		const [segment] = buildSceneSegments(
+			[scene("s1", "fg1")],
+			layout({ fg1: sequence(0, 2, null) }),
+		);
+		expect(segment.thumbnail).toBeNull();
 	});
 });

--- a/app/components/video/useSceneSegments.ts
+++ b/app/components/video/useSceneSegments.ts
@@ -1,11 +1,9 @@
 import type { PlayerRef } from "@remotion/player";
-import { useMemo } from "react";
 import { isForeground } from "@/lib/canvas/guards";
 import type { SceneElement } from "@/lib/canvas/types";
 import { toSeconds } from "@/lib/video/frames";
 import type { Sequence, VideoLayout } from "@/lib/video/types";
 import type { SeekThumbnail } from "./SeekTooltip";
-import { useLayout } from "./VideoLayoutContext";
 import { FRAME_EVENTS, usePlayerValue } from "./usePlayerState";
 
 export type SceneSegment = {
@@ -51,33 +49,36 @@ export function useActiveSegmentIndex(
 	);
 }
 
-export function useSceneSegments(): SceneSegment[] {
-	const { layout, scenes } = useLayout();
-	return useMemo<SceneSegment[]>(() => {
-		const out: SceneSegment[] = [];
-		for (let i = 0; i < scenes.length; i++) {
-			const scene = scenes[i];
-			const seq = findSceneSequence(scene, layout);
-			if (!seq) continue;
-			const prev = out[out.length - 1];
-			if (prev) {
-				prev.duration = Math.max(
-					0,
-					prev.duration - layout.transitionDurationSec,
-				);
-			}
-			const el = seq.element;
-			out.push({
-				sceneId: scene.id,
-				sceneIndex: i + 1,
-				start: seq.start,
-				duration: seq.duration,
-				label: `Scene ${i + 1}`,
-				thumbnail: el
-					? { url: el.url, kind: el.type === "image" ? "image" : "video" }
-					: null,
-			});
+/**
+ * Derives the seek-bar scene segments from the layout. Consecutive scenes
+ * overlap by `transitionDurationSec`, so each segment's duration is trimmed by
+ * that overlap to keep the timeline contiguous. Owned by `VideoLayoutContext`
+ * so it is computed once for all consumers.
+ */
+export function buildSceneSegments(
+	scenes: SceneElement[],
+	layout: VideoLayout,
+): SceneSegment[] {
+	const out: SceneSegment[] = [];
+	for (let i = 0; i < scenes.length; i++) {
+		const scene = scenes[i];
+		const seq = findSceneSequence(scene, layout);
+		if (!seq) continue;
+		const prev = out[out.length - 1];
+		if (prev) {
+			prev.duration = Math.max(0, prev.duration - layout.transitionDurationSec);
 		}
-		return out;
-	}, [scenes, layout]);
+		const el = seq.element;
+		out.push({
+			sceneId: scene.id,
+			sceneIndex: i + 1,
+			start: seq.start,
+			duration: seq.duration,
+			label: `Scene ${i + 1}`,
+			thumbnail: el
+				? { url: el.url, kind: el.type === "image" ? "image" : "video" }
+				: null,
+		});
+	}
+	return out;
 }


### PR DESCRIPTION
## What

Centralize the seek-bar **scene-segment derivation** in `VideoLayoutContext` so it is computed **once** instead of twice across the two live video subtrees.

`VideoPreview` (via `VideoPanel`) and `BottomTransportBar` are both mounted whenever the player is visible, and each independently called `useSceneSegments()` — a `useMemo` over `{ layout, scenes }`, both of which already live in `VideoLayoutContext`. The context is the natural single owner of that derived array.

## How

- Extract the pure `buildSceneSegments(scenes, layout)` helper out of the `useSceneSegments()` hook (logic moved verbatim).
- `VideoLayoutProvider` computes `segments` once via `useMemo` and exposes it on the context value. The interface **narrows** from raw `scenes` (whose only consumer was the hook) to the derived `segments`, so `scenes` becomes an internal detail.
- `VideoPreview` and `BottomTransportBar` now read `useLayout().segments` instead of calling the hook.
- Removes an incidental import cycle (`useSceneSegments` no longer imports `VideoLayoutContext`).

## Behavior

No behavior change: same pure function, same inputs (`layout`, `scenes`), same output. Only *where* and *how often* the derivation runs changes. `useActiveSegmentIndex` / `findSceneSequence` / `findSegmentIndexAt` stay as pure exports (still used by `SegmentedSeekBar`, `SceneContainer`, `PlayFromHereButton`, and tests).

## Tests

Added unit coverage for the new `buildSceneSegments` seam: scene→segment mapping, transition-overlap duration trimming, skipped scenes (no foreground / unresolved sequence), and the null-thumbnail branch.

Full gate green: typecheck, lint, knip, prettier, **946 tests**, production build.

## Open PR overlap check

Considered open PRs:
- **#464** (`lib/components/ImageWithShimmer.tsx`, `lib/components/Waveform.tsx`)
- **#463** (`lib/connectors/animated_image/**`, `base.ts`, `types.ts`, `lib/generation/*`, `ElementContainer.tsx`)
- **#438** (`app/components/canvas/**`, `lib/canvas/types.ts`)

This PR touches only `app/components/video/**` (`VideoLayoutContext`, `useSceneSegments`, `VideoPreview`, `BottomTransportBar`, and the segments test). No file or theme overlap with any open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)