### PR TITLE
refactor: nightly maintainability 2026-08-01

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Open [http://localhost:3000](http://localhost:3000) and you should see the app.
 | Auth + DB | [Supabase](https://supabase.com) (Auth, Postgres, RLS)                                                       |
 | Video     | [Remotion 4](https://remotion.dev) (composition, rendering, player)                                          |
 | Storage   | [Vercel Blob](https://vercel.com/docs/storage/vercel-blob) (generated asset storage)                         |
-| Icons     | [Lucide](https://lucide.dev)                                                                                 |
+| Icons     | In-house masked-SVG set (`components/ui/icon.tsx` + `icons.css`), no icon dependency                         |
 
 ## Project structure
 
@@ -120,9 +120,12 @@ lib/
   gateway/       HTTP clients to /api/v1/*
   providers/     Server-side vendor adapters (Runware, ElevenLabs, …)
   generation/    Generation queue and job orchestration
-  video/         Remotion compositions and scene layout
+  canvas/        Slate document model: element types, guards, OSML parse/serialize
+  script/        Script context and refinement
+  project/       Per-project Zustand store, autosave, persistence
+  video/         Scene layout and render client
   supabase/      Browser/server Supabase clients
-remotion/        Remotion entry point
+remotion/        Remotion entry point and compositions
 supabase/        Database migrations
 ```
 

--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -10,7 +10,6 @@ import {
 } from "@dnd-kit/sortable";
 import { useDragAndDrop } from "./dnd/useDragAndDrop";
 import { DragTransferContext } from "./dnd/DragTransferContext";
-import type { CanvasContentElement } from "@/lib/canvas/types";
 import { findElementById } from "@/lib/canvas/editorOps";
 import { isSceneElement } from "@/lib/canvas/scenes";
 import { SortableScene } from "./dnd/SortableScene";
@@ -53,9 +52,7 @@ export default function Canvas({
 		if (isSceneElement(element)) {
 			return <SortableScene {...props} element={element} />;
 		}
-		return (
-			<SortableContent {...props} element={element as CanvasContentElement} />
-		);
+		return <SortableContent {...props} element={element} />;
 	}, []);
 
 	const activeElement = useMemo(


### PR DESCRIPTION
Small, behavior-free pass. Mostly docs accuracy — see the note at the bottom on why the code side is thin tonight.

## Docs (`README.md`)

- **Tech stack said Icons = Lucide. It isn't.** There is no lucide dependency in `package.json`; icons are an in-house masked-SVG set (`components/ui/icon.tsx` + `components/ui/icons.css`, each icon a `--<name>-icon` CSS variable painted via `mask-image`). A contributor reading the table would reach for the wrong library.
- Project-structure map was missing three of the domain directories a new contributor needs first: `lib/canvas/` (Slate document model, OSML parse/serialize), `lib/script/`, `lib/project/`.
- `lib/video/` was described as "Remotion compositions and scene layout" — compositions actually live in `remotion/`. Corrected both lines.

## Code

- `app/components/canvas/Canvas.tsx`: dropped `element as CanvasContentElement` in `renderElement`. `isSceneElement` is a type predicate over the `SceneElement | CanvasContentElement` union, so the else branch already narrows; the cast was load-bearing for nothing and would have silently held if the union ever grew. Typecheck confirms it's redundant.

## Complexity delta

1 unsafe cast and 1 now-unused type import removed. No functions restructured, no branching changed.

## Open PR overlap check

Considered all 17 open PRs (#438, #480, #481, #484, #485, #486, #487, #488, #493–#501); their diffs cover 166 source files, which I diffed against before choosing anything.

- `README.md` — not touched by any open PR.
- `app/components/canvas/Canvas.tsx` — listed under #438, but #438's hunks are an added `CollapsedVoidSync` import and a JSX insert inside `<Slate>`; this change is an import removal and the `renderElement` callback. Different hunks, no semantic overlap.

## Skipped, with reasons

- **`components.json` has `"iconLibrary": "lucide"`.** That's the shadcn CLI generator setting, so `npx shadcn add ...` will emit `lucide-react` imports that contradict the in-house icon system. Left alone: shadcn only accepts `lucide` or `radix`, and `radix` is not what this repo uses either. Needs a human call (drop the field, or document the post-add fixup).
- **`(Node.parent(editor, path) as SceneElement).id` duplicated** in `dnd/SortableContent.tsx:42` and `elements/ElementContainer.tsx:170`. A `parentSceneId()` helper in `lib/canvas` would define the cast out of existence, but `ElementContainer.tsx` is under open PR #480 — fixing one site alone is worse than leaving both.
- **"characters live on image + animated_image"** knowledge sits in `lib/canvas/preservedAttributes.ts` and `elements/ElementCharacters.tsx`. Two sites; rule of three says wait, and the natural declarative home (`ElementTypeSpec` in `lib/canvas/types.ts`) is under #438.
- **`NewCharacterDialog`'s submit button** is a raw `<button>` with one-off Tailwind instead of the design-system `Button`. Swapping it changes pixels, and this job is behavior-free.
- **No substantial architecture change was available.** The 17 open PRs already claim every recently-flagged hotspot, and my own read of the largest uncovered modules (`lib/api/route-handler.ts`, `canvas/plugins/*`, `canvas/dnd/*`, `Canvas`/`CanvasProviders`/`ViewModeContext`/`useEditorSession`, the character dialog cluster, `AttributeBadge`, `ExportButton`, `EditorSidebar`, `lib/api/asset-bundle.ts`, `app/api/render`) turned up only sub-trivial nits. Rather than manufacture churn, I kept the pass to what's actually wrong.

## Validation

`npm run lint`, `format:check`, `typecheck`, `knip`, `build` all clean. Tests: 114 files, 980 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)