### PR TITLE
refactor: nightly maintainability 2026-08-03

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,7 @@ The prompt goes through the LLM connector to `POST /api/v1/llm`, which streams O
 
 ### 2. Generate
 
-Stale elements are queued client-side (bounded by `DEFAULT_BATCH_SIZE`, results cached by inputs) and submitted to `POST /api/v1/{asset}`, which records a `jobs` row and enqueues to the Vercel Queue. Workers call the provider, upload results to Vercel Blob, and mark the job complete. The client polls until the asset URL arrives and the preview updates. Music and sfx check a Pinecone similarity cache first.
+Generate resolves the element into a dependency graph (see [Generation graph](#generation-graph)) and queues the stale nodes client-side, dependencies first, `DEFAULT_BATCH_SIZE` at a time. Each job is submitted to `POST /api/v1/{asset}`, which records a `jobs` row and enqueues to the Vercel Queue. Workers call the provider, upload results to Vercel Blob, and mark the job complete. The client polls until the asset URL arrives and the preview updates. Music and sfx check a Pinecone similarity cache first.
 
 ### 3. Save / restore
 
@@ -36,9 +36,23 @@ The generation pipeline is split so providers and asset types can be swapped ind
 
 Every route that takes request data is built from a factory in `lib/api/route-handler.ts` that handles auth, parsing, model validation, and error mapping. One `routeHandler(authTier, parseSource)` builder produces them all, so the factories vary only along those two axes: `createApiRouteHandler` (api-access, JSON body), `createSessionRouteHandler` (session, JSON body), `createApiQueryRouteHandler` (api-access, search params), `createSessionFormRouteHandler` (session, multipart form), `createPublicRouteHandler` (no auth, JSON body), and `createPublicQueryRouteHandler` (no auth, search params). Every handler receives the parsed, validated payload as `input`, whatever the source. Two routes fall outside that shape: `api/queues/asset-generate` is a `@vercel/queue` callback and `auth/callback` is an OAuth redirect. Reusable Zod field schemas live in `lib/api/request-schema-fields.ts`. If a provider's API key isn't set, the route falls back to a mock provider.
 
+## Generation graph
+
+A generation is a small dependency graph, not a lone job. `lib/generation/graph.ts` defines it:
+
+- A **node** is one unit of generation, keyed by element id, holding `inputs` (the authored prompt plus non-layout attributes) and `dependsOn` edges.
+- A **source node** stands for project state that is read rather than generated: art style, reference images, aspect ratio, a character's voice (`sourceNodes.ts`). It has no job, and its identity is its own inputs.
+- Edges come from the plugin chain. A connector plugin declares `dependencies(element)`, so one declaration drives what a job reads, what it waits for, and what makes it stale.
+
+`resolveGraph.ts` turns a `NodeSpec` such as `forElement(element)` into the built node and everything under it, resolving each element's connector and deduping nodes shared within the call. `useNodeBuilder` supplies the connector registry and a project-state snapshot, and rebuilds on any store write.
+
+Staleness falls out of the graph: a node needs generating when it has no result, when a dependency does, or when its current inputs differ from the inputs its result was made from. One element (`useGenerate`) and Generate All (`useGenerateAll`) run the same check. A result the user supplied is `pinned` and never regenerated.
+
+`queue.ts` runs the graph. It flattens roots dependencies-first, skips nodes that are already fresh, and owns per-element status, elapsed time, abort controllers, and a result history keyed by serialized inputs, so undoing an edit restores the earlier result instead of regenerating it.
+
 ## Editor state
 
-- `lib/generation/queue.ts` schedules generation jobs from the editor, caches results per element, and exposes status to the UI. UI dispatches jobs; it never calls connectors directly.
+- `lib/generation/` decides what to generate and runs it, as above. The UI dispatches nodes; it never calls connectors directly.
 - `lib/project/store.ts` holds per-project metadata in Zustand. Every mutation rule lives in a store action. Components subscribe to reactive state through `useProject(selector)`; `getProjectStore(projectId)` is the escape hatch for imperative access that a render-time selector can't express — non-React callers (connector plugins, queue workers), plus hooks doing one-shot init, `.subscribe`, or reads outside render (`ProjectEditor`, `useAutosave`, `useGenerateAll`).
 - `lib/canvas/elementConnector.ts` answers "which connector, provider and model does this element use?" for both the UI and the queue. An element pins its provider when created, so this is also where a pin that no longer resolves falls back to the registry default.
 - `lib/script/` provides script context and refinement utilities.

--- a/app/components/canvas/dnd/SortableContent.tsx
+++ b/app/components/canvas/dnd/SortableContent.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useMemo } from "react";
-import { Node, Path } from "slate";
+import { Path } from "slate";
 import { RenderElementProps, ReactEditor, useSlateStatic } from "slate-react";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import type {
 	CanvasContentElement,
 	CanvasElementType,
-	SceneElement,
 } from "@/lib/canvas/types";
+import { parentSceneId } from "@/lib/canvas/scenes";
 import { ELEMENT_LIST } from "@/lib/canvas/elementConfigs";
 import { insertElement } from "@/lib/canvas/insertElement";
 import { useViewMode } from "../ViewModeContext";
@@ -39,7 +39,7 @@ export function SortableContent({
 	const { isCollapsed } = useViewMode();
 
 	const path = ReactEditor.findPath(editor, element);
-	const sceneId = (Node.parent(editor, path) as SceneElement).id;
+	const sceneId = parentSceneId(editor, path);
 	const collapsed = isCollapsed(sceneId);
 
 	const insertGap =

--- a/lib/canvas/__tests__/scenes.test.ts
+++ b/lib/canvas/__tests__/scenes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { createEditor, type Editor } from "slate";
 import type { CanvasElement, SceneElement } from "../types";
-import { sceneIndexOf } from "../scenes";
+import { parentSceneId, sceneIndexOf } from "../scenes";
 
 const scene = (id: string): SceneElement => ({
 	id,
@@ -33,5 +34,29 @@ describe("sceneIndexOf", () => {
 		const nodes = [text("t1"), scene("a"), text("t2"), scene("b")];
 		expect(sceneIndexOf(nodes, "a")).toBe(1);
 		expect(sceneIndexOf(nodes, "b")).toBe(2);
+	});
+});
+
+describe("parentSceneId", () => {
+	const editorWith = (children: CanvasElement[]): Editor => {
+		const editor = createEditor();
+		editor.children = children;
+		return editor;
+	};
+
+	it("returns the id of the scene holding the node", () => {
+		const editor = editorWith([
+			scene("s1"),
+			{
+				...scene("s2"),
+				children: [{ id: "n1", type: "narration" as const, children: [] }],
+			},
+		]);
+		expect(parentSceneId(editor, [1, 0])).toBe("s2");
+	});
+
+	it("throws when the parent is not a scene", () => {
+		const editor = editorWith([scene("s1")]);
+		expect(() => parentSceneId(editor, [0])).toThrow(/not inside a scene/);
 	});
 });

--- a/lib/canvas/scenes.ts
+++ b/lib/canvas/scenes.ts
@@ -1,4 +1,4 @@
-import { Element, type Descendant } from "slate";
+import { Element, Node, type Descendant, type Editor, type Path } from "slate";
 import {
 	type CanvasContentElement,
 	type SceneElement,
@@ -7,6 +7,14 @@ import {
 
 export const isSceneElement = (n: unknown): n is SceneElement =>
 	Element.isElement(n) && n.type === SCENE_TYPE;
+
+/** The scene holding the node at `path`. `withScenes` guarantees content has one. */
+export function parentSceneId(editor: Editor, path: Path): string {
+	const parent = Node.parent(editor, path);
+	if (!isSceneElement(parent))
+		throw new Error(`Node at [${path}] is not inside a scene`);
+	return parent.id;
+}
 
 export const getContentElements = (
 	nodes: Descendant[],


### PR DESCRIPTION
## What

Two non-overlapping maintainability items. No behavior change.

### 1. Document the generation dependency graph (`ARCHITECTURE.md`)

PR #480 turned generation from "one element, one job" into a dependency graph (`lib/generation/graph.ts`, `resolveGraph.ts`, `sourceNodes.ts`, `useNodeBuilder.ts`), but `ARCHITECTURE.md` still described `queue.ts` scheduling lone jobs. The graph is now the central abstraction of the generation path and it was the one core module with no 10k-foot explanation.

Adds a `## Generation graph` section covering nodes, source nodes, where edges come from (a plugin's `dependencies(element)` declaration), how `resolveGraph` builds a node and its subtree, how staleness falls out of the graph, and what `queue.ts` is left owning. Flow 2 and the `Editor state` bullet now point at it instead of restating a stale summary.

### 2. `parentSceneId` helper replaces an unchecked cast

`app/components/canvas/dnd/SortableContent.tsx` did `(Node.parent(editor, path) as SceneElement).id` — an unguarded cast that would silently yield `undefined` if the invariant ever broke. New `parentSceneId(editor, path)` in `lib/canvas/scenes.ts` type-guards the parent and throws on violation, giving the knowledge one home in the domain layer. Covered by tests.

## Complexity delta

- `ARCHITECTURE.md`: +1 section, 2 stale passages corrected.
- 1 unsafe `as` cast removed; 1 unused type import dropped from `SortableContent.tsx`.
- 2 new tests on `lib/canvas/scenes.ts`.

## Validation

`lint`, `format:check`, `knip`, `build` clean. `1023/1023` tests pass.

`typecheck` reports one failure in `lib/project/__tests__/autosave.test.ts` (`ElementSnapshot.pinned` missing). It is pre-existing on `master`, untouched by this diff, and already covered by open PR #511.

## Open PR overlap check

Considered all 18 open PRs (#511, #509, #508, #507, #504, #503, #502, #501, #500, #499, #498, #497, #496, #495, #494, #493, #488, #487) and their file lists. None touches `ARCHITECTURE.md`, `lib/canvas/scenes.ts`, `lib/canvas/__tests__/scenes.test.ts`, or `app/components/canvas/dnd/*`. Non-overlapping.

## Skipped, with reasons

- **`graph.ts` ↔ `queue.ts` type cycle** and the `GenerationNode.buildJob` nullable that `requireJob` has to throw on. Both fixes require editing `lib/generation/queue.ts`, which is under open PR #507.
- **Second site of the parent-scene cast** (`elements/ElementContainer.tsx:168`). Same one-line change, but the file is under open PR #508. Worth folding in once that lands.
- **`AttributeBadge` / `TextAttributePopover` label divergence.** The text-edit path re-implements label rendering and ignores `spec.icon` and `spec.unit`, so an icon-or-unit attribute renders differently when it is editable. A real inconsistency, but unifying it changes what renders, and this pass is behavior-preserving. Wants a human call.
- **`lib/api/with-auth.ts` returning `stringifyError` to clients**, **`lib/supabase/env.ts` empty-string env defaults**, **`Waveform` silent peaks-decode failure**. All behavior/API-contract changes.
- **`clearProjectStore` has no production callers** and `lib/api/sse.ts` `createSSEResponse` has none either. Left in place per the "unused is not dead" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)