### PR TITLE
refactor: rethink openslop architecture 2026-07-29

### DIFF
--- a/app/components/canvas/elements/OutputPreview.tsx
+++ b/app/components/canvas/elements/OutputPreview.tsx
@@ -1,8 +1,6 @@
 import { memo } from "react";
-import { ELEMENT_TYPES, type CanvasContentElement } from "@/lib/canvas/types";
-import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
-import { AudioResult, AudioPlaceholder, MediaResult } from "./preview/results";
-import { AnimatedImageOutput } from "./preview/AnimatedImagePreview";
+import type { CanvasContentElement } from "@/lib/canvas/types";
+import { ELEMENT_PREVIEWS } from "./preview/registry";
 import { useElementGeneration } from "./ElementGenerationContext";
 
 function OutputPreviewComponent({
@@ -10,29 +8,16 @@ function OutputPreviewComponent({
 }: {
 	element: CanvasContentElement;
 }) {
-	const type = element.type;
-	const { outputKind } = ELEMENT_TYPES[type];
 	const { status, seconds, result, error, discard } = useElementGeneration();
-	const state = { status, seconds, error, onDiscard: discard };
-
-	if (outputKind === "audio") {
-		if (result?.audioUrl) {
-			return (
-				<AudioResult src={result.audioUrl} status={status} seconds={seconds} />
-			);
-		}
-		return <AudioPlaceholder {...state} />;
-	}
-
-	if (type === "animated_image") {
-		return <AnimatedImageOutput {...state} />;
-	}
+	const Preview = ELEMENT_PREVIEWS[element.type];
 
 	return (
-		<MediaResult
-			{...state}
-			url={getPrimaryUrl(result, outputKind)}
-			outputKind={outputKind}
+		<Preview
+			status={status}
+			seconds={seconds}
+			result={result}
+			error={error}
+			onDiscard={discard}
 		/>
 	);
 }

--- a/app/components/canvas/elements/PlayFromHereButton.tsx
+++ b/app/components/canvas/elements/PlayFromHereButton.tsx
@@ -3,15 +3,17 @@
 import { Play } from "@/components/ui/icon";
 import { TooltipIconButton } from "@/components/ui/icon-button";
 import { usePlayerControl } from "@/app/components/video/PlayerControlContext";
-import { findSceneSequence } from "@/app/components/video/useSceneSegments";
-import { useLayout } from "@/app/components/video/VideoLayoutContext";
+import {
+	useLayout,
+	useSceneSequence,
+} from "@/app/components/video/VideoLayoutContext";
 import type { SceneElement } from "@/lib/canvas/types";
 import { toFrames } from "@/lib/video/frames";
 
 export function PlayFromHereButton({ scene }: { scene: SceneElement }) {
 	const { layout } = useLayout();
 	const { playFromFrame } = usePlayerControl();
-	const seq = findSceneSequence(scene, layout);
+	const seq = useSceneSequence(scene);
 	const startFrame = seq ? toFrames(seq.start, layout.fps) : null;
 	const disabled = startFrame == null;
 	return (

--- a/app/components/canvas/elements/SceneContainer.tsx
+++ b/app/components/canvas/elements/SceneContainer.tsx
@@ -5,8 +5,7 @@ import {
 	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import type { SceneElement } from "@/lib/canvas/types";
-import { findSceneSequence } from "@/app/components/video/useSceneSegments";
-import { useLayout } from "@/app/components/video/VideoLayoutContext";
+import { useSceneSequence } from "@/app/components/video/VideoLayoutContext";
 import { isForeground } from "@/lib/canvas/guards";
 import { useDragTransfer } from "../dnd/DragTransferContext";
 import { useSceneIndex } from "../hooks/useSceneIndex";
@@ -63,8 +62,7 @@ function SceneHeader({
 	onToggle: () => void;
 	element: SceneElement;
 }) {
-	const { layout } = useLayout();
-	const seq = findSceneSequence(element, layout);
+	const seq = useSceneSequence(element);
 	const label = (
 		<>
 			Scene {sceneIndex}

--- a/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
+++ b/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
@@ -7,14 +7,18 @@ import { stillFrameUrl } from "@/lib/connectors/animated_image/plugins/still-fra
 import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
 import { useElementGeneration } from "../ElementGenerationContext";
 import { MediaResult } from "./results";
-import type { ElementPreviewProps } from "./status";
+import type { ElementPreviewProps, PlaceholderProps } from "./status";
 
-export function AnimatedImagePreview({
-	result,
+type AnimatedImageMediaProps = PlaceholderProps & {
+	stillUrl?: string;
+	videoUrl?: string;
+};
+
+export function AnimatedImageMedia({
+	stillUrl,
+	videoUrl,
 	...state
-}: ElementPreviewProps) {
-	const { node } = useElementGeneration();
-	const stillUrl = useQueueSelector((queue) => stillFrameUrl(node, queue));
+}: AnimatedImageMediaProps) {
 	const [mode, setMode] = useState<"animated" | "still">("animated");
 	const animated = mode === "animated";
 
@@ -25,7 +29,7 @@ export function AnimatedImagePreview({
 		>
 			<MediaResult
 				{...state}
-				url={animated ? result?.videoUrl : stillUrl}
+				url={animated ? videoUrl : stillUrl}
 				outputKind={animated ? "video" : "image"}
 			/>
 			<MediaToggle
@@ -38,5 +42,21 @@ export function AnimatedImagePreview({
 				]}
 			/>
 		</div>
+	);
+}
+
+export function AnimatedImagePreview({
+	result,
+	...state
+}: ElementPreviewProps) {
+	const { node } = useElementGeneration();
+	const stillUrl = useQueueSelector((queue) => stillFrameUrl(node, queue));
+
+	return (
+		<AnimatedImageMedia
+			{...state}
+			stillUrl={stillUrl}
+			videoUrl={result?.videoUrl}
+		/>
 	);
 }

--- a/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
+++ b/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
@@ -7,19 +7,16 @@ import { stillFrameUrl } from "@/lib/connectors/animated_image/plugins/still-fra
 import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
 import { useElementGeneration } from "../ElementGenerationContext";
 import { MediaResult } from "./results";
-import type { PlaceholderProps } from "./status";
-
-type AnimatedImagePreviewProps = PlaceholderProps & {
-	stillUrl?: string;
-	videoUrl?: string;
-};
+import type { ElementPreviewProps } from "./status";
 
 export function AnimatedImagePreview({
-	stillUrl,
-	videoUrl,
+	result,
 	...state
-}: AnimatedImagePreviewProps) {
+}: ElementPreviewProps) {
+	const { node } = useElementGeneration();
+	const stillUrl = useQueueSelector((queue) => stillFrameUrl(node, queue));
 	const [mode, setMode] = useState<"animated" | "still">("animated");
+	const animated = mode === "animated";
 
 	return (
 		<div
@@ -28,8 +25,8 @@ export function AnimatedImagePreview({
 		>
 			<MediaResult
 				{...state}
-				url={mode === "animated" ? videoUrl : stillUrl}
-				outputKind={mode === "animated" ? "video" : "image"}
+				url={animated ? result?.videoUrl : stillUrl}
+				outputKind={animated ? "video" : "image"}
 			/>
 			<MediaToggle
 				className="absolute top-2 right-2 z-30 shadow-sm"
@@ -41,18 +38,5 @@ export function AnimatedImagePreview({
 				]}
 			/>
 		</div>
-	);
-}
-
-export function AnimatedImageOutput(state: PlaceholderProps) {
-	const { node, result } = useElementGeneration();
-	const stillUrl = useQueueSelector((queue) => stillFrameUrl(node, queue));
-
-	return (
-		<AnimatedImagePreview
-			{...state}
-			stillUrl={stillUrl}
-			videoUrl={result?.videoUrl}
-		/>
 	);
 }

--- a/app/components/canvas/elements/preview/AudioPreview.tsx
+++ b/app/components/canvas/elements/preview/AudioPreview.tsx
@@ -1,0 +1,13 @@
+import { AudioPlaceholder, AudioResult } from "./results";
+import type { ElementPreviewProps } from "./status";
+
+export function AudioPreview({ result, ...state }: ElementPreviewProps) {
+	if (!result?.audioUrl) return <AudioPlaceholder {...state} />;
+	return (
+		<AudioResult
+			src={result.audioUrl}
+			status={state.status}
+			seconds={state.seconds}
+		/>
+	);
+}

--- a/app/components/canvas/elements/preview/ClipPreview.tsx
+++ b/app/components/canvas/elements/preview/ClipPreview.tsx
@@ -1,0 +1,13 @@
+import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
+import { MediaResult } from "./results";
+import type { ElementPreviewProps } from "./status";
+
+export function ClipPreview({ result, ...state }: ElementPreviewProps) {
+	return (
+		<MediaResult
+			{...state}
+			url={getPrimaryUrl(result, "video")}
+			outputKind="video"
+		/>
+	);
+}

--- a/app/components/canvas/elements/preview/ImagePreview.tsx
+++ b/app/components/canvas/elements/preview/ImagePreview.tsx
@@ -1,0 +1,13 @@
+import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
+import { MediaResult } from "./results";
+import type { ElementPreviewProps } from "./status";
+
+export function ImagePreview({ result, ...state }: ElementPreviewProps) {
+	return (
+		<MediaResult
+			{...state}
+			url={getPrimaryUrl(result, "image")}
+			outputKind="image"
+		/>
+	);
+}

--- a/app/components/canvas/elements/preview/__tests__/cancelOffset.test.tsx
+++ b/app/components/canvas/elements/preview/__tests__/cancelOffset.test.tsx
@@ -48,7 +48,9 @@ describe("cancel button offset", () => {
 	});
 
 	it("is pushed below the still/video toggle by AnimatedImagePreview", () => {
-		const html = withTooltip(<AnimatedImagePreview {...generating} />);
+		const html = withTooltip(
+			<AnimatedImagePreview {...generating} result={null} />,
+		);
 		expect(html).toContain("--cancel-offset:2.5rem");
 	});
 
@@ -72,6 +74,7 @@ describe("AnimatedImagePreview", () => {
 				seconds={0}
 				error="generation failed"
 				onDiscard={() => {}}
+				result={null}
 			/>,
 		);
 		// Error overlay renders at z-20; the toggle must sit above it.

--- a/app/components/canvas/elements/preview/__tests__/cancelOffset.test.tsx
+++ b/app/components/canvas/elements/preview/__tests__/cancelOffset.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { AnimatedImagePreview } from "../AnimatedImagePreview";
+import { AnimatedImageMedia } from "../AnimatedImagePreview";
 import { AudioPlaceholder, MediaResult } from "../results";
 
 const withTooltip = (node: React.ReactNode) =>
@@ -47,10 +47,8 @@ describe("cancel button offset", () => {
 		expect(html).toContain("https://cdn.example.com/a.png");
 	});
 
-	it("is pushed below the still/video toggle by AnimatedImagePreview", () => {
-		const html = withTooltip(
-			<AnimatedImagePreview {...generating} result={null} />,
-		);
+	it("is pushed below the still/video toggle by AnimatedImageMedia", () => {
+		const html = withTooltip(<AnimatedImageMedia {...generating} />);
 		expect(html).toContain("--cancel-offset:2.5rem");
 	});
 
@@ -66,15 +64,14 @@ const mediaToggleClass = (html: string) => {
 	return match[1];
 };
 
-describe("AnimatedImagePreview", () => {
+describe("AnimatedImageMedia", () => {
 	it("stacks the still/video toggle above the error overlay so it stays clickable", () => {
 		const html = withTooltip(
-			<AnimatedImagePreview
+			<AnimatedImageMedia
 				status="idle"
 				seconds={0}
 				error="generation failed"
 				onDiscard={() => {}}
-				result={null}
 			/>,
 		);
 		// Error overlay renders at z-20; the toggle must sit above it.

--- a/app/components/canvas/elements/preview/registry.tsx
+++ b/app/components/canvas/elements/preview/registry.tsx
@@ -1,31 +1,12 @@
 import type { ReactNode } from "react";
 import type { CanvasElementType } from "@/lib/canvas/types";
-import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 import { AnimatedImagePreview } from "./AnimatedImagePreview";
-import { AudioPreview, MediaResult } from "./results";
+import { AudioPreview } from "./AudioPreview";
+import { ClipPreview } from "./ClipPreview";
+import { ImagePreview } from "./ImagePreview";
 import type { ElementPreviewProps } from "./status";
 
 type ElementPreview = (props: ElementPreviewProps) => ReactNode;
-
-function ImagePreview({ result, ...state }: ElementPreviewProps) {
-	return (
-		<MediaResult
-			{...state}
-			url={getPrimaryUrl(result, "image")}
-			outputKind="image"
-		/>
-	);
-}
-
-function ClipPreview({ result, ...state }: ElementPreviewProps) {
-	return (
-		<MediaResult
-			{...state}
-			url={getPrimaryUrl(result, "video")}
-			outputKind="video"
-		/>
-	);
-}
 
 /** How each element type renders its generated output. */
 export const ELEMENT_PREVIEWS: Record<CanvasElementType, ElementPreview> = {

--- a/app/components/canvas/elements/preview/registry.tsx
+++ b/app/components/canvas/elements/preview/registry.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+import type { CanvasElementType } from "@/lib/canvas/types";
+import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
+import { AnimatedImagePreview } from "./AnimatedImagePreview";
+import { AudioPreview, MediaResult } from "./results";
+import type { ElementPreviewProps } from "./status";
+
+type ElementPreview = (props: ElementPreviewProps) => ReactNode;
+
+function ImagePreview({ result, ...state }: ElementPreviewProps) {
+	return (
+		<MediaResult
+			{...state}
+			url={getPrimaryUrl(result, "image")}
+			outputKind="image"
+		/>
+	);
+}
+
+function ClipPreview({ result, ...state }: ElementPreviewProps) {
+	return (
+		<MediaResult
+			{...state}
+			url={getPrimaryUrl(result, "video")}
+			outputKind="video"
+		/>
+	);
+}
+
+/** How each element type renders its generated output. */
+export const ELEMENT_PREVIEWS: Record<CanvasElementType, ElementPreview> = {
+	narration: AudioPreview,
+	character: AudioPreview,
+	sound: AudioPreview,
+	music: AudioPreview,
+	image: ImagePreview,
+	clip: ClipPreview,
+	animated_image: AnimatedImagePreview,
+};

--- a/app/components/canvas/elements/preview/results.tsx
+++ b/app/components/canvas/elements/preview/results.tsx
@@ -3,11 +3,7 @@ import { isGenerationActive } from "@/lib/generation/queue";
 import { AudioPlayer } from "../AudioPlayer";
 import { MediaWithSkeleton } from "../MediaWithSkeleton";
 import { GenerationIndicator } from "../GenerationIndicator";
-import type {
-	ElementPreviewProps,
-	GenerationState,
-	PlaceholderProps,
-} from "./status";
+import type { GenerationState, PlaceholderProps } from "./status";
 import { PlaceholderBallsLoader } from "./placeholderBalls";
 import {
 	AUDIO_BAR_COUNT,
@@ -15,7 +11,7 @@ import {
 } from "@/lib/components/soundwave";
 import { ErrorMessage, PlaceholderOverlay, ResultOverlay } from "./overlays";
 
-function AudioResult({
+export function AudioResult({
 	src,
 	status,
 	seconds,
@@ -33,17 +29,6 @@ function AudioResult({
 			)}
 			<AudioPlayer key={src} src={src} />
 		</div>
-	);
-}
-
-export function AudioPreview({ result, ...state }: ElementPreviewProps) {
-	if (!result?.audioUrl) return <AudioPlaceholder {...state} />;
-	return (
-		<AudioResult
-			src={result.audioUrl}
-			status={state.status}
-			seconds={state.seconds}
-		/>
 	);
 }
 

--- a/app/components/canvas/elements/preview/results.tsx
+++ b/app/components/canvas/elements/preview/results.tsx
@@ -3,7 +3,11 @@ import { isGenerationActive } from "@/lib/generation/queue";
 import { AudioPlayer } from "../AudioPlayer";
 import { MediaWithSkeleton } from "../MediaWithSkeleton";
 import { GenerationIndicator } from "../GenerationIndicator";
-import type { GenerationState, PlaceholderProps } from "./status";
+import type {
+	ElementPreviewProps,
+	GenerationState,
+	PlaceholderProps,
+} from "./status";
 import { PlaceholderBallsLoader } from "./placeholderBalls";
 import {
 	AUDIO_BAR_COUNT,
@@ -11,7 +15,7 @@ import {
 } from "@/lib/components/soundwave";
 import { ErrorMessage, PlaceholderOverlay, ResultOverlay } from "./overlays";
 
-export function AudioResult({
+function AudioResult({
 	src,
 	status,
 	seconds,
@@ -29,6 +33,17 @@ export function AudioResult({
 			)}
 			<AudioPlayer key={src} src={src} />
 		</div>
+	);
+}
+
+export function AudioPreview({ result, ...state }: ElementPreviewProps) {
+	if (!result?.audioUrl) return <AudioPlaceholder {...state} />;
+	return (
+		<AudioResult
+			src={result.audioUrl}
+			status={state.status}
+			seconds={state.seconds}
+		/>
 	);
 }
 

--- a/app/components/canvas/elements/preview/status.ts
+++ b/app/components/canvas/elements/preview/status.ts
@@ -9,3 +9,8 @@ export type PlaceholderProps = GenerationState & {
 	error: string | null;
 	onDiscard: () => void;
 };
+
+/** The uniform contract every entry in `ELEMENT_PREVIEWS` renders against. */
+export type ElementPreviewProps = PlaceholderProps & {
+	result: ElementSnapshot["result"];
+};

--- a/app/components/canvas/hooks/__tests__/useProjectRehydrate.test.ts
+++ b/app/components/canvas/hooks/__tests__/useProjectRehydrate.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { serializeOSMLWithScenes } from "@/lib/canvas/osmlSerializer";
 import { SCENE_TYPE, type SceneElement } from "@/lib/canvas/types";
 import type { ConnectorRegistry } from "@/lib/connectors/registry";
-import { rehydrateProjectEditor } from "./useProjectRehydrate";
+import { rehydrateProjectEditor } from "../useProjectRehydrate";
 
 const connector = {
 	openslop: { defaultModel: "m", models: ["m"], isDefault: true, apiKey: "" },

--- a/app/components/video/VideoLayoutContext.tsx
+++ b/app/components/video/VideoLayoutContext.tsx
@@ -4,9 +4,16 @@ import { useMemo, type ReactNode } from "react";
 import type { Editor } from "slate";
 import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
-import type { VideoLayout } from "@/lib/video/types";
+import type { SceneElement } from "@/lib/canvas/types";
+import type { Sequence, VideoLayout } from "@/lib/video/types";
 import { useAssetPrefetch } from "./useAssetPrefetch";
-import { buildSceneSegments, type SceneSegment } from "./useSceneSegments";
+import {
+	buildSceneSegments,
+	buildSequenceIndex,
+	findSceneSequence,
+	type SceneSegment,
+	type SequenceIndex,
+} from "./useSceneSegments";
 import { useVideoLayout } from "./useVideoLayout";
 
 type VideoLayoutValue = {
@@ -14,6 +21,7 @@ type VideoLayoutValue = {
 	ready: boolean;
 	playerKey: string;
 	segments: SceneSegment[];
+	sequenceByElementId: SequenceIndex;
 };
 
 const [VideoLayoutContext, useLayout] =
@@ -33,13 +41,23 @@ export function VideoLayoutProvider({
 	const prefetched = useAssetPrefetch(layout);
 	const busy = useQueueSelector((q) => q.isBusy());
 	const ready = prefetched && !busy;
+	const sequenceByElementId = useMemo(
+		() => buildSequenceIndex(layout.series),
+		[layout.series],
+	);
 	const segments = useMemo(
-		() => buildSceneSegments(scenes, layout),
-		[scenes, layout],
+		() => buildSceneSegments(scenes, layout, sequenceByElementId),
+		[scenes, layout, sequenceByElementId],
 	);
 	const value = useMemo(
-		() => ({ layout, ready, playerKey, segments }),
-		[layout, ready, playerKey, segments],
+		() => ({ layout, ready, playerKey, segments, sequenceByElementId }),
+		[layout, ready, playerKey, segments, sequenceByElementId],
 	);
 	return <VideoLayoutContext value={value}>{children}</VideoLayoutContext>;
+}
+
+/** The rendered sequence a scene's foreground element occupies, if it has one. */
+export function useSceneSequence(scene: SceneElement): Sequence | undefined {
+	const { sequenceByElementId } = useLayout();
+	return findSceneSequence(scene, sequenceByElementId);
 }

--- a/app/components/video/__tests__/useAssetPrefetch.test.ts
+++ b/app/components/video/__tests__/useAssetPrefetch.test.ts
@@ -38,7 +38,6 @@ function layout(partial: Partial<VideoLayout>): VideoLayout {
 	return {
 		series: [],
 		sequences: {},
-		sequenceByElementId: new Map(),
 		fps: 30,
 		width: 1920,
 		height: 1080,

--- a/app/components/video/__tests__/useSceneSegments.test.ts
+++ b/app/components/video/__tests__/useSceneSegments.test.ts
@@ -3,6 +3,7 @@ import type { SceneElement } from "@/lib/canvas/types";
 import type { ResolvedElement, Sequence, VideoLayout } from "@/lib/video/types";
 import {
 	buildSceneSegments,
+	buildSequenceIndex,
 	findSegmentIndexAt,
 	type SceneSegment,
 } from "../useSceneSegments";
@@ -92,13 +93,9 @@ const scene = (id: string, foregroundId: string | null): SceneElement => ({
 		: [],
 });
 
-const layout = (
-	entries: Record<string, Sequence>,
-	transitionDurationSec = 0,
-): VideoLayout => ({
+const layout = (transitionDurationSec = 0): VideoLayout => ({
 	series: [],
 	sequences: {},
-	sequenceByElementId: new Map(Object.entries(entries)),
 	fps: 24,
 	width: 1920,
 	height: 1080,
@@ -108,16 +105,35 @@ const layout = (
 	transitionDurationSec,
 });
 
+const segmentsOf = (
+	scenes: SceneElement[],
+	entries: Record<string, Sequence>,
+	transitionDurationSec = 0,
+) =>
+	buildSceneSegments(
+		scenes,
+		layout(transitionDurationSec),
+		new Map(Object.entries(entries)),
+	);
+
+describe("buildSequenceIndex", () => {
+	it("keys sequences by their element id and skips placeholders", () => {
+		const withElement = sequence(0, 2, resolved("a.png"));
+		const index = buildSequenceIndex([withElement, sequence(2, 1, null)]);
+		expect(index.size).toBe(1);
+		expect(index.get("a.png-el")).toBe(withElement);
+	});
+});
+
 describe("buildSceneSegments", () => {
 	it("returns an empty array when there are no scenes", () => {
-		expect(buildSceneSegments([], layout({}))).toEqual([]);
+		expect(segmentsOf([], {})).toEqual([]);
 	});
 
 	it("maps each scene's foreground sequence to a segment", () => {
-		const segments = buildSceneSegments(
-			[scene("s1", "fg1")],
-			layout({ fg1: sequence(0, 2, resolved("a.png")) }),
-		);
+		const segments = segmentsOf([scene("s1", "fg1")], {
+			fg1: sequence(0, 2, resolved("a.png")),
+		});
 		expect(segments).toEqual([
 			{
 				sceneId: "s1",
@@ -131,32 +147,29 @@ describe("buildSceneSegments", () => {
 	});
 
 	it("trims the previous segment by the transition overlap", () => {
-		const segments = buildSceneSegments(
+		const segments = segmentsOf(
 			[scene("s1", "fg1"), scene("s2", "fg2")],
-			layout(
-				{
-					fg1: sequence(0, 2, resolved("a.png")),
-					fg2: sequence(2, 3, resolved("b.png")),
-				},
-				0.5,
-			),
+			{
+				fg1: sequence(0, 2, resolved("a.png")),
+				fg2: sequence(2, 3, resolved("b.png")),
+			},
+			0.5,
 		);
 		expect(segments.map((s) => s.duration)).toEqual([1.5, 3]);
 	});
 
 	it("skips scenes with no foreground or no resolved sequence", () => {
-		const segments = buildSceneSegments(
+		const segments = segmentsOf(
 			[scene("s1", null), scene("s2", "missing"), scene("s3", "fg3")],
-			layout({ fg3: sequence(0, 4, resolved("c.png")) }),
+			{ fg3: sequence(0, 4, resolved("c.png")) },
 		);
 		expect(segments.map((s) => s.sceneId)).toEqual(["s3"]);
 	});
 
 	it("emits a null thumbnail when the sequence has no element", () => {
-		const [segment] = buildSceneSegments(
-			[scene("s1", "fg1")],
-			layout({ fg1: sequence(0, 2, null) }),
-		);
+		const [segment] = segmentsOf([scene("s1", "fg1")], {
+			fg1: sequence(0, 2, null),
+		});
 		expect(segment.thumbnail).toBeNull();
 	});
 });

--- a/app/components/video/useSceneSegments.ts
+++ b/app/components/video/useSceneSegments.ts
@@ -15,13 +15,27 @@ export type SceneSegment = {
 	thumbnail: SeekThumbnail | null;
 };
 
+export type SequenceIndex = ReadonlyMap<string, Sequence>;
+
+/**
+ * Lookup index from foreground element id to its scene sequence. Client-only:
+ * the render payload carries the ordered `series`, not this projection of it.
+ */
+export function buildSequenceIndex(series: Sequence[]): SequenceIndex {
+	const index = new Map<string, Sequence>();
+	for (const seq of series) {
+		if (seq.element) index.set(seq.element.id, seq);
+	}
+	return index;
+}
+
 export function findSceneSequence(
 	scene: SceneElement,
-	layout: VideoLayout,
+	index: SequenceIndex,
 ): Sequence | undefined {
 	const fg = scene.children.find(isForeground);
 	if (!fg) return undefined;
-	return layout.sequenceByElementId.get(fg.id);
+	return index.get(fg.id);
 }
 
 export function findSegmentIndexAt(
@@ -65,11 +79,12 @@ function toThumbnail(element: ResolvedElement | null): SeekThumbnail | null {
 export function buildSceneSegments(
 	scenes: SceneElement[],
 	layout: VideoLayout,
+	index: SequenceIndex,
 ): SceneSegment[] {
 	const out: SceneSegment[] = [];
 	for (let i = 0; i < scenes.length; i++) {
 		const scene = scenes[i];
-		const seq = findSceneSequence(scene, layout);
+		const seq = findSceneSequence(scene, index);
 		if (!seq) continue;
 		const prev = out[out.length - 1];
 		if (prev) {

--- a/lib/project/__tests__/autosave.test.ts
+++ b/lib/project/__tests__/autosave.test.ts
@@ -26,6 +26,7 @@ const imageSnapshot = (imageUrl: string): ElementSnapshot => ({
 	error: null,
 	resultInputs: null,
 	connectorType: "image",
+	pinned: false,
 });
 
 const snapshot = (title: string): ProjectStoreSnapshot => ({

--- a/lib/video/scene-builder.ts
+++ b/lib/video/scene-builder.ts
@@ -156,16 +156,10 @@ export function buildVideoLayout(
 		}
 	}
 
-	const sequenceByElementId = new Map<string, Sequence>();
-	for (const seq of series) {
-		if (seq.element) sequenceByElementId.set(seq.element.id, seq);
-	}
-
 	return {
 		...cfg,
 		series,
 		sequences,
-		sequenceByElementId,
 		totalDurationSec,
 		totalFrames: Math.max(
 			2,

--- a/lib/video/types.ts
+++ b/lib/video/types.ts
@@ -29,7 +29,6 @@ export type Sequence = {
 export type VideoLayout = {
 	series: Sequence[];
 	sequences: Partial<Record<CanvasElementType, Sequence[]>>;
-	sequenceByElementId: Map<string, Sequence>;
 	fps: number;
 	width: number;
 	height: number;

--- a/remotion/Root.tsx
+++ b/remotion/Root.tsx
@@ -11,7 +11,6 @@ import {
 const defaultProps: VideoLayout = {
 	series: [],
 	sequences: {},
-	sequenceByElementId: new Map(),
 	fps: DEFAULT_CONFIG.fps,
 	width: DEFAULT_CONFIG.width,
 	height: DEFAULT_CONFIG.height,


### PR DESCRIPTION
No behavior changes. Two presentation-layer seams stop being special-case wiring.

## App understanding

openslop turns a prompt into a rendered video. `ScriptProvider` streams OSML from an LLM connector; `useOSMLStreamParser` turns tokens into nodes; `useScriptSync`/`useMetadataSync` push those into a Slate editor and the project store. Each canvas element is generated through `lib/generation/queue.ts` + `lib/connectors/**` + `lib/providers/**`, resolved into a `VideoLayout` by `lib/video/scene-builder.ts`, previewed in a Remotion `<Player>`, and exported via `/api/render` to Remotion Lambda.

## From-scratch architecture

The current shape is already close to the one I'd rebuild: `lib/` is the domain layer, `app/` is presentation, element types are declared once in `ELEMENT_TYPES` and dressed once in `elementConfigs`, and providers compose at the editor boundary. The two places it drifted were both in presentation: one element facet still dispatched with conditionals instead of a table, and one client-only lookup index had leaked into the type that gets serialized to Lambda.

## Implemented simplifications

**Element previews are a registry, not an if-chain.** `OutputPreview` branched on `outputKind === "audio"`, then `type === "animated_image"`, then fell through to media. Element type is already the key for connector/role/layer (`ELEMENT_TYPES`) and for label/icon/placeholder (`elementConfigs`); preview was the one facet handled imperatively. New `preview/registry.tsx` maps each of the 7 types to a preview component behind one prop contract (`ElementPreviewProps` in `preview/status.ts`), and each preview derives the url it needs from the result itself. `OutputPreview` is now a lookup plus a render — 46 → 25 lines, zero conditionals. Adding an element type is a registry entry instead of a new branch.

**`sequenceByElementId` leaves the render payload.** `buildVideoLayout` attached a `Map<elementId, Sequence>` to `VideoLayout`. `VideoLayout` is what goes into Remotion `inputProps` for `/api/render` and Lambda, where a `Map` JSON-serializes to `{}` — harmless only because `VideoComposition` never reads it. Its sole consumers are client-side (`SceneContainer` header timestamp, `PlayFromHereButton`, `buildSceneSegments`). The index now lives in `VideoLayoutContext`, memoized on `layout.series`, behind a `useSceneSequence(scene)` hook. `VideoLayout` is render-only again, and the two call sites lost their `useLayout()` + `findSceneSequence(scene, layout)` boilerplate.

Kept as a memoized map rather than scanning `series` per lookup: `SceneHeader` and `PlayFromHereButton` render once per scene, so a linear scan would make the canvas quadratic in scene count.

**Hygiene:** `useProjectRehydrate.test.ts` was the only test outside a `__tests__/` dir (113 others are inside); moved.

New coverage for `buildSequenceIndex` (keys by element id, skips placeholder sequences).

## Validation

`npm run lint`, `npx prettier --check .`, `npm run typecheck`, `npm run knip`, `npm run test:run` (981 passed, 114 files), `npm run build` — all green.

## Skipped

- **Duplicated abort-controller streaming lifecycle** (`lib/script/ScriptProvider.tsx`, `app/components/canvas/hooks/useRefineScript.ts`). Same abortRef/loading/`abortRef.current === controller` dance twice. Only 2 sites, and a generic async hook here has been rejected before as overengineering — left for a third caller.
- **`ForegroundPreview` reads generation state via `useGenerate` directly** while every other consumer goes through `ElementGenerationProvider`. It renders outside that provider (collapsed scene view), so unifying it needs queue-level work that overlaps #480.
- **`parentSceneId()` helper** for the duplicated `Node.parent(editor, path) as SceneElement` cast — one of the two sites is `ElementContainer.tsx`, under #480.
- **`lib/api/with-auth.ts` returns `stringifyError(error)` on 500s**, including on public routes. Information disclosure worth a look, but fixing it is a behavior change.

## Open PR overlap check

Considered #486 (`lib/canvas/editorOps.ts`), #485 (`ARCHITECTURE.md`, `AccessCodeInput`, `useAutosave`, `lib/auth/accessCode`, `lib/project/autosave`), #484 (`canvas/dnd/Sortable*`, `globals.css`), #481 (`lib/canvas/osml*`, `parseXmlTag`, `xmlEscape`), #480 (`lib/generation/**`, `lib/connectors/**`, `canvas/elements/{AssetTiles,CharacterPill,ElementContainer,ElementUploadButton}`, `ProjectEditor.tsx`, `lib/video/{aspectRatio,useAspectRatio}` + `resolve.test.ts`), #438 (`canvas/Canvas.tsx`, `CompactElement.tsx`, `withCollapsedVoids`, `useEditorSetup.ts`, `lib/canvas/types.ts`).

None of the 16 files here appear in any of them. `ElementContainer.tsx` (#480) renders `OutputPreview` but its props are unchanged; `CompactElement.tsx` (#438) renders `ForegroundPreview`, which is untouched; `lib/canvas/types.ts` (#438) is read, not modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)