### PR TITLE
refactor: derive seek thumbnails from the element registry

### DIFF
--- a/app/components/video/useSceneSegments.ts
+++ b/app/components/video/useSceneSegments.ts
@@ -1,8 +1,8 @@
 import type { PlayerRef } from "@remotion/player";
 import { isForeground } from "@/lib/canvas/guards";
-import type { SceneElement } from "@/lib/canvas/types";
+import { ELEMENT_TYPES, type SceneElement } from "@/lib/canvas/types";
 import { toSeconds } from "@/lib/video/frames";
-import type { Sequence, VideoLayout } from "@/lib/video/types";
+import type { ResolvedElement, Sequence, VideoLayout } from "@/lib/video/types";
 import type { SeekThumbnail } from "./SeekTooltip";
 import { FRAME_EVENTS, usePlayerValue } from "./usePlayerState";
 
@@ -49,6 +49,13 @@ export function useActiveSegmentIndex(
 	);
 }
 
+function toThumbnail(element: ResolvedElement | null): SeekThumbnail | null {
+	if (!element) return null;
+	const { outputKind } = ELEMENT_TYPES[element.type];
+	if (outputKind === "audio") return null;
+	return { url: element.url, kind: outputKind };
+}
+
 /**
  * Derives the seek-bar scene segments from the layout. Consecutive scenes
  * overlap by `transitionDurationSec`, so each segment's duration is trimmed by
@@ -68,16 +75,13 @@ export function buildSceneSegments(
 		if (prev) {
 			prev.duration = Math.max(0, prev.duration - layout.transitionDurationSec);
 		}
-		const el = seq.element;
 		out.push({
 			sceneId: scene.id,
 			sceneIndex: i + 1,
 			start: seq.start,
 			duration: seq.duration,
 			label: `Scene ${i + 1}`,
-			thumbnail: el
-				? { url: el.url, kind: el.type === "image" ? "image" : "video" }
-				: null,
+			thumbnail: toThumbnail(seq.element),
 		});
 	}
 	return out;


### PR DESCRIPTION
Nightly CONVENTIONS.md audit. One violation found and fixed; the rest of the sweep came back clean.

## The violation

`buildSceneSegments` decided a scene thumbnail's media kind with a hardcoded type check:

```ts
thumbnail: el ? { url: el.url, kind: el.type === "image" ? "image" : "video" } : null
```

That is special-case wiring for a fact the registry already owns. `ELEMENT_TYPES[type].outputKind` declares the output kind for every element type, and every other preview path (`OutputPreview`, `ForegroundPreview`, `resolveElements`) reads it. The sniffing version also encodes "image is the only image-output type", so a new image-output element type would silently get thumbnailed as a `<video>`.

Now derived from the registry via a small named helper. No behavior change for today's element types: `image` → image, `animated_image`/`clip` → video.

## Checks

`npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run test:run` (978 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)