### PR TITLE
fix: nightly bug fixes 2026-08-02

### DIFF
--- a/lib/generation/__tests__/queue.test.ts
+++ b/lib/generation/__tests__/queue.test.ts
@@ -173,6 +173,34 @@ describe("GenerationQueue", () => {
 			generationQueue.discard("m2");
 		});
 
+		it("clears a previous failure so a retry does not show a stale error", async () => {
+			generateMock.mockRejectedValueOnce(new Error("generation failed"));
+			generationQueue.enqueueGraph([makeJob("retry1")]);
+			await vi.runAllTimersAsync();
+			expect(generationQueue.getElementSnapshot("retry1").error).toBe(
+				"generation failed",
+			);
+
+			generateMock.mockReturnValueOnce(new Promise(() => {}));
+			generationQueue.enqueueGraph([makeJob("retry1")]);
+
+			const snap = generationQueue.getElementSnapshot("retry1");
+			expect(snap.status).toBe("generating");
+			expect(snap.error).toBeNull();
+
+			generationQueue.discard("retry1");
+		});
+
+		it("clears an error set outside the queue when the element is queued", () => {
+			generationQueue.setError("retry2", "Enter a prompt first");
+			generateMock.mockReturnValueOnce(new Promise(() => {}));
+
+			generationQueue.enqueueGraph([makeJob("retry2")]);
+			expect(generationQueue.getElementSnapshot("retry2").error).toBeNull();
+
+			generationQueue.discard("retry2");
+		});
+
 		it("does not notify if no new jobs were added", () => {
 			generateMock.mockReturnValue(new Promise(() => {}));
 			generationQueue.enqueueGraph([makeJob("existing")]);

--- a/lib/generation/__tests__/queueDependencies.test.ts
+++ b/lib/generation/__tests__/queueDependencies.test.ts
@@ -221,6 +221,26 @@ describe("dependency ordering", () => {
 		expect(queue.getElementSnapshot("a").error).toMatch(/root boom/);
 	});
 
+	it("runs a waiting dependent against a result committed over its running dependency", async () => {
+		const pending = new Promise<AssetResult>(() => {});
+		generateMock.mockImplementation((job) =>
+			(job as GenerationJob).elementId === "avatar:Alice"
+				? pending
+				: Promise.resolve({ videoUrl: "x.mp4", durationSec: 5 }),
+		);
+
+		const avatar = node("avatar:Alice");
+		queue.enqueueGraph([node("image", [avatar])]);
+		expect(queue.getElementSnapshot("image").status).toBe("queued");
+
+		// An upload lands while the dependency is still generating.
+		queue.commitResult(avatar, { imageUrl: "uploaded.png", durationSec: 0 });
+		await vi.runAllTimersAsync();
+
+		expect(startedIds()).toContain("image");
+		expect(queue.getElementSnapshot("image").result?.videoUrl).toBe("x.mp4");
+	});
+
 	it("leaves no error on a dependent released for a reason other than failure", async () => {
 		generateMock.mockResolvedValue({ imageUrl: "x.png", durationSec: 0 });
 

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -189,6 +189,7 @@ export class GenerationQueue {
 			this.update(node.id, {
 				status: "queued",
 				seconds: 0,
+				error: null,
 				connectorType: requireJob(node).connectorType,
 			});
 			this.pending.push(node);
@@ -237,15 +238,17 @@ export class GenerationQueue {
 
 	/**
 	 * Aborts any in-flight job first, which would otherwise land later and clobber
-	 * this. Pass `pinned` for a result the user supplied rather than asked us to
-	 * make, so drifting project state cannot let Generate All overwrite it.
+	 * this. The queue only resumes once the result is committed, so dependents
+	 * waiting on this node see it arrive rather than being released as blocked.
+	 * Pass `pinned` for a result the user supplied rather than asked us to make,
+	 * so drifting project state cannot let Generate All overwrite it.
 	 */
 	commitResult(
 		node: GenerationNode,
 		result: AssetResult,
 		{ pinned = false }: { pinned?: boolean } = {},
 	): void {
-		this.cancel(node.id);
+		this.abortJob(node.id);
 		this.commit(
 			node.id,
 			result,
@@ -253,6 +256,7 @@ export class GenerationQueue {
 			requireJob(node).connectorType,
 			pinned,
 		);
+		this.processQueue();
 	}
 
 	private commit(


### PR DESCRIPTION
Two real correctness bugs in the generation queue, each with a regression test that fails without the fix.

## Bugs fixed

**A retry shows the previous failure.** `enqueueGraph` set `status: "queued"` but left `error` in place, so the red error overlay stayed pinned over the placeholder for the entire retry. Same for the `"Enter a prompt first"` message: adding a prompt and hitting Generate kept showing it until the job settled. Queuing now clears the error.

**Uploading over a generating element silently kills its dependents.** `commitResult` cancelled the in-flight job *before* committing, and `cancel` resumes the queue. At that moment the element still had no result, so `releaseBlocked` treated every dependent waiting on it as unrunnable, dropped it from the queue and reset it to idle with no error. Uploading an image (or seeding a character avatar from a template) mid-run left the derived video/animated-image never generated and nothing on screen to say so. `commitResult` now aborts the in-flight job, commits the result, and only then resumes the queue.

## Tests added

- `queue.test.ts`: re-queueing clears a previous failure; clears an error set via `setError`.
- `queueDependencies.test.ts`: a dependent waiting on a running dependency runs against the result committed over it.

All three fail on master and pass here. Full suite: 997 passing. Lint, format, typecheck, knip and build all clean.

## Open PR overlap check

Considered open PRs #438, #481, #484, #485, #486, #487, #488, #493, #494, #495, #496, #497, #498, #499, #500, #501, #502, #503, #504. None touches `lib/generation/` — the closest are #501 (`lib/api/jobs.ts`, `lib/connectors/asset-base.ts`, `lib/providers/cache.ts`) and #487 (canvas preview + video layout components). This PR is non-overlapping in both files and theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)