### PR TITLE
refactor: nightly CONVENTIONS.md compliance 2026-07-23

### DIFF
--- a/app/components/canvas/elements/character/NewCharacterDialog.tsx
+++ b/app/components/canvas/elements/character/NewCharacterDialog.tsx
@@ -70,7 +70,7 @@ function NewCharacterDialogBody({
 				/>
 
 				{collision && (
-					<span className="text-label-xs text-rose-400" role="alert">
+					<span className="text-label-xs text-destructive" role="alert">
 						A character named &quot;{normalized}&quot; already exists.
 					</span>
 				)}

--- a/app/components/canvas/elements/character/VoicePicker.tsx
+++ b/app/components/canvas/elements/character/VoicePicker.tsx
@@ -95,7 +95,7 @@ export function VoicePicker({
 	return (
 		<div className="flex min-w-0 flex-col gap-1.5">
 			<FieldLabel>Voices</FieldLabel>
-			{error && <span className="text-label-xs text-rose-400">{error}</span>}
+			{error && <span className="text-label-xs text-destructive">{error}</span>}
 			<div className="flex max-h-64 min-w-0 flex-col gap-0.5 overflow-y-auto">
 				{loading &&
 					Array.from({ length: SKELETON_ROWS }).map((_, i) => (


### PR DESCRIPTION
## Summary

Nightly CONVENTIONS.md compliance audit. The codebase is in strong shape — a four-way parallel audit (connectors/gateway/providers, api/clients/supabase, canvas/generation/video/project, app/lib components) surfaced almost no defensible violations. This PR applies the one clean, no-behavior-change fix found; everything else is either defensible-as-written or a design-level call flagged below for a human.

## Auto-fixed (safe, no behavior change)

**Design-system token compliance** — two error spans used `text-rose-400`, an undefined Tailwind palette color that is not a design-system token. The canonical error-span pattern everywhere else is `text-label-xs text-destructive` (e.g. `ImpersonateDialog`, `AccessCodeInput`, `AuthForm`). Swapped both to `text-destructive`:
- `app/components/canvas/elements/character/NewCharacterDialog.tsx:73`
- `app/components/canvas/elements/character/VoicePicker.tsx:98`

## Flagged for human judgment (not touched — behavior/design change)

These are low-severity and defensible as-is; listed so they're on record:

- **`lib/providers/video/runware.ts:6-18`** — `status as VideoJobStatus` blind-casts the vendor's raw status string (parse-don't-validate gap). A `parseVideoJobStatus` at the boundary would be safer, but changes the unknown-status path.
- **`lib/api/asset-bundle.ts:31-35`** — `BundleFile` is an untagged union distinguished by `"data" in file` rather than a `kind` discriminant. Two members only; adding a discriminant touches all construction sites.
- **`app/components/canvas/elements/character/NewCharacterDialog.tsx:79-85`** — submit button is hand-rolled Tailwind (`bg-muted`) rather than the off-the-shelf `<Button variant="secondary">`. Visual differs slightly (muted vs secondary), so needs a design call.
- **`app/components/AuthForm.tsx:62-69`** — `handleGoogleAuth` ignores the `{ error }` from `signInWithOAuth` (the OTP path surfaces its error). Mild fail-loudly gap.
- **`lib/providers/llm/{anthropic,mock}.ts`** — LLM providers are wired inconsistently (`AnthropicLLM extends BaseProvider` but neuters `toFiles`/`store`; `MockLLM` is standalone). One canonical contract would be cleaner.
- **`lib/api/route-handler.ts:122`** — inline 404 `NextResponse.json` instead of a `response.ts` builder; single occurrence, rule-of-three not met.
- **`lib/script/refine/parseOps.ts:25-31`** — silently drops malformed streamed refine ops; defensible for line-by-line NDJSON, but could add an observability log.

## Checks

`npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run test:run` (941 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)