### PR TITLE
fix: keep the element card header a fixed height as characters change

### DIFF
--- a/app/components/canvas/elements/CharacterPill.tsx
+++ b/app/components/canvas/elements/CharacterPill.tsx
@@ -55,8 +55,8 @@ export function CharacterPill({
 	const avatarUrl = useCharacterAvatarUrl(name);
 	return (
 		<div
-			className={`group/pill relative inline-flex max-w-[140px] shrink-0 items-center rounded-md transition-colors hover:bg-button-hover ${
-				name ? "gap-1.5 py-0.5 pl-1 pr-2" : "p-0.5"
+			className={`group/pill relative inline-flex h-6 max-w-[140px] shrink-0 items-center rounded-md transition-colors hover:bg-button-hover ${
+				name ? "gap-1.5 pl-1 pr-2" : "px-0.5"
 			}`}
 		>
 			<CharacterAvatar


### PR DESCRIPTION
## Summary

Removing the last character from an image / animated-image element made the element card header row (and everything under it) jump up ~4px. The row is `items-center` with no height floor, so it tracked its tallest child: every other chip in it (type badge, `ModelBadge`, `ElementSettings`, add-character button) is `h-6` / 24px, but `CharacterPill` was a 24px avatar plus `py-0.5`, measuring 28px.

Fixed the class of problem rather than the instance: `CharacterPill` now carries the same `h-6` as its siblings with horizontal-only padding, so the row is 24px regardless of how many pills are mounted. That also removes the mirrored jump when the first character is added.

## Changes

- `app/components/canvas/elements/CharacterPill.tsx` — add `h-6`, drop `py-0.5` / `p-0.5` in favour of `pl-1 pr-2` and `px-0.5`.

One file, two class tokens. The avatar is `size-6` (24px) so it fits the fixed height exactly; `RemoveCrossButton` is absolutely positioned and never contributed to the measured height, and name truncation (`max-w-[140px]` + `truncate`) is untouched.

## Why this issue was safe and small

`#449` is labelled `size: XS` / `good first issue`, names the exact files and lines, and states the intended fix direction and acceptance criteria. It is a pure layout correction with no product, design-direction, or auth surface.

## Validation

- `npm run lint` — pass
- `npm run format:check` — pass
- `npm run typecheck` — pass
- `npm run knip` — pass
- `npm run build` — pass
- `npm run test:coverage` — pass (108 files, 942 tests)
- `npm run test:e2e` — **skipped**: Playwright's web server could not bind port 3000 (already in use locally). No smoke test covers this component's chrome height.

No test added: the change is a Tailwind class on a presentational component, and asserting class names would test internals rather than behaviour.

## Open PR overlap check

Checked open PRs #472, #471, #470, #469, #467, #465, #463, #438 with `gh pr diff --name-only`. None touch `CharacterPill.tsx`. #463 touches `ElementContainer.tsx` and #438 touches element chrome, which is why this fix stays confined to the pill itself. Issue #424 was skipped as already covered by #438.

## Skipped candidates

- `#259` (size: XS) — explicitly gated on BYOK landing first.
- `#452`, `#461`, `#424` — `size: S` or larger; #424 overlaps open PR #438.
- All remaining open issues are M/L/XL, or need product/design direction (BYOK, i18n, publishing kit, community feed, provider selection).

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)