### PR TITLE
fix: stop the scene header jumping when a scene is highlighted

### DIFF
--- a/app/components/canvas/dnd/SortableItem.tsx
+++ b/app/components/canvas/dnd/SortableItem.tsx
@@ -12,6 +12,7 @@ interface SortableItemProps {
 	sortableType: "scene" | "content";
 	wrapperClassName?: string;
 	wrapperStyle?: React.CSSProperties;
+	contentClassName?: string;
 	insertOptions?: InsertOption<CanvasElementType>[];
 	onInsert?: (type: CanvasElementType) => void;
 	disabled?: boolean;
@@ -25,6 +26,7 @@ export function SortableItem({
 	sortableType,
 	wrapperClassName,
 	wrapperStyle,
+	contentClassName,
 	insertOptions,
 	onInsert,
 	disabled,
@@ -51,7 +53,11 @@ export function SortableItem({
 	return (
 		<div {...attributes} className={wrapperClassName} style={wrapperStyle}>
 			<div
-				className={styles.sortable}
+				className={
+					contentClassName
+						? `${styles.sortable} ${contentClassName}`
+						: styles.sortable
+				}
 				{...sortableAttributes}
 				ref={setNodeRef}
 				style={{

--- a/app/components/canvas/dnd/SortableScene.tsx
+++ b/app/components/canvas/dnd/SortableScene.tsx
@@ -22,7 +22,8 @@ export function SortableScene({
 			sceneId={element.id}
 			sortableType="scene"
 			disabled={!isCollapsed(element.id)}
-			wrapperClassName={`border-t border-border pt-3 mt-3 first:border-t-0 first:pt-0 first:mt-0 ${isActive ? ACTIVE_SCENE_CLASS : ""}`}
+			wrapperClassName={`border-t pt-3 mt-3 first:border-t-0 first:pt-0 first:mt-0 ${isActive ? "border-transparent" : "border-border"}`}
+			contentClassName={isActive ? ACTIVE_SCENE_CLASS : undefined}
 			attributes={attributes}
 			element={element}
 		>

--- a/app/globals.css
+++ b/app/globals.css
@@ -449,15 +449,13 @@
 	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='6' height='6' viewBox='0 0 12 12'%3E%3Cpath fill='%23f1eaed' fill-opacity='0.08' d='M3 2h2v1H3v2H2V3H0V2h2V0h1z'/%3E%3C/svg%3E");
 }
 
-/* Active (currently playing) scene */
+/* Active (currently playing) scene. Painted on the scene's content box, not on
+   the wrapper that carries inter-scene spacing, so highlighting never moves the
+   scene. */
 .scene-active {
 	position: relative;
 	isolation: isolate;
 	overflow: hidden;
-	border-width: 0;
-	/* The wrapper carries inter-scene padding on every scene but the first
-	   (first:pt-0); zero it so the active card's box is identical for all. */
-	padding-top: 0;
 	border-radius: var(--radius);
 	background-color: var(--scene-active-border);
 	box-shadow:


### PR DESCRIPTION
## Summary

Highlighting a scene shifted its header up ~13px in expanded (non-compact) view. The active-scene card (`.scene-active`) was painted on the same wrapper that carries the inter-scene separator and spacing (`border-t pt-3 mt-3`), so it zeroed `padding-top` and `border-width` to keep the card box uniform across scenes. For every scene but the first, that removed 12px of padding plus the 1px border from the layout, moving the content up whenever the highlight toggled.

Now the card is painted on the scene's content box (the sortable inner element) and the spacing wrapper is left untouched, so the highlight only changes color and shadow. The separator above an active scene still disappears, via `border-transparent` instead of `border-width: 0`, so the appearance is unchanged in both states.

## Why this issue was safe and small

Issue #474 is a self-contained layout bug with an obvious cause in CSS, no product or design decision involved, and no auth/secrets needed. The change is three files and does not alter any visual value from `DESIGN.md`.

## Changes

- `app/globals.css`: drop `padding-top: 0` / `border-width: 0` from `.scene-active`.
- `app/components/canvas/dnd/SortableScene.tsx`: pass the highlight class as `contentClassName`; hide the separator with `border-transparent` when active.
- `app/components/canvas/dnd/SortableItem.tsx`: optional `contentClassName` on the sortable content element.

## Validation

- `npm run lint` — pass
- `npm run format:check` — pass
- `npm run typecheck` — pass
- `npm run knip` — pass
- `npm run build` — pass
- `npm run test:run` — 978 tests, 113 files, all pass
- `npm run test:e2e` — **skipped**: port 3000 was already occupied by a running dev server on the machine, so Playwright could not start its web server. The change touches no routes or copy that the smoke tests assert.

No test added: this is pure layout, which jsdom cannot assert, and asserting on the class strings would be testing internals.

## Open PR overlap check

Open PRs #483, #482, #481, #480, #438 were inspected with `gh pr diff --name-only`. None touches `app/globals.css`, `SortableItem.tsx`, or `SortableScene.tsx`. #438 (dead caret) is the closest in theme but works in `Canvas.tsx` / `CompactElement.tsx` / `withCollapsedVoids.ts`.

## Skipped candidates

- #424 (dead caret on element label) — already covered by open PR #438.
- #259 (queue concurrency, size XS) — blocked on BYOK.
- #332 / #250 / #254 (size S, good first issue) — each needs product/design decisions (new read-only surface, length presets, mixing defaults).
- Everything M/L/XL — too large for one unattended run.

Closes #474