### PR TITLE
perf: nightly performance optimizations 2026-07-29

### DIFF
--- a/lib/canvas/__tests__/editorOps.test.ts
+++ b/lib/canvas/__tests__/editorOps.test.ts
@@ -53,6 +53,15 @@ describe("findNodeById", () => {
 		const editor = makeEditor([scene([content("narration", "n1")], "s1")]);
 		expect(findNodeById(editor, "s1")).toBeNull();
 	});
+
+	it("finds a content element sitting at the top level", () => {
+		const editor = createEditor();
+		editor.children = [
+			scene([content("narration", "n1")]),
+			content("image", "img1"),
+		];
+		expect(findNodeById(editor, "img1")?.[1]).toEqual([1]);
+	});
 });
 
 describe("findElementById", () => {

--- a/lib/canvas/editorOps.ts
+++ b/lib/canvas/editorOps.ts
@@ -1,28 +1,49 @@
 import { Editor, Element, type NodeEntry, type Path, Transforms } from "slate";
 import type { CanvasContentElement, CanvasElement } from "@/lib/canvas/types";
 import { isContentElement } from "./guards";
+import { isSceneElement } from "./scenes";
+
+/**
+ * Canvas elements only ever live at two depths: scenes are the editor's
+ * children and content elements are theirs. Walking those levels directly
+ * keeps lookups off the whole-document traversal `Editor.nodes` performs,
+ * which matters because these run per streamed token and per drag-over frame.
+ */
+function findEntry<T extends CanvasElement>(
+	editor: Editor,
+	match: (node: CanvasElement) => node is T,
+): NodeEntry<T> | null {
+	const scenes = editor.children;
+	for (let i = 0; i < scenes.length; i++) {
+		const node = scenes[i];
+		if (!Element.isElement(node)) continue;
+		if (match(node)) return [node, [i]];
+		if (!isSceneElement(node)) continue;
+		for (let j = 0; j < node.children.length; j++) {
+			const child = node.children[j];
+			if (match(child)) return [child, [i, j]];
+		}
+	}
+	return null;
+}
 
 /** Any canvas element by id — scenes included. Use {@link findNodeById} when only content will do. */
 export function findElementById(
 	editor: Editor,
 	id: string,
 ): NodeEntry<CanvasElement> | null {
-	const [entry] = Editor.nodes<CanvasElement>(editor, {
-		at: [],
-		match: (n) => Element.isElement(n) && n.id === id,
-	});
-	return entry ?? null;
+	return findEntry(editor, (node): node is CanvasElement => node.id === id);
 }
 
 export function findNodeById(
 	editor: Editor,
 	id: string,
 ): NodeEntry<CanvasContentElement> | null {
-	const [entry] = Editor.nodes<CanvasContentElement>(editor, {
-		at: [],
-		match: (n) => isContentElement(n) && n.id === id,
-	});
-	return entry ?? null;
+	return findEntry(
+		editor,
+		(node): node is CanvasContentElement =>
+			isContentElement(node) && node.id === id,
+	);
 }
 
 /**


### PR DESCRIPTION
## What

`findElementById` / `findNodeById` resolved a canvas element by scanning the whole document with `Editor.nodes(editor, { at: [] })`. That generator visits every node, text leaves included. Both functions sit on paths that fire continuously:

- `useScriptSync` resolves up to three ids **per streamed token** while a script generates.
- dnd-kit's `handleDragOver` resolves one **per pointer frame** during a drag, and `moveDraggedElement` two more on drop.

The per-lookup cost grows linearly with script length while the event rate stays constant, so the total work during a long generation is quadratic.

Canvas elements only live at two depths — scenes are the editor's children, content elements are theirs — so walking those levels directly returns the same entry without touching text nodes.

## Measured

Same lookup, same documents, 2000 iterations each (worst-case id, last element):

| document | before | after | |
|---|---|---|---|
| 40 elements | 0.140 ms | 0.023 ms | 6.0x |
| 120 elements | 0.307 ms | 0.050 ms | 6.1x |
| 240 elements | 0.527 ms | 0.088 ms | 6.0x |

At 240 elements that's ~1.6 ms → ~0.26 ms of lookup per streamed token, and ~0.53 ms → ~0.09 ms per drag-over frame against a 16 ms budget.

No behavior change: both finders return the same entry and path. Added a test pinning the top-level-content case (`useScriptSync` inserts there before normalization).

## Checks

`npm run lint`, `prettier --check`, `npm run typecheck`, `npm run test:run` (981 passed), `npm run build` — all green.

## Open PR overlap check

Considered open PRs #485, #484, #481, #480, #438. This PR touches only `lib/canvas/editorOps.ts` and its test. #481 covers `lib/canvas/osml*`/`parseXmlTag`/`xmlEscape`; #438 covers `lib/canvas/types.ts`, `Canvas.tsx`, `useEditorSetup.ts`, `withCollapsedVoids.ts`. No file or theme overlap — callers in those PRs' files are unmodified and pick up the speedup for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)