### PR TITLE
fix: show an animated image as generating while its still frame runs

### DIFF
--- a/app/components/canvas/hooks/useGenerate.ts
+++ b/app/components/canvas/hooks/useGenerate.ts
@@ -3,7 +3,12 @@ import {
 	useGenerationQueue,
 	useQueueSelector,
 } from "@/lib/generation/GenerationQueueProvider";
-import { forElement, isNodeStale, nodeInputs } from "@/lib/generation/graph";
+import {
+	forElement,
+	isNodeStale,
+	nodeInputs,
+	nodeProgress,
+} from "@/lib/generation/graph";
 import { useNodeBuilder } from "@/lib/generation/useNodeBuilder";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 
@@ -16,6 +21,7 @@ export function useGenerate(element: CanvasContentElement) {
 		[buildNode, element],
 	);
 	const stale = useQueueSelector((q) => isNodeStale(node, q));
+	const progress = useQueueSelector((q) => nodeProgress(node, q));
 
 	useEffect(() => {
 		if (!stale) return;
@@ -36,8 +42,8 @@ export function useGenerate(element: CanvasContentElement) {
 
 	return {
 		node,
-		status: snapshot.status,
-		seconds: snapshot.seconds,
+		status: progress.status,
+		seconds: progress.seconds,
 		result: snapshot.result,
 		error: snapshot.error,
 		stale,

--- a/lib/generation/__tests__/graph.test.ts
+++ b/lib/generation/__tests__/graph.test.ts
@@ -1,15 +1,20 @@
 import { MetadataSchema } from "@/lib/project/types";
-import { describe, expect, it } from "vitest";
-import type { ConnectorConfig } from "@/lib/connectors/types";
+import { describe, expect, it, vi } from "vitest";
+import type { AssetResult, ConnectorConfig } from "@/lib/connectors/types";
 import {
 	flattenGraph,
 	isNodeStale,
 	needsGeneration,
 	nodeInputs,
+	nodeProgress,
 	sourceNode,
 	type GenerationNode,
 } from "../graph";
 import { GenerationQueue, type GenerationJob } from "../queue";
+
+vi.mock("../generateForElement", () => ({
+	generateForElement: () => new Promise<AssetResult>(() => {}),
+}));
 
 const EMPTY_STATE = {
 	hydrated: true,
@@ -146,6 +151,42 @@ describe("isNodeStale", () => {
 		expect(isNodeStale(sourceNode("project:refs", { urls: "a" }), queue)).toBe(
 			false,
 		);
+	});
+});
+
+describe("nodeProgress", () => {
+	// An animated image is a still node feeding an animation node: the animation
+	// stays queued for the whole time the still is generating.
+	const stillGraph = () => {
+		const still = node("~still:animation");
+		return { still, animation: node("animation", [still]) };
+	};
+
+	it("reports a dependency's generation as the dependent's own", () => {
+		const queue = new GenerationQueue({ batchSize: 1 });
+		const { still, animation } = stillGraph();
+		queue.enqueueGraph([animation]);
+
+		expect(queue.getElementSnapshot(still.id).status).toBe("generating");
+		expect(queue.getElementSnapshot(animation.id).status).toBe("queued");
+		expect(nodeProgress(animation, queue).status).toBe("generating");
+	});
+
+	it("stays queued while nothing in the subtree is running", () => {
+		const queue = new GenerationQueue({ batchSize: 1 });
+		const { animation } = stillGraph();
+		const image = node("image");
+		queue.enqueueGraph([animation, image]);
+
+		expect(nodeProgress(image, queue).status).toBe("queued");
+	});
+
+	it("leaves a single-node element on its own snapshot", () => {
+		const queue = new GenerationQueue({ batchSize: 1 });
+		const image = node("image");
+		queue.enqueueGraph([image]);
+
+		expect(nodeProgress(image, queue)).toBe(queue.getElementSnapshot(image.id));
 	});
 });
 

--- a/lib/generation/graph.ts
+++ b/lib/generation/graph.ts
@@ -9,7 +9,7 @@ import {
 	type GenerationInputs,
 	type NodeInputs,
 } from "./inputs";
-import type { GenerationJob, GenerationQueue } from "./queue";
+import type { ElementSnapshot, GenerationJob, GenerationQueue } from "./queue";
 
 export type NodeId = string;
 
@@ -137,4 +137,21 @@ export function flattenGraph(roots: GenerationNode[]): GenerationNode[] {
 	};
 	for (const root of roots) visit(root);
 	return ordered;
+}
+
+/**
+ * The snapshot of the work `node` owns. A dependency running on its behalf is
+ * the node's own progress, so a card whose element expands into several nodes
+ * never reads as queued while its subtree is already generating.
+ */
+export function nodeProgress(
+	node: GenerationNode,
+	results: NodeResults,
+): ElementSnapshot {
+	const own = results.getElementSnapshot(node.id);
+	if (node.dependsOn.length === 0) return own;
+	const subtree = flattenGraph([node])
+		.filter((dep) => !isSourceNode(dep))
+		.map((dep) => results.getElementSnapshot(dep.id));
+	return subtree.find((snap) => snap.status === "generating") ?? own;
 }


### PR DESCRIPTION
## Summary

An `animated_image` is two nodes under the dependency graph: a still-image node feeding the animation node. `enqueueGraph` queues both, then runs the still first; the animation stays `"queued"` until the still settles. The card only ever read the animation's snapshot, so the element that does the most work was the one that looked idle — pulsing hourglass and "Queued…" for the larger share of the wall time, with no elapsed counter.

`nodeProgress(node, results)` joins the other graph walkers in `lib/generation/graph.ts`: it returns the snapshot of whichever node in the subtree is generating, falling back to the node's own. `useGenerate` reports that instead of the raw element snapshot, so `GenerationIndicator`, the shimmer, and the disabled state all inherit the fix through `ElementGenerationProvider` with no change of their own.

Nothing in the UI learns that animated images are two jobs, and any element that grows a derived node later gets an honest status for free.

## Selected issue and why it was safe

#506 — size S, priority medium bug, with the change point named in the issue (`useGenerate.ts:13`) and a suggested direction that solves the class rather than special-casing `animated_image`. Three files, one new pure function, no queue-mechanics change.

## Behavior

- Animated image reads "Generating Ns" while its still frame runs.
- Still reads "Queued…" when genuinely waiting on a batch slot with nothing of its own running (covered by a test).
- Single-node elements are byte-identical: a node with no dependencies short-circuits to its own snapshot.
- Result, error, staleness and every write path are untouched — only the reported status and elapsed seconds change.

## Deliberately not done

The elapsed counter still restarts at the still → animation boundary. `queue.commit` zeroes `seconds` when a node settles, so accumulating across the subtree needs a queue-side change, and `lib/generation/queue.ts` is under open PR #507. The issue permits either option ("the simpler of the two is fine"), so this takes the one that shows the elapsed time of whichever node is running. The counter now runs during the still instead of not running at all.

## Validation

- `npx vitest run lib/generation/` — 6 files, 90 tests pass (3 new `nodeProgress` cases at the graph/queue seam)
- `npm test` — 117 files, 1024 tests pass
- `npm run lint`, `npm run format:check`, `npm run knip`, `npm run build` — all pass
- `npm run typecheck` — one **pre-existing** failure on `master`, unrelated to this diff: `lib/project/__tests__/autosave.test.ts(22,63)` is missing `pinned` on an `ElementSnapshot` fixture. That file is untouched here and is already being fixed by open PR #511.

## Open PR overlap check

Diffed all 20 open PRs by file. This PR touches `lib/generation/graph.ts`, `lib/generation/__tests__/graph.test.ts`, and `app/components/canvas/hooks/useGenerate.ts` — none appear in any of them. Nearest neighbours, both avoided: #507 (`lib/generation/queue.ts` + its two tests, including hunks inside `commit`) and #508 (`ElementGenerationContext.tsx` and the element card, which only consume `useGenerate`'s return value).

## Issues skipped this run

- #489 (frame-vs-seconds scene skip) — well scoped, but its three named files are each under an open PR: `BottomTransportBar.tsx` (#495), `SegmentedSeekBar.tsx` (#499), `useSceneSegments.ts` + `scene-builder.ts` (#487).
- #505 — already implemented by open PR #509.
- #259 — blocked on BYOK (#331).
- Everything else open is size M+ or product/design direction (#490, #492, #461, #451, #385, …).

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)