### PR TITLE
refactor: nightly CONVENTIONS.md compliance 2026-07-26

### DIFF
--- a/app/components/AccessCodeInput.tsx
+++ b/app/components/AccessCodeInput.tsx
@@ -2,6 +2,8 @@
 
 import { useRef, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import { apiJson } from "@/lib/clients/http";
+import { errorMessage } from "@/lib/errors";
 
 const CODE_LENGTH = 6;
 const EMPTY_CODE = () => Array<string>(CODE_LENGTH).fill("");
@@ -24,20 +26,14 @@ export default function AccessCodeInput() {
 			setLoading(true);
 			setError("");
 			try {
-				const res = await fetch("/api/validate-code", {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ code }),
-				});
-				const data = await res.json();
-				if (res.ok && data.redirect) {
-					router.push(data.redirect);
-				} else {
-					resetWithError(data.error || "Invalid access code");
-				}
+				const { redirect } = await apiJson<{ redirect: string }>(
+					"/api/validate-code",
+					{ method: "POST", body: { code } },
+				);
+				router.push(redirect);
 			} catch (err) {
 				console.error("Access code validation failed", err);
-				resetWithError("Something went wrong. Please try again.");
+				resetWithError(errorMessage(err));
 			} finally {
 				setLoading(false);
 			}

--- a/lib/providers/llm/mock.ts
+++ b/lib/providers/llm/mock.ts
@@ -171,28 +171,31 @@ Twists: The "big bad wolf" is the kindest soul in the forest; Owl has been silen
 
 Resolution: Red and Wolf arrive together at Granny's cottage, share their baskets, and the village learns that friendship can grow in the most unlikely places.`;
 
-function isRefineRequest(params: LLMGenerateParams): boolean {
-	return params.prompt.includes("## Refinement Request");
-}
-
-function isStyleRequest(params: LLMGenerateParams): boolean {
-	return /describe the visual art style/i.test(params.prompt);
-}
-
-function isCharacterAppearanceRequest(params: LLMGenerateParams): boolean {
-	return /describe the visual appearance of the character/i.test(params.prompt);
-}
-
-function isOutlineRequest(params: LLMGenerateParams): boolean {
-	return params.prompt.startsWith("Briefly outline an engaging story");
-}
+const MOCK_RESPONSES: {
+	matches: (prompt: string) => boolean;
+	respond: (params: LLMGenerateParams) => string;
+}[] = [
+	{
+		matches: (p) => /describe the visual art style/i.test(p),
+		respond: () => MOCK_STYLE,
+	},
+	{
+		matches: (p) => /describe the visual appearance of the character/i.test(p),
+		respond: () => MOCK_CHARACTER_APPEARANCE,
+	},
+	{
+		matches: (p) => p.startsWith("Briefly outline an engaging story"),
+		respond: () => MOCK_OUTLINE,
+	},
+	{
+		matches: (p) => p.includes("## Refinement Request"),
+		respond: (params) => buildRefineResponse(params),
+	},
+];
 
 function mockResponse(params: LLMGenerateParams): string {
-	if (isStyleRequest(params)) return MOCK_STYLE;
-	if (isCharacterAppearanceRequest(params)) return MOCK_CHARACTER_APPEARANCE;
-	if (isOutlineRequest(params)) return MOCK_OUTLINE;
-	if (isRefineRequest(params)) return buildRefineResponse(params);
-	return MOCK_SCRIPT;
+	const match = MOCK_RESPONSES.find((m) => m.matches(params.prompt));
+	return match ? match.respond(params) : MOCK_SCRIPT;
 }
 
 function buildRefineResponse(params: LLMGenerateParams): string {


### PR DESCRIPTION
Full-codebase sweep for the CONVENTIONS.md rules on errors-out-of-existence, special-case wiring, policy/mechanism separation, dumb units, one canonical way, fail-loudly, and declarative-reads-like-config. The codebase is in good shape — only two genuine violations surfaced, both fixed here. Files touched by open PRs (#438, #463, #465, #467, #469, #470, #471) were left alone.

## Fixed

**`app/components/AccessCodeInput.tsx` — one canonical way / parse-don't-validate**

The component hand-rolled `fetch` + `Content-Type` header + `res.ok` + `await res.json()`, then read `data.redirect` and `data.error` off an untyped `any`. `lib/clients/http.ts#apiJson` already owns exactly this (URL building, JSON body, and unwrapping the `{ error }` envelope every internal route returns), and it's what `useRendering` and the auth components use. Swapped in `apiJson` + `errorMessage`.

Behavior is identical for a server-rejected code (the route's `{ error }` message still reaches the user verbatim). The one change: a network-level failure now surfaces the underlying error rather than a generic "Something went wrong" — the same shape `ImpersonateDialog` uses.

**`lib/providers/llm/mock.ts` — declarative reads like config**

`mockResponse` dispatched through a chain of four single-use `isStyleRequest` / `isCharacterAppearanceRequest` / `isOutlineRequest` / `isRefineRequest` predicates feeding a four-branch `if` ladder. Replaced with an ordered `MOCK_RESPONSES` match table. Same match order, same outputs; adding a mock case is now one table entry instead of a predicate plus a branch.

## Flagged, not fixed

- `lib/api/asset-bundle.ts:3` — local `fetchJson` duplicates `apiFetch`'s ok-check-and-parse. Not merged: it fetches blob URLs, which don't carry our `{ error }` envelope, so `apiFetch`'s error semantics don't apply. Deduping would need a lower-level split of `http.ts`. Design call, not a mechanical fix.
- `app/api/validate-code/route.ts:35` — builds `NextResponse.json({ error }, { status: 401 })` inline instead of using a `lib/api/response.ts` helper. Left alone: the file is covered by open PR #470.

## Checks

`lint`, `typecheck`, `format:check`, `test:run` (942 passed), and `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)