### PR TITLE
perf: nightly performance optimizations 2026-08-04

### DIFF
--- a/app/components/PostPromptView.tsx
+++ b/app/components/PostPromptView.tsx
@@ -2,7 +2,7 @@
 
 import UserProfile from "./UserProfile";
 import { EditorToolbar } from "./EditorToolbar";
-import Canvas from "./canvas/Canvas";
+import { CanvasSession } from "./canvas/CanvasSession";
 import { CanvasProviders } from "./canvas/CanvasProviders";
 import { EditorSidebar } from "./canvas/panel/EditorSidebar";
 import { ProjectTitle } from "./canvas/ProjectTitle";
@@ -15,7 +15,7 @@ import {
 } from "./video/PlayerPositionContext";
 
 function PostPromptViewInner() {
-	const { editor, value, setValue, layoutKey } = useEditorSession();
+	const { editor, layoutKey } = useEditorSession();
 	const { position, visible } = usePlayerPosition();
 	const isTop = position === "top";
 
@@ -42,7 +42,7 @@ function PostPromptViewInner() {
 								>
 									<div className="mx-auto max-w-6xl px-4 py-4">
 										<ProjectTitle />
-										<Canvas editor={editor} value={value} setValue={setValue} />
+										<CanvasSession editor={editor} />
 									</div>
 								</div>
 

--- a/app/components/canvas/CanvasSession.tsx
+++ b/app/components/canvas/CanvasSession.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState } from "react";
+import type { Descendant, Editor } from "slate";
+import { useConfig } from "@/lib/config/ConfigProvider";
+import Canvas from "./Canvas";
+import { useAutosave } from "./hooks/useAutosave";
+
+const initialValue: Descendant[] = [];
+
+/**
+ * Owns the document snapshot the canvas renders from, and the autosave that
+ * follows it. Holding it here rather than in the editor view keeps a keystroke
+ * inside the canvas: the toolbar, sidebar, player and transport bar all render
+ * off the layout key, which text edits never change.
+ */
+export function CanvasSession({ editor }: { editor: Editor }) {
+	const { projectId } = useConfig();
+	const [value, setValue] = useState<Descendant[]>(initialValue);
+
+	useAutosave(projectId, value);
+
+	return <Canvas editor={editor} value={value} setValue={setValue} />;
+}

--- a/app/components/canvas/__tests__/withDocumentSignal.test.ts
+++ b/app/components/canvas/__tests__/withDocumentSignal.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { createEditor, Transforms } from "slate";
+import type { CanvasEditor } from "@/lib/canvas/types";
+import { withDocumentSignal } from "../plugins/withDocumentSignal";
+
+const SCENE = {
+	id: "scene-1",
+	type: "scene" as const,
+	children: [
+		{
+			id: "el-1",
+			type: "image" as const,
+			children: [{ id: "text-1", type: "image" as const, text: "a" }],
+		},
+	],
+};
+
+function editorWithScene() {
+	const editor = withDocumentSignal(createEditor() as CanvasEditor);
+	Transforms.insertNodes(editor, SCENE, { at: [0] });
+	editor.onChange();
+	return editor;
+}
+
+describe("withDocumentSignal", () => {
+	it("notifies subscribers when the document changes", () => {
+		const editor = editorWithScene();
+		const listener = vi.fn();
+		editor.subscribeToDocument(listener);
+
+		Transforms.insertText(editor, "b", { at: { path: [0, 0, 0], offset: 1 } });
+		editor.onChange();
+
+		expect(listener).toHaveBeenCalledTimes(1);
+	});
+
+	it("stays quiet when only the selection moves", () => {
+		const editor = editorWithScene();
+		const listener = vi.fn();
+		editor.subscribeToDocument(listener);
+
+		Transforms.select(editor, { path: [0, 0, 0], offset: 0 });
+		editor.onChange();
+
+		expect(listener).not.toHaveBeenCalled();
+	});
+
+	it("stops notifying once unsubscribed", () => {
+		const editor = editorWithScene();
+		const listener = vi.fn();
+		const unsubscribe = editor.subscribeToDocument(listener);
+		unsubscribe();
+
+		Transforms.insertText(editor, "b", { at: { path: [0, 0, 0], offset: 1 } });
+		editor.onChange();
+
+		expect(listener).not.toHaveBeenCalled();
+	});
+
+	it("keeps the wrapped onChange running", () => {
+		const editor = createEditor() as CanvasEditor;
+		const onChange = vi.fn();
+		editor.onChange = onChange;
+
+		withDocumentSignal(editor).onChange();
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+	});
+});

--- a/app/components/canvas/hooks/useEditorSession.ts
+++ b/app/components/canvas/hooks/useEditorSession.ts
@@ -1,42 +1,28 @@
-import { useMemo } from "react";
-import type { Descendant, Editor } from "slate";
-import { getContentElements } from "@/lib/canvas/scenes";
-import { useConfig } from "@/lib/config/ConfigProvider";
 import { useScriptInitial } from "@/lib/script/ScriptProvider";
-import { getLayoutKey } from "@/lib/video/layoutKey";
-import { useTransitionType } from "@/lib/video/useTransitionType";
-import { useAutosave } from "./useAutosave";
+import type { SignallingEditor } from "../plugins/withDocumentSignal";
 import { useEditorSetup } from "./useEditorSetup";
+import { useLayoutKey } from "./useLayoutKey";
 import { useMetadataSync } from "./useMetadataSync";
 import { useProjectRehydrate } from "./useProjectRehydrate";
 import { useScriptSync } from "./useScriptSync";
 
 interface EditorSession {
-	editor: Editor;
-	value: Descendant[];
-	setValue: (value: Descendant[]) => void;
+	editor: SignallingEditor;
 	layoutKey: string;
 }
 
 /**
  * Owns every wire between the Slate editor and the project: initial hydration,
- * streaming script sync, metadata sync, and autosave. Views render the editor;
- * they don't assemble it.
+ * streaming script sync, and metadata sync. Views render the editor; they don't
+ * assemble it. The document stays in the editor, so the only thing derived from
+ * it that crosses back into the view is the layout key.
  */
 export function useEditorSession(): EditorSession {
-	const { editor, value, setValue } = useEditorSetup();
-	const { projectId } = useConfig();
+	const editor = useEditorSetup();
 
 	useProjectRehydrate(editor, useScriptInitial());
-	useAutosave(projectId, value);
 	useScriptSync(editor);
 	useMetadataSync();
 
-	const transitionType = useTransitionType();
-	const layoutKey = useMemo(
-		() => getLayoutKey(getContentElements(value), transitionType),
-		[value, transitionType],
-	);
-
-	return { editor, value, setValue, layoutKey };
+	return { editor, layoutKey: useLayoutKey(editor) };
 }

--- a/app/components/canvas/hooks/useEditorSetup.ts
+++ b/app/components/canvas/hooks/useEditorSetup.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { createEditor, Descendant } from "slate";
+import { createEditor } from "slate";
 import { withReact } from "slate-react";
 import { withHistory } from "slate-history";
 import flow from "lodash/flow";
@@ -8,10 +8,12 @@ import { withNodeId } from "../plugins/withNodeId";
 import { withLayout } from "../plugins/withLayout";
 import { withScenes } from "../plugins/withScenes";
 import { withFlatPaste } from "../plugins/withFlatPaste";
+import {
+	withDocumentSignal,
+	type SignallingEditor,
+} from "../plugins/withDocumentSignal";
 
-const initialValue: Descendant[] = [];
-
-export function useEditorSetup() {
+export function useEditorSetup(): SignallingEditor {
 	const { connectorConfig } = useConfig();
 
 	const [editor] = useState(() =>
@@ -22,10 +24,9 @@ export function useEditorSetup() {
 			withScenes,
 			withFlatPaste,
 			withNodeId,
+			withDocumentSignal,
 		)(createEditor()),
 	);
 
-	const [value, setValue] = useState<Descendant[]>(initialValue);
-
-	return { editor, value, setValue };
+	return editor;
 }

--- a/app/components/canvas/hooks/useLayoutKey.ts
+++ b/app/components/canvas/hooks/useLayoutKey.ts
@@ -1,0 +1,19 @@
+import { useCallback, useSyncExternalStore } from "react";
+import { getContentElements } from "@/lib/canvas/scenes";
+import { getLayoutKey } from "@/lib/video/layoutKey";
+import { useTransitionType } from "@/lib/video/useTransitionType";
+import type { SignallingEditor } from "../plugins/withDocumentSignal";
+
+/**
+ * The layout key for the live document. Reading it through a subscription keeps
+ * the editor view out of the typing path: edits that cannot change the key —
+ * every text edit — resolve to the same string and re-render nothing.
+ */
+export function useLayoutKey(editor: SignallingEditor): string {
+	const transitionType = useTransitionType();
+	const read = useCallback(
+		() => getLayoutKey(getContentElements(editor.children), transitionType),
+		[editor, transitionType],
+	);
+	return useSyncExternalStore(editor.subscribeToDocument, read, read);
+}

--- a/app/components/canvas/plugins/withDocumentSignal.ts
+++ b/app/components/canvas/plugins/withDocumentSignal.ts
@@ -1,0 +1,36 @@
+import type { CanvasEditor } from "@/lib/canvas/types";
+
+export type DocumentSignal = {
+	/** Notifies on every change that replaces the document; returns an unsubscribe. */
+	subscribeToDocument: (listener: () => void) => () => void;
+};
+
+export type SignallingEditor = CanvasEditor & DocumentSignal;
+
+/**
+ * Lets code outside `<Slate>` derive values from the document without holding a
+ * copy of it in React state. Slate rebuilds `children` for every document
+ * operation and leaves it alone for selection moves, so identity is the signal.
+ */
+export const withDocumentSignal = (editor: CanvasEditor): SignallingEditor => {
+	const { onChange } = editor;
+	const listeners = new Set<() => void>();
+	const signalling = editor as SignallingEditor;
+	let document = editor.children;
+
+	signalling.subscribeToDocument = (listener) => {
+		listeners.add(listener);
+		return () => {
+			listeners.delete(listener);
+		};
+	};
+
+	signalling.onChange = (options) => {
+		onChange(options);
+		if (signalling.children === document) return;
+		document = signalling.children;
+		for (const listener of listeners) listener();
+	};
+
+	return signalling;
+};


### PR DESCRIPTION
## What

Typing one character used to re-render the entire editor view.

`useEditorSession` held the Slate document in React state at the top of `PostPromptView`. Slate fires `onChange` for every operation, `setValue` swapped in the new `editor.children`, and everything under that component re-rendered: the seven providers in `CanvasProviders`, `EditorToolbar`, `EditorSidebar`, the Remotion `PlayerPanel` with its scrub bar and one seek segment per scene, `BottomTransportBar`, and `ProjectTitle`. The cost scaled with scene count, on the most latency-sensitive interaction in the app. `EditorToolbar` and `EditorSidebar` already carried `memo` to blunt it, which treated the symptom at two leaves and left the rest.

The only thing the view actually needs from the document is `layoutKey` — a string over element ids, types and the four layout-affecting attributes. Text edits never change it.

So the document stays in the editor:

- `withDocumentSignal` (new Slate plugin) exposes `subscribeToDocument`. Slate rebuilds `editor.children` for every document operation and leaves it alone for selection moves, so array identity is the signal.
- `useLayoutKey` reads the key through that subscription with `useSyncExternalStore`. Same string in, no re-render — this is the walkthrough's "subscribe to a derived value, not to the editor" guidance applied above `<Slate>`, where `useSlateSelector` can't reach.
- `CanvasSession` (new) owns the document snapshot and the autosave that follows it, next to the `Canvas` that renders from them.

A keystroke now re-renders `CanvasSession` and the Slate subtree. Adding, removing, reordering or re-typing an element still re-renders the view, because at that point the layout genuinely changed.

No behavior change. Autosave, rehydration, script sync and metadata sync all fire in the same order as before.

## Skipped

- The `memo` on `EditorToolbar` / `EditorSidebar` is now redundant. Left alone: `EditorToolbar.tsx` is open in #498, and removing a guard is not worth the conflict.
- `useNodeBuilder` subscribes to the whole project store, so any store write rebuilds every element's generation node. Real, but it lands on `useGenerate.ts` / `graph.ts`, both open in #514.
- Remotion's composition, `MotionLayer` and `Captions` are already tight — memoized nodes, per-frame subscriptions scoped to the component that needs the frame, binary-searched caption lookup. Nothing worth changing.

## Open PR overlap check

Considered #493, #495, #496, #497, #498, #499, #500, #501, #502, #503, #504, #507, #508, #509, #511, #512, #513, #514 and diffed each one's files.

Non-overlapping. The video components (#495, #499, #503), `Canvas.tsx` (#502), `useDragAndDrop.ts` (#513), the element cards (#508, #509), the canvas hooks `useScriptSync` / `useMetadataSync` / `useGenerate` (#500, #514) and the generation queue (#507, #511) are all untouched here. #513 is the closest in theme — it steadies dnd-kit's sortable items against the same per-keystroke `value` churn, one layer below this. The two compose; neither file is shared.

## Checks

`npm run lint`, `format:check`, `typecheck`, `build`, `test:run` (1030 passed) all green. `knip` flags `lib/connectors/tts/voiceDescriptor.ts`, which belongs to another branch's uncommitted work in the shared tree, not to this change.