### PR TITLE
fix: nightly bug fixes 2026-07-31

### DIFF
--- a/lib/api/handlers/__tests__/video.test.ts
+++ b/lib/api/handlers/__tests__/video.test.ts
@@ -16,7 +16,10 @@ vi.mock("@/lib/api/jobs", () => ({
 	updateJob: (...args: unknown[]) => updateJob(...args),
 }));
 
-type VideoJobRow = TypedJobRow<VideoGenerateParams, { providerJobId?: string }>;
+type VideoJobRow = TypedJobRow<
+	VideoGenerateParams,
+	{ providerJobId?: string; durationSec?: number }
+>;
 
 const bundle = { id: "bundle-1" } as unknown as BundleResponse;
 
@@ -29,7 +32,7 @@ function job(overrides: Partial<VideoJobRow> = {}): VideoJobRow {
 		status: "processing",
 		request: { prompt: "a cat" } as VideoGenerateParams,
 		result: null,
-		metadata: { providerJobId: "upstream-1" },
+		metadata: { providerJobId: "upstream-1", durationSec: 10 },
 		error: null,
 		created_at: "2026-01-01T00:00:00Z",
 		updated_at: "2026-01-01T00:00:00Z",
@@ -40,20 +43,30 @@ function job(overrides: Partial<VideoJobRow> = {}): VideoJobRow {
 describe("videoHandler.process", () => {
 	beforeEach(() => vi.clearAllMocks());
 
-	it("returns the provider job id as pending metadata", async () => {
-		generate.mockResolvedValue({ metadata: { jobId: "upstream-9" } });
+	it("records the provider job id and the submitted clip length", async () => {
+		generate.mockResolvedValue({
+			metadata: { jobId: "upstream-9", durationSec: 8 },
+		});
 
 		await expect(videoHandler.process(job())).resolves.toEqual({
 			kind: "pending",
-			metadata: { providerJobId: "upstream-9" },
+			metadata: { providerJobId: "upstream-9", durationSec: 8 },
 		});
 	});
 
 	it("throws when the provider returns no job id", async () => {
-		generate.mockResolvedValue({ metadata: {} });
+		generate.mockResolvedValue({ metadata: { durationSec: 8 } });
 
 		await expect(videoHandler.process(job())).rejects.toThrow(
 			"Video provider returned no jobId",
+		);
+	});
+
+	it("throws when the provider returns no clip length", async () => {
+		generate.mockResolvedValue({ metadata: { jobId: "upstream-9" } });
+
+		await expect(videoHandler.process(job())).rejects.toThrow(
+			"Video provider returned no durationSec",
 		);
 	});
 });
@@ -102,15 +115,49 @@ describe("videoHandler.poll", () => {
 	it("persists the bundle once upstream reports a video", async () => {
 		poll.mockResolvedValue({ ...bundle, result: { video: "v.mp4" } });
 
+		const expected = {
+			...bundle,
+			result: { video: "v.mp4" },
+			metadata: { jobId: "upstream-1", durationSec: 10 },
+		};
 		await expect(videoHandler.poll?.(job())).resolves.toEqual({
 			jobId: "job-1",
 			status: "completed",
-			result: { ...bundle, result: { video: "v.mp4" } },
+			result: expected,
 			error: null,
 		});
 		expect(updateJob).toHaveBeenCalledWith("job-1", {
 			status: "completed",
-			result: { ...bundle, result: { video: "v.mp4" } },
+			result: expected,
+		});
+	});
+
+	it("keeps the clip length the provider measured over the submitted one", async () => {
+		poll.mockResolvedValue({
+			...bundle,
+			result: { video: "v.mp4" },
+			metadata: { jobId: "upstream-1", status: "completed", durationSec: 174 },
+		});
+
+		const result = await videoHandler.poll?.(job());
+
+		expect(result?.result?.metadata).toEqual({
+			jobId: "upstream-1",
+			status: "completed",
+			durationSec: 174,
+		});
+	});
+
+	it("leaves the clip length unset for rows recorded without one", async () => {
+		poll.mockResolvedValue({ ...bundle, result: { video: "v.mp4" } });
+
+		const result = await videoHandler.poll?.(
+			job({ metadata: { providerJobId: "upstream-1" } }),
+		);
+
+		expect(result?.result?.metadata).toEqual({
+			jobId: "upstream-1",
+			durationSec: undefined,
 		});
 	});
 

--- a/lib/api/handlers/video.ts
+++ b/lib/api/handlers/video.ts
@@ -6,16 +6,26 @@ import { rowView } from "../job-handlers";
 import { updateJob } from "../jobs";
 import { getVideoProvider } from "../providers";
 
-type VideoMetadata = { providerJobId?: string };
+type VideoMetadata = { providerJobId?: string; durationSec?: number };
 
 export const videoHandler: JobHandler<VideoGenerateParams, VideoMetadata> = {
 	process: async (job) => {
-		const submitted = await getVideoProvider().generate(job.request);
-		const providerJobId = submitted.metadata?.jobId;
-		if (!providerJobId) {
+		const { metadata } = await getVideoProvider().generate(job.request);
+		if (!metadata?.jobId) {
 			throw new Error("Video provider returned no jobId for async generation");
 		}
-		return { kind: "pending", metadata: { providerJobId } };
+		if (metadata.durationSec === undefined) {
+			throw new Error(
+				"Video provider returned no durationSec for async generation",
+			);
+		}
+		return {
+			kind: "pending",
+			metadata: {
+				providerJobId: metadata.jobId,
+				durationSec: metadata.durationSec,
+			},
+		};
 	},
 	poll: async (job): Promise<JobPoll> => {
 		if (isTerminal(job.status)) return rowView(job);
@@ -26,8 +36,9 @@ export const videoHandler: JobHandler<VideoGenerateParams, VideoMetadata> = {
 		const upstream = await getVideoProvider().poll(providerJobId);
 		const status = mapVideoStatus(upstream);
 		if (status === "completed") {
-			await updateJob(job.id, { status, result: upstream });
-			return { jobId: job.id, status, result: upstream, error: null };
+			const result = withDuration(upstream, providerJobId, job.metadata);
+			await updateJob(job.id, { status, result });
+			return { jobId: job.id, status, result, error: null };
 		}
 		if (status === "failed") {
 			const error = upstream.metadata?.error ?? "Video generation failed";
@@ -37,6 +48,26 @@ export const videoHandler: JobHandler<VideoGenerateParams, VideoMetadata> = {
 		return { jobId: job.id, status, result: null, error: null };
 	},
 };
+
+/**
+ * An async poll only tells us the video's URL, so the clip length is the one
+ * recorded when the job was submitted. Without it the bundle reaches the
+ * timeline with `durationSec` 0 and the clip is laid out with no duration.
+ */
+function withDuration(
+	upstream: VideoProviderResponse,
+	providerJobId: string,
+	stored: VideoMetadata,
+): VideoProviderResponse {
+	return {
+		...upstream,
+		metadata: {
+			jobId: providerJobId,
+			...upstream.metadata,
+			durationSec: upstream.metadata?.durationSec ?? stored.durationSec,
+		},
+	};
+}
 
 function mapVideoStatus(upstream: VideoProviderResponse): JobStatus {
 	if (upstream.result?.video) return "completed";


### PR DESCRIPTION
## Bug

An async video job's clip length is only known at submit time. Runware's poll response reports the video URL and a status, but no duration.

`videoHandler.poll` persisted that poll response verbatim as the job result, so the completed bundle reached the client with no `durationSec` in its metadata. `BaseAssetConnector.resolveBundle` then coerces the missing value to 0 (`Number(bundle.manifest.metadata?.durationSec ?? 0)`), and `scene-builder` lays the clip out with zero duration — so every real generated video clip landed on the timeline with no length.

Mock providers happen to report a real length on poll, which is why the mock path always looked correct and this never showed up in tests.

## Fix

`videoHandler.process` now records `durationSec` next to `providerJobId` in the job row's metadata (the provider already returns it on submit — `params.duration ?? 5` for Runware, 5 for the mock). `poll` merges it into the completed result, preferring a length the provider actually measured over the requested one.

A submission that reports no length now throws with an actionable message instead of silently producing a zero-duration clip, matching the existing missing-`jobId` guard.

Behavior is otherwise unchanged. Rows recorded before this change still poll and complete; they just keep the old (absent) duration rather than crashing.

## Tests

`lib/api/handlers/__tests__/video.test.ts`:
- `process` records both the provider job id and the submitted clip length
- `process` throws when the provider reports no clip length
- `poll` stamps the submitted length onto the completed bundle
- `poll` prefers a provider-measured length over the submitted one
- `poll` leaves the length unset for rows recorded before this change

## Validation

`npm run lint`, `format:check`, `typecheck`, `knip`, `build`, `test:coverage` all pass (114 files / 983 tests).

## Open PR overlap check

Considered open PRs #438, #480, #481, #484, #485, #486, #487, #488, #493, #494, #495, #496. None touches `lib/api/handlers/` or the server-side async video job path. #487 and #480 are the nearest in theme (video layout / client-side generation scheduling) but neither touches these files or the job handler contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)