### PR TITLE
perf: nightly performance optimizations 2026-07-30

### DIFF
--- a/app/components/video/ActiveSceneSync.tsx
+++ b/app/components/video/ActiveSceneSync.tsx
@@ -6,16 +6,26 @@ import { useSetActiveSceneId } from "@/app/components/scene-selection/ActiveScen
 import { useAutoScroll } from "@/app/components/scene-selection/AutoScrollContext";
 import { scrollToScene } from "@/app/components/canvas/utils/scrollToScene";
 import { usePlayerPlaying } from "./usePlayerState";
-import type { SceneSegment } from "./useSceneSegments";
+import { useActiveSegmentIndex, type SceneSegment } from "./useSceneSegments";
 
-export function useActiveSceneSync(
-	player: PlayerRef | null,
-	segments: SceneSegment[],
-	activeIndex: number,
-) {
+/**
+ * Renders nothing. It owns the frame subscription that tracks the playing
+ * scene, so crossing a scene boundary re-renders this leaf instead of the
+ * Remotion player it sits beside.
+ */
+export function ActiveSceneSync({
+	player,
+	segments,
+	fps,
+}: {
+	player: PlayerRef | null;
+	segments: SceneSegment[];
+	fps: number;
+}) {
 	const setActiveSceneId = useSetActiveSceneId();
 	const { enabled: autoScrollEnabled } = useAutoScroll();
 	const playing = usePlayerPlaying(player);
+	const activeIndex = useActiveSegmentIndex(player, segments, fps);
 	const activeId =
 		activeIndex >= 0 ? (segments[activeIndex]?.sceneId ?? null) : null;
 
@@ -28,4 +38,6 @@ export function useActiveSceneSync(
 	}, [activeId, autoScrollEnabled, playing]);
 
 	useEffect(() => () => setActiveSceneId(null), [setActiveSceneId]);
+
+	return null;
 }

--- a/app/components/video/BottomTransportBar.tsx
+++ b/app/components/video/BottomTransportBar.tsx
@@ -7,7 +7,7 @@ import { toFrames, toSeconds } from "@/lib/video/frames";
 import { usePlayerControl } from "./PlayerControlContext";
 import { usePlayerPosition } from "./PlayerPositionContext";
 import { useLayout } from "./VideoLayoutContext";
-import { findSegmentIndexAt, useActiveSegmentIndex } from "./useSceneSegments";
+import { findSegmentIndexAt } from "./useSceneSegments";
 import { usePlayerPlaying } from "./usePlayerState";
 import { SegmentedSeekBar } from "./SegmentedSeekBar";
 import {
@@ -22,7 +22,6 @@ function BottomTransportBarComponent() {
 	const { showPlayer } = usePlayerPosition();
 	const { layout, segments } = useLayout();
 	const playing = usePlayerPlaying(player);
-	const activeIndex = useActiveSegmentIndex(player, segments, layout.fps);
 
 	const ready = player !== null && segments.length > 0;
 
@@ -48,7 +47,7 @@ function BottomTransportBarComponent() {
 					{ready && <TimeDisplay player={player} layout={layout} />}
 					{ready && (
 						<div className="hidden @[520px]:contents">
-							<ScenePill segments={segments} activeIndex={activeIndex} />
+							<ScenePill player={player} segments={segments} fps={layout.fps} />
 						</div>
 					)}
 				</div>

--- a/app/components/video/PlayerControls.tsx
+++ b/app/components/video/PlayerControls.tsx
@@ -14,7 +14,7 @@ import {
 	usePlayerValue,
 	usePlayerVolume,
 } from "./usePlayerState";
-import type { SceneSegment } from "./useSceneSegments";
+import { useActiveSegmentIndex, type SceneSegment } from "./useSceneSegments";
 import { ScrubBar } from "./ScrubBar";
 
 export function TimeDisplay({
@@ -39,12 +39,15 @@ export function TimeDisplay({
 }
 
 export function ScenePill({
+	player,
 	segments,
-	activeIndex,
+	fps,
 }: {
+	player: PlayerRef | null;
 	segments: SceneSegment[];
-	activeIndex: number;
+	fps: number;
 }) {
+	const activeIndex = useActiveSegmentIndex(player, segments, fps);
 	const active = segments[activeIndex];
 	if (!active) return null;
 	return (

--- a/app/components/video/VideoPreview.tsx
+++ b/app/components/video/VideoPreview.tsx
@@ -5,11 +5,10 @@ import dynamic from "next/dynamic";
 import { useEffect, useState, type MutableRefObject, type Ref } from "react";
 import type { VideoLayout } from "@/lib/video/types";
 import { ToastErrorBoundary } from "../ToastErrorBoundary";
+import { ActiveSceneSync } from "./ActiveSceneSync";
 import { usePlayerControl } from "./PlayerControlContext";
 import { PlayPauseFlash } from "./PlayPauseFlash";
-import { useActiveSceneSync } from "./useActiveSceneSync";
 import { usePreservedPlayhead } from "./usePreservedPlayhead";
-import { useActiveSegmentIndex } from "./useSceneSegments";
 import { useLayout } from "./VideoLayoutContext";
 import styles from "./VideoPlayer.module.css";
 
@@ -63,8 +62,6 @@ export function VideoPreview({ layout, restoreFrameRef }: VideoPreviewProps) {
 	const [isFullscreen, setIsFullscreen] = useState(false);
 	const { segments } = useLayout();
 	const { player, registerPlayer } = usePlayerControl();
-	const activeIndex = useActiveSegmentIndex(player, segments, layout.fps);
-	useActiveSceneSync(player, segments, activeIndex);
 	const [flash, setFlash] = useState<{ key: number; playing: boolean } | null>(
 		null,
 	);
@@ -96,6 +93,7 @@ export function VideoPreview({ layout, restoreFrameRef }: VideoPreviewProps) {
 				onClick={toggleAndFlash}
 			/>
 			<PlayPauseFlash flash={flash} />
+			<ActiveSceneSync player={player} segments={segments} fps={layout.fps} />
 		</div>
 	);
 }


### PR DESCRIPTION
## What

The active-scene index is derived from the Remotion player's `frameupdate` events, but the subscription lived in the two components that render the heaviest subtrees:

- `VideoPreview` — renders `<Player>` and, through it, the entire `VideoComposition` (transition series, every `Img`/`OffthreadVideo`/`Html5Audio` sequence).
- `BottomTransportBar` — renders `SegmentedSeekBar`, which rebuilds its per-scene basis array and reconciles 2 divs per scene on each render.

So every scene boundary during playback re-rendered both trees, for a value only two leaves display.

This pushes the subscription down to those leaves:

- `useActiveSceneSync` becomes `ActiveSceneSync`, a render-nothing sibling of the player that owns the frame subscription and the scene-selection/auto-scroll effects. Same effects, same deps.
- `ScenePill` reads the active index itself instead of receiving it as a prop, so the transport bar no longer subscribes at all.

Net effect: the Remotion player and the seek bar re-render only when their own inputs change, instead of once per scene crossed.

No behavior change — the effects, their ordering, and the rendered output are identical.

## Why it matters

Scene boundaries are exactly the moments playback is most likely to hitch: media is switching and a transition is animating. Re-rendering the whole composition and the seek bar at that instant is avoidable work on the frame budget.

This is state locality, not a memo shim — no `React.memo`, no ad-hoc guards, nothing to keep in sync.

## Slate pass

Checked against the Slate performance walkthrough: `renderElement` is already a stable `useCallback`, `renderLeaf`/`decorate` are unused, every editor consumer already uses `useSlateStatic`, and the `withScenes`/`withLayout` normalizers are already depth-guarded to the node they are handed. Chunking does not apply at this document size. Nothing left to do there.

## Skipped

- **Whole-`metadata` subscription in `useGenerate`** — every element card subscribes to `s.metadata`, so any metadata mutation re-renders every card and recomputes `getGenerationInputs` for each. This is the largest remaining fanout, but `useGenerate.ts` and `lib/generation/inputs.ts` are both owned by open PR #480.
- **`ForegroundPreview` using the full `useGenerate`** — it only needs `result`/`status`, but its staleness/restore effect is load-bearing for collapsed scenes. Not worth the behavior risk.
- **Serialized `auth.getUser()` before the project query** in `app/projects/[id]/page.tsx` — an initial-load round trip, which is the class of change closed in #476.
- **`SegmentedSeekBar` re-rendering per frame** — inherent to drawing a progress fill.
- **`structuredClone` of trailing nodes per streamed token** — measured cost is a few microseconds per token.

## Open PR overlap check

Considered #494, #493, #488, #487, #486, #485, #484, #481, #480, #438. This PR touches `ActiveSceneSync.tsx` (renamed from `useActiveSceneSync.ts`), `VideoPreview.tsx`, `PlayerControls.tsx`, `BottomTransportBar.tsx` — none appear in any open PR's file list. #487 touches neighbouring video files (`VideoLayoutContext.tsx`, `useSceneSegments.ts`, `remotion/Root.tsx`), which this PR deliberately leaves alone; it consumes `useActiveSegmentIndex` at its existing signature.

## Validation

`lint`, `format:check`, `typecheck`, `knip`, `build`, and `test` (980 passed) all green.