### PR TITLE
fix: keep animated-image still/video toggle above the error overlay

### DIFF
--- a/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
+++ b/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
@@ -27,7 +27,7 @@ export function AnimatedImagePreview({
 				cancelClassName="top-10"
 			/>
 			<MediaToggle
-				className="absolute top-2 right-2 z-10 shadow-sm"
+				className="absolute top-2 right-2 z-30 shadow-sm"
 				value={mode}
 				onChange={setMode}
 				options={[

--- a/app/components/canvas/elements/preview/__tests__/cancelClassName.test.tsx
+++ b/app/components/canvas/elements/preview/__tests__/cancelClassName.test.tsx
@@ -61,6 +61,12 @@ describe("MediaResult cancelClassName forwarding", () => {
 	});
 });
 
+const mediaToggleClass = (html: string) => {
+	const match = html.match(/class="([^"]*bg-media-toggle-bg[^"]*)"/);
+	if (!match) throw new Error("media toggle not found in rendered markup");
+	return match[1];
+};
+
 describe("AnimatedImagePreview", () => {
 	it("positions the cancel button below the still/video toggle while generating", () => {
 		const html = withTooltip(
@@ -74,5 +80,19 @@ describe("AnimatedImagePreview", () => {
 		const className = cancelButtonClass(html);
 		expect(className).toContain("top-10");
 		expect(className).not.toContain("top-2");
+	});
+
+	it("stacks the still/video toggle above the error overlay so it stays clickable", () => {
+		const html = withTooltip(
+			<AnimatedImagePreview
+				status="idle"
+				seconds={0}
+				error="generation failed"
+				onDiscard={() => {}}
+			/>,
+		);
+		// Error overlay renders at z-20; the toggle must sit above it.
+		expect(html).toContain("z-20");
+		expect(mediaToggleClass(html)).toContain("z-30");
 	});
 });


### PR DESCRIPTION
## Summary

On an animated-image element, the still/video `MediaToggle` was rendered at `z-10`, while the error-message overlay spans the full preview at `z-20` (`absolute inset-0`). When a generation error was surfaced, the error box painted over the toggle, so the user couldn't switch between the video and the still — exactly when they most want to, since one of the two may have generated fine while the other failed.

Raise the toggle to `z-30` so it stacks above the error overlay and stays visible and clickable. The error box is centered with `px-12` padding and does not visually collide with the top-right toggle, so no layout change is needed.

## Why this was safe/small

- One-class stacking-order change (`z-10 → z-30`) in a single presentational component; no geometry, layout, or behavior change.
- The generation indicator and cancel button intentionally stay under the error overlay; only the toggle is lifted, matching the issue's suggested direction.
- Aligned with `DESIGN.md` (no token/color/spacing change — pure stacking order).

## Validation

- New focused test in `preview/__tests__/cancelClassName.test.tsx` asserting the toggle carries `z-30` above the `z-20` error overlay.
- `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run knip` — all pass.
- `npm run test:run` — 942 tests pass (includes the new assertion).
- `npm run build` — passes.

## Open PR overlap check

Considered open PRs: **#467** (`lib/auth/**` + AuthForm/UserProfile/ImpersonateDialog), **#466** (character NewCharacterDialog/VoicePicker), **#465** (`app/components/video/**`), **#464** (`lib/components/{ImageWithShimmer,Waveform}`), **#463** (`animated_image` connector/generation + `ElementContainer.tsx`), **#438** (canvas plugins/hooks + `CompactElement`). This PR touches only `preview/AnimatedImagePreview.tsx` and its preview test — no file overlap with any open PR. (#463 is animated-image-themed but modifies the connector/generation layer and `ElementContainer`, not the preview UI.)

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)