### PR TITLE
refactor: nightly maintainability 2026-07-30

### DIFF
--- a/app/components/video/useRendering.ts
+++ b/app/components/video/useRendering.ts
@@ -1,21 +1,16 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import { apiJson } from "@/lib/clients/http";
 import { errorMessage } from "@/lib/errors";
-import type { RenderHandle, RenderProgress } from "@/lib/video/render-api";
+import { runRender } from "@/lib/video/render-client";
 import type { VideoLayout } from "@/lib/video/types";
 
 type RenderState =
 	| { status: "idle" }
 	| { status: "invoking" }
-	| ({ status: "rendering"; progress: number } & RenderHandle)
+	| { status: "rendering"; progress: number }
 	| { status: "done"; url: string; size: number }
 	| { status: "error"; message: string };
-
-const POLL_INTERVAL_MS = 5000;
-
-const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 export function useRendering() {
 	const [state, setState] = useState<RenderState>({ status: "idle" });
@@ -23,34 +18,7 @@ export function useRendering() {
 	const render = useCallback(async (layout: VideoLayout, scale?: number) => {
 		setState({ status: "invoking" });
 		try {
-			const handle = await apiJson<RenderHandle>("/api/render", {
-				method: "POST",
-				body: { inputProps: layout, scale },
-			});
-
-			setState({ status: "rendering", ...handle, progress: 0 });
-
-			for (;;) {
-				const result = await apiJson<RenderProgress>("/api/render/progress", {
-					method: "POST",
-					body: handle,
-				});
-
-				if (result.type === "error") {
-					setState({ status: "error", message: result.message });
-					return;
-				}
-				if (result.type === "done") {
-					setState({ status: "done", url: result.url, size: result.size });
-					return;
-				}
-				setState({
-					status: "rendering",
-					...handle,
-					progress: result.progress,
-				});
-				await wait(POLL_INTERVAL_MS);
-			}
+			for await (const update of runRender(layout, scale)) setState(update);
 		} catch (err) {
 			setState({ status: "error", message: errorMessage(err) });
 		}

--- a/lib/video/__tests__/render-client.test.ts
+++ b/lib/video/__tests__/render-client.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { apiJson } from "@/lib/clients/http";
+import type { VideoLayout } from "../types";
+import { runRender, type RenderUpdate } from "../render-client";
+
+vi.mock("@/lib/clients/http", () => ({ apiJson: vi.fn() }));
+
+const apiJsonMock = vi.mocked(apiJson);
+
+const LAYOUT = { series: [] } as unknown as VideoLayout;
+const HANDLE = { renderId: "r1", bucketName: "b1" };
+
+/** Drains the generator while letting the poll delay elapse between yields. */
+async function collect(
+	updates: AsyncGenerator<RenderUpdate>,
+): Promise<RenderUpdate[]> {
+	const seen: RenderUpdate[] = [];
+	const settled = (async () => {
+		for await (const update of updates) seen.push(update);
+	})().then(
+		() => null,
+		(err: unknown) => err,
+	);
+	await vi.runAllTimersAsync();
+	const failure = await settled;
+	if (failure) throw failure;
+	return seen;
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	apiJsonMock.mockReset();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("runRender", () => {
+	it("submits the layout, then polls until the output is ready", async () => {
+		apiJsonMock
+			.mockResolvedValueOnce(HANDLE)
+			.mockResolvedValueOnce({ type: "progress", progress: 0.4 })
+			.mockResolvedValueOnce({ type: "done", url: "/out.mp4", size: 1024 });
+
+		const seen = await collect(runRender(LAYOUT, 0.5));
+
+		expect(seen).toEqual([
+			{ status: "rendering", progress: 0 },
+			{ status: "rendering", progress: 0.4 },
+			{ status: "done", url: "/out.mp4", size: 1024 },
+		]);
+		expect(apiJsonMock).toHaveBeenNthCalledWith(1, "/api/render", {
+			method: "POST",
+			body: { inputProps: LAYOUT, scale: 0.5 },
+		});
+		expect(apiJsonMock).toHaveBeenNthCalledWith(2, "/api/render/progress", {
+			method: "POST",
+			body: HANDLE,
+		});
+	});
+
+	it("stops polling once the render is done", async () => {
+		apiJsonMock
+			.mockResolvedValueOnce(HANDLE)
+			.mockResolvedValueOnce({ type: "done", url: "/out.mp4", size: 1 });
+
+		await collect(runRender(LAYOUT));
+
+		expect(apiJsonMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("throws the upstream message when the render fails", async () => {
+		apiJsonMock
+			.mockResolvedValueOnce(HANDLE)
+			.mockResolvedValueOnce({ type: "error", message: "Render failed" });
+
+		await expect(collect(runRender(LAYOUT))).rejects.toThrow("Render failed");
+	});
+
+	it("propagates a failure to start the render", async () => {
+		apiJsonMock.mockRejectedValueOnce(new Error("Unauthorized"));
+
+		await expect(collect(runRender(LAYOUT))).rejects.toThrow("Unauthorized");
+	});
+});

--- a/lib/video/render-client.ts
+++ b/lib/video/render-client.ts
@@ -1,0 +1,42 @@
+import { apiJson } from "@/lib/clients/http";
+import type { RenderHandle, RenderProgress } from "./render-api";
+import type { VideoLayout } from "./types";
+
+export type RenderUpdate =
+	| { status: "rendering"; progress: number }
+	| { status: "done"; url: string; size: number };
+
+const POLL_INTERVAL_MS = 5000;
+
+const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * Starts a Lambda render and yields progress until the output is ready.
+ * A render that fails upstream throws, so callers handle one error path.
+ */
+export async function* runRender(
+	layout: VideoLayout,
+	scale?: number,
+): AsyncGenerator<RenderUpdate> {
+	const handle = await apiJson<RenderHandle>("/api/render", {
+		method: "POST",
+		body: { inputProps: layout, scale },
+	});
+	yield { status: "rendering", progress: 0 };
+
+	for (;;) {
+		const result = await apiJson<RenderProgress>("/api/render/progress", {
+			method: "POST",
+			body: handle,
+		});
+
+		if (result.type === "error") throw new Error(result.message);
+		if (result.type === "done") {
+			yield { status: "done", url: result.url, size: result.size };
+			return;
+		}
+
+		yield { status: "rendering", progress: result.progress };
+		await wait(POLL_INTERVAL_MS);
+	}
+}


### PR DESCRIPTION
No behavior changes. One seam moved out of the UI layer, plus the tests that make it checkable.

## Architecture

`useRendering` owned the whole Lambda export protocol: POST `/api/render`, then an open-ended poll loop against `/api/render/progress`, with the three terminal outcomes each writing React state from a different place. That is domain logic living in a `"use client"` hook — untestable in practice (nothing exercised it), invisible to coverage (`vitest.config.ts` only instruments `lib/**` and `app/api/**`), and sitting one directory away from `lib/video/render-api.ts`, which already owns the wire contract for exactly these two routes.

- **`lib/video/render-client.ts` (new)** — `runRender(layout, scale)` is an async generator that submits the render and yields `{status: "rendering", progress}` until it yields `{status: "done", url, size}`. An upstream render failure throws instead of returning a fourth shape, so callers have one error path rather than two (`result.type === "error"` and the `catch`) that produced the same state.
- **`useRendering`** is now state plumbing: set `invoking`, drain the generator into `setState`, map any throw through `errorMessage`. 62 → 30 lines, and the client half of the render contract now sits next to the schema half.

The `RenderHandle` (`renderId`/`bucketName`) that the `rendering` state carried is gone. Nothing read it — not `ExportButton`, not `RenderProvider` — and it made the state union wider than the UI it feeds.

## Maintainability

- `lib/video/__tests__/render-client.test.ts` (new) — 4 tests over a previously-uncovered path: the submit → poll → done sequence and its request payloads, that polling stops on `done`, that an upstream `error` surfaces its own message, and that a failed submit propagates. Fake timers keep the 5s poll interval out of the runtime.
- Moving the module under `lib/` also brings it under the coverage gate, so it can't silently rot back to untested.

## Complexity delta

- `useRendering.ts` 62 → 30 lines; the `render` callback drops from 4 nesting levels and 3 terminal branches to a single `for await` plus one `catch`.
- `RenderState` loses one intersection member.
- Net +131/−35 across 3 files, 96 of which is the new module and its tests.

## Skipped

- **`runRender` has no cancellation.** The poll loop runs until the render terminates; unmounting or firing a second export leaves the first loop polling and calling `setState`. That is a real defect, but fixing it changes behavior and belongs in a bug PR, not a no-behavior-change refactor.
- **`RenderProvider`'s toast effect.** The obvious cleanup — one shared options object for all four branches — would give the error toast `duration: Infinity`, which it does not have today. Not worth a behavior change for four saved lines.
- **`app/projects/[id]/loading.tsx`** re-implements the entire `PostPromptView` chrome (rail widths, card shell, transport bar) as skeletons. Genuine duplicated knowledge that will drift, but deduplicating a skeleton against a live component is not a mechanical change; flagging for a human call.
- **`useAutosave`** (6 effects, no tests) — already claimed by open PR #485.

## Open PR overlap check

Considered #493 (`lib/providers/tts`), #488 (`ComposerCopilot`), #487 (`lib/video/scene-builder|types`, `remotion/`, `app/components/video/VideoLayoutContext|useSceneSegments`), #486 (`lib/canvas/editorOps`), #485 (`lib/auth/accessCode`, `lib/project/autosave`, `useAutosave`, `ARCHITECTURE.md`), #484 (`canvas/dnd`, `globals.css`), #481 (`lib/canvas/osml*`), #480 (`lib/generation/**`, `lib/connectors/**`, `canvas/elements/**`), #438 (`withCollapsedVoids`).

This PR touches `lib/video/render-client.ts`, `lib/video/__tests__/render-client.test.ts`, and `app/components/video/useRendering.ts` — none of which appear in any open PR. #487 is the nearest neighbour (same two directories) but works on the Remotion layout contract, not the render API client; no shared file.

## Checks

`npm run lint`, `format:check`, `typecheck`, `knip`, `build`, and `test:coverage` (984 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)