### PR TITLE
refactor: nightly maintainability 2026-08-02

### DIFF
--- a/app/components/canvas/elements/AnimateButton.tsx
+++ b/app/components/canvas/elements/AnimateButton.tsx
@@ -3,10 +3,11 @@
 import { MagicVideo } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { animateImagePrompt } from "@/lib/script/refine/animatePrompt";
-import type { CanvasContentElement } from "@/lib/canvas/types";
 import { useRefine } from "../RefineProvider";
+import { useElementGeneration } from "./ElementGenerationContext";
 
-export function AnimateButton({ element }: { element: CanvasContentElement }) {
+export function AnimateButton() {
+	const { element } = useElementGeneration();
 	const { refineScript, refineLoading } = useRefine();
 
 	if (element.type !== "image") return null;

--- a/app/components/canvas/elements/ElementCharacters.tsx
+++ b/app/components/canvas/elements/ElementCharacters.tsx
@@ -2,19 +2,16 @@
 
 import { useSlateStatic } from "slate-react";
 import { getElementCharacterNames } from "@/lib/canvas/characterNames";
-import type { CanvasContentElement } from "@/lib/canvas/types";
 import { CharacterPill } from "./CharacterPill";
 import {
 	CharacterSwitcher,
 	CharactersPicker,
 	removeCharacter,
 } from "./CharactersPicker";
+import { useElementGeneration } from "./ElementGenerationContext";
 
-export function ElementCharacters({
-	element,
-}: {
-	element: CanvasContentElement;
-}) {
+export function ElementCharacters() {
+	const { element } = useElementGeneration();
 	const editor = useSlateStatic();
 	if (element.type === "character")
 		return <CharacterSwitcher element={element} />;

--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -15,7 +15,10 @@ import { SceneContainer } from "./SceneContainer";
 import { ElementCharacters } from "./ElementCharacters";
 import { AttributeBadge } from "./AttributeBadge";
 import { ElementGenerateButton, ElementStaleIndicator } from "./GenerateButton";
-import { ElementGenerationProvider } from "./ElementGenerationContext";
+import {
+	ElementGenerationProvider,
+	useElementGeneration,
+} from "./ElementGenerationContext";
 import { AnimateButton } from "./AnimateButton";
 import { ElementUploadButton } from "./ElementUploadButton";
 import { ModelBadge } from "./ModelBadge";
@@ -27,7 +30,8 @@ import {
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { SlidersHorizontal } from "@/components/ui/icon";
 
-function ElementSettings({ element }: { element: CanvasContentElement }) {
+function ElementSettings() {
+	const { element } = useElementGeneration();
 	const { connectorConfig } = useConfig();
 	const schema = resolveElementSchema(element, connectorConfig);
 	const entries = Object.entries(schema.visibleAttributes);
@@ -102,9 +106,9 @@ export function ElementContainer({
 										{config.label}
 									</span>
 								</span>
-								<ElementCharacters element={element} />
-								<ModelBadge element={element} />
-								<ElementSettings element={element} />
+								<ElementCharacters />
+								<ModelBadge />
+								<ElementSettings />
 							</div>
 							<div className="shrink-0 opacity-0 pointer-events-none transition-opacity duration-200 group-hover/card:opacity-100 group-hover/card:pointer-events-auto">
 								<DeleteButton element={element} />
@@ -130,7 +134,7 @@ export function ElementContainer({
 							<ElementStaleIndicator />
 							{(element.type === "image" ||
 								element.type === "animated_image") && <ElementUploadButton />}
-							<AnimateButton element={element} />
+							<AnimateButton />
 							<ElementGenerateButton />
 						</div>
 					</div>

--- a/app/components/canvas/elements/ElementGenerationContext.tsx
+++ b/app/components/canvas/elements/ElementGenerationContext.tsx
@@ -5,7 +5,9 @@ import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { useGenerate } from "../hooks/useGenerate";
 
-type ElementGeneration = ReturnType<typeof useGenerate>;
+type ElementGeneration = ReturnType<typeof useGenerate> & {
+	element: CanvasContentElement;
+};
 
 const [ElementGenerationContext, useElementGeneration] =
 	createRequiredContext<ElementGeneration>("ElementGenerationContext");
@@ -13,7 +15,8 @@ export { useElementGeneration };
 
 // One subscription, one staleness check and one restore effect per element card.
 // Children are passed through untouched, so a queue tick re-renders only the
-// consumers below, not the Slate-managed subtree.
+// consumers below, not the Slate-managed subtree. The element rides along so
+// card-scoped controls read it here instead of taking it as a prop.
 export function ElementGenerationProvider({
 	element,
 	children,
@@ -23,7 +26,7 @@ export function ElementGenerationProvider({
 }) {
 	const generation = useGenerate(element);
 	return (
-		<ElementGenerationContext value={generation}>
+		<ElementGenerationContext value={{ ...generation, element }}>
 			{children}
 		</ElementGenerationContext>
 	);

--- a/app/components/canvas/elements/ModelBadge.tsx
+++ b/app/components/canvas/elements/ModelBadge.tsx
@@ -3,10 +3,11 @@ import { useConfig } from "@/lib/config/ConfigProvider";
 import { resolveElementConnector } from "@/lib/canvas/elementConnector";
 import { resolveAttributeSchema } from "@/lib/connectors/factory";
 import { reconcileAttributes } from "@/lib/connectors/attributes/reconcile";
-import type { CanvasContentElement } from "@/lib/canvas/types";
 import { AttributeBadge } from "./AttributeBadge";
+import { useElementGeneration } from "./ElementGenerationContext";
 
-export function ModelBadge({ element }: { element: CanvasContentElement }) {
+export function ModelBadge() {
+	const { element } = useElementGeneration();
 	const { connectorConfig } = useConfig();
 	const { type, provider, model, config } = resolveElementConnector(
 		element,

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Trash2 } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { CloseButton } from "@/components/ui/close-button";
@@ -13,15 +13,7 @@ import {
 	MountedDialog,
 } from "@/components/ui/dialog";
 import { useConfig } from "@/lib/config/ConfigProvider";
-import {
-	useGenerationQueue,
-	useQueueSelector,
-} from "@/lib/generation/GenerationQueueProvider";
-import { isNodeStale } from "@/lib/generation/graph";
-import { isGenerationActive } from "@/lib/generation/queue";
-import { forCharacterAvatar } from "@/lib/connectors/image/plugins/characterAvatarNode";
-import { useNodeBuilder } from "@/lib/generation/useNodeBuilder";
-import { characterAvatarElementId } from "@/lib/project/characterAvatar";
+import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
 import { deleteCharacter } from "@/lib/project/deleteCharacter";
 import { useProject } from "@/lib/project/useProject";
 import type { MetadataCharacter } from "@/lib/project/types";
@@ -30,6 +22,7 @@ import { GenerateButton, StaleIndicator } from "../GenerateButton";
 import { MediaPlaceholder, MediaPreview } from "../preview/results";
 import { TextAreaField } from "./fields";
 import { StaleAvatarCloseDialog } from "./StaleAvatarCloseDialog";
+import { useAvatarGeneration } from "./useAvatarGeneration";
 import { VoiceSection } from "./VoiceMetadataFields";
 
 export function CharacterEditModal({
@@ -63,44 +56,22 @@ function CharacterEditDialogBody({
 }) {
 	const { projectId } = useConfig();
 	const queue = useGenerationQueue();
-	const buildNode = useNodeBuilder();
 	const character = useProject((s) => s.metadata.characters[name]);
 	const updateCharacter = useProject((s) => s.updateCharacter);
+	const avatar = useAvatarGeneration(name);
 
 	const [confirmDelete, setConfirmDelete] = useState(false);
 	const [closeConfirm, setCloseConfirm] = useState(false);
-
-	const avatarElementId = characterAvatarElementId(name);
-	const avatarSnapshot = useQueueSelector((q) =>
-		q.getElementSnapshot(avatarElementId),
-	);
-	const avatarUrl = avatarSnapshot.result?.imageUrl;
-	const avatarNode = useMemo(
-		() => buildNode(forCharacterAvatar(name)),
-		[buildNode, name],
-	);
 
 	if (!character) return null;
 
 	const update = (partial: Partial<MetadataCharacter>) =>
 		updateCharacter(name, partial);
 
-	const regenerateAvatar = () => {
-		if (character.avatarUploaded) update({ avatarUploaded: false });
-		queue.enqueueGraph([avatarNode]);
-	};
-
-	const isStale = isNodeStale(avatarNode, queue);
-
-	const generating = isGenerationActive(avatarSnapshot.status);
-	const hasAppearance = Boolean(character.appearance?.trim());
-	const generateDisabled = generating || !hasAppearance;
-	const revertAppearance = avatarSnapshot.resultInputs?.attributes.appearance;
-
-	const requestClose = () => (isStale ? setCloseConfirm(true) : onClose());
+	const requestClose = () => (avatar.stale ? setCloseConfirm(true) : onClose());
 
 	const interceptClose = (e: { preventDefault(): void }) => {
-		if (isStale && !closeConfirm) {
+		if (avatar.stale && !closeConfirm) {
 			e.preventDefault();
 			setCloseConfirm(true);
 		}
@@ -145,55 +116,48 @@ function CharacterEditDialogBody({
 							placeholder="Describe the character's look"
 						/>
 						<div className="flex items-center justify-end gap-2">
-							{isStale && revertAppearance != null && (
+							{avatar.stale && avatar.generatedAppearance != null && (
 								<Button
 									type="button"
 									variant="outline"
 									size="sm"
 									onClick={() =>
-										update({ appearance: String(revertAppearance) })
+										update({ appearance: String(avatar.generatedAppearance) })
 									}
 								>
 									Revert
 								</Button>
 							)}
-							{isStale && <StaleIndicator />}
+							{avatar.stale && <StaleIndicator />}
 							<GenerateButton
-								status={avatarSnapshot.status}
-								hasResult={Boolean(avatarUrl)}
-								disabled={generateDisabled}
-								onGenerate={regenerateAvatar}
+								status={avatar.status}
+								hasResult={Boolean(avatar.url)}
+								disabled={avatar.generating || !character.appearance.trim()}
+								onGenerate={avatar.regenerate}
 							/>
 						</div>
 					</div>
 					<div className="relative">
-						{avatarUrl ? (
+						{avatar.url ? (
 							<MediaPreview
-								key={avatarUrl}
-								url={avatarUrl}
+								key={avatar.url}
+								url={avatar.url}
 								outputKind="image"
-								status={avatarSnapshot.status}
-								seconds={avatarSnapshot.seconds}
-								error={avatarSnapshot.error}
+								status={avatar.status}
+								seconds={avatar.seconds}
+								error={avatar.error}
 							/>
 						) : (
 							<MediaPlaceholder
-								status={avatarSnapshot.status}
-								seconds={avatarSnapshot.seconds}
-								error={avatarSnapshot.error}
-								onDiscard={() => queue.discard(avatarElementId)}
+								status={avatar.status}
+								seconds={avatar.seconds}
+								error={avatar.error}
+								onDiscard={avatar.discard}
 							/>
 						)}
 						<UploadImageButton
 							className="absolute left-2 top-2 z-10 bg-card shadow-sm ring-1 ring-border"
-							onUpload={(url) => {
-								queue.commitResult(
-									avatarNode,
-									{ imageUrl: url, durationSec: 0 },
-									{ pinned: true },
-								);
-								update({ avatarUploaded: true });
-							}}
+							onUpload={avatar.commitUpload}
 						/>
 					</div>
 				</div>
@@ -224,7 +188,7 @@ function CharacterEditDialogBody({
 				characterName={name}
 				onLeaveStale={onClose}
 				onRegenerate={() => {
-					regenerateAvatar();
+					avatar.regenerate();
 					onClose();
 				}}
 			/>

--- a/app/components/canvas/elements/character/useAvatarGeneration.ts
+++ b/app/components/canvas/elements/character/useAvatarGeneration.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+	useGenerationQueue,
+	useQueueSelector,
+} from "@/lib/generation/GenerationQueueProvider";
+import { isNodeStale } from "@/lib/generation/graph";
+import { isGenerationActive } from "@/lib/generation/queue";
+import { useNodeBuilder } from "@/lib/generation/useNodeBuilder";
+import { forCharacterAvatar } from "@/lib/connectors/image/plugins/characterAvatarNode";
+import { characterAvatarElementId } from "@/lib/project/characterAvatar";
+import { useProject } from "@/lib/project/useProject";
+
+/**
+ * One character's avatar node: its live status and the three writes that can
+ * change it. `avatarUploaded` tracks whether the current image came from the
+ * user, so uploading pins the result and regenerating releases the pin.
+ */
+export function useAvatarGeneration(name: string) {
+	const queue = useGenerationQueue();
+	const buildNode = useNodeBuilder();
+	const updateCharacter = useProject((s) => s.updateCharacter);
+	const uploaded = useProject(
+		(s) => s.metadata.characters[name]?.avatarUploaded,
+	);
+
+	const elementId = characterAvatarElementId(name);
+	const snapshot = useQueueSelector((q) => q.getElementSnapshot(elementId));
+	const node = useMemo(
+		() => buildNode(forCharacterAvatar(name)),
+		[buildNode, name],
+	);
+
+	return {
+		url: snapshot.result?.imageUrl,
+		status: snapshot.status,
+		seconds: snapshot.seconds,
+		error: snapshot.error,
+		stale: isNodeStale(node, queue),
+		generating: isGenerationActive(snapshot.status),
+		/** The appearance the current image was generated from, for a revert. */
+		generatedAppearance: snapshot.resultInputs?.attributes.appearance,
+		regenerate: () => {
+			if (uploaded) updateCharacter(name, { avatarUploaded: false });
+			queue.enqueueGraph([node]);
+		},
+		commitUpload: (imageUrl: string) => {
+			queue.commitResult(node, { imageUrl, durationSec: 0 }, { pinned: true });
+			updateCharacter(name, { avatarUploaded: true });
+		},
+		discard: () => queue.discard(elementId),
+	};
+}


### PR DESCRIPTION
Behavior-preserving maintainability pass on the canvas element card and the character edit modal.

## Architecture

**`useAvatarGeneration(name)`** (new, `app/components/canvas/elements/character/`) owns one character avatar's generation node: its live snapshot, staleness, and the three writes that can change it (`regenerate`, `commitUpload`, `discard`). `CharacterEditModal` was hand-rolling that orchestration inline — building the node, reading the queue snapshot, computing staleness, clearing `avatarUploaded` before enqueue, and pinning uploads — a second copy of what `useGenerate` already does for canvas elements. The modal now holds only dialog policy (delete confirm, stale-close intercept) and markup.

**Element card prop drilling.** `ElementGenerationProvider` already receives the element; it now exposes it. `ElementSettings`, `ModelBadge`, `ElementCharacters`, and `AnimateButton` read it from context instead of taking an `element` prop, matching `ElementStaleIndicator` / `ElementUploadButton` / `ElementGenerateButton`, which already did. `AttributeBadge`, `TextAttributePopover`, `CharactersPicker`, and `DeleteButton` keep their explicit `element` prop — they are generic and used outside the card, so the prop is their contract, not drilling.

## Complexity delta

- `CharacterEditModal` body: 5 generation-wiring hooks/derivations removed, ~30 lines of orchestration moved behind one named interface.
- 4 components lose a required prop; `ElementContainer` loses 4 prop passes.
- No new branching; no behavior change (same store writes, same enqueue/pin semantics, no restore-on-stale effect added to the avatar node).

## Skipped

- **Docs.** `README.md` (#502) and `ARCHITECTURE.md` (#485) are both under open PRs, and nothing in this diff changes an interface those files describe. No doc line would have earned its place.
- **`CharacterAssetTiles`'s unused `onRemove` prop.** Reusable surface with no caller today; left for a human call rather than deleted.
- **Unit test for `useAvatarGeneration`.** Would need a client-hook harness (Config + queue + project providers) that does not exist in this repo yet; the underlying graph/queue mechanics are already covered by `lib/generation/__tests__`.

## Open PR overlap check

Considered all 20 open PRs (#507, #504, #503, #502, #501, #500, #499, #498, #497, #496, #495, #494, #493, #488, #487, #486, #485, #484, #481, #438) and diffed each for touched files. No file in this PR appears in any of them. Nearest neighbours: #487 touches `elements/preview/*`, `SceneContainer.tsx`, and `OutputPreview.tsx` (all untouched here) and imports `useElementGeneration` from `AnimatedImagePreview.tsx` — this PR only *adds* a field to that context value, so the existing consumers are source-compatible.

## Validation

`npm run lint`, `format:check`, `typecheck`, `knip`, `build`, and `npm test` (114 files, 994 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)