### PR TITLE
fix: surface Supabase auth failures instead of swallowing them

### DIFF
--- a/app/components/AuthForm.tsx
+++ b/app/components/AuthForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { sendMagicLink, signInWithGoogle } from "@/lib/auth/session";
+import { errorMessage } from "@/lib/errors";
 import OnboardingCard from "./OnboardingCard";
 import EmailSentCard from "./EmailSentCard";
 import OrDivider from "./OrDivider";
@@ -54,6 +55,15 @@ export default function AuthForm({
 		setLoading(false);
 	};
 
+	const handleGoogle = async () => {
+		setError("");
+		try {
+			await signInWithGoogle();
+		} catch (cause) {
+			setError(errorMessage(cause));
+		}
+	};
+
 	if (sent) {
 		return (
 			<EmailSentCard
@@ -102,7 +112,7 @@ export default function AuthForm({
 			)}
 
 			<OrDivider />
-			<GoogleOAuthButton onClick={signInWithGoogle} />
+			<GoogleOAuthButton onClick={handleGoogle} />
 		</OnboardingCard>
 	);
 }

--- a/app/components/UserProfile.tsx
+++ b/app/components/UserProfile.tsx
@@ -2,7 +2,9 @@
 
 import { memo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { signOut } from "@/lib/auth/session";
+import { errorMessage } from "@/lib/errors";
 import { useUser } from "@/lib/user/UserProvider";
 import { useTheme } from "next-themes";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -38,7 +40,12 @@ function UserProfile() {
 	const name: string | undefined = user.user_metadata?.full_name;
 
 	const handleLogout = async () => {
-		await signOut();
+		try {
+			await signOut();
+		} catch (cause) {
+			toast.error(errorMessage(cause));
+			return;
+		}
 		router.refresh();
 	};
 

--- a/lib/auth/__tests__/session.test.ts
+++ b/lib/auth/__tests__/session.test.ts
@@ -87,6 +87,12 @@ describe("signInWithGoogle", () => {
 			options: { redirectTo: CALLBACK },
 		});
 	});
+
+	it("throws when the provider redirect fails", async () => {
+		signInWithOAuth.mockResolvedValue({ error: new Error("oauth down") });
+
+		await expect(signInWithGoogle()).rejects.toThrow("oauth down");
+	});
 });
 
 describe("signOut", () => {
@@ -94,5 +100,11 @@ describe("signOut", () => {
 		await signOut();
 
 		expect(signOutFn).toHaveBeenCalledTimes(1);
+	});
+
+	it("throws when the session cannot be cleared", async () => {
+		signOutFn.mockResolvedValue({ error: new Error("network") });
+
+		await expect(signOut()).rejects.toThrow("network");
 	});
 });

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -28,12 +28,14 @@ export async function sendMagicLink({
 }
 
 export async function signInWithGoogle(): Promise<void> {
-	await createClient().auth.signInWithOAuth({
+	const { error } = await createClient().auth.signInWithOAuth({
 		provider: "google",
 		options: { redirectTo: callbackUrl() },
 	});
+	if (error) throw error;
 }
 
 export async function signOut(): Promise<void> {
-	await createClient().auth.signOut();
+	const { error } = await createClient().auth.signOut();
+	if (error) throw error;
 }


### PR DESCRIPTION
Nightly CONVENTIONS.md compliance audit. One hard-rule violation was safe to fix.

## The violation

`lib/auth/session.ts` destructured nothing from the two Supabase calls that can fail:

```ts
export async function signInWithGoogle(): Promise<void> {
	await createClient().auth.signInWithOAuth({ ... });   // { error } dropped
}

export async function signOut(): Promise<void> {
	await createClient().auth.signOut();                  // { error } dropped
}
```

Hard rule: *"Never swallow an error on a critical path to keep going. Propagate it or surface it."* `sendMagicLink`, in the same 39-line module, already returns a typed `{ error? }` — so this was also two ways to do one thing in one file.

Observable consequences:
- A failed Google sign-in left the user clicking a button that did nothing.
- A failed sign-out still ran `router.refresh()`, rendering the app as if the session had been cleared when it hadn't.

## The fix

Both now throw (an infrastructure failure is unexpected, so it throws rather than returning a typed result — that form stays reserved for expected failures like `sendMagicLink`'s validation errors).

The callers own the policy:
- `AuthForm` routes it into the inline error slot it already renders for the magic-link path.
- `UserProfile` toasts and skips the refresh.

Tests cover both new error paths.

## Also audited, not changed

Everything else found was either behavior-changing or under an open PR, and is recorded rather than fixed:
- `lib/api/with-auth.ts:18` — 500s return `stringifyError(error)` (stack included) to the client on public routes.
- `lib/components/Waveform.tsx:111` — peaks decode failure is logged, then `.finally` marks loaded, so the waveform renders bar-less with no user-visible error.
- `GlobalErrorToaster` / `ToastErrorBoundary` toast raw `stringifyError` JSON while every other call site uses `errorMessage`.
- Duplicated abort-controller streaming lifecycle (`ScriptProvider`, `useRefineScript`) and the `(Node.parent(...) as SceneElement).id` cast (`SortableContent`, `ElementContainer`) — both still at two sites, so rule-of-three says wait; `ElementContainer` is under #480.

Verified: lint, typecheck, format:check, 982 tests, `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)