### PR TITLE
perf: nightly performance optimizations 2026-08-03

### DIFF
--- a/app/components/canvas/dnd/useDragAndDrop.ts
+++ b/app/components/canvas/dnd/useDragAndDrop.ts
@@ -21,9 +21,17 @@ export function useDragAndDrop(editor: Editor, value: Descendant[]) {
 
 	const sensors = useSensors(useSensor(PointerSensor), useSensor(TouchSensor));
 
+	// Every keystroke hands Slate's editor a fresh `value`, and dnd-kit rebuilds
+	// its sortable context whenever `items` changes identity, re-rendering every
+	// card in the document. Keying on the ids themselves holds the list steady
+	// until scenes are actually added, removed or reordered.
+	const sceneIdKey = value
+		.filter(isSceneElement)
+		.map((s) => s.id)
+		.join("\n");
 	const sceneItems = useMemo<string[]>(
-		() => value.filter(isSceneElement).map((s) => s.id),
-		[value],
+		() => (sceneIdKey === "" ? [] : sceneIdKey.split("\n")),
+		[sceneIdKey],
 	);
 
 	const handleDragStart = useCallback((event: DragStartEvent) => {


### PR DESCRIPTION
## What

Typing anywhere in the canvas re-rendered **every** element card in the document. This makes the editor re-render only the element being edited.

`Canvas` feeds `useDragAndDrop` Slate's `value`, and every document change produces a fresh `value` array. The scene id list derived from it was memoized on `[value]`, so it changed identity on every keystroke.

dnd-kit keys its sortable context value on that array (`@dnd-kit/sortable` v10, `SortableContext`: `items` is a dep of the `contextValue` memo, and `sortedRects` is rebuilt with it). A new context value re-renders every `useSortable` consumer — which here is every `SortableItem`, i.e. every scene *and* every content card, pulling in the card chrome underneath it: settings popover, attribute badges, character pills, generate/animate/upload buttons. Only `OutputPreview` is memoized, so the rest of each card was rebuilt per keystroke. Cost scales with script length, which is exactly backwards.

Keying the memo on the joined ids holds the list steady until scenes are actually added, removed or reordered. dnd-kit already compares `items` by value internally (`itemsEqual`), so drag, reorder and measurement behaviour is unchanged.

This is the non-memoized-context-value anti-pattern called out in the [Slate performance walkthrough](https://docs.slatejs.org/walkthroughs/09-performance) — unmodified elements re-rendering because they subscribe to a context whose value churns.

## Validation

- `npm run build` ✅
- `npm test -- --run` ✅ 117 files, 1021 tests
- `npm run lint`, `prettier --check` ✅

Note: `npm run typecheck` reports a pre-existing failure in `lib/project/__tests__/autosave.test.ts` (`pinned` missing from an `ElementSnapshot` fixture) that is already on `master` and covered by #511. Untouched here.

## Open PR overlap check

Considered open PRs #487, #488, #493–#504, #507–#509, #511, #512. This PR touches one file, `app/components/canvas/dnd/useDragAndDrop.ts`, which appears in none of them. Adjacent-but-separate: #512 touches `SortableContent.tsx`/`scenes.ts` (a `parentSceneId` helper), #502 touches `Canvas.tsx`. Neither overlaps this change.

## Skipped

- `findElementById`/`findNodeById` do a full-document `Editor.nodes` walk (text nodes included) per call — hot during drag-over and script streaming. Deliberately left alone: `lib/canvas/editorOps.ts` is already open in #511.
- Remotion `Captions`/`MotionLayer`/`motionTransform`: already binary-searched and memoized, no material win found.
- Canvas contexts (`ViewMode`, `PreviewCache`, `ActiveScene`) already memoize their values correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)