### PR TITLE
perf: fix canvas typing and drag stalls

### DIFF
--- a/app/components/canvas/dnd/SortableActions.tsx
+++ b/app/components/canvas/dnd/SortableActions.tsx
@@ -2,6 +2,9 @@ import { GripVertical, Plus } from "@/components/ui/icon";
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
 import { ActionMenu } from "@/components/ui/action-menu";
 
+const ACTION_BUTTON_CLASS =
+	"inline-flex items-center rounded-md p-0.5 text-muted-foreground hover:text-foreground hover:bg-muted transition-[color,background-color] duration-200";
+
 export interface InsertOption<K extends string = string> {
 	key: K;
 	label: string;
@@ -10,57 +13,53 @@ export interface InsertOption<K extends string = string> {
 	colorClass: string;
 }
 
-interface SortableActionsProps<K extends string> {
-	options?: InsertOption<K>[];
-	onInsert?: (key: K) => void;
-	listeners?: SyntheticListenerMap;
-	onMenuOpenChange?: (open: boolean) => void;
-}
-
-export function SortableActions<K extends string>({
+export function InsertMenu<K extends string>({
 	options,
 	onInsert,
-	listeners,
-	onMenuOpenChange,
-}: SortableActionsProps<K>) {
+	onOpenChange,
+}: {
+	options: InsertOption<K>[];
+	onInsert: (key: K) => void;
+	onOpenChange?: (open: boolean) => void;
+}) {
+	if (options.length === 0) return null;
 	return (
-		<>
-			{onInsert && options && options.length > 0 && (
-				<ActionMenu
-					items={options.map((option) => ({
-						key: option.key,
-						label: option.label,
-						icon: (
-							<span
-								className={`${option.iconBgClass} ${option.colorClass} mr-1 inline-flex size-6 items-center justify-center rounded-md`}
-							>
-								{option.icon}
-							</span>
-						),
-						onSelect: () => onInsert(option.key),
-					}))}
-					contentClassName="w-40"
-					itemClassName="rounded-lg py-1"
-					onOpenChange={onMenuOpenChange}
-				>
-					<button
-						aria-label="Insert item"
-						className="inline-flex items-center rounded-md p-0.5 text-muted-foreground
-              hover:text-foreground hover:bg-muted transition-[color,background-color] duration-200"
+		<ActionMenu
+			items={options.map((option) => ({
+				key: option.key,
+				label: option.label,
+				icon: (
+					<span
+						className={`${option.iconBgClass} ${option.colorClass} mr-1 inline-flex size-6 items-center justify-center rounded-md`}
 					>
-						<Plus size={18} />
-					</button>
-				</ActionMenu>
-			)}
-			<button
-				aria-label="Drag to reorder"
-				className="inline-flex items-center rounded-md p-0.5 text-muted-foreground
-        hover:text-foreground hover:bg-muted transition-[color,background-color] duration-200
-        cursor-grab active:cursor-grabbing"
-				{...listeners}
-			>
-				<GripVertical size={22} />
+						{option.icon}
+					</span>
+				),
+				onSelect: () => onInsert(option.key),
+			}))}
+			contentClassName="w-40"
+			itemClassName="rounded-lg py-1"
+			onOpenChange={onOpenChange}
+		>
+			<button aria-label="Insert item" className={ACTION_BUTTON_CLASS}>
+				<Plus size={18} />
 			</button>
-		</>
+		</ActionMenu>
+	);
+}
+
+export function DragHandle({
+	listeners,
+}: {
+	listeners?: SyntheticListenerMap;
+}) {
+	return (
+		<button
+			aria-label="Drag to reorder"
+			className={`${ACTION_BUTTON_CLASS} cursor-grab active:cursor-grabbing`}
+			{...listeners}
+		>
+			<GripVertical size={22} />
+		</button>
 	);
 }

--- a/app/components/canvas/dnd/SortableContent.tsx
+++ b/app/components/canvas/dnd/SortableContent.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Path } from "slate";
 import { RenderElementProps, ReactEditor, useSlateStatic } from "slate-react";
 import { useConfig } from "@/lib/config/ConfigProvider";
@@ -10,9 +10,10 @@ import { parentSceneId } from "@/lib/canvas/scenes";
 import { ELEMENT_LIST } from "@/lib/canvas/elementConfigs";
 import { insertElement } from "@/lib/canvas/insertElement";
 import { useViewMode } from "../ViewModeContext";
+import { renderCanvasElement } from "../elements/ElementContainer";
 import { SortableItem } from "./SortableItem";
 import { useDragTransfer } from "./DragTransferContext";
-import type { InsertOption } from "./SortableActions";
+import { InsertMenu, type InsertOption } from "./SortableActions";
 
 const INSERT_OPTIONS: InsertOption<CanvasElementType>[] = ELEMENT_LIST.map(
 	(c) => ({
@@ -33,6 +34,7 @@ export function SortableContent({
 	element: CanvasContentElement;
 	children: React.ReactNode;
 }) {
+	const [isMenuOpen, setIsMenuOpen] = useState(false);
 	const editor = useSlateStatic();
 	const { connectorConfig } = useConfig();
 	const transfer = useDragTransfer();
@@ -68,14 +70,20 @@ export function SortableContent({
 			sceneId={sceneId}
 			sortableType="content"
 			wrapperStyle={wrapperStyle}
-			insertOptions={INSERT_OPTIONS}
-			onInsert={handleInsert}
+			insertMenu={
+				<InsertMenu
+					options={INSERT_OPTIONS}
+					onInsert={handleInsert}
+					onOpenChange={setIsMenuOpen}
+				/>
+			}
+			menuOpen={isMenuOpen}
 			disabled={collapsed}
 			readOnly={collapsed}
 			attributes={attributes}
 			element={element}
 		>
-			{children}
+			{renderCanvasElement({ attributes, children, element })}
 		</SortableItem>
 	);
 }

--- a/app/components/canvas/dnd/SortableItem.tsx
+++ b/app/components/canvas/dnd/SortableItem.tsx
@@ -1,20 +1,20 @@
-import { useState } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { RenderElementProps } from "slate-react";
-import type { CanvasElement, CanvasElementType } from "@/lib/canvas/types";
+import type { CanvasElement } from "@/lib/canvas/types";
 import styles from "../styles/sortable.module.css";
-import { SortableActions, type InsertOption } from "./SortableActions";
-import { renderCanvasElement } from "../elements/ElementContainer";
+import { DragHandle } from "./SortableActions";
 
+// Drag start re-renders every sortable, so `children` and `insertMenu` are
+// built by the caller: constructing them here rebuilds N card subtrees.
 interface SortableItemProps {
 	sceneId: string;
 	sortableType: "scene" | "content";
 	wrapperClassName?: string;
 	wrapperStyle?: React.CSSProperties;
 	contentClassName?: string;
-	insertOptions?: InsertOption<CanvasElementType>[];
-	onInsert?: (type: CanvasElementType) => void;
+	insertMenu?: React.ReactNode;
+	menuOpen?: boolean;
 	disabled?: boolean;
 	readOnly?: boolean;
 	attributes: RenderElementProps["attributes"];
@@ -28,8 +28,8 @@ export function SortableItem({
 	wrapperClassName,
 	wrapperStyle,
 	contentClassName,
-	insertOptions,
-	onInsert,
+	insertMenu,
+	menuOpen,
 	disabled,
 	readOnly,
 	attributes,
@@ -50,8 +50,6 @@ export function SortableItem({
 		disabled,
 	});
 
-	const [isMenuOpen, setIsMenuOpen] = useState(false);
-
 	return (
 		<div {...attributes} className={wrapperClassName} style={wrapperStyle}>
 			<div
@@ -70,24 +68,18 @@ export function SortableItem({
 				}}
 			>
 				<div
-					className={`${styles.hoverTarget} align-middle${isMenuOpen ? ` ${styles.menuOpen}` : ""}`}
+					className={`${styles.hoverTarget} align-middle${menuOpen ? ` ${styles.menuOpen}` : ""}`}
 				>
 					{!disabled && (
 						<div
 							className={`self-center ${styles.actions}`}
 							contentEditable={false}
 						>
-							<SortableActions
-								options={insertOptions}
-								onInsert={onInsert}
-								listeners={listeners}
-								onMenuOpenChange={setIsMenuOpen}
-							/>
+							{insertMenu}
+							<DragHandle listeners={listeners} />
 						</div>
 					)}
-					<div contentEditable={readOnly ? false : undefined}>
-						{renderCanvasElement({ attributes, children, element })}
-					</div>
+					<div contentEditable={readOnly ? false : undefined}>{children}</div>
 				</div>
 			</div>
 		</div>

--- a/app/components/canvas/dnd/SortableScene.tsx
+++ b/app/components/canvas/dnd/SortableScene.tsx
@@ -2,6 +2,7 @@ import { RenderElementProps } from "slate-react";
 import type { SceneElement } from "@/lib/canvas/types";
 import { useActiveSceneId } from "@/app/components/scene-selection/ActiveSceneContext";
 import { useViewMode } from "../ViewModeContext";
+import styles from "../styles/sortable.module.css";
 import { SortableItem } from "./SortableItem";
 
 const ACTIVE_SCENE_CLASS = "scene-active bg-element-card";
@@ -22,7 +23,7 @@ export function SortableScene({
 			sceneId={element.id}
 			sortableType="scene"
 			disabled={!isCollapsed(element.id)}
-			wrapperClassName={`border-t pt-3 mt-3 first:border-t-0 first:pt-0 first:mt-0 ${isActive ? "border-transparent" : "border-border"}`}
+			wrapperClassName={`${styles.scene} border-t pt-3 mt-3 first:border-t-0 first:pt-0 first:mt-0 ${isActive ? "border-transparent" : "border-border"}`}
 			contentClassName={isActive ? ACTIVE_SCENE_CLASS : undefined}
 			attributes={attributes}
 			element={element}

--- a/app/components/canvas/dnd/SortableScene.tsx
+++ b/app/components/canvas/dnd/SortableScene.tsx
@@ -3,6 +3,7 @@ import type { SceneElement } from "@/lib/canvas/types";
 import { useActiveSceneId } from "@/app/components/scene-selection/ActiveSceneContext";
 import { useViewMode } from "../ViewModeContext";
 import styles from "../styles/sortable.module.css";
+import { renderCanvasElement } from "../elements/ElementContainer";
 import { SortableItem } from "./SortableItem";
 
 const ACTIVE_SCENE_CLASS = "scene-active bg-element-card";
@@ -28,7 +29,7 @@ export function SortableScene({
 			attributes={attributes}
 			element={element}
 		>
-			{children}
+			{renderCanvasElement({ attributes, children, element })}
 		</SortableItem>
 	);
 }

--- a/app/components/canvas/dnd/useDragAndDrop.ts
+++ b/app/components/canvas/dnd/useDragAndDrop.ts
@@ -23,11 +23,8 @@ export function useDragAndDrop(editor: Editor, value: Descendant[]) {
 
 	const sensors = useSensors(useSensor(PointerSensor), useSensor(TouchSensor));
 
-	/**
-	 * Keying on `value` gives `SortableContext` a new `items` identity per
-	 * keystroke, and context updates bypass Slate's memoization: every
-	 * `useSortable` consumer re-renders. Key on the ids instead.
-	 */
+	// Keying on `value` gives SortableContext a new `items` identity per
+	// keystroke, re-rendering every useSortable consumer. Key on the ids.
 	const sceneIdKey = value
 		.filter(isSceneElement)
 		.map((s) => s.id)

--- a/app/components/canvas/dnd/useDragAndDrop.ts
+++ b/app/components/canvas/dnd/useDragAndDrop.ts
@@ -15,15 +15,26 @@ import { findElementById } from "@/lib/canvas/editorOps";
 import { isSceneElement } from "@/lib/canvas/scenes";
 import type { DragTransfer } from "./DragTransferContext";
 
+const SCENE_ID_SEPARATOR = ",";
+
 export function useDragAndDrop(editor: Editor, value: Descendant[]) {
 	const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
 	const [dragTransfer, setDragTransfer] = useState<DragTransfer>(null);
 
 	const sensors = useSensors(useSensor(PointerSensor), useSensor(TouchSensor));
 
+	/**
+	 * Keying on `value` gives `SortableContext` a new `items` identity per
+	 * keystroke, and context updates bypass Slate's memoization: every
+	 * `useSortable` consumer re-renders. Key on the ids instead.
+	 */
+	const sceneIdKey = value
+		.filter(isSceneElement)
+		.map((s) => s.id)
+		.join(SCENE_ID_SEPARATOR);
 	const sceneItems = useMemo<string[]>(
-		() => value.filter(isSceneElement).map((s) => s.id),
-		[value],
+		() => sceneIdKey.split(SCENE_ID_SEPARATOR).filter(Boolean),
+		[sceneIdKey],
 	);
 
 	const handleDragStart = useCallback((event: DragStartEvent) => {

--- a/app/components/canvas/styles/sortable.module.css
+++ b/app/components/canvas/styles/sortable.module.css
@@ -3,11 +3,8 @@
 	z-index: 0;
 }
 
-/*
- * Offscreen scenes used to pay style recalc and paint on every pointer move of
- * a drag. `auto` caches each scene's real height once rendered, so the
- * scrollbar settles after first paint.
- */
+/* Skips style recalc and paint for offscreen scenes during a drag. `auto`
+   caches each scene's real height, so the scrollbar settles after first paint. */
 .scene {
 	content-visibility: auto;
 	contain-intrinsic-size: auto 600px;

--- a/app/components/canvas/styles/sortable.module.css
+++ b/app/components/canvas/styles/sortable.module.css
@@ -3,6 +3,16 @@
 	z-index: 0;
 }
 
+/*
+ * Offscreen scenes used to pay style recalc and paint on every pointer move of
+ * a drag. `auto` caches each scene's real height once rendered, so the
+ * scrollbar settles after first paint.
+ */
+.scene {
+	content-visibility: auto;
+	contain-intrinsic-size: auto 600px;
+}
+
 .sortable > div:last-child {
 	flex: 1;
 	min-width: 0;


### PR DESCRIPTION
Fixes the typing and drag hangs reported in #510.

All numbers are from a **production build** (`next start`) — the dev server inflates a keystroke to ~340ms with StrictMode double-renders and swamps the signal. Attribution is from CPU profiles plus render counters compiled into the build, not inference.

Three distinct causes, measured one at a time. **None of them is the Slate reconciliation the issue assumed.**

---

## 1. Typing: `sceneItems` identity churn fans out to every card

`sceneItems` was memoized on `value`, which Slate replaces on every keystroke. That handed `SortableContext` a new `items` identity per character. dnd-kit context updates bypass `React.memo` *and* Slate's element memoization, so all `useSortable` consumers re-rendered and rebuilt their card subtrees.

Fixed by keying on the scene ids, so the identity only changes when scenes are added, removed, or reordered.

Typing, 20 keystrokes, 37 scenes / 242 elements:

| | before | after |
|---|---|---|
| `SortableItem` renders | 4840 (242/key) | 200 (10/key) |
| long tasks | 22 | 1 |
| blocking time | 1424 ms | **71 ms** |

## 2. Drag moves: style recalc and paint, not JS

A CPU profile of a full drag showed only ~64ms in script; the rest was `(program)` — browser-internal style recalc and paint across 21221px of content in an 868px viewport. `content-visibility: auto` on scene containers skips the offscreen ones.

Drag, 25 pointer moves (A/B'd by toggling `content-visibility` on the same build, 3 runs):

| | before | after |
|---|---|---|
| long tasks | 4 | 0 |
| max frame | 245 ms | 48 ms |
| main-thread busy | 1.4–1.7 s | **0.34–0.52 s** |
| style recalcs | 211–256 | 74–87 |

## 3. Drag start: every card rebuilt its whole subtree

Pressing the grip on a 132-scene / 862-element slop fired **one 2925ms synchronous task** (2.76s script, 4ms layout, 46ms style); the overlay appeared the moment it ended.

`useSortable` subscribes to dnd-kit context, which changes on drag start, so all 862 `SortableItem`s re-render — inherent to dnd-kit. The cost was what sat *inside* them: `SortableItem` called `renderCanvasElement` and built `SortableActions` in its own render body, so every card reconstructed its settings popover, tooltips, and an 11-item Radix insert menu. None of that depends on drag state.

Both are now built by the caller (which doesn't re-render on drag) and passed down as props. Element references stay identical across `SortableItem`'s re-render, so React reuses the subtrees — **no `memo()` involved**. `SortableActions` splits into `InsertMenu` (caller-built) and `DragHandle` (needs `listeners`); `isMenuOpen` moves up with the menu.

Drag start, 132 scenes / 862 elements:

| | before | after |
|---|---|---|
| overlay latency | 2381–3116 ms | **340–488 ms** (median 383) |
| `ContentElement` renders | 1202 | **1** |
| `ElementSettings` renders | 1202 | **1** |
| `InsertMenu` renders | 1200 | **0** |

---

## Corrections to the issue's plan

- **Chunking (#1, the "10x headline") is not the typing fix and is not included.** `SortableContent` renders exactly 2× per keystroke both before and after — Slate's `MemoizedElement` was already confining element re-renders to the edited node. Reconciliation never fanned out over scenes.
- **`content-visibility` (#2) belongs on the drag path, not typing.** It measured as a no-op for typing once the render fan-out was fixed, but it is the entire drag-move win.
- **`pointerWithin` / droppable count (#5) was not the drag-start cost either** — drag start was JS building card subtrees, and layout was 4ms.

## Known remaining cost

Drag start still spends ~383ms in 1729 `SortableItem` renders at ~0.22ms each — `useSortable`'s own hook cost across two React passes. Cutting that means not registering every element as a droppable, which risks cross-scene drop correctness and deserves its own measurement rather than being folded in here.

## Verification

- Hover actions render, insert menu opens with its items, `menuOpen` class applies and clears.
- A real drag reorders correctly with structure intact (132 scenes / 862 elements).
- Deep-scrolled scenes render fully (video, waveforms, prompts); caret placement works inside `content-visibility`-skipped subtrees.
- Lint, format, typecheck, `npm run build`, 1086 tests pass.

## Not included

No unit test for the identity invariant. The repo has no jsdom/testing-library setup — tests are pure-logic only — so covering this seam would mean adding React test infra as new dependencies. Flagging rather than expanding scope; the invariant is documented at the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
