### PR TITLE
refactor: nightly CONVENTIONS.md compliance 2026-07-27

### DIFF
--- a/lib/canvas/__tests__/parseXmlTag.test.ts
+++ b/lib/canvas/__tests__/parseXmlTag.test.ts
@@ -3,24 +3,24 @@ import { parseXmlTag } from "../parseXmlTag";
 
 describe("parseXmlTag", () => {
 	it("parses a tag name only", () => {
-		expect(parseXmlTag("image")).toEqual({ tag: "image" });
+		expect(parseXmlTag("image")).toEqual({ tag: "image", attributes: {} });
 	});
 
 	it("parses a tag with attributes", () => {
 		expect(parseXmlTag('character name="Lyra" gender="feminine"')).toEqual({
 			tag: "character",
-			name: "Lyra",
-			gender: "feminine",
+			attributes: { name: "Lyra", gender: "feminine" },
 		});
 	});
 
 	it("strips trailing slash from self-closing tags", () => {
-		expect(parseXmlTag("image/")).toEqual({ tag: "image" });
+		expect(parseXmlTag("image/")).toEqual({ tag: "image", attributes: {} });
 	});
 
-	it("returns just { tag } when there are no attributes", () => {
-		const result = parseXmlTag("music");
-		expect(Object.keys(result)).toEqual(["tag"]);
-		expect(result.tag).toBe("music");
+	it("keeps a `tag` attribute separate from the tag name", () => {
+		expect(parseXmlTag('image tag="hero"')).toEqual({
+			tag: "image",
+			attributes: { tag: "hero" },
+		});
 	});
 });

--- a/lib/canvas/osmlStreamParser.ts
+++ b/lib/canvas/osmlStreamParser.ts
@@ -51,7 +51,7 @@ export class OSMLStreamParser {
 
 			const openTag = match[1];
 			if (openTag) {
-				const { tag, ...attributes } = parseXmlTag(openTag);
+				const { tag, attributes } = parseXmlTag(openTag);
 				this.appendNext(tag, attributes, connectors);
 			}
 			lastIndex = match.index + match[0].length;
@@ -61,14 +61,12 @@ export class OSMLStreamParser {
 		return updated;
 	}
 
-	private updateCurrent(text: string | undefined): void {
+	private updateCurrent(text: string): void {
 		const current = this.nodes[this.nodes.length - 1];
-		if (!current) {
-			return;
-		}
+		if (!current) return;
 		const lastChild = current.children[current.children.length - 1];
 		if (!lastChild) return;
-		lastChild.text += text ?? "";
+		lastChild.text += text;
 	}
 
 	private appendNext(

--- a/lib/canvas/parseXmlTag.ts
+++ b/lib/canvas/parseXmlTag.ts
@@ -1,8 +1,13 @@
-export function parseXmlTag(tagString: string): Record<string, string> {
+/** An OSML open tag split into its name and its attributes. */
+export type XmlTag = {
+	tag: string;
+	attributes: Record<string, string>;
+};
+
+export function parseXmlTag(tagString: string): XmlTag {
 	const [rawTag, ...rest] = tagString.trim().split(/\s+/);
-	const tag = rawTag.replace(/\/$/, "");
 	const attributesString = rest.join(" ");
-	const attributes: Record<string, string> = { tag };
+	const attributes: Record<string, string> = {};
 	const regex = /(\w+)="([^"]*)"/g;
 	let match: RegExpExecArray | null;
 
@@ -10,5 +15,5 @@ export function parseXmlTag(tagString: string): Record<string, string> {
 		attributes[match[1]] = match[2];
 	}
 
-	return attributes;
+	return { tag: rawTag.replace(/\/$/, ""), attributes };
 }


### PR DESCRIPTION
Nightly CONVENTIONS.md audit. The codebase held up well — one real violation worth fixing, the rest is flagged below for a human call.

## Fixed

**`lib/canvas/parseXmlTag.ts` — define errors out of existence**

`parseXmlTag` returned a single flat `Record<string, string>` in which the element type lived under the `tag` key alongside every parsed attribute. Two problems fall out of that shape:

- The caller had to know the convention and undo it: `const { tag, ...attributes } = parseXmlTag(openTag)`.
- The namespaces collide. An OSML tag written as `<image tag="hero">` parsed to `{ tag: "hero" }`, so the element silently became type `hero` instead of `image` with a `tag` attribute.

Now returns `{ tag, attributes }`, so the collision can't be expressed. Covered by a new test.

Also tightened `OSMLStreamParser.updateCurrent` to take `string` instead of `string | undefined` — both call sites always pass a string, and the `?? ""` was dead.

## Flagged, not fixed

- `lib/generation/buildGenerationJob.ts:19` — `(customAttributes.provider as ProviderKey) ?? defaultProvider` casts an untrusted attribute straight to `ProviderKey`. `isKnownProvider(type, provider)` already exists in `lib/connectors/factory.ts` for exactly this; an unrecognized string currently survives the cast and throws deep inside `createConnector`. Left alone: the file is in open PR #475.
- `app/components/canvas/hooks/useScriptSync.ts:17` — `shouldSkip` re-derives the `CANVAS_ELEMENT_TYPES.has(...)` check that `isContentElement` in `lib/canvas/guards.ts` already encodes, then casts with `node as CanvasContentElement`. A shared guard would remove the cast, but `ParsedElement` and Slate's `Element` aren't the same shape, so this needs a design decision rather than a mechanical edit.

## Clean

Swept the whole tree against all seven rules. No provider-sniffing `isX`/switch chains (`lib/connectors/factory.ts` and `lib/api/job-handlers.ts` are both proper registries), no silent catches on critical paths (every catch either logs and rethrows, surfaces to the user, or returns a typed result), and the v1 routes read like config already.

Checks: lint, typecheck, format:check, 966 tests, and `npm run build` all pass.