### PR TITLE
perf: nightly performance optimizations 2026-08-06

### DIFF
--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -9,8 +9,7 @@ export default async function ProjectPage({
 }) {
 	const { id } = await params;
 	const supabase = await createClient();
-	// Both calls are round trips to Supabase and neither needs the other's
-	// result: row access is enforced by RLS, not by the user read.
+	// Safe to run concurrently: row access is enforced by RLS, not by this user read.
 	const [
 		{
 			data: { user },

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -9,17 +9,23 @@ export default async function ProjectPage({
 }) {
 	const { id } = await params;
 	const supabase = await createClient();
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
+	// Both calls are round trips to Supabase and neither needs the other's
+	// result: row access is enforced by RLS, not by the user read.
+	const [
+		{
+			data: { user },
+		},
+		{ data: project, error },
+	] = await Promise.all([
+		supabase.auth.getUser(),
+		supabase
+			.from("projects")
+			.select("id, script, store, generation")
+			.eq("id", id)
+			.maybeSingle(),
+	]);
+
 	if (!user) redirect("/");
-
-	const { data: project, error } = await supabase
-		.from("projects")
-		.select("id, script, store, generation")
-		.eq("id", id)
-		.maybeSingle();
-
 	if (error) throw error;
 	if (!project) notFound();
 

--- a/lib/supabase/__tests__/proxy-matcher.test.ts
+++ b/lib/supabase/__tests__/proxy-matcher.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { config } from "@/proxy";
+
+const matches = (path: string) =>
+	config.matcher.some((pattern) => new RegExp(`^${pattern}$`).test(path));
+
+describe("proxy matcher", () => {
+	it.each(["/", "/login", "/signup", "/projects/abc"])(
+		"refreshes the session on %s",
+		(path) => {
+			expect(matches(path)).toBe(true);
+		},
+	);
+
+	it.each([
+		"/api/v1/image",
+		"/api/v1/image/job-1",
+		"/api/render/progress",
+		"/api/queues/asset-generate",
+	])("leaves %s to the route's own auth guard", (path) => {
+		expect(matches(path)).toBe(false);
+	});
+
+	it.each(["/_next/static/chunk.js", "/favicon.ico", "/logo.svg"])(
+		"skips static asset %s",
+		(path) => {
+			expect(matches(path)).toBe(false);
+		},
+	);
+});

--- a/proxy.ts
+++ b/proxy.ts
@@ -5,8 +5,12 @@ export async function proxy(request: NextRequest) {
 	return await updateSession(request);
 }
 
+// `api` is excluded because every route under it authenticates itself through
+// `withApiAccess`/`withSession`, which refresh the session the same way this
+// does. Running here too costs a second Supabase Auth round trip per request,
+// on a path polled once a second per in-flight generation job.
 export const config = {
 	matcher: [
-		"/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+		"/((?!api/|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
 	],
 };

--- a/proxy.ts
+++ b/proxy.ts
@@ -5,10 +5,8 @@ export async function proxy(request: NextRequest) {
 	return await updateSession(request);
 }
 
-// `api` is excluded because every route under it authenticates itself through
-// `withApiAccess`/`withSession`, which refresh the session the same way this
-// does. Running here too costs a second Supabase Auth round trip per request,
-// on a path polled once a second per in-flight generation job.
+// `api` is excluded: those routes refresh the session themselves via
+// `withApiAccess`/`withSession`, so running here too doubles the auth round trip.
 export const config = {
 	matcher: [
 		"/((?!api/|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",


### PR DESCRIPTION
## What

Two round trips to the Supabase Auth server, removed from paths the app hits constantly.

### 1. The proxy no longer runs on `/api`

`proxy.ts` matched every non-static path and called `supabase.auth.getUser()` on it. That call is a network round trip to Supabase Auth — it verifies the JWT against the auth server, it does not read a cookie.

Every route under `/api` already authenticates itself: `createAssetRouteHandlers`, `createSessionRouteHandler`, `createSessionFormRouteHandler`, and `pollJob` all go through `withApiAccess`/`withSession` → `lib/api/auth.ts` `getUser()`. So every API request was paying that round trip **twice, sequentially**, before the handler ran.

The matcher now excludes `api/`. What that takes off the wire:

- **The job poll.** `awaitCompletion` polls `/api/v1/<type>/[jobId]` every second per in-flight job, for the full duration of a generation (`DEFAULT_BATCH_SIZE` = 2 concurrent). Each poll's auth cost is halved.
- Every `/api/render/progress` poll (5s), every `/api/render` start, every `/api/upload/image`.
- `/api/queues/asset-generate`, which Vercel Queue calls server-to-server with no session cookie at all — the proxy's `getUser()` there was guaranteed waste.

Session refresh is unaffected. The reason the Supabase middleware exists is that Server Components can't write cookies; Route Handlers can, and `lib/supabase/server.ts` already sets them, so `getUser()` inside a handler refreshes and persists exactly as the proxy did. Pages, `/login`, `/signup`, and `/auth/callback` keep their proxy coverage — the `AUTH_ROUTES` redirect is about navigations, not API calls.

`lib/supabase/__tests__/proxy-matcher.test.ts` pins the contract: pages match, `/api/**` does not, static assets still don't.

### 2. `/projects/[id]` fetches auth and data concurrently

The page awaited `getUser()` and only then started the project query. Neither needs the other's result — access to the row is enforced by the RLS policy in `002_create_projects.sql` (`auth.uid() = user_id`), not by the user read. They now run in a `Promise.all`, so the server render costs one round trip instead of two. The `redirect("/")` and the error throw are unchanged, just moved after the join.

## Why it matters

This is the app's busiest server path and the work was pure duplication — the same auth call, to the same server, twice per request. Removing it shortens every generation poll and every project open, and on Vercel it also drops a middleware invocation per API call.

No behavior change: same auth decisions, same errors, same redirects.

## Skipped

- **`app/page.tsx`** has the same serial `getUser()` → projects query, but parallelizing it would fire a DB query for logged-out visitors on the landing page, where there is no session and nothing to fetch. Not worth the regression.
- **`supabase.auth.getClaims()`** would remove the auth round trip entirely by verifying the JWT locally, but only if the project is on asymmetric signing keys; on the legacy shared secret it silently falls back to a network call. Not verifiable from the repo, so left alone.
- **`createProject()`** does a client-side `getUser()` before its insert, adding a round trip to the "New project" click. Dropping it means either trusting `getSession()` or a `default auth.uid()` migration — both larger conversations than a perf pass.
- **Slate**, re-checked against the [performance walkthrough](https://docs.slatejs.org/walkthroughs/09-performance): `renderElement` is a stable `useCallback`, every consumer uses `useSlateStatic`, `renderLeaf`/`decorate` are unused, normalizers are depth-guarded. Nothing left.
- **Remotion**: the per-frame React cost in the player tree was already taken out by #495 (scene-index subscription pushed to leaves) and #499 (seek-bar fill geometry moved to CSS). `Captions` binary-searches, `MotionLayer` computes one transform. Nothing material left.
- The generation-queue and editor render paths were surveyed; what remains there is sub-millisecond bookkeeping, not user-visible.

## Validation

`lint`, `format:check`, `typecheck`, `knip`, `build` all clean. `1079/1079` tests pass across 124 files.

## Open PR overlap check

One open PR at the time of this pass: **#516** (`refactor: nightly maintainability 2026-08-06`), which touches `lib/generation/**`, `lib/connectors/**`, `lib/config/ConfigProvider.tsx`, `lib/script/ScriptProvider.tsx`, `app/components/canvas/hooks/useRefineScript.ts`, `app/components/canvas/elements/ElementContainer.tsx`, and `ARCHITECTURE.md`. This PR touches `proxy.ts`, `app/projects/[id]/page.tsx`, and a new test under `lib/supabase/__tests__/`. No file or theme overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)