### PR TITLE
fix: keep the character edit affordance open while the avatar is generating

### DIFF
--- a/app/components/canvas/elements/AssetTile.tsx
+++ b/app/components/canvas/elements/AssetTile.tsx
@@ -89,7 +89,7 @@ export function AssetTile({
 						<Icon className="h-3 w-3" />
 					</div>
 				)}
-				{onEdit && status !== "generating" && (
+				{onEdit && (
 					<OverlayButton
 						icon={Pencil}
 						label={`Edit ${name ?? "asset"}`}


### PR DESCRIPTION
## Summary

The pencil overlay on an `AssetTile` was gated on `status !== "generating"`, and that tile is the only entry point to `CharacterEditModal`. So for the entire duration of an avatar generation you could not open the character's appearance, voice, or name fields — exactly when you most want to fix the typo you just noticed.

The dialog was already built for this case. It subscribes to the avatar snapshot, renders the live status inline, disables only the Generate button (`generateDisabled = generating || !hasAppearance`), and `StaleAvatarCloseDialog` already handles edits that outrun the avatar. The tile was the only thing refusing to open the door.

One-line fix: drop the guard from the edit overlay.

```diff
-{onEdit && status !== "generating" && (
+{onEdit && (
```

**Remove is deliberately left gated.** Deleting a character whose avatar job is mid-flight is a different question — the queue would need to cancel that job — and the issue calls it out as separable.

## Why this issue was safe and small

`#505` is labelled `size: XS` / `good first issue`, names the exact change point, and the receiving dialog is already implemented for the mid-generation case. Single file, single condition.

Checked every `AssetTile` caller, since the guard removal widens when the overlay renders:

| Caller | `onEdit` | `elementId` | Effect |
|---|---|---|---|
| `NarratorAssetTile` | yes | none → always `idle` | unchanged |
| `CharacterAssetTile` | yes | avatar node | the fix; uses `removeAffordance="corner"` |
| `ReferenceAssetTiles` | no | none | unchanged |

No caller combines `onEdit` with an overlay-style remove, so nothing stacks two `inset-0` buttons. The overlay is `opacity-0` at rest, so the shimmer and `GenerationIndicator` still read clearly; it only paints over them on hover/focus, which is when the user is asking for the affordance. Keyboard access comes along for free — it is a real `<button>` with `focus-visible:opacity-100`.

No visual/design-system change, so no `DESIGN.md` deviation.

## Validation

| Check | Result |
|---|---|
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm run knip` | pass |
| `npm run build` | pass |
| `npm run test:run` | pass — 114 files, 994 tests |
| `npm run test:e2e` | **skipped** — port 3000 was already in use by a running dev server |

The Playwright smoke suite covers public routes rather than the canvas, so it is not the check that would catch this either way. CI will run it.

### On test coverage

No unit test added, deliberately. The change is a JSX render guard with no logic seam, and a render test asserting the pencil appears mid-generation is not reachable with the current setup: there is no DOM test environment (no jsdom/happy-dom/testing-library — component tests here use `renderToStaticMarkup`), and `GenerationQueueProvider` intentionally coerces seeded state to `status: "idle"` on construction, so a `"generating"` status cannot exist at first render. Covering it would mean either exporting `GenerationQueueContext` purely for injection or adding a DOM test environment — both larger than the fix, and the first leaks internals for a test's benefit. Flagging rather than forcing it.

## Open PR overlap check

Diffed all 21 open PRs for `AssetTile.tsx` — no hits. The nearest neighbour is #508, which refactors `CharacterEditModal.tsx` internals (extracts a `useAvatarGeneration` hook). Different file, different theme, no conflict.

## Candidates skipped

- **#506** (`size: S`) — depends on landing #480's dependency graph and wants a new aggregate-status graph walker plus an elapsed-time policy decision. Not XS.
- **#424**, **#474**, **#359** — already covered by open PRs #438, #484, #488.
- **#259** (`size: XS`) — explicitly blocked on BYOK (#331).
- Everything else open is `size: M`/`L`/`XL`, or product/design-direction work (#492, #491, #385, #379, #331), which the runbook excludes.

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)