### PR TITLE
perf: nightly performance optimizations 2026-08-01

### DIFF
--- a/app/components/video/PlayerPanel.tsx
+++ b/app/components/video/PlayerPanel.tsx
@@ -37,7 +37,7 @@ function FitToAspectRatio({
 function TopPlayerPanelComponent() {
 	const aspectRatio = useAspectRatio();
 
-	const { size, handleMouseDown, resizing } = useResize({
+	const { panelRef, style, handleMouseDown, resizing } = useResize({
 		axis: "vertical",
 		defaultSize: TOP_DEFAULT,
 		minSize: 150,
@@ -45,7 +45,7 @@ function TopPlayerPanelComponent() {
 	});
 
 	return (
-		<div className="shrink-0" style={{ height: size }}>
+		<div ref={panelRef} className="shrink-0" style={style}>
 			<div className="relative mx-auto h-[calc(100%-0.5rem)] max-w-6xl p-2">
 				<FitToAspectRatio ratio={getAspectRatioValue(aspectRatio)}>
 					<VideoPanel />
@@ -63,7 +63,7 @@ function TopPlayerPanelComponent() {
 function SidePlayerPanelComponent() {
 	const aspectRatio = useAspectRatio();
 
-	const { size, handleMouseDown, resizing } = useResize({
+	const { panelRef, style, handleMouseDown, resizing } = useResize({
 		axis: "horizontal",
 		defaultSize: SIDE_DEFAULT,
 		minSize: 250,
@@ -71,7 +71,7 @@ function SidePlayerPanelComponent() {
 	});
 
 	return (
-		<div className="flex shrink-0" style={{ width: size }}>
+		<div ref={panelRef} className="flex shrink-0" style={style}>
 			<ResizeHandle
 				axis="horizontal"
 				resizing={resizing}

--- a/app/components/video/useResize.ts
+++ b/app/components/video/useResize.ts
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type CSSProperties,
+} from "react";
 import { clamp } from "@/lib/utils";
 
 export type ResizeAxis = "vertical" | "horizontal";
@@ -70,6 +77,13 @@ export function attachResizeListeners(
 	return cleanup;
 }
 
+const SIZE_PROPERTY = { vertical: "height", horizontal: "width" } as const;
+
+/**
+ * Drags write the panel dimension straight to the DOM node. Holding it in React
+ * state would re-render the panel — and everything it wraps — on every
+ * mousemove, which for the player panel means the whole Remotion composition.
+ */
 export function useResize({
 	axis,
 	defaultSize,
@@ -81,14 +95,10 @@ export function useResize({
 	minSize: number;
 	maxViewportFraction: number;
 }) {
-	const [size, setSize] = useState(defaultSize);
+	const panelRef = useRef<HTMLDivElement>(null);
 	const [resizing, setResizing] = useState(false);
-	const sizeRef = useRef(size);
-	useEffect(() => {
-		sizeRef.current = size;
-	}, [size]);
-
 	const cleanupRef = useRef<(() => void) | null>(null);
+	const property = SIZE_PROPERTY[axis];
 
 	useEffect(
 		() => () => {
@@ -100,23 +110,33 @@ export function useResize({
 
 	const handleMouseDown = useCallback(
 		(e: React.MouseEvent) => {
+			const panel = panelRef.current;
+			if (!panel) throw new Error("Resize started before the panel mounted");
 			e.preventDefault();
 			cleanupRef.current?.();
 			setResizing(true);
-			const viewport =
-				axis === "vertical" ? window.innerHeight : window.innerWidth;
+			const vertical = axis === "vertical";
+			const viewport = vertical ? window.innerHeight : window.innerWidth;
+			const rect = panel.getBoundingClientRect();
 			cleanupRef.current = attachResizeListeners(document, {
 				axis,
-				startPos: axis === "vertical" ? e.clientY : e.clientX,
-				startSize: sizeRef.current,
+				startPos: vertical ? e.clientY : e.clientX,
+				startSize: vertical ? rect.height : rect.width,
 				minSize,
 				maxSize: viewport * maxViewportFraction,
-				onResize: setSize,
+				onResize: (size) => {
+					panel.style[property] = `${size}px`;
+				},
 				onEnd: () => setResizing(false),
 			});
 		},
-		[axis, minSize, maxViewportFraction],
+		[axis, minSize, maxViewportFraction, property],
 	);
 
-	return { size, handleMouseDown, resizing };
+	const style = useMemo<CSSProperties>(
+		() => ({ [property]: defaultSize }),
+		[property, defaultSize],
+	);
+
+	return { panelRef, style, handleMouseDown, resizing };
 }


### PR DESCRIPTION
## What

Dragging either player panel's resize handle held the new dimension in React state. Every `mousemove` therefore re-rendered `TopPlayerPanel`/`SidePlayerPanel` and everything they wrap — `VideoPanel` → `VideoPreview` → the Remotion `<Player>` and its whole composition tree — for a value that only ever lands in one inline style. At pointer rate that is 60–120 full player re-renders per second, exactly while the user is asking for a smooth drag.

`useResize` now owns a ref to the panel it sizes and writes the dimension straight to the node during the drag, returning a memoized `style` for the initial size. React re-renders during a resize drop to zero; `resizing` still flips twice per drag so the handle keeps its own styling.

Reading `startSize` from the panel's measured rect also retires the `sizeRef` mirror and its syncing effect, so the hook is shorter than before.

## Why it matters

This is the one place in the app where high-frequency pointer state sat above an expensive subtree. Playback state is already scoped correctly (`usePlayerFrame` is confined to `SegmentedSeekBar`), and the canvas contexts are all memoized, so the resize path was the outlier.

## Validation

`npm run lint`, `format:check`, `typecheck`, `knip`, `npm test` (980 passing), `npm run build` — all green. Behavior is unchanged: same clamping, same min/max, same handle affordances, dimension persists after drag end.

## Considered and skipped

- **Slate pass.** Re-read the [performance walkthrough](https://docs.slatejs.org/walkthroughs/09-performance) against the editor. Every consumer already uses `useSlateStatic` (no `useSlate` subscriptions), `renderElement` is stable, `withScenes` normalizes only `path.length === 1`, and the canvas contexts (`ViewMode`, `PreviewCache`, `DragTransfer`) are all memoized. Chunking (`getChunkSize`) targets 10k+ block documents and would need CSS selector rework for a document size this app never reaches. No change warranted.
- **Remotion pass.** `VideoComposition` already memoizes its series/layer nodes, presentation, and timing; `MotionLayer`/`motionTransform` are pure per-frame math with no allocation churn; `Captions` binary-searches a memoized envelope. Nothing to take.
- **Audio waveform peaks.** `loadPeaks` decodes at the default 48 kHz and scans every sample on the main thread. Decoding into an `OfflineAudioContext` at 8 kHz measured ~6x faster (24.6 ms → 4.1 ms for 20×12 s clips) with 2.3 MB → 0.4 MB transient PCM per clip. Real, but it is a once-per-project-load cost of ~20 ms, i.e. the same marginal initial-load category as #476. Left alone rather than shipped as filler.
- **`AssetBundle.upload` manifest round-trip.** Could join the parallel file uploads, but publishing the manifest before its files exist is a real invariant break for ~200 ms on a multi-second generation. Not worth it.

## Open PR overlap check

Checked open PRs #502, #501, #500, #499, #498, #497, #496, #495, #494, #493, #488, #487, #486, #485, #484, #481, #480, #438 via `gh pr diff --name-only`. Neither `app/components/video/useResize.ts` nor `app/components/video/PlayerPanel.tsx` appears in any of them. The nearest neighbours are #495 (`VideoPreview`, `PlayerControls`, `BottomTransportBar`, `ActiveSceneSync`) and #499 (`ScrubBar`, `SegmentedSeekBar`) — different files, different mechanism, no shared lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)