### PR TITLE
refactor: route every user-facing error through toastError

### DIFF
--- a/app/components/UserProfile.tsx
+++ b/app/components/UserProfile.tsx
@@ -2,9 +2,8 @@
 
 import { memo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { toast } from "sonner";
 import { signOut } from "@/lib/auth/session";
-import { errorMessage } from "@/lib/errors";
+import { toastError } from "@/lib/toastError";
 import { useUser } from "@/lib/user/UserProvider";
 import { useTheme } from "next-themes";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -43,7 +42,7 @@ function UserProfile() {
 		try {
 			await signOut();
 		} catch (cause) {
-			toast.error(errorMessage(cause));
+			toastError(cause);
 			return;
 		}
 		router.refresh();

--- a/app/components/canvas/hooks/useAutosave.ts
+++ b/app/components/canvas/hooks/useAutosave.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import type { Descendant } from "slate";
 import { toast } from "sonner";
+import { toastError } from "@/lib/toastError";
 import { serializeOSMLWithScenes } from "@/lib/canvas/osmlSerializer";
 import { createAutosaver } from "@/lib/project/autosave";
 import { getProjectStore } from "@/lib/project/store";
@@ -25,8 +26,11 @@ export function useAutosave(projectId: string, value: Descendant[]): void {
 				projectId,
 				getGeneration: () => queue.snapshot(),
 				onSaved: () => toast("Saved", TOAST_OPTIONS),
-				onError: () =>
-					toast.error("Save failed", { ...TOAST_OPTIONS, duration: 4000 }),
+				onError: (err) =>
+					toastError(err, "Save failed", {
+						...TOAST_OPTIONS,
+						duration: 4000,
+					}),
 			}),
 		[projectId, queue],
 	);

--- a/lib/__tests__/toastError.test.ts
+++ b/lib/__tests__/toastError.test.ts
@@ -13,25 +13,33 @@ describe("toastError", () => {
 
 	it("shows the error's message, not its serialized form", () => {
 		toastError(new Error("Upload failed"));
-		expect(errorToast).toHaveBeenCalledWith("Upload failed");
+		expect(errorToast).toHaveBeenCalledWith("Upload failed", undefined);
 	});
 
 	it("prefixes the label when one is given", () => {
 		toastError(new Error("network down"), "Could not create project");
 		expect(errorToast).toHaveBeenCalledWith(
 			"Could not create project: network down",
+			undefined,
 		);
 	});
 
 	it("stringifies non-Error causes", () => {
 		toastError("plain rejection");
-		expect(errorToast).toHaveBeenCalledWith("plain rejection");
+		expect(errorToast).toHaveBeenCalledWith("plain rejection", undefined);
 	});
 
 	it("never leaks a stack trace", () => {
 		const error = new Error("boom");
 		error.stack = "Error: boom\n    at secret/path.ts:1:1";
 		toastError(error);
-		expect(errorToast).toHaveBeenCalledWith("boom");
+		expect(errorToast).toHaveBeenCalledWith("boom", undefined);
+	});
+
+	it("passes toast options through", () => {
+		toastError(new Error("boom"), "Save failed", { id: "autosave" });
+		expect(errorToast).toHaveBeenCalledWith("Save failed: boom", {
+			id: "autosave",
+		});
 	});
 });

--- a/lib/toastError.ts
+++ b/lib/toastError.ts
@@ -1,14 +1,18 @@
 "use client";
 
-import { toast } from "sonner";
+import { toast, type ExternalToast } from "sonner";
 import { errorMessage } from "./errors";
 
 /**
  * The one way an error reaches the user. Callers hand over the raw cause; this
  * decides what a human sees, so no UI has to pick between `errorMessage` and
- * the transport-only `stringifyError`.
+ * the transport-only `stringifyError`. `options` only styles the toast.
  */
-export function toastError(error: unknown, label?: string): void {
+export function toastError(
+	error: unknown,
+	label?: string,
+	options?: ExternalToast,
+): void {
 	const message = errorMessage(error);
-	toast.error(label ? `${label}: ${message}` : message);
+	toast.error(label ? `${label}: ${message}` : message, options);
 }


### PR DESCRIPTION
Nightly CONVENTIONS.md audit. The rolling audit state is saturated, so this was a delta pass over the files merged since the last sweep (#504, #509, #511, #512), skipping everything under open PRs #516 and #517.

Both findings are the same rule pair: **fail loudly** and **one canonical way**. PR #504 made `toastError` the single path an error takes to the user; two sites never got moved onto it.

### `app/components/canvas/hooks/useAutosave.ts`

```ts
onError: () => toast.error("Save failed", { ...TOAST_OPTIONS, duration: 4000 }),
```

The cause was discarded at the callback boundary. A save that failed on a 413, an auth expiry, or a serialization bug all rendered the same three words, and the only record of which was a `console.error` in `autosave.ts` the user never sees.

The reason this site was left behind is that it passes custom sonner options, which `toastError` had no way to accept. So `toastError` now takes an optional third `ExternalToast` argument. It stays the sole owner of *what a human reads*; the options only style the toast.

### `app/components/UserProfile.tsx`

```ts
toast.error(errorMessage(cause));
```

Hand-rolled `toastError`. Exactly equivalent, so this is a pure no-behavior-change consolidation, and it removes the last place UI code had to pick between `errorMessage` and `stringifyError` by hand.

### Behavior change

One, deliberate: a failed autosave now reads `Save failed: <reason>` instead of `Save failed`. That matches `ProjectsList`'s existing `Could not create project: <reason>` phrasing.

Covered by a new `toastError` options-passthrough test. lint, typecheck, format:check, 1069 tests and `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)