### PR TITLE
perf: nightly performance optimizations 2026-07-26

### DIFF
--- a/app/components/canvas/elements/preview/placeholderBalls.module.css
+++ b/app/components/canvas/elements/preview/placeholderBalls.module.css
@@ -1,3 +1,13 @@
+/* Every ungenerated element card paints 11 blurred, blend-composited orbs, so a
+   fresh script pays for hundreds of them at once. Skipping the ones outside the
+   viewport keeps that cost proportional to what is actually on screen. The clip
+   box matches the card's own overflow clip, so nothing renders differently. */
+.clip {
+	position: absolute;
+	inset: 0;
+	content-visibility: auto;
+}
+
 .containerLoader {
 	--size: 400px;
 	width: var(--size);

--- a/app/components/canvas/elements/preview/placeholderBalls.tsx
+++ b/app/components/canvas/elements/preview/placeholderBalls.tsx
@@ -72,11 +72,13 @@ export function PlaceholderBallsLoader({
 }) {
 	const staticRotations = useStaticRotations();
 	return (
-		<div className={loaderStyles.containerLoader} aria-hidden="true">
-			<PlaceholderBalls
-				generating={generating}
-				staticRotations={staticRotations}
-			/>
+		<div className={loaderStyles.clip} aria-hidden="true">
+			<div className={loaderStyles.containerLoader}>
+				<PlaceholderBalls
+					generating={generating}
+					staticRotations={staticRotations}
+				/>
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
Canvas paint-path pass. No behavior changes; rendering is pixel-identical.

## What was optimized

**Every ungenerated element card paints 11 heavily blurred, blend-composited orbs.**

`PlaceholderBallsLoader` renders 11 `<span>`s, each sized `400px + 10–20px` with `filter: blur(58px)` and `mix-blend-mode: hard-light`. It is the placeholder for every element that has no result yet — `MediaPlaceholder`, `AudioPlaceholder` (which nests it under a second `blur-[6px]` layer and a mask), and `ForegroundPreview` for every collapsed scene.

A freshly generated script is *all* placeholders. 20 scenes at 3 elements each is 60 loaders, 660 blurred layers, all painted whether or not they are anywhere near the viewport. The [Slate performance walkthrough](https://docs.slatejs.org/walkthroughs/09-performance) is direct about where that lands: painting is "over 100x slower than core Slate logic and React rendering combined," and its prescribed fix is `content-visibility: auto` so off-screen content is not painted.

The loader now renders inside a `content-visibility: auto` clip box. Off-screen placeholders cost nothing; on-screen ones are unchanged.

The clip box is `position: absolute; inset: 0`, which resolves to the same rect the card already clips to with `overflow-hidden`, so the paint containment that `content-visibility` implies does not change what is visible. `.containerLoader` keeps its `transform: scale(0.5)`, so the orbs' `mix-blend-mode` grouping is also untouched.

## Measurements

4s scripted scroll over 60 placeholder cards (660 orbs), headless Chromium, 560x820 viewport:

| mode | content-visibility | fps | median frame | p95 frame | main thread |
| --- | --- | --- | --- | --- | --- |
| idle | off | 22.5 | 50.0ms | 66.6ms | 3.67s |
| idle | auto | 24.9 | **33.4ms** | **50.1ms** | 3.65s |
| generating | off | 18.2 | 50.0ms | 100.0ms | 1.30s |
| generating | auto | 24.1 | **33.4ms** | **83.4ms** | **0.46s** |

Median frame time drops a third in both states, and while the orbit animation is running the main thread does ~65% less work. Headless CPU rasterization inflates the absolute numbers; the ratios are the signal.

Visual equivalence was checked by byte-comparing screenshots with and without the change, at `scrollTop` 0 and 2400. Both are identical.

## What was skipped

- **`findNodeById`'s full-document `Editor.nodes` scan** (3 per streamed token in `useScriptSync`). Real, but microseconds against the Slate transforms and React renders on the same path — not worth the churn.
- **`Waveform`'s duplicate audio fetch** (a `fetch` for peak extraction plus the `<audio>` element's own load). The premise depends on asset cache headers making the second request free or not, which I could not confirm; left alone rather than guess.
- **`content-visibility` on scenes or element cards more broadly.** Tempting for the same reason, but size containment on in-flow blocks would feed estimated heights to `@dnd-kit`'s rect measurement and to `scrollToScene`. Restricted to the decorative, fixed-size, already-clipped placeholder subtree where none of that applies.
- **Cutting the orb count or blur radius.** That is a design decision, not a perf change.

## Open PR overlap check

Considered #470, #469, #467, #465, #463, #438. This PR touches only `app/components/canvas/elements/preview/placeholderBalls.{tsx,module.css}`, which appears in none of their diffs. #438 and #463 cover the canvas element render path (`Canvas.tsx`, `CompactElement.tsx`, `ElementContainer.tsx`) and #465 covers the video preview, so both areas were deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)