### PR TITLE
fix: nightly bug fixes 2026-07-30

### DIFF
--- a/lib/providers/__tests__/cartesia-tts.test.ts
+++ b/lib/providers/__tests__/cartesia-tts.test.ts
@@ -49,7 +49,18 @@ vi.mock("@ai-sdk/openai", () => ({
 
 import type Cartesia from "@cartesia/cartesia-js";
 import { TTSEmotion } from "@/lib/connectors/tts/enums";
-import { CartesiaTTS, collectVoices } from "../tts/cartesia";
+import { CartesiaTTS, collectVoices, pcmDurationSec } from "../tts/cartesia";
+
+/** pcm_f32le @ 44.1kHz mono: 4 bytes per sample. */
+const PCM_BYTES_PER_SEC = 44100 * 4;
+const pcmChunk = (seconds: number) =>
+	Buffer.alloc(seconds * PCM_BYTES_PER_SEC, 1);
+
+const streamOf = (responses: object[]) => ({
+	[Symbol.asyncIterator]: async function* () {
+		for (const r of responses) yield r;
+	},
+});
 
 const makeVoices = (count: number, offset = 0) =>
 	Array.from({ length: count }, (_, i) => ({
@@ -180,6 +191,14 @@ describe("collectVoices", () => {
 	});
 });
 
+describe("pcmDurationSec", () => {
+	it("converts raw pcm_f32le byte length to seconds", () => {
+		expect(pcmDurationSec(PCM_BYTES_PER_SEC)).toBe(1);
+		expect(pcmDurationSec(PCM_BYTES_PER_SEC / 2)).toBe(0.5);
+		expect(pcmDurationSec(0)).toBe(0);
+	});
+});
+
 describe("CartesiaTTS", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -219,12 +238,65 @@ describe("CartesiaTTS", () => {
 			expect(mockClose).toHaveBeenCalled();
 		});
 
-		it("passes custom model", async () => {
-			mockGenerate.mockReturnValue({
-				[Symbol.asyncIterator]: async function* () {
-					yield { type: "done", done: true };
-				},
+		it("reports duration from the audio length, not the last word timestamp", async () => {
+			mockGenerate.mockReturnValue(
+				streamOf([
+					{ type: "chunk", audio: pcmChunk(2) },
+					{
+						type: "timestamps",
+						word_timestamps: {
+							words: ["hello"],
+							start: [0.0],
+							end: [0.4],
+						},
+					},
+					{ type: "done", done: true },
+				]),
+			);
+
+			const provider = new CartesiaTTS("test-key");
+			const result = await provider.generate({
+				prompt: "hello",
+				voiceId: "voice-1",
 			});
+
+			expect(result.metadata?.durationSec).toBe(3);
+		});
+
+		it("reports duration even when the model returns no timestamps", async () => {
+			mockGenerate.mockReturnValue(
+				streamOf([
+					{ type: "chunk", audio: pcmChunk(3) },
+					{ type: "done", done: true },
+				]),
+			);
+
+			const provider = new CartesiaTTS("test-key");
+			const result = await provider.generate({
+				prompt: "hello",
+				voiceId: "voice-1",
+			});
+
+			expect(result.metadata?.durationSec).toBe(4);
+		});
+
+		it("throws when the stream yields no audio", async () => {
+			mockGenerate.mockReturnValue(streamOf([{ type: "done", done: true }]));
+
+			const provider = new CartesiaTTS("test-key");
+			await expect(
+				provider.generate({ prompt: "hello", voiceId: "voice-1" }),
+			).rejects.toThrow("Cartesia returned no audio for voice voice-1");
+			expect(mockClose).toHaveBeenCalled();
+		});
+
+		it("passes custom model", async () => {
+			mockGenerate.mockReturnValue(
+				streamOf([
+					{ type: "chunk", audio: pcmChunk(1) },
+					{ type: "done", done: true },
+				]),
+			);
 
 			const provider = new CartesiaTTS("test-key");
 			await provider.generate({
@@ -239,11 +311,12 @@ describe("CartesiaTTS", () => {
 		});
 
 		it("forwards emotion controls to Cartesia", async () => {
-			mockGenerate.mockReturnValue({
-				[Symbol.asyncIterator]: async function* () {
-					yield { type: "done", done: true };
-				},
-			});
+			mockGenerate.mockReturnValue(
+				streamOf([
+					{ type: "chunk", audio: pcmChunk(1) },
+					{ type: "done", done: true },
+				]),
+			);
 
 			const provider = new CartesiaTTS("test-key");
 			await provider.generate({

--- a/lib/providers/__tests__/voicePreview.test.ts
+++ b/lib/providers/__tests__/voicePreview.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchAllowedVoicePreview } from "../tts/voicePreview";
+
+const ALLOWED_HOST = "files.cartesia.ai";
+const ALLOWED_URL = `https://${ALLOWED_HOST}/voices/preview.mp3`;
+
+describe("fetchAllowedVoicePreview", () => {
+	const fetchMock = vi.fn();
+
+	beforeEach(() => {
+		fetchMock.mockReset().mockResolvedValue(new Response("ok"));
+		vi.stubGlobal("fetch", fetchMock);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("fetches an allowed origin with redirects disabled", async () => {
+		await fetchAllowedVoicePreview(ALLOWED_URL, ALLOWED_HOST);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			ALLOWED_URL,
+			expect.objectContaining({ redirect: "manual" }),
+		);
+	});
+
+	it("forwards caller init while keeping redirects disabled", async () => {
+		await fetchAllowedVoicePreview(ALLOWED_URL, ALLOWED_HOST, {
+			headers: { Authorization: "Bearer secret" },
+			redirect: "follow",
+		});
+
+		expect(fetchMock).toHaveBeenCalledWith(ALLOWED_URL, {
+			headers: { Authorization: "Bearer secret" },
+			redirect: "manual",
+		});
+	});
+
+	it.each([
+		["plaintext http", `http://${ALLOWED_HOST}/preview.mp3`],
+		["another host", "https://evil.example/preview.mp3"],
+		["a subdomain of the allowed host", `https://a.${ALLOWED_HOST}/p.mp3`],
+		["a non-default port", `https://${ALLOWED_HOST}:8443/preview.mp3`],
+		["the host in userinfo", `https://${ALLOWED_HOST}@evil.example/p.mp3`],
+	])("refuses %s", async (_label, url) => {
+		expect(() => fetchAllowedVoicePreview(url, ALLOWED_HOST)).toThrow(
+			"Voice preview origin not allowed",
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("throws on a value that is not a URL", () => {
+		expect(() => fetchAllowedVoicePreview("not a url", ALLOWED_HOST)).toThrow();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});

--- a/lib/providers/tts/cartesia.ts
+++ b/lib/providers/tts/cartesia.ts
@@ -48,10 +48,21 @@ const PCM_WAV_PARAMS: Record<
 	pcm_alaw: { audioFormat: 6, bitsPerSample: 8 },
 };
 
+const { audioFormat: AUDIO_FORMAT, bitsPerSample: BITS_PER_SAMPLE } =
+	PCM_WAV_PARAMS[ENCODING];
+const BLOCK_ALIGN = NUM_CHANNELS * (BITS_PER_SAMPLE / 8);
+const BYTE_RATE = SAMPLE_RATE * BLOCK_ALIGN;
+
+/**
+ * Duration of the raw PCM Cartesia streamed back. Word timestamps can't stand in
+ * for it: they stop at the last word, and are absent entirely when the model
+ * emits no timestamp frames.
+ */
+export function pcmDurationSec(byteLength: number): number {
+	return byteLength / BYTE_RATE;
+}
+
 function wrapPcmInWav(pcm: Buffer): Buffer {
-	const { audioFormat, bitsPerSample } = PCM_WAV_PARAMS[ENCODING];
-	const byteRate = SAMPLE_RATE * NUM_CHANNELS * (bitsPerSample / 8);
-	const blockAlign = NUM_CHANNELS * (bitsPerSample / 8);
 	const header = Buffer.alloc(44);
 
 	header.write("RIFF", 0);
@@ -59,12 +70,12 @@ function wrapPcmInWav(pcm: Buffer): Buffer {
 	header.write("WAVE", 8);
 	header.write("fmt ", 12);
 	header.writeUInt32LE(16, 16);
-	header.writeUInt16LE(audioFormat, 20);
+	header.writeUInt16LE(AUDIO_FORMAT, 20);
 	header.writeUInt16LE(NUM_CHANNELS, 22);
 	header.writeUInt32LE(SAMPLE_RATE, 24);
-	header.writeUInt32LE(byteRate, 28);
-	header.writeUInt16LE(blockAlign, 32);
-	header.writeUInt16LE(bitsPerSample, 34);
+	header.writeUInt32LE(BYTE_RATE, 28);
+	header.writeUInt16LE(BLOCK_ALIGN, 32);
+	header.writeUInt16LE(BITS_PER_SAMPLE, 34);
 	header.write("data", 36);
 	header.writeUInt32LE(pcm.length, 40);
 
@@ -229,12 +240,18 @@ export class CartesiaTTS extends BaseProvider<TTSGenerateParams, RawTTSResult> {
 			}
 
 			const combined = Buffer.concat(audioChunks);
+			if (combined.length === 0) {
+				throw new Error(
+					`Cartesia returned no audio for voice ${params.voiceId}`,
+				);
+			}
 
-			const lastTs = textTimestamps[textTimestamps.length - 1];
 			return {
 				data: wrapPcmInWav(combined).toString("base64"),
 				textTimestamps,
-				metadata: lastTs ? { durationSec: lastTs.end + 1 } : undefined,
+				// We add an extra second for brief pauses between audio segments
+				// to make it sound more natural
+				metadata: { durationSec: pcmDurationSec(combined.length) + 1 },
 			};
 		} finally {
 			ws.close();

--- a/lib/providers/tts/voicePreview.ts
+++ b/lib/providers/tts/voicePreview.ts
@@ -15,5 +15,5 @@ export function fetchAllowedVoicePreview(
 	if (new URL(url).origin !== allowedOrigin) {
 		throw new Error(`Voice preview origin not allowed: ${url}`);
 	}
-	return fetch(url, { redirect: "manual", ...init });
+	return fetch(url, { ...init, redirect: "manual" });
 }


### PR DESCRIPTION
## What

Two correctness fixes in the TTS provider layer, plus tests.

### Cartesia clip duration came from word timestamps, not the audio

`CartesiaTTS._generate` reported `durationSec` as `lastWordTimestamp.end + 1`. Two problems:

- The word timestamps stop at the last word, so the padded value drifts from the real audio length. That duration is what `scene-builder` advances the timeline cursor by (`cursor += element.durationSec`), so the narration's slot disagreed with its own audio.
- When the model emits no timestamp frames, `metadata` was `undefined` entirely — and `BaseAssetConnector.resolveBundle` coerces a missing `durationSec` to `0`, so the narration gets a zero-frame sequence and silently disappears from the render.

Now the duration is computed from the raw PCM byte length (`pcmDurationSec`), which is exact and always available. The WAV byte-rate math that `wrapPcmInWav` already did is hoisted into module constants so the header and the duration can't drift apart.

An audio stream that yields zero chunks now throws instead of storing a zero-length asset that would vanish from the timeline with no error.

### `fetchAllowedVoicePreview` let callers undo its own redirect guard

`fetch(url, { redirect: "manual", ...init })` spread the caller's init *after* `redirect`, so an `init.redirect` would override the setting the function's doc comment promises (no replaying the `Authorization` header across a cross-origin redirect). Swapped the spread order. No current caller passes `redirect`, so behavior is unchanged today.

## Tests

- `pcmDurationSec` unit conversion.
- Duration derived from audio length rather than the last word timestamp.
- Duration still reported when the model returns no timestamps.
- Empty audio stream throws, and the websocket is still closed.
- New `voicePreview.test.ts`: the origin allow-list previously had no direct tests. Covers plaintext HTTP, a different host, a subdomain, a non-default port, and the allowed host smuggled into userinfo — plus that caller init is forwarded while `redirect: "manual"` holds.

## Checks

`lint`, `format:check`, `typecheck`, `knip`, `build`, and the full vitest suite (992 tests) all pass.

## Open PR overlap check

Considered open PRs #488, #487, #486, #485, #484, #481, #480, #438. Their file/theme coverage: the composer copilot, canvas element previews / scene-builder / Remotion root, `lib/canvas/editorOps`, access codes + autosave, canvas DnD, the OSML serializer/parser, `lib/generation` + `lib/connectors`, and the collapsed-void plugin. This PR only touches `lib/providers/tts/*` and its tests, which no open PR touches — non-overlapping.