### PR TITLE
fix: scene skip buttons get stuck at non-frame-aligned scene boundaries

### DIFF
--- a/app/components/video/BottomTransportBar.tsx
+++ b/app/components/video/BottomTransportBar.tsx
@@ -3,11 +3,11 @@
 import { memo } from "react";
 import { ChevronsLeft, ChevronsRight, Pause, Play } from "@/components/ui/icon";
 import { TooltipIconButton } from "@/components/ui/icon-button";
-import { toFrames, toSeconds } from "@/lib/video/frames";
+import { toFrames } from "@/lib/video/frames";
 import { usePlayerControl } from "./PlayerControlContext";
 import { usePlayerPosition } from "./PlayerPositionContext";
 import { useLayout } from "./VideoLayoutContext";
-import { findSegmentIndexAt } from "./useSceneSegments";
+import { findSegmentIndexAtFrame } from "./useSceneSegments";
 import { usePlayerPlaying } from "./usePlayerState";
 import { SegmentedSeekBar } from "./SegmentedSeekBar";
 import {
@@ -27,9 +27,10 @@ function BottomTransportBarComponent() {
 
 	const seekToAdjacentScene = (dir: -1 | 1) => {
 		if (!player || segments.length === 0) return;
-		const current = findSegmentIndexAt(
+		const current = findSegmentIndexAtFrame(
 			segments,
-			toSeconds(player.getCurrentFrame(), layout.fps),
+			player.getCurrentFrame(),
+			layout.fps,
 		);
 		const target = segments[current + dir];
 		if (target) player.seekTo(toFrames(target.start, layout.fps));

--- a/app/components/video/SegmentedSeekBar.tsx
+++ b/app/components/video/SegmentedSeekBar.tsx
@@ -6,7 +6,7 @@ import { clamp } from "@/lib/utils";
 import type { VideoLayout } from "@/lib/video/types";
 import { usePlayerFrame } from "./usePlayerState";
 import { SeekTooltip } from "./SeekTooltip";
-import { findSegmentIndexAt, type SceneSegment } from "./useSceneSegments";
+import { findSegmentIndexAtFrame, type SceneSegment } from "./useSceneSegments";
 import { ScrubBar, type ScrubHover } from "./ScrubBar";
 import { silenceMediaIn } from "./silenceMedia";
 
@@ -22,6 +22,7 @@ export function SegmentedSeekBar({
 	segments: SceneSegment[];
 }) {
 	const { totalDurationSec, totalFrames } = layout;
+	const toScrubFrame = (ratio: number) => Math.round(ratio * (totalFrames - 1));
 	const frame = usePlayerFrame(player);
 	const progress = clamp(frame / Math.max(1, totalFrames - 1), 0, 1);
 
@@ -57,7 +58,11 @@ export function SegmentedSeekBar({
 			setSettledIndex(null);
 			return;
 		}
-		const index = findSegmentIndexAt(segments, h.ratio * totalDurationSec);
+		const index = findSegmentIndexAtFrame(
+			segments,
+			toScrubFrame(h.ratio),
+			layout.fps,
+		);
 		setHoverIndex(index);
 		settleTimerRef.current = setTimeout(
 			() => setSettledIndex(index),
@@ -77,7 +82,7 @@ export function SegmentedSeekBar({
 			segments={scrubSegments}
 			onScrub={(ratio) => {
 				if (!player) return;
-				player.seekTo(Math.round(ratio * (totalFrames - 1)));
+				player.seekTo(toScrubFrame(ratio));
 				if (wasPlayingRef.current) silenceMediaIn(player.getContainerNode());
 			}}
 			onScrubStart={() => {

--- a/app/components/video/__tests__/useSceneSegments.test.ts
+++ b/app/components/video/__tests__/useSceneSegments.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { SceneElement } from "@/lib/canvas/types";
+import { toFrames } from "@/lib/video/frames";
 import type { ResolvedElement, Sequence, VideoLayout } from "@/lib/video/types";
 import {
 	buildSceneSegments,
 	buildSequenceIndex,
-	findSegmentIndexAt,
+	findSegmentIndexAtFrame,
 	type SceneSegment,
 } from "../useSceneSegments";
 
@@ -27,38 +28,73 @@ const segments: SceneSegment[] = [
 	seg("c", 5, 1),
 ];
 
-describe("findSegmentIndexAt", () => {
+const FPS = 24;
+
+/** Starts on `frame` but a hair after it, so `toFrames` rounds back down. */
+const unalignedStart = (frame: number, fps: number) => (frame + 0.2) / fps;
+
+describe("findSegmentIndexAtFrame", () => {
 	it("returns -1 when there are no segments", () => {
-		expect(findSegmentIndexAt([], 0)).toBe(-1);
-		expect(findSegmentIndexAt([], 10)).toBe(-1);
+		expect(findSegmentIndexAtFrame([], 0, FPS)).toBe(-1);
+		expect(findSegmentIndexAtFrame([], 240, FPS)).toBe(-1);
 	});
 
-	it("returns the first segment for time before any end", () => {
-		expect(findSegmentIndexAt(segments, 0)).toBe(0);
-		expect(findSegmentIndexAt(segments, 1.9)).toBe(0);
+	it("returns the first segment for frames before any end", () => {
+		expect(findSegmentIndexAtFrame(segments, 0, FPS)).toBe(0);
+		expect(findSegmentIndexAtFrame(segments, 47, FPS)).toBe(0);
 	});
 
 	it("crosses to the next segment exactly at the previous boundary", () => {
-		expect(findSegmentIndexAt(segments, 2)).toBe(1);
-		expect(findSegmentIndexAt(segments, 5)).toBe(2);
+		expect(findSegmentIndexAtFrame(segments, 48, FPS)).toBe(1);
+		expect(findSegmentIndexAtFrame(segments, 120, FPS)).toBe(2);
 	});
 
-	it("returns the last segment for time at or beyond the total duration", () => {
-		expect(findSegmentIndexAt(segments, 5.999)).toBe(2);
-		expect(findSegmentIndexAt(segments, 6)).toBe(2);
-		expect(findSegmentIndexAt(segments, 999)).toBe(2);
+	it("returns the last segment at or beyond the total duration", () => {
+		expect(findSegmentIndexAtFrame(segments, 143, FPS)).toBe(2);
+		expect(findSegmentIndexAtFrame(segments, 144, FPS)).toBe(2);
+		expect(findSegmentIndexAtFrame(segments, 9999, FPS)).toBe(2);
 	});
 
-	it("clamps negative times to the first segment", () => {
-		expect(findSegmentIndexAt(segments, -1)).toBe(0);
+	it("clamps negative frames to the first segment", () => {
+		expect(findSegmentIndexAtFrame(segments, -1, FPS)).toBe(0);
 	});
 
 	it("handles a single segment", () => {
 		const one = [seg("only", 0, 10)];
-		expect(findSegmentIndexAt(one, 0)).toBe(0);
-		expect(findSegmentIndexAt(one, 5)).toBe(0);
-		expect(findSegmentIndexAt(one, 100)).toBe(0);
+		expect(findSegmentIndexAtFrame(one, 0, FPS)).toBe(0);
+		expect(findSegmentIndexAtFrame(one, 120, FPS)).toBe(0);
+		expect(findSegmentIndexAtFrame(one, 9999, FPS)).toBe(0);
 	});
+
+	it.each([24, 25, 30])(
+		"resolves a start that rounds down to its own segment at %ifps",
+		(fps) => {
+			const start = unalignedStart(151, fps);
+			const unaligned = [seg("a", 0, start), seg("b", start, 2)];
+			const frame = toFrames(start, fps);
+			expect(frame).toBe(151);
+			expect(findSegmentIndexAtFrame(unaligned, frame, fps)).toBe(1);
+		},
+	);
+
+	it.each([24, 25, 30])(
+		"steps one segment per seek across unaligned starts at %ifps",
+		(fps) => {
+			const starts = [0, ...[151, 307, 461].map((f) => unalignedStart(f, fps))];
+			const unaligned = starts.map((start, i) =>
+				seg(`s${i}`, start, (starts[i + 1] ?? starts[i] + 2) - start),
+			);
+			let index = 0;
+			for (let step = 1; step < unaligned.length; step++) {
+				index = findSegmentIndexAtFrame(
+					unaligned,
+					toFrames(unaligned[index + 1].start, fps),
+					fps,
+				);
+				expect(index).toBe(step);
+			}
+		},
+	);
 });
 
 const resolved = (url: string): ResolvedElement => ({

--- a/app/components/video/useSceneSegments.ts
+++ b/app/components/video/useSceneSegments.ts
@@ -1,7 +1,7 @@
 import type { PlayerRef } from "@remotion/player";
 import { isForeground } from "@/lib/canvas/guards";
 import { ELEMENT_TYPES, type SceneElement } from "@/lib/canvas/types";
-import { toSeconds } from "@/lib/video/frames";
+import { toFrames } from "@/lib/video/frames";
 import type { ResolvedElement, Sequence, VideoLayout } from "@/lib/video/types";
 import type { SeekThumbnail } from "./SeekTooltip";
 import { FRAME_EVENTS, usePlayerValue } from "./usePlayerState";
@@ -38,14 +38,23 @@ export function findSceneSequence(
 	return index.get(fg.id);
 }
 
-export function findSegmentIndexAt(
+/**
+ * Frame space, not seconds: the player only ever addresses whole frames, and
+ * `toFrames` rounds. Segment starts are arbitrary reals, so comparing a rounded
+ * playhead against an unrounded boundary reports the previous segment whenever
+ * the seek rounded down — which is what stuck the scene skip buttons. Rounding
+ * both sides the same way makes a seek to `toFrames(seg.start, fps)` land in
+ * `seg` by construction.
+ */
+export function findSegmentIndexAtFrame(
 	segments: SceneSegment[],
-	timeSec: number,
+	frame: number,
+	fps: number,
 ): number {
 	if (segments.length === 0) return -1;
 	for (let i = 0; i < segments.length; i++) {
 		const seg = segments[i];
-		if (timeSec < seg.start + seg.duration) return i;
+		if (frame < toFrames(seg.start + seg.duration, fps)) return i;
 	}
 	return segments.length - 1;
 }
@@ -58,7 +67,7 @@ export function useActiveSegmentIndex(
 	return usePlayerValue(
 		player,
 		FRAME_EVENTS,
-		(p) => findSegmentIndexAt(segments, toSeconds(p.getCurrentFrame(), fps)),
+		(p) => findSegmentIndexAtFrame(segments, p.getCurrentFrame(), fps),
 		-1,
 	);
 }


### PR DESCRIPTION
## Summary

Scene segment lookup compared raw seconds while every seek rounds to a whole frame. Segment starts are arbitrary reals, so when `start * fps` had a fractional part below `0.5`, `toFrames` rounded down and the seek landed a fraction of a frame before the segment it was aiming at. Since segments are exactly contiguous, `findSegmentIndexAt` then reported the *previous* index, "Next scene" recomputed the same target, and the playhead never advanced past that boundary.

The fix classifies on the same grid the seek uses:

- `findSegmentIndexAt(segments, timeSec)` becomes `findSegmentIndexAtFrame(segments, frame, fps)`, comparing `frame < toFrames(seg.start + seg.duration, fps)`. Because segments are contiguous, `toFrames(prev.start + prev.duration, fps) === toFrames(next.start, fps)`, so a seek to `toFrames(next.start, fps)` lands exactly on the boundary frame and classifies as `next`. No epsilon.
- `seekToAdjacentScene` and `useActiveSegmentIndex` pass `getCurrentFrame()` directly and stop converting to seconds. `ScenePill` / `ActiveSceneSync` read the scene that is actually playing right after a boundary seek.
- `SegmentedSeekBar` converts its hover ratio once, through the same `toScrubFrame` helper its scrub already used, so the tooltip labels the segment a scrub would actually land in.

`PlayFromHereButton` needs no change: it already seeks `toFrames(seq.start, fps)`, which now classifies into the intended scene by construction. The stray `console.log` mentioned in the issue is no longer present on master.

## Why this was safe and small

Size S, priority high bug with a clear root cause, a suggested direction in the issue, and three callers all in `app/components/video/`. Pure unit-of-comparison change; no behavior added, no UI/visual change, no design-system surface touched.

## Validation

- `npx vitest run app/components/video/__tests__/useSceneSegments.test.ts` — 18 passed
- `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run knip` — clean
- `npm run build` — success
- `npm run test` — 123 files, 1074 tests passed

Added coverage in `app/components/video/__tests__/useSceneSegments.test.ts`: the existing lookup cases restated in frame space, plus two parameterized cases at 24/25/30fps — a deliberately non-frame-aligned start round-tripping through `toFrames` and resolving to its own segment, and a walk that steps exactly one segment per seek across a run of unaligned starts (the stuck-button repro).

Not validated: manual playback against a real project with fractional provider durations, which needs a generated project.

## Open PR overlap check

Open PRs #516, #517, #518 touch `lib/connectors/*`, `lib/generation/*`, `lib/script/*`, `app/projects/[id]/page.tsx`, `proxy.ts`, `lib/toastError.ts`, `app/components/UserProfile.tsx`, `app/components/canvas/{elements/ElementContainer,hooks/*}`. No overlap with the four `app/components/video/` files changed here.

## Skipped candidates

Everything else open is size M/L/XL or product-decision heavy (#492, #491, #490, #462, #454, #451, #385, #379 …). The only XS issue, #259, is explicitly blocked on BYOK (#331). #506 (size S) is a generation-state bug needing live provider queue behavior to validate.

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)