### PR TITLE
perf: nightly performance optimizations 2026-07-27

### DIFF
--- a/app/components/canvas/elements/MediaWithSkeleton.tsx
+++ b/app/components/canvas/elements/MediaWithSkeleton.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ImageWithShimmer } from "@/lib/components/ImageWithShimmer";
+import { useNearViewport } from "@/lib/components/useNearViewport";
 import type { ResultKind } from "@/lib/canvas/types";
 
 interface MediaWithSkeletonProps {
@@ -18,6 +19,10 @@ export function MediaWithSkeleton({
 	videoInteractive = false,
 	objectFit = "cover",
 }: MediaWithSkeletonProps) {
+	const videoRef = useRef<HTMLVideoElement>(null);
+	// `<video>` has no `loading="lazy"` counterpart, so an off-screen preview
+	// would otherwise fetch and decode its whole clip on mount.
+	const near = useNearViewport(videoRef);
 	const [videoLoaded, setVideoLoaded] = useState(false);
 	const fitClass = objectFit === "contain" ? "object-contain" : "object-cover";
 
@@ -35,7 +40,8 @@ export function MediaWithSkeleton({
 	return (
 		<>
 			<video
-				src={src}
+				ref={videoRef}
+				src={near ? src : undefined}
 				controls={videoInteractive}
 				className={`w-full h-full ${fitClass} ${videoInteractive ? "" : "pointer-events-none"}`}
 				onLoadedData={() => setVideoLoaded(true)}

--- a/lib/components/Waveform.tsx
+++ b/lib/components/Waveform.tsx
@@ -13,6 +13,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { clamp, cn } from "@/lib/utils";
 import { AUDIO_BAR_COUNT, buildSoundwaveMask } from "./soundwave";
+import { useNearViewport } from "./useNearViewport";
 
 export interface WaveformProps {
 	src: string;
@@ -77,6 +78,7 @@ export function Waveform({
 	onFinish,
 }: WaveformProps & { ref?: Ref<WaveformHandle> }) {
 	const audioRef = useRef<HTMLAudioElement>(null);
+	const trackRef = useRef<HTMLDivElement>(null);
 	const barsRef = useRef<HTMLDivElement>(null);
 	const progressRef = useRef<HTMLDivElement>(null);
 	const peaksRef = useRef<number[]>([]);
@@ -84,6 +86,9 @@ export function Waveform({
 		peaksCache?.has(src) ? src : null,
 	);
 	const [audioSettledFor, setAudioSettledFor] = useState<string | null>(null);
+	// Peak extraction downloads and PCM-decodes the whole clip, so it waits until
+	// the track is nearly on screen rather than running for every card on mount.
+	const near = useNearViewport(trackRef);
 	const loading = loadedSrc !== src || audioSettledFor !== src;
 
 	// Adjust state during render when src changes to a cached value
@@ -124,6 +129,7 @@ export function Waveform({
 			return;
 		}
 		peaksRef.current = [];
+		if (!near) return;
 
 		let cancelled = false;
 		fetch(src, { mode: "cors" })
@@ -148,7 +154,7 @@ export function Waveform({
 			cancelled = true;
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps -- peaksCache is a stable ref, not a direct dep
-	}, [src]);
+	}, [src, near]);
 
 	useImperativeHandle(
 		ref,
@@ -189,6 +195,7 @@ export function Waveform({
 	return (
 		<>
 			<div
+				ref={trackRef}
 				className={cn("relative cursor-pointer", className)}
 				onClick={handleClick}
 			>

--- a/lib/components/useNearViewport.ts
+++ b/lib/components/useNearViewport.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState, type RefObject } from "react";
+
+/** How far outside the scroll viewport a preview starts loading. */
+const PRELOAD_MARGIN_PX = 400;
+
+function scrollParentOf(node: Element): Element | null {
+	for (let el = node.parentElement; el; el = el.parentElement) {
+		const { overflowY } = getComputedStyle(el);
+		if (overflowY === "auto" || overflowY === "scroll") return el;
+	}
+	return null;
+}
+
+/**
+ * Latches true once `ref` scrolls within `PRELOAD_MARGIN_PX` of its nearest
+ * scroll container, and stays true. Gates media previews that have no native
+ * lazy loading, so an off-screen card costs nothing until it is nearly visible.
+ */
+export function useNearViewport(ref: RefObject<Element | null>): boolean {
+	const [near, setNear] = useState(false);
+
+	useEffect(() => {
+		const node = ref.current;
+		if (!node) return;
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				if (!entry.isIntersecting) return;
+				setNear(true);
+				observer.disconnect();
+			},
+			{ root: scrollParentOf(node), rootMargin: `${PRELOAD_MARGIN_PX}px` },
+		);
+		observer.observe(node);
+		return () => observer.disconnect();
+	}, [ref]);
+
+	return near;
+}


### PR DESCRIPTION
## What

Canvas element cards eagerly load their whole preview asset on mount, no matter how far off-screen they are:

- `<video>` has no `loading="lazy"` counterpart, so every clip preview fetches and decodes in full.
- `Waveform` fetches the audio, PCM-decodes it, and scans every sample for peaks — for every audio card at once.

`useNearViewport` latches once a node comes within 400px of its nearest scroll container. A preview that is nearly visible behaves exactly as before; one that isn't costs nothing until you scroll to it. The existing shimmer already covers the not-yet-loaded state, so nothing changes on screen.

This is the same "keep the cost proportional to what's on screen" fix as the placeholder orbs in #471, applied to the media itself, and follows the [Slate performance walkthrough](https://docs.slatejs.org/walkthroughs/09-performance)'s point that paint and decode dominate everything else in the frame.

## Measured

Headless Chromium, 24 preview cards, ~3.5 cards on screen.

**Video previews** (1.7 MB clips)

| | before | after |
|---|---|---|
| transferred | 41.9 MB | **7.0 MB** |
| live video decoders | 24 | **4** |
| first on-screen frame @ 12 Mbps | 799 ms | **612 ms** |

**Audio previews** (283 KB clips)

| | before | after |
|---|---|---|
| transferred | 6.94 MB | **2.02 MB** |
| clips PCM-decoded | 24 | **7** |
| peak scan on main thread | 67 ms | **19 ms** |

Also measured and rejected: `preload="metadata"` on the preview video. Chromium buffers it identically to the default (41.9 MB either way), so it buys nothing — only not mounting the source does.

## Open PR overlap check

Open PRs considered: #475 (nightly maintainability — `ElementContainer.tsx`, `ModelBadge.tsx`, `elementConnector.ts`, `buildGenerationJob.ts`, `route-handler.ts`) and #438 (dead caret — `Canvas.tsx`, `CompactElement.tsx`, `useEditorSetup.ts`, `withCollapsedVoids.ts`, `lib/canvas/types.ts`).

This PR touches `MediaWithSkeleton.tsx`, `lib/components/Waveform.tsx` and the new `lib/components/useNearViewport.ts` — no file or theme overlap with either.

## Checks

`lint`, `format:check`, `typecheck`, `knip`, `build`, `test:coverage` and the Playwright smoke suite all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)