### PR TITLE
refactor: rethink openslop architecture 2026-07-23

### DIFF
--- a/app/components/AuthForm.tsx
+++ b/app/components/AuthForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { createClient } from "@/lib/supabase/client";
+import { sendMagicLink, signInWithGoogle } from "@/lib/auth/session";
 import OnboardingCard from "./OnboardingCard";
 import EmailSentCard from "./EmailSentCard";
 import OrDivider from "./OrDivider";
@@ -35,37 +35,23 @@ export default function AuthForm({
 	const [sent, setSent] = useState(false);
 	const [error, setError] = useState("");
 
-	const supabase = createClient();
-
 	const handleMagicLink = async (e?: React.FormEvent) => {
 		e?.preventDefault();
 		setLoading(true);
 		setError("");
 
-		const { error } = await supabase.auth.signInWithOtp({
+		const { error } = await sendMagicLink({
 			email,
-			options: {
-				emailRedirectTo: `${window.location.origin}/auth/callback`,
-				...(shouldCreateUser === false && { shouldCreateUser: false }),
-				...(otpData && { data: otpData }),
-			},
+			shouldCreateUser,
+			data: otpData,
 		});
 
 		if (error) {
-			setError(error.message);
+			setError(error);
 		} else {
 			setSent(true);
 		}
 		setLoading(false);
-	};
-
-	const handleGoogleAuth = async () => {
-		await supabase.auth.signInWithOAuth({
-			provider: "google",
-			options: {
-				redirectTo: `${window.location.origin}/auth/callback`,
-			},
-		});
 	};
 
 	if (sent) {
@@ -116,7 +102,7 @@ export default function AuthForm({
 			)}
 
 			<OrDivider />
-			<GoogleOAuthButton onClick={handleGoogleAuth} />
+			<GoogleOAuthButton onClick={signInWithGoogle} />
 		</OnboardingCard>
 	);
 }

--- a/app/components/ImpersonateDialog.tsx
+++ b/app/components/ImpersonateDialog.tsx
@@ -13,6 +13,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { AlertCircle } from "@/components/ui/icon";
+import { impersonateUser } from "@/lib/auth/impersonate";
 import { errorMessage } from "@/lib/errors";
 
 export default function ImpersonateDialog({
@@ -40,15 +41,9 @@ function ImpersonateDialogBody() {
 		setError("");
 
 		try {
-			const response = await fetch(
-				`/api/dev/impersonate?email=${encodeURIComponent(email)}`,
-			);
-			if (response.ok) {
-				window.location.assign("/");
-				return;
-			}
-			const body = await response.json();
-			setError(body.error ?? `Impersonation failed (${response.status})`);
+			await impersonateUser(email);
+			window.location.assign("/");
+			return;
 		} catch (cause) {
 			setError(errorMessage(cause));
 		}

--- a/app/components/UserProfile.tsx
+++ b/app/components/UserProfile.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClient } from "@/lib/supabase/client";
+import { signOut } from "@/lib/auth/session";
 import { useUser } from "@/lib/user/UserProvider";
 import { useTheme } from "next-themes";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -38,8 +38,7 @@ function UserProfile() {
 	const name: string | undefined = user.user_metadata?.full_name;
 
 	const handleLogout = async () => {
-		const supabase = createClient();
-		await supabase.auth.signOut();
+		await signOut();
 		router.refresh();
 	};
 

--- a/lib/auth/__tests__/impersonate.test.ts
+++ b/lib/auth/__tests__/impersonate.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { impersonateUser } from "../impersonate";
+
+describe("impersonateUser", () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+	});
+
+	it("GETs the impersonate route with the email query param", async () => {
+		fetchMock.mockResolvedValue({ ok: true });
+
+		await impersonateUser("user@example.com");
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/dev/impersonate?email=user%40example.com",
+			{ method: "GET" },
+		);
+	});
+
+	it("surfaces the route's error envelope on failure", async () => {
+		fetchMock.mockResolvedValue({
+			ok: false,
+			status: 400,
+			statusText: "Bad Request",
+			json: async () => ({ error: "Cannot impersonate unknown@x.com" }),
+		});
+
+		await expect(impersonateUser("unknown@x.com")).rejects.toThrow(
+			"Cannot impersonate unknown@x.com",
+		);
+	});
+});

--- a/lib/auth/__tests__/session.test.ts
+++ b/lib/auth/__tests__/session.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { signInWithOtp, signInWithOAuth, signOutFn } = vi.hoisted(() => ({
+	signInWithOtp: vi.fn(),
+	signInWithOAuth: vi.fn(),
+	signOutFn: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+	createClient: () => ({
+		auth: {
+			signInWithOtp,
+			signInWithOAuth,
+			signOut: signOutFn,
+		},
+	}),
+}));
+
+import { sendMagicLink, signInWithGoogle, signOut } from "../session";
+
+const CALLBACK = "https://app.test/auth/callback";
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	signInWithOtp.mockResolvedValue({ error: null });
+	signInWithOAuth.mockResolvedValue({ error: null });
+	signOutFn.mockResolvedValue({ error: null });
+	vi.stubGlobal("window", { location: { origin: "https://app.test" } });
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("sendMagicLink", () => {
+	it("omits shouldCreateUser and data when not supplied", async () => {
+		await sendMagicLink({ email: "a@b.com" });
+
+		expect(signInWithOtp).toHaveBeenCalledWith({
+			email: "a@b.com",
+			options: { emailRedirectTo: CALLBACK },
+		});
+	});
+
+	it("includes shouldCreateUser only when explicitly false", async () => {
+		await sendMagicLink({ email: "a@b.com", shouldCreateUser: true });
+		expect(signInWithOtp).toHaveBeenLastCalledWith({
+			email: "a@b.com",
+			options: { emailRedirectTo: CALLBACK },
+		});
+
+		await sendMagicLink({ email: "a@b.com", shouldCreateUser: false });
+		expect(signInWithOtp).toHaveBeenLastCalledWith({
+			email: "a@b.com",
+			options: { emailRedirectTo: CALLBACK, shouldCreateUser: false },
+		});
+	});
+
+	it("forwards otp data when supplied", async () => {
+		await sendMagicLink({ email: "a@b.com", data: { plan: "pro" } });
+
+		expect(signInWithOtp).toHaveBeenCalledWith({
+			email: "a@b.com",
+			options: { emailRedirectTo: CALLBACK, data: { plan: "pro" } },
+		});
+	});
+
+	it("maps a Supabase error to its message", async () => {
+		signInWithOtp.mockResolvedValue({ error: { message: "rate limited" } });
+
+		expect(await sendMagicLink({ email: "a@b.com" })).toEqual({
+			error: "rate limited",
+		});
+	});
+
+	it("returns no error on success", async () => {
+		expect(await sendMagicLink({ email: "a@b.com" })).toEqual({});
+	});
+});
+
+describe("signInWithGoogle", () => {
+	it("requests the Google provider with the callback redirect", async () => {
+		await signInWithGoogle();
+
+		expect(signInWithOAuth).toHaveBeenCalledWith({
+			provider: "google",
+			options: { redirectTo: CALLBACK },
+		});
+	});
+});
+
+describe("signOut", () => {
+	it("delegates to the Supabase client", async () => {
+		await signOut();
+
+		expect(signOutFn).toHaveBeenCalledTimes(1);
+	});
+});

--- a/lib/auth/impersonate.ts
+++ b/lib/auth/impersonate.ts
@@ -1,0 +1,6 @@
+import { apiFetch } from "@/lib/clients/http";
+
+/** Dev-only: signs the current browser in as `email` via the impersonate route. */
+export async function impersonateUser(email: string): Promise<void> {
+	await apiFetch("/api/dev/impersonate", { params: { email } });
+}

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -1,0 +1,39 @@
+import { createClient } from "@/lib/supabase/client";
+
+/** All Supabase sign-in links land back on the OAuth/OTP callback route. */
+function callbackUrl(): string {
+	return `${window.location.origin}/auth/callback`;
+}
+
+export type MagicLinkParams = {
+	email: string;
+	shouldCreateUser?: boolean;
+	data?: Record<string, unknown>;
+};
+
+export async function sendMagicLink({
+	email,
+	shouldCreateUser,
+	data,
+}: MagicLinkParams): Promise<{ error?: string }> {
+	const { error } = await createClient().auth.signInWithOtp({
+		email,
+		options: {
+			emailRedirectTo: callbackUrl(),
+			...(shouldCreateUser === false && { shouldCreateUser: false }),
+			...(data && { data }),
+		},
+	});
+	return error ? { error: error.message } : {};
+}
+
+export async function signInWithGoogle(): Promise<void> {
+	await createClient().auth.signInWithOAuth({
+		provider: "google",
+		options: { redirectTo: callbackUrl() },
+	});
+}
+
+export async function signOut(): Promise<void> {
+	await createClient().auth.signOut();
+}


### PR DESCRIPTION
## App understanding

openslop is a Next.js 16 (App Router) + React 19 + Remotion app for AI-generated video. Users write a script on a Slate canvas, elements (image / animated_image / tts / music / sfx / video) are generated through a connector→gateway→provider pipeline, and scenes are composed into a Remotion video. Auth is Supabase (magic-link OTP + Google OAuth), with a dev-only impersonation flow. `lib/` is the domain layer; `app/` is the UI; the dependency direction is enforced one-way.

## From-scratch architecture

The domain layer already owns almost everything cleanly (API routes are one-liners over `createAssetRouteHandlers`/`pollJob`; the connector/gateway/provider seam is deep and well-separated). A four-way survey found the codebase in strong shape. The one remaining altitude smell: **auth/session mutations and internal-API calls lived inside presentational components** — `AuthForm` and `UserProfile` imported the Supabase browser client and built redirect URLs inline, and `ImpersonateDialog` was the last component doing a raw `fetch("/api/...")` with a hand-rolled `{ error }` envelope dig. From scratch, those belong behind a typed `lib/auth/` boundary, matching the existing `lib/project/api.ts` + `lib/clients/http.ts` (`apiFetch`) conventions, so components only render state.

## Implemented simplifications

New `lib/auth/` domain module; components now call typed helpers:

- **`lib/auth/session.ts`** — `sendMagicLink`, `signInWithGoogle`, `signOut`. Owns callback-URL construction and the conditional OTP options (`shouldCreateUser`/`data`), returning `{ error? }` instead of leaking the Supabase error object.
- **`lib/auth/impersonate.ts`** — `impersonateUser(email)` over `apiFetch`, so the route's error envelope surfaces as a thrown `Error` via the shared `readErrorMessage` (no more manual `res.json()` / `body.error ??` parsing).
- **`AuthForm`** and **`UserProfile`** no longer import `@/lib/supabase/client`; auth mechanics moved out of the render body.
- **`ImpersonateDialog`** drops the last raw `fetch("/api/...")` call site in `app/`.

Behavior-preserving throughout: same callback URLs, same OTP option shaping, same impersonate happy-path (`apiFetch` follows the redirect → `window.location.assign("/")` for the real reload), same error copy. The pre-existing choice for `signInWithGoogle` to not surface its `{ error }` is kept as-is (not newly changed).

## Validation

`npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run knip`, `npm run test:run` (950 tests, incl. 9 new for the `lib/auth` seam), and `npm run build` all pass.

## Skipped items / risks

- **`AccessCodeInput`** raw `fetch("/api/validate-code")` — deliberately left. It has a two-tier error UX (server rejection reason vs. a friendly generic on transport failure) that a mechanical `apiJson` extraction would collapse, changing user-visible copy. Flagged for a human call rather than silently altering behavior.
- **`lib/api/sse.ts` `createSSEResponse`** (push-based) has no production callers, but it is a legitimate alternative SSE primitive (pull-based `createSSEStreamResponse` is used). Left in place per the "unused reusable seam is not dead code" rule; noted for a human call.

## Open PR overlap check

Considered open PRs: **#466** (character `NewCharacterDialog`/`VoicePicker`), **#465** (`app/components/video/**`), **#464** (`lib/components/{ImageWithShimmer,Waveform}`), **#463** (`lib/connectors/animated_image/**` + generation + `ElementContainer`), **#438** (canvas plugins/hooks + `CompactElement`). This PR touches only new `lib/auth/**` plus `AuthForm`, `UserProfile`, `ImpersonateDialog` — no file or theme overlap with any open PR. (#466's body *mentioned* `AuthForm`'s Google-error gap but does not modify the file; this PR preserves that behavior.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)