### PR TITLE
fix: bound the composer textarea height so long scripts scroll internally

### DIFF
--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -216,7 +216,7 @@ export default function ComposerCopilot({
 							}}
 							placeholder={placeholder}
 							style={{ fieldSizing: "content" }}
-							className=" w-full resize-none bg-transparent font-body text-body text-foreground caret-accent placeholder:text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:rounded-sm"
+							className=" max-h-[40vh] w-full resize-none overflow-y-auto bg-transparent font-body text-body text-foreground caret-accent placeholder:text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:rounded-sm"
 						/>
 						{!hasText && !isTemplateMode && placeholderOverlay && (
 							<div className="pointer-events-none overflow-hidden font-body text-body">


### PR DESCRIPTION
## Summary

Pasting a long script into the hero composer made the prompt `textarea` grow to the full script height (`fieldSizing: "content"` with no cap), ballooning the input card and pushing the character/reference row and the submit/attach controls far apart.

Caps the textarea at `max-h-[40vh]` with `overflow-y-auto`, so a long script scrolls inside the field instead of expanding the card unbounded. `ComposerAssets` above and the controls row below stay adjacent to the input at any script length, which covers all three acceptance criteria without adding sticky positioning.

`max-h-[40vh] overflow-y-auto` matches the existing bounded-scroll pattern already used in `AppToaster.tsx`.

## Why this was safe and small

One-line class change on a single component. No behavior, state, or layout structure changes; short scripts render exactly as before since the textarea only hits the cap once content exceeds 40vh.

## Validation

- `npm run lint` — pass
- `npm run format:check` — pass
- `npm run typecheck` — pass
- `npm run knip` — pass
- `npm run build` — pass
- `npm run test:coverage` — 114 files, 980 tests, all pass
- `npm run test:e2e` — skipped: port 3000 was already in use by a running dev server, so Playwright's webServer could not start. The change is CSS-only and touches no route or copy asserted by the smoke suite.

## Open PR overlap check

Checked open PRs #487, #486, #485, #484, #481, #480, #438 via `gh pr diff --name-only`. None touches `app/components/copilot/`. No overlap.

## Skipped candidates

- #474 (scene header shift) and #424 (dead caret) — already covered by open PRs #484 and #438.
- #259 (queue concurrency) — explicitly gated behind BYOK, which has not shipped.
- #332 (storyboard timeline), #254 (audio mixing defaults/controls) — new product surface and volume-balance/product decisions respectively.
- #316 (SFX crossfade) — needs an audio-quality judgment call and can't be validated headlessly.
- Everything else open is size M or larger, or requires product/design direction.

Closes #359