### PR TITLE
fix: nightly bug fixes 2026-07-28

### DIFF
--- a/lib/canvas/__tests__/osmlStreamParser.test.ts
+++ b/lib/canvas/__tests__/osmlStreamParser.test.ts
@@ -64,6 +64,15 @@ describe("OSMLStreamParser", () => {
 		expect(getElementText(nodes[0])).toContain("Some long narration text here");
 	});
 
+	it("decodes an entity split across chunk boundaries", () => {
+		const s = new OSMLStreamParser();
+		s.appendChunk("<narration>Rock &a", connectors);
+		s.appendChunk("mp; Roll forever</narration>", connectors);
+
+		const nodes = s.getNodes() as ParsedElement[];
+		expect(getElementText(nodes[0])).toContain("Rock & Roll forever");
+	});
+
 	it("preserves raw tag name for unknown tags", () => {
 		const s = new OSMLStreamParser();
 		s.appendChunk("<unknowntag>content</unknowntag>", connectors);

--- a/lib/canvas/__tests__/parseXmlTag.test.ts
+++ b/lib/canvas/__tests__/parseXmlTag.test.ts
@@ -17,6 +17,15 @@ describe("parseXmlTag", () => {
 		expect(parseXmlTag("image/")).toEqual({ tag: "image", attributes: {} });
 	});
 
+	it("decodes escaped characters in attribute values", () => {
+		expect(
+			parseXmlTag('image prompt="a 24&quot; monitor &amp; a &lt;box&gt;"'),
+		).toEqual({
+			tag: "image",
+			attributes: { prompt: 'a 24" monitor & a <box>' },
+		});
+	});
+
 	it("keeps a `tag` attribute separate from the tag name", () => {
 		expect(parseXmlTag('image tag="hero"')).toEqual({
 			tag: "image",

--- a/lib/canvas/__tests__/xmlEscape.test.ts
+++ b/lib/canvas/__tests__/xmlEscape.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { escapeXml, unescapeXml } from "../xmlEscape";
+
+describe("xmlEscape", () => {
+	it("round-trips the characters that would break an OSML tag", () => {
+		const raw = 'a 24" monitor & a <box> for R&D';
+		expect(escapeXml(raw)).toBe(
+			"a 24&quot; monitor &amp; a &lt;box&gt; for R&amp;D",
+		);
+		expect(unescapeXml(escapeXml(raw))).toBe(raw);
+	});
+
+	it("does not decode an entity the user typed literally", () => {
+		expect(unescapeXml(escapeXml("&amp; means and"))).toBe("&amp; means and");
+	});
+
+	it("leaves unknown entities untouched", () => {
+		expect(unescapeXml("&nbsp; &#39;")).toBe("&nbsp; &#39;");
+	});
+});

--- a/lib/canvas/osmlSerializer.ts
+++ b/lib/canvas/osmlSerializer.ts
@@ -1,6 +1,7 @@
 import { Descendant } from "slate";
 import type { CanvasContentElement, ParsedElement } from "@/lib/canvas/types";
 import { getContentElements, isSceneElement } from "@/lib/canvas/scenes";
+import { escapeXml } from "./xmlEscape";
 
 export const SCENE_MARKER_PATTERN = /^---\s*Scene\s+\d+\s*---\s*$/m;
 const sceneMarker = (n: number) => `\n--- Scene ${n} ---\n`;
@@ -12,9 +13,9 @@ export function getElementText(element: ParsedElement): string {
 function serializeElement(element: CanvasContentElement): string {
 	const attributes = element.customAttributes ?? {};
 	const attrString = Object.entries({ id: element.id, ...attributes })
-		.map(([key, value]) => ` ${key}="${value}"`)
+		.map(([key, value]) => ` ${key}="${escapeXml(value)}"`)
 		.join("");
-	return `<${element.type}${attrString}>${getElementText(element)}</${element.type}>\n`;
+	return `<${element.type}${attrString}>${escapeXml(getElementText(element))}</${element.type}>\n`;
 }
 
 export function serializeOSML(descendants: Descendant[]): string {

--- a/lib/canvas/osmlStreamParser.ts
+++ b/lib/canvas/osmlStreamParser.ts
@@ -7,9 +7,13 @@ import type { ConnectorRegistry } from "@/lib/connectors/registry";
 import { makeNodeId } from "./nodeUtils";
 import { parseXmlTag } from "./parseXmlTag";
 import { createCanvasNode } from "./createCanvasNode";
+import { unescapeXml } from "./xmlEscape";
 
 const MIN_BUFFER_LENGTH = 5;
 const TAG_PATTERN = /<([^<>/][^<>]*?)>|<\/([^<>/][^<>]*?)>/g;
+// A chunk can end mid-entity ("&am"); flushing it would decode the two halves
+// separately and lose the character.
+const PARTIAL_ENTITY = /&[a-z]*$/i;
 
 /**
  * Incrementally turns a stream of OSML text chunks into canvas nodes. Feed
@@ -66,7 +70,7 @@ export class OSMLStreamParser {
 		if (!current) return;
 		const lastChild = current.children[current.children.length - 1];
 		if (!lastChild) return;
-		lastChild.text += text;
+		lastChild.text += unescapeXml(text);
 	}
 
 	private appendNext(
@@ -95,6 +99,7 @@ export class OSMLStreamParser {
 		return (
 			!this.buffer.includes("<") &&
 			!this.buffer.includes(">") &&
+			!PARTIAL_ENTITY.test(this.buffer) &&
 			this.buffer.length >= MIN_BUFFER_LENGTH
 		);
 	}

--- a/lib/canvas/parseXmlTag.ts
+++ b/lib/canvas/parseXmlTag.ts
@@ -1,3 +1,5 @@
+import { unescapeXml } from "./xmlEscape";
+
 /** An OSML open tag split into its name and its attributes. */
 export type XmlTag = {
 	tag: string;
@@ -12,7 +14,7 @@ export function parseXmlTag(tagString: string): XmlTag {
 	let match: RegExpExecArray | null;
 
 	while ((match = regex.exec(attributesString)) !== null) {
-		attributes[match[1]] = match[2];
+		attributes[match[1]] = unescapeXml(match[2]);
 	}
 
 	return { tag: rawTag.replace(/\/$/, ""), attributes };

--- a/lib/canvas/xmlEscape.ts
+++ b/lib/canvas/xmlEscape.ts
@@ -1,0 +1,31 @@
+/**
+ * OSML is the persisted project format, so anything a user types into element
+ * text or an attribute has to survive a serialize/parse round trip. Without
+ * escaping, a quote or angle bracket in a prompt truncates the attribute or
+ * reparses as a new tag, silently destroying the element on reload.
+ */
+
+const ESCAPES: Record<string, string> = {
+	"&": "&amp;",
+	"<": "&lt;",
+	">": "&gt;",
+	'"': "&quot;",
+};
+
+const UNESCAPES: Record<string, string> = {
+	amp: "&",
+	lt: "<",
+	gt: ">",
+	quot: '"',
+};
+
+export function escapeXml(value: string): string {
+	return value.replace(/[&<>"]/g, (char) => ESCAPES[char] ?? char);
+}
+
+export function unescapeXml(value: string): string {
+	return value.replace(
+		/&(amp|lt|gt|quot);/g,
+		(entity, name: string) => UNESCAPES[name] ?? entity,
+	);
+}

--- a/lib/project/__tests__/serialize.test.ts
+++ b/lib/project/__tests__/serialize.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { serializeOSMLWithScenes } from "@/lib/canvas/osmlSerializer";
+import {
+	getElementText,
+	serializeOSMLWithScenes,
+} from "@/lib/canvas/osmlSerializer";
 import type { ConnectorRegistry } from "@/lib/connectors/registry";
 import {
 	SCENE_TYPE,
@@ -56,6 +59,27 @@ describe("splitScenes", () => {
 describe("deserializeWithScenes", () => {
 	it("returns [] for empty input", () => {
 		expect(deserializeWithScenes("", connectors)).toEqual([]);
+	});
+
+	it("round-trips quotes and angle brackets in attributes and text", () => {
+		const original = [
+			makeScene([
+				makeEl("image", "5 < 10 & 20 > 15", {
+					prompt: 'a 24" monitor & a <box>',
+				}),
+			]),
+		];
+
+		const scenes = deserializeWithScenes(
+			serializeOSMLWithScenes(original),
+			connectors,
+		);
+
+		const image = scenes[0].children[0];
+		expect(image.type).toBe("image");
+		expect(image.id).toBe("image-id");
+		expect(image.customAttributes?.prompt).toBe('a 24" monitor & a <box>');
+		expect(getElementText(image)).toContain("5 < 10 & 20 > 15");
 	});
 
 	it("round-trips with serializeWithScenes preserving customAttributes.url", () => {


### PR DESCRIPTION
## The bug

OSML is the persisted project format: `useAutosave` serializes the editor with `serializeOSMLWithScenes`, and `deserializeWithScenes` parses it back on load. Neither side escaped anything, so any `"`, `<`, `>`, or `&` a user typed into element text or an attribute broke the round trip.

An image whose prompt is `a 24" monitor & a <box>` serialized to:

```
<image id="e1" prompt="a 24" monitor & a <box>">hi</image>
```

and came back from `deserializeWithScenes` as an element of type `box` with no id, no attributes, and the text `">hi`. The user's element is silently destroyed on the next reload. Angle brackets in narration text corrupt structure the same way, splitting one element into two bogus ones.

## The fix

One `escapeXml`/`unescapeXml` pair in `lib/canvas/xmlEscape.ts`, applied at the two boundaries that own the format:

- `osmlSerializer` escapes attribute values and element text on the way out.
- `parseXmlTag` and `OSMLStreamParser` decode on the way in.

`unescapeXml` decodes in a single pass over known entities, so text a user literally typed as `&amp;` survives instead of being double-decoded.

The stream parser flushes loose text once the buffer has no tag characters in it, which could split `&amp;` across two chunks and decode the halves separately. It now holds a trailing partial entity in the buffer until the rest arrives.

Behavior is otherwise unchanged: escaping is only visible inside the serialized string. Projects saved before this change keep whatever their old text was; the corruption path is closed for everything written from now on.

## Tests

- `lib/project/__tests__/serialize.test.ts` — end-to-end serialize → deserialize round trip with quotes, ampersands, and angle brackets in both an attribute and element text. Fails on master by producing a `box` element.
- `lib/canvas/__tests__/xmlEscape.test.ts` — round trip, no double-decoding of a literal `&amp;`, unknown entities left alone.
- `lib/canvas/__tests__/parseXmlTag.test.ts` — attribute values are decoded.
- `lib/canvas/__tests__/osmlStreamParser.test.ts` — an entity split across chunk boundaries decodes once.

## Open PR overlap check

Open PRs considered: #480 (generation dependency graph — `lib/generation/*`, `lib/connectors/*`, `lib/project/{characterAvatar,deleteCharacter,ensureCharacterAvatars,thumbnail,types}`, `lib/video/aspectRatio*`, canvas element components) and #438 (dead caret on collapsed elements — `app/components/canvas/*`, `lib/canvas/types.ts`).

This PR touches `lib/canvas/{xmlEscape,osmlSerializer,parseXmlTag,osmlStreamParser}` and `lib/project/__tests__/serialize.test.ts`. No file or theme overlap with either.

## Validation

`npm run lint`, `format:check`, `typecheck`, `knip`, `npm test` (984 passed), `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)