### PR TITLE
perf: nightly performance optimizations 2026-07-31

### DIFF
--- a/app/components/video/ScrubBar.tsx
+++ b/app/components/video/ScrubBar.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { type PointerEvent, type ReactNode, useRef, useState } from "react";
+import {
+	type CSSProperties,
+	type PointerEvent,
+	type ReactNode,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { clamp, cn } from "@/lib/utils";
 
 /** A slice of a segmented track; `basis` is its fraction (0–1) of the whole. */
@@ -38,9 +45,39 @@ interface ScrubBarProps {
 const SINGLE: ScrubSegment[] = [{ id: "_", basis: 1 }];
 
 /**
+ * A segment's fill is the track-wide ratio mapped into the segment's own span:
+ * `clamp((ratio - start) / basis, 0, 1)`, expressed so the browser recomputes it
+ * from one variable write instead of a React render per value change.
+ */
+const fillFrom = (ratio: string): CSSProperties => ({
+	width: `clamp(0%, calc((var(${ratio}) - var(--seg-start)) * var(--seg-scale) * 100%), 100%)`,
+});
+
+const previewFill = fillFrom("--scrub-preview");
+const progressFill = fillFrom("--scrub-pos");
+const thumbStyle: CSSProperties = { left: "calc(var(--scrub-pos) * 100%)" };
+
+export function segmentStyle(segs: readonly ScrubSegment[]): CSSProperties[] {
+	let start = 0;
+	return segs.map((seg) => {
+		const style = {
+			flexBasis: `${seg.basis * 100}%`,
+			"--seg-start": start,
+			"--seg-scale": seg.basis > 0 ? 1 / seg.basis : 0,
+		} as CSSProperties;
+		start += seg.basis;
+		return style;
+	});
+}
+
+/**
  * Shared draggable track used by both the seek bar (segmented) and the volume
  * bar (continuous). Renders a rest track, a hover preview fill, a progress
  * fill, and a thumb — all driven by the `--scrub-*` tokens.
+ *
+ * `value` and the hover ratio reach the DOM as `--scrub-pos` / `--scrub-preview`
+ * on the root, so the segment elements below stay referentially stable while the
+ * playhead moves.
  */
 export function ScrubBar({
 	value,
@@ -97,20 +134,34 @@ export function ScrubBar({
 		onHoverChange?.(null);
 	};
 
-	const starts = new Array<number>(segs.length);
-	for (let i = 0, acc = 0; i < segs.length; i++) {
-		starts[i] = acc;
-		acc += segs[i].basis;
-	}
-	const fills = segs.map((seg, i) => {
-		const start = starts[i];
-		const at = (r: number) => clamp((r - start) / seg.basis, 0, 1);
-		return {
-			seg,
-			fill: at(value),
-			hover: hoverRatio == null ? 0 : at(hoverRatio),
-		};
-	});
+	const track = useMemo(() => {
+		const styles = segmentStyle(segs);
+		return (
+			<div
+				className={cn("flex h-1 w-full", continuous ? "gap-0" : "gap-[2px]")}
+			>
+				{segs.map((seg, i) => (
+					<div
+						key={seg.id}
+						className={cn(
+							"relative h-full overflow-hidden bg-scrub-track",
+							continuous && "rounded-full",
+						)}
+						style={styles[i]}
+					>
+						<div
+							className="absolute inset-y-0 left-0 bg-scrub-hover"
+							style={previewFill}
+						/>
+						<div
+							className="absolute inset-y-0 left-0 bg-scrub-progress"
+							style={progressFill}
+						/>
+					</div>
+				))}
+			</div>
+		);
+	}, [segs, continuous]);
 
 	return (
 		<div
@@ -120,39 +171,23 @@ export function ScrubBar({
 				"group relative flex h-5 cursor-pointer items-center",
 				className,
 			)}
-			style={{ touchAction: "none" }}
+			style={
+				{
+					touchAction: "none",
+					"--scrub-pos": value,
+					"--scrub-preview": hoverRatio ?? 0,
+				} as CSSProperties
+			}
 			onPointerDown={onPointerDown}
 			onPointerMove={onPointerMove}
 			onPointerUp={endDrag}
 			onPointerCancel={endDrag}
 			onPointerLeave={onPointerLeave}
 		>
-			<div
-				className={cn("flex h-1 w-full", continuous ? "gap-0" : "gap-[2px]")}
-			>
-				{fills.map(({ seg, fill, hover }) => (
-					<div
-						key={seg.id}
-						className={cn(
-							"relative h-full overflow-hidden bg-scrub-track",
-							continuous && "rounded-full",
-						)}
-						style={{ flexBasis: `${seg.basis * 100}%` }}
-					>
-						<div
-							className="absolute inset-y-0 left-0 bg-scrub-hover"
-							style={{ width: `${hover * 100}%` }}
-						/>
-						<div
-							className="absolute inset-y-0 left-0 bg-scrub-progress"
-							style={{ width: `${fill * 100}%` }}
-						/>
-					</div>
-				))}
-			</div>
+			{track}
 			<div
 				className="pointer-events-none absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-scrub-progress ring-2 ring-border"
-				style={{ left: `${value * 100}%` }}
+				style={thumbStyle}
 			/>
 			{children}
 		</div>

--- a/app/components/video/SegmentedSeekBar.tsx
+++ b/app/components/video/SegmentedSeekBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { PlayerRef } from "@remotion/player";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { clamp } from "@/lib/utils";
 import type { VideoLayout } from "@/lib/video/types";
 import { usePlayerFrame } from "./usePlayerState";
@@ -38,12 +38,16 @@ export function SegmentedSeekBar({
 		[],
 	);
 
-	if (segments.length === 0) return null;
+	const scrubSegments = useMemo(
+		() =>
+			segments.map((seg) => ({
+				id: seg.sceneId,
+				basis: seg.duration / totalDurationSec,
+			})),
+		[segments, totalDurationSec],
+	);
 
-	const scrubSegments = segments.map((seg) => ({
-		id: seg.sceneId,
-		basis: seg.duration / totalDurationSec,
-	}));
+	if (segments.length === 0) return null;
 
 	const onHoverChange = (h: ScrubHover | null) => {
 		setHover(h);

--- a/app/components/video/__tests__/ScrubBar.test.ts
+++ b/app/components/video/__tests__/ScrubBar.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { segmentStyle } from "../ScrubBar";
+
+type Vars = Record<string, unknown>;
+
+describe("segmentStyle", () => {
+	it("lays segments end to end by their basis", () => {
+		const styles = segmentStyle([
+			{ id: "a", basis: 0.25 },
+			{ id: "b", basis: 0.5 },
+			{ id: "c", basis: 0.25 },
+		]) as Vars[];
+
+		expect(styles.map((s) => s.flexBasis)).toEqual(["25%", "50%", "25%"]);
+		expect(styles.map((s) => s["--seg-start"])).toEqual([0, 0.25, 0.75]);
+		expect(styles.map((s) => s["--seg-scale"])).toEqual([4, 2, 4]);
+	});
+
+	it("keeps a zero-width segment's scale finite", () => {
+		const [zero] = segmentStyle([{ id: "a", basis: 0 }]) as Vars[];
+
+		expect(zero["--seg-scale"]).toBe(0);
+	});
+});


### PR DESCRIPTION
## What

`SegmentedSeekBar` subscribes to the Remotion player's `frameupdate`, so it re-renders 30–60 times a second during playback. PR #495 looked at this and deferred it as *"inherent to drawing a progress fill."* It isn't — only one number changes per frame.

Every one of those renders was doing:

- `segments.map(...)` to rebuild the per-scene basis array (new array, new object per scene)
- inside `ScrubBar`, a cumulative-starts pass plus a `clamp((ratio - start) / basis, 0, 1)` per segment for both the progress fill and the hover fill
- three React elements and three inline style objects **per scene**, all with fresh identities

For a 20-scene project that's ~60 elements and ~60 style objects reconciled per frame, to move one playhead.

## The change

The fill geometry moves from JS into CSS, where it was always expressible:

- `value` and the hover ratio are written to the track root as `--scrub-pos` / `--scrub-preview`.
- Each segment carries its static span as `--seg-start` / `--seg-scale` (`1 / basis`), set once.
- A fill's width is the same clamp, in CSS:
  `clamp(0%, calc((var(--scrub-pos) - var(--seg-start)) * var(--seg-scale) * 100%), 100%)`
- The segment subtree is `useMemo`'d on the segments, so React skips it entirely when only the playhead moved.
- `SegmentedSeekBar` memoizes the basis array it passes down, keeping that identity stable.

A frame update now commits two custom-property writes on one element. The browser recomputes the fills; React never sees them.

Both `ScrubBar` callers are unaffected — the props API is unchanged, so the continuous volume bar in `PlayerControls` gets the same treatment for free (single segment, `start=0`, `scale=1`).

## Why it matters

Playback is the one place in this app with a real frame budget, and the seek bar was the largest per-frame React cost left in that tree after #495 pushed the scene-index subscription down to its leaves. This removes the remainder rather than shrinking it.

It's also less code doing less work, not a memo shim over the same work: the JS that computed percentages is gone, not cached.

## Verification

The CSS expression is the load-bearing part, so it was checked against real Chromium rather than assumed. With `--scrub-pos: 0.6` over segments of basis `0.25 / 0.5 / 0.25`:

| segment | span | measured fill | expected |
| --- | --- | --- | --- |
| s0 | 0–0.25 | 250 / 250px | full |
| s1 | 0.25–0.75 | 350 / 500px | `(0.6 − 0.25) × 2 = 0.7` |
| s2 | 0.75–1 | 0 / 250px | clamped to 0 |

Identical to the old JS output. React writes custom properties through `style.setProperty` with no unit coercion, so the unitless numbers land as-is.

New `segmentStyle` unit test covers the cumulative layout and the zero-basis segment (which previously produced `Infinity` inside the clamp and now resolves to a finite scale).

## Slate pass

Re-checked against the performance walkthrough. `renderElement` is a stable `useCallback`, `renderLeaf`/`decorate` are unused, every editor consumer already uses `useSlateStatic` (no `useSlate` anywhere in the tree), and the normalizers stay on the node they're handed. Chunking doesn't apply at this document size. Nothing to do.

## Skipped

- **`Captions` per-frame style object** in `remotion/components/Captions.tsx` — the container/text styles are already module-level and the word lookup is a memoized binary search. The one remaining per-frame allocation is a single wrapper style object. Marginal.
- **`SeekTooltip` re-rendering per frame while hovered** — real, but hovering is not a sustained state and the subtree is one element deep.
- **`useGenerate`'s whole-`metadata` subscription** — still the largest fanout in the app, still owned by open PR #480.
- **Anything in the canvas element render path** — `ElementContainer`, `SceneContainer`, `OutputPreview`, `SortableItem`, `SortableScene`, and `Canvas.tsx` are all claimed by open PRs.

## Open PR overlap check

Considered #498, #497, #496, #495, #494, #493, #488, #487, #486, #485, #484, #481, #480, #438.

This PR touches `ScrubBar.tsx`, `SegmentedSeekBar.tsx`, and a new `__tests__/ScrubBar.test.ts`. None of the three appears in any open PR's file list. #495 is the nearest neighbour — it touches `PlayerControls.tsx`, which *renders* `ScrubBar` — but `ScrubBar`'s props are unchanged, so the two are independent. This PR deliberately picks up the item #495 explicitly listed as skipped.

## Validation

`lint`, `typecheck`, `format:check`, `knip`, `build`, and `test:run` (982 passed, +2 new) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)