### PR TITLE
refactor: rethink openslop architecture 2026-08-01

### DIFF
--- a/app/components/GlobalErrorToaster.tsx
+++ b/app/components/GlobalErrorToaster.tsx
@@ -1,16 +1,15 @@
 "use client";
 
 import { useEffect } from "react";
-import { toast } from "sonner";
-import { stringifyError } from "@/lib/errors";
+import { toastError } from "@/lib/toastError";
 
 export function GlobalErrorToaster() {
 	useEffect(() => {
 		const onRejection = (e: PromiseRejectionEvent) => {
-			toast.error(stringifyError(e.reason));
+			toastError(e.reason);
 		};
 		const onError = (e: ErrorEvent) => {
-			toast.error(stringifyError(e.error ?? e.message));
+			toastError(e.error ?? e.message);
 		};
 		window.addEventListener("unhandledrejection", onRejection);
 		window.addEventListener("error", onError);

--- a/app/components/ToastErrorBoundary.tsx
+++ b/app/components/ToastErrorBoundary.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { Component, type ReactNode } from "react";
-import { toast } from "sonner";
-import { stringifyError } from "@/lib/errors";
+import { toastError } from "@/lib/toastError";
 
 type Props = { children: ReactNode; label?: string };
 type State = { hasError: boolean };
@@ -20,8 +19,7 @@ export class ToastErrorBoundary extends Component<Props, State> {
 	}
 
 	componentDidCatch(error: unknown) {
-		const prefix = this.props.label ? `${this.props.label}: ` : "";
-		toast.error(`${prefix}${stringifyError(error)}`);
+		toastError(error, this.props.label);
 	}
 
 	render() {

--- a/app/components/projects/ProjectsList.tsx
+++ b/app/components/projects/ProjectsList.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Plus } from "@/components/ui/icon";
-import { toast } from "sonner";
+import { toastError } from "@/lib/toastError";
 import { createProject, deleteProject } from "@/lib/project/api";
 import type { ProjectRow } from "@/lib/project/api";
 import UserProfile from "@/app/components/UserProfile";
@@ -28,8 +28,7 @@ export default function ProjectsList({
 				const project = await createProject();
 				router.push(`/projects/${project.id}`);
 			} catch (err) {
-				console.error(err);
-				toast.error("Could not create project");
+				toastError(err, "Could not create project");
 			}
 		});
 	};
@@ -40,8 +39,7 @@ export default function ProjectsList({
 		try {
 			await deleteProject(id);
 		} catch (err) {
-			console.error(err);
-			toast.error("Could not delete project");
+			toastError(err, "Could not delete project");
 			setProjects(previous);
 		}
 	};

--- a/lib/__tests__/toastError.test.ts
+++ b/lib/__tests__/toastError.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { toastError } from "../toastError";
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
+
+const errorToast = vi.mocked(toast.error);
+
+describe("toastError", () => {
+	beforeEach(() => {
+		errorToast.mockReset();
+	});
+
+	it("shows the error's message, not its serialized form", () => {
+		toastError(new Error("Upload failed"));
+		expect(errorToast).toHaveBeenCalledWith("Upload failed");
+	});
+
+	it("prefixes the label when one is given", () => {
+		toastError(new Error("network down"), "Could not create project");
+		expect(errorToast).toHaveBeenCalledWith(
+			"Could not create project: network down",
+		);
+	});
+
+	it("stringifies non-Error causes", () => {
+		toastError("plain rejection");
+		expect(errorToast).toHaveBeenCalledWith("plain rejection");
+	});
+
+	it("never leaks a stack trace", () => {
+		const error = new Error("boom");
+		error.stack = "Error: boom\n    at secret/path.ts:1:1";
+		toastError(error);
+		expect(errorToast).toHaveBeenCalledWith("boom");
+	});
+});

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,7 +1,9 @@
 import { serializeError } from "serialize-error";
 
+/** For logs and transport, where the whole error (name, stack, cause) matters. */
 export const stringifyError = (error: unknown): string =>
 	JSON.stringify(serializeError(error));
 
+/** For anything a person reads. UI code reaches for `toastError` instead. */
 export const errorMessage = (error: unknown): string =>
 	error instanceof Error ? error.message : String(error);

--- a/lib/toastError.ts
+++ b/lib/toastError.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { toast } from "sonner";
+import { errorMessage } from "./errors";
+
+/**
+ * The one way an error reaches the user. Callers hand over the raw cause; this
+ * decides what a human sees, so no UI has to pick between `errorMessage` and
+ * the transport-only `stringifyError`.
+ */
+export function toastError(error: unknown, label?: string): void {
+	const message = errorMessage(error);
+	toast.error(label ? `${label}: ${message}` : message);
+}

--- a/lib/upload/useImageUpload.tsx
+++ b/lib/upload/useImageUpload.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { toast } from "sonner";
-import { errorMessage } from "@/lib/errors";
+import { toastError } from "@/lib/toastError";
 import { uploadImage } from "@/lib/upload/uploadImage";
 
 export function useImageUpload({
@@ -24,7 +23,7 @@ export function useImageUpload({
 			const urls: string[] = [];
 			for (const r of results) {
 				if (r.status === "fulfilled") urls.push(r.value);
-				else toast.error(errorMessage(r.reason));
+				else toastError(r.reason);
 			}
 			if (urls.length > 0) onUpload(urls);
 		} finally {


### PR DESCRIPTION
## App understanding

OpenSlop turns a prompt into a rendered video. A Slate canvas holds an OSML script (narration / character / image / animated_image / clip / sound / music elements grouped into scenes). `lib/connectors` is a plugin-chain layer over `lib/gateway` → `lib/providers` (Anthropic, Runware, Cartesia, ElevenLabs, mocks). `lib/generation` models generation as a dependency graph with staleness. `app/api/v1/*` exposes the same connectors as a public job API backed by Supabase `jobs` rows and a Vercel queue. Remotion + Lambda render the timeline.

## From-scratch architecture

The current one is close to it: registry-driven route handlers, a plugin chain per connector type, `lib/` as a domain layer that never imports `app/`, and per-type specs as data tables rather than switch chains. The gaps left are policy boundaries where a rule exists but isn't enforced by the API. This PR closes the one that leaks to users.

## Implemented simplification: one canonical user-facing error surface

`lib/errors` exported `stringifyError` (full serialized error, for logs and transport) and `errorMessage` (human-readable) side by side, with nothing steering the caller. `GlobalErrorToaster` and `ToastErrorBoundary` picked the wrong one, so an unhandled rejection or a render crash toasted `{"name":"TypeError","message":"…","stack":"…"}` at the user, while every other call site toasted the message.

- New `lib/toastError.ts` — `toastError(cause, label?)`. Callers hand over the raw cause; the helper decides what a person sees, so UI code never picks between the two converters again. Six call sites across four files, so this clears the rule of three.
- `GlobalErrorToaster`, `ToastErrorBoundary`, `useImageUpload`, `ProjectsList` now go through it.
- `ProjectsList`'s `console.error(err)` + fixed-copy `toast.error("Could not create project")` pair collapses into one call. The copy survives as a prefix and the cause is no longer dropped (it was previously visible only in the console).
- `lib/errors.ts` gains a one-line comment on each export recording which side of the boundary it belongs to.
- New `lib/__tests__/toastError.test.ts` covers the seam, including that a stack never reaches the toast.

No product behavior changes beyond user-visible error copy getting more accurate.

## Validation

| Check | Result |
| --- | --- |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm run knip` | pass |
| `npm run build` | pass |
| `npm run test:coverage` | 115 files, 984 tests pass |
| `npm run test:e2e` | **not run** — port 3000 already in use on the runner, so Playwright's webServer could not start. Environmental, unrelated to this diff. |

## Open PR overlap check

Considered all 19 open PRs (#503, #502, #501, #500, #499, #498, #497, #496, #495, #494, #493, #488, #487, #486, #485, #484, #481, #480, #438) and diffed each one's file list against this branch. **No file in this PR appears in any of them.**

## Skipped items

Larger architectural targets were inspected and left alone, mostly because they are already covered:

- `lib/api/with-auth.ts` returns `stringifyError(error)` (stack included) in 500 bodies, on public routes too. Same boundary rule, but fixing it changes the API contract and its tests — wants a human call.
- `lib/api/sse.ts` sends `stringifyError` in its error frame, and `app/api/queues/asset-generate/route.ts` stores it in `jobs.error`, which surfaces in the UI. Both are third and fourth sites for this rule; the queue route is under open PR #501.
- `useAutosave.ts` has the same `console.error` + fixed-copy toast pair — under open PR #485.
- `parentSceneId()` helper for the duplicated `(Node.parent(...) as SceneElement).id` cast — `ElementContainer.tsx` is under open PR #480.
- A shared `keysOf` helper for the repeated `Object.keys(X) as K[]` cast — one of its four sites is under open PR #488, and it does not belong in an error-handling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)