### PR TITLE
fix: nightly bug fixes 2026-08-01

### DIFF
--- a/app/api/queues/__tests__/asset-generate.test.ts
+++ b/app/api/queues/__tests__/asset-generate.test.ts
@@ -54,14 +54,34 @@ describe("asset-generate queue worker", () => {
 		expect(mockUpdateJob).not.toHaveBeenCalled();
 	});
 
-	it("throws when no handler is registered for the connector type", async () => {
+	it("marks the job failed and rethrows when no handler is registered", async () => {
 		mockLoadJobForProcessing.mockResolvedValue({ status: "pending" });
 		mockGetJobHandler.mockReturnValue(undefined);
 
 		await expect(processMessage(message)).rejects.toThrow(
 			"No job handler registered for image",
 		);
-		expect(mockUpdateJob).not.toHaveBeenCalled();
+		expect(mockUpdateJob).toHaveBeenNthCalledWith(2, "job-1", {
+			status: "failed",
+			error: expect.stringContaining("No job handler registered for image"),
+		});
+	});
+
+	it("marks the job failed when writing the completed result throws", async () => {
+		mockLoadJobForProcessing.mockResolvedValue({ status: "pending" });
+		mockGetJobHandler.mockReturnValue({
+			process: vi.fn().mockResolvedValue({ kind: "completed", result: {} }),
+		});
+		mockUpdateJob
+			.mockResolvedValueOnce(undefined)
+			.mockRejectedValueOnce(new Error("db unreachable"))
+			.mockResolvedValueOnce(undefined);
+
+		await expect(processMessage(message)).rejects.toThrow("db unreachable");
+		expect(mockUpdateJob).toHaveBeenNthCalledWith(3, "job-1", {
+			status: "failed",
+			error: expect.stringContaining("db unreachable"),
+		});
 	});
 
 	it("marks the job processing then completed with the handler result", async () => {

--- a/app/api/queues/asset-generate/route.ts
+++ b/app/api/queues/asset-generate/route.ts
@@ -11,15 +11,22 @@ export const POST = handleCallback<AssetQueueMessage>(
 		const job = await loadJobForProcessing(jobId);
 		if (isTerminal(job.status)) return;
 
-		const handler = getJobHandler(connectorType);
-		if (!handler) {
-			throw new Error(`No job handler registered for ${connectorType}`);
-		}
-
 		await updateJob(jobId, { status: "processing" });
-		let outcome;
+
+		// Every failure past this point has to land on the row: the client only
+		// ever learns the outcome by polling it, so a job left `processing`
+		// after the queue exhausts its retries is polled forever.
 		try {
-			outcome = await handler.process(job);
+			const handler = getJobHandler(connectorType);
+			if (!handler) {
+				throw new Error(`No job handler registered for ${connectorType}`);
+			}
+			const outcome = await handler.process(job);
+			if (outcome.kind === "completed") {
+				await updateJob(jobId, { status: "completed", result: outcome.result });
+			} else {
+				await updateJob(jobId, { metadata: outcome.metadata });
+			}
 		} catch (error) {
 			logger.error(error, `Job ${jobId} failed`);
 			await updateJob(jobId, {
@@ -27,12 +34,6 @@ export const POST = handleCallback<AssetQueueMessage>(
 				error: stringifyError(error),
 			});
 			throw error;
-		}
-
-		if (outcome.kind === "completed") {
-			await updateJob(jobId, { status: "completed", result: outcome.result });
-		} else {
-			await updateJob(jobId, { metadata: outcome.metadata });
 		}
 	},
 );

--- a/lib/api/__tests__/jobs.test.ts
+++ b/lib/api/__tests__/jobs.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type Result = { data: unknown; error: unknown };
+
+const single = vi.fn<() => Promise<Result>>();
+const maybeSingle = vi.fn<() => Promise<Result>>();
+const updateResult = vi.fn<() => Promise<{ error: unknown }>>();
+
+const insert = vi.fn(() => ({ select: () => ({ single }) }));
+const select = vi.fn(() => {
+	const filter = {
+		eq: () => filter,
+		single,
+		maybeSingle,
+	};
+	return filter;
+});
+const update = vi.fn(() => ({ eq: () => updateResult() }));
+const from = vi.fn(() => ({ insert, select, update }));
+
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: () => Promise.resolve({ from }),
+}));
+vi.mock("@/lib/supabase/service", () => ({
+	createServiceClient: () => ({ from }),
+}));
+
+const send = vi.fn();
+vi.mock("@vercel/queue", () => ({
+	send: (...args: unknown[]) => send(...args),
+}));
+
+const { createJob, getJob, loadJobForProcessing, updateJob, enqueueJob } =
+	await import("../jobs");
+
+describe("createJob", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("defaults a missing projectId to null rather than dropping the column", async () => {
+		single.mockResolvedValue({ data: { id: "job-1" }, error: null });
+
+		await expect(
+			createJob({
+				userId: "user-1",
+				connectorType: "image",
+				request: { prompt: "a cat" },
+			}),
+		).resolves.toEqual({ id: "job-1" });
+
+		expect(from).toHaveBeenCalledWith("jobs");
+		expect(insert).toHaveBeenCalledWith({
+			user_id: "user-1",
+			project_id: null,
+			connector_type: "image",
+			request: { prompt: "a cat" },
+		});
+	});
+
+	it("throws when the insert reports an error", async () => {
+		single.mockResolvedValue({ data: null, error: { message: "rls denied" } });
+
+		await expect(
+			createJob({ userId: "u", connectorType: "tts", request: {} }),
+		).rejects.toThrow("Failed to create job: rls denied");
+	});
+
+	it("throws when the insert returns no row", async () => {
+		single.mockResolvedValue({ data: null, error: null });
+
+		await expect(
+			createJob({ userId: "u", connectorType: "tts", request: {} }),
+		).rejects.toThrow("Failed to create job");
+	});
+});
+
+describe("getJob", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("returns null for a job the user does not own", async () => {
+		maybeSingle.mockResolvedValue({ data: null, error: null });
+
+		await expect(getJob("job-1", "user-1")).resolves.toBeNull();
+	});
+
+	it("throws instead of masking a query error as a missing job", async () => {
+		maybeSingle.mockResolvedValue({ data: null, error: { message: "boom" } });
+
+		await expect(getJob("job-1", "user-1")).rejects.toThrow(
+			"Failed to load job: boom",
+		);
+	});
+});
+
+describe("loadJobForProcessing", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("throws with the job id when the row is absent", async () => {
+		single.mockResolvedValue({ data: null, error: { message: "no rows" } });
+
+		await expect(loadJobForProcessing("job-9")).rejects.toThrow(
+			"Job job-9 not found: no rows",
+		);
+	});
+});
+
+describe("updateJob", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("skips the write when every field is undefined", async () => {
+		await updateJob("job-1", { status: undefined, error: undefined });
+
+		expect(from).not.toHaveBeenCalled();
+	});
+
+	it("drops undefined fields so they cannot null out existing columns", async () => {
+		updateResult.mockResolvedValue({ error: null });
+
+		await updateJob("job-1", { status: "failed", result: undefined });
+
+		expect(update).toHaveBeenCalledWith({ status: "failed" });
+	});
+
+	it("throws when the update reports an error", async () => {
+		updateResult.mockResolvedValue({ error: { message: "conflict" } });
+
+		await expect(updateJob("job-1", { status: "completed" })).rejects.toThrow(
+			"Failed to update job: conflict",
+		);
+	});
+});
+
+describe("enqueueJob", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("publishes the job id and connector type to the asset topic", async () => {
+		await enqueueJob("job-1", "video");
+
+		expect(send).toHaveBeenCalledWith("asset-generate", {
+			jobId: "job-1",
+			connectorType: "video",
+		});
+	});
+});

--- a/lib/connectors/__tests__/asset-base.test.ts
+++ b/lib/connectors/__tests__/asset-base.test.ts
@@ -127,6 +127,42 @@ describe("BaseAssetConnector", () => {
 			const result = await connector.resolveBundle(bundle);
 			expect(result.durationSec).toBe(0);
 		});
+
+		it("defaults duration to 0 when durationSec is not a finite number", async () => {
+			const connector = new TestAssetConnector(config);
+			for (const durationSec of ["", "abc", null, {}, Number.NaN, Infinity]) {
+				const bundle = new AssetBundle(
+					"https://blob.example.com/assets/image/mock/xyz",
+					{
+						version: 1,
+						type: "image",
+						createdAt: "",
+						result: { image: "output.jpg" },
+						metadata: { durationSec },
+					},
+				);
+
+				const result = await connector.resolveBundle(bundle);
+				expect(result.durationSec).toBe(0);
+			}
+		});
+
+		it("parses a numeric string duration", async () => {
+			const connector = new TestAssetConnector(config);
+			const bundle = new AssetBundle(
+				"https://blob.example.com/assets/image/mock/xyz",
+				{
+					version: 1,
+					type: "image",
+					createdAt: "",
+					result: { image: "output.jpg" },
+					metadata: { durationSec: "7.5" },
+				},
+			);
+
+			const result = await connector.resolveBundle(bundle);
+			expect(result.durationSec).toBe(7.5);
+		});
 	});
 
 	describe("_generate (via generate)", () => {

--- a/lib/connectors/asset-base.ts
+++ b/lib/connectors/asset-base.ts
@@ -6,6 +6,17 @@ import { assetUrlField } from "./assetUrl";
 import { BaseConnector } from "./base";
 import type { ConnectorConfig } from "./types";
 
+/**
+ * Bundle metadata is untyped JSON, so anything at all can sit on `durationSec`.
+ * A non-numeric value must not become `NaN` here: this is the boundary where it
+ * turns into `AssetResult.durationSec`, and the layout builder propagates a NaN
+ * duration through every start/length it derives from it.
+ */
+function finiteSeconds(value: unknown): number {
+	const seconds = Number(value);
+	return Number.isFinite(seconds) ? seconds : 0;
+}
+
 export abstract class BaseAssetConnector<
 	TParams extends { prompt: string },
 	TResult,
@@ -23,7 +34,7 @@ export abstract class BaseAssetConnector<
 	async resolveBundle(bundle: AssetBundle): Promise<TResult> {
 		return {
 			[assetUrlField(this.assetKey)]: bundle.resolve(this.assetKey),
-			durationSec: Number(bundle.manifest.metadata?.durationSec ?? 0),
+			durationSec: finiteSeconds(bundle.manifest.metadata?.durationSec),
 		} as TResult;
 	}
 

--- a/lib/providers/__tests__/cache.test.ts
+++ b/lib/providers/__tests__/cache.test.ts
@@ -485,6 +485,26 @@ describe("audioBundleCache", () => {
 		expect(cache.fromMetadata({ url: "", duration: 5 })).toBe(undefined);
 	});
 
+	it("fromMetadata forces a miss when the row carries no usable duration", async () => {
+		const { audioBundleCache } = await loadCache();
+		const cache = audioBundleCache("music");
+		expect(
+			cache.fromMetadata({ url: "https://legacy/audio.mp3" }),
+		).toBeUndefined();
+		expect(
+			cache.fromMetadata({ url: "https://legacy/audio.mp3", duration: "n/a" }),
+		).toBeUndefined();
+	});
+
+	it("fromMetadata keeps a zero duration, which is a real stored value", async () => {
+		const { audioBundleCache } = await loadCache();
+		const restored = audioBundleCache("music").fromMetadata({
+			url: "https://blob/audio.mp3",
+			duration: 0,
+		});
+		expect(restored?.metadata?.durationSec).toBe(0);
+	});
+
 	it("defaults duration to 0 when metadata missing", async () => {
 		const { audioBundleCache } = await loadCache();
 		const m = audioBundleCache("music").toMetadata(

--- a/lib/providers/cache.ts
+++ b/lib/providers/cache.ts
@@ -121,13 +121,15 @@ export const audioBundleCache = (type: string) => ({
 	fromMetadata: (m: Metadata): BundleResponse | undefined => {
 		const url = m.url || m.audioUrl;
 		if (typeof url !== "string" || url === "") return undefined;
+		const durationSec = Number(m.duration);
+		if (!Number.isFinite(durationSec)) return undefined;
 		return {
 			id: url,
 			type,
 			provider: "pinecone-cache",
 			result: { audio: url },
 			metadata: {
-				durationSec: Number(m.duration),
+				durationSec,
 				cached: true,
 				description: String(m.description),
 			},


### PR DESCRIPTION
## Bugs fixed

**1. A non-numeric asset duration became `NaN` on the timeline** (`lib/connectors/asset-base.ts`)

`resolveBundle` coerced with `Number(metadata?.durationSec ?? 0)`. `??` only catches `null`/`undefined`, so any other non-numeric value (`""`, `"abc"`, an object) produced `NaN`. This is the one boundary where untyped bundle JSON becomes a typed `AssetResult.durationSec`, and `buildVideoLayout` has no defence downstream — `createSequence` does `Math.max(duration, MIN_DURATION_SEC)`, which is `NaN` for `NaN`, and every start offset, `totalDurationSec` and `totalFrames` derived from it follows. Parsed to a finite number at that boundary instead, keeping the intended `0` default.

**2. A cached audio row with no usable duration was served as a hit** (`lib/providers/cache.ts`)

`audioBundleCache.fromMetadata` rehydrated `durationSec: Number(m.duration)` unconditionally, so a row missing `duration` (the legacy `audioUrl` rows this function explicitly supports) came back as a `NaN` duration — feeding bug 1. The option's own contract is "return `undefined` when the stored row can't be rehydrated, forcing a miss", so it now does. A stored `0` is still a real value and still hits.

**3. Some asset-job failures never reached the job row** (`app/api/queues/asset-generate/route.ts`)

Handler lookup and the terminal `updateJob` writes sat outside the try/catch that marks a job `failed`. An unregistered connector type, or a write that fails after the handler succeeded, threw with the row left at `pending`/`processing`. The client only learns the outcome by polling that row, so once the queue exhausted its retries the job was polled forever. Moved the whole body inside the existing catch, which also drops the `let outcome` and one nesting level.

## Tests added

- `lib/api/__tests__/jobs.test.ts` (new) — `lib/api/jobs.ts` was at 4% line coverage despite being the persistence layer behind every async generation. Covers the `projectId ?? null` default, error-vs-missing-row distinction in `createJob`/`getJob`/`loadJobForProcessing`, `updateJob`'s undefined-stripping and no-op write, and the `enqueueJob` topic payload.
- `lib/connectors/__tests__/asset-base.test.ts` — non-finite `durationSec` values (`""`, `"abc"`, `null`, `{}`, `NaN`, `Infinity`) all default to 0; a numeric string still parses.
- `lib/providers/__tests__/cache.test.ts` — a row with no/garbage `duration` forces a miss; `duration: 0` still hits.
- `app/api/queues/__tests__/asset-generate.test.ts` — missing handler and a failing result write both mark the job failed and rethrow.

Coverage: statements 80.00% → 81.07%, branches 76.68% → 78.50%.

## Skipped

Swept the rest of the non-overlapping surface (`lib/api`, `lib/gateway`, `lib/clients`, `lib/upload`, `lib/video` helpers, `lib/canvas` ops, `lib/script/refine`, `remotion/`, the free `app/components` hooks) without finding another defect worth a change. Two things were checked and cleared rather than "fixed": `moveDraggedElement`'s Slate path arithmetic (probed all four drag directions — correct as written) and `readSSE`'s dropped trailing buffer (unreachable, every producer terminates frames with `\n\n`).

## Open PR overlap check

Considered #500, #499, #498, #497, #496, #495, #494, #493, #488, #487, #486, #485, #484, #481, #480, #438. Diffed the final file list against the union of their touched files — zero intersection. Nearest neighbours are #497 (`lib/api/handlers/video.ts`, not `lib/api/jobs.ts`), #493 (`lib/providers/tts/*`, not `lib/providers/cache.ts`) and #480 (`lib/connectors/base.ts`/`factory.ts`, not `asset-base.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)