### PR TITLE
fix: make the drag overlay resolve scene facts from the canvas

### DIFF
--- a/app/components/canvas/dnd/DragOverlay.tsx
+++ b/app/components/canvas/dnd/DragOverlay.tsx
@@ -1,15 +1,52 @@
 import { GripVertical, Plus } from "@/components/ui/icon";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { createEditor, Descendant } from "slate";
-import { Editable, Slate, withReact } from "slate-react";
-import { renderCanvasElement } from "../elements/ElementContainer";
+import { Editable, RenderElementProps, Slate, withReact } from "slate-react";
+import type { CanvasElement } from "@/lib/canvas/types";
+import { isSceneElement } from "@/lib/canvas/scenes";
+import { CompactElement } from "../elements/CompactElement";
+import { ElementContainer } from "../elements/ElementContainer";
+import { SceneContainer } from "../elements/SceneContainer";
+import { useSceneIndex } from "../hooks/useSceneIndex";
+import { useViewMode } from "../ViewModeContext";
 import styles from "../styles/sortable.module.css";
 
-export function DragOverlayContent({ element }: { element: Descendant }) {
+/**
+ * Previews the dragged node in a scratch editor holding only that node. What a
+ * node would otherwise read off its own document (scene number, collapsed
+ * state) is resolved against the real canvas, which this renders inside of.
+ */
+export function DragOverlayContent({ element }: { element: CanvasElement }) {
 	const editor = useMemo(() => withReact(createEditor()), []);
 	const value = useMemo<Descendant[]>(
 		() => [structuredClone(element)],
 		[element],
+	);
+
+	const sceneIndex = useSceneIndex(element.id);
+	const { isCollapsed } = useViewMode();
+	const collapsed = isSceneElement(element) && isCollapsed(element.id);
+
+	const renderElement = useCallback(
+		({ attributes, children, element: node }: RenderElementProps) => {
+			if (isSceneElement(node))
+				return (
+					<SceneContainer
+						attributes={attributes}
+						element={node}
+						sceneIndex={sceneIndex}
+					>
+						{children}
+					</SceneContainer>
+				);
+			const Content = collapsed ? CompactElement : ElementContainer;
+			return (
+				<Content attributes={attributes} element={node}>
+					{children}
+				</Content>
+			);
+		},
+		[collapsed, sceneIndex],
 	);
 
 	return (
@@ -31,7 +68,7 @@ export function DragOverlayContent({ element }: { element: Descendant }) {
 				</div>
 				<Editable
 					readOnly={true}
-					renderElement={renderCanvasElement}
+					renderElement={renderElement}
 					className="text-xl leading-relaxed text-center break-all"
 				/>
 			</Slate>

--- a/app/components/canvas/dnd/SortableContent.tsx
+++ b/app/components/canvas/dnd/SortableContent.tsx
@@ -10,7 +10,8 @@ import { parentSceneId } from "@/lib/canvas/scenes";
 import { ELEMENT_LIST } from "@/lib/canvas/elementConfigs";
 import { insertElement } from "@/lib/canvas/insertElement";
 import { useViewMode } from "../ViewModeContext";
-import { renderCanvasElement } from "../elements/ElementContainer";
+import { CompactElement } from "../elements/CompactElement";
+import { ElementContainer } from "../elements/ElementContainer";
 import { SortableItem } from "./SortableItem";
 import { useDragTransfer } from "./DragTransferContext";
 import { InsertMenu, type InsertOption } from "./SortableActions";
@@ -43,6 +44,7 @@ export function SortableContent({
 	const path = ReactEditor.findPath(editor, element);
 	const sceneId = parentSceneId(editor, path);
 	const collapsed = isCollapsed(sceneId);
+	const Content = collapsed ? CompactElement : ElementContainer;
 
 	const insertGap =
 		sceneId === transfer?.toSceneId &&
@@ -83,7 +85,9 @@ export function SortableContent({
 			attributes={attributes}
 			element={element}
 		>
-			{renderCanvasElement({ attributes, children, element })}
+			<Content attributes={attributes} element={element}>
+				{children}
+			</Content>
 		</SortableItem>
 	);
 }

--- a/app/components/canvas/dnd/SortableScene.tsx
+++ b/app/components/canvas/dnd/SortableScene.tsx
@@ -3,7 +3,8 @@ import type { SceneElement } from "@/lib/canvas/types";
 import { useActiveSceneId } from "@/app/components/scene-selection/ActiveSceneContext";
 import { useViewMode } from "../ViewModeContext";
 import styles from "../styles/sortable.module.css";
-import { renderCanvasElement } from "../elements/ElementContainer";
+import { SceneContainer } from "../elements/SceneContainer";
+import { useSceneIndex } from "../hooks/useSceneIndex";
 import { SortableItem } from "./SortableItem";
 
 const ACTIVE_SCENE_CLASS = "scene-active bg-element-card";
@@ -19,6 +20,7 @@ export function SortableScene({
 }) {
 	const isActive = useActiveSceneId() === element.id;
 	const { isCollapsed } = useViewMode();
+	const sceneIndex = useSceneIndex(element.id);
 	return (
 		<SortableItem
 			sceneId={element.id}
@@ -29,7 +31,13 @@ export function SortableScene({
 			attributes={attributes}
 			element={element}
 		>
-			{renderCanvasElement({ attributes, children, element })}
+			<SceneContainer
+				attributes={attributes}
+				element={element}
+				sceneIndex={sceneIndex}
+			>
+				{children}
+			</SceneContainer>
 		</SortableItem>
 	);
 }

--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -1,17 +1,12 @@
-import { JSX } from "react";
-import { RenderElementProps, ReactEditor, useSlateStatic } from "slate-react";
+import { RenderElementProps } from "slate-react";
 import { Node } from "slate";
 import type { CanvasContentElement } from "@/lib/canvas/types";
-import { isSceneElement, parentSceneId } from "@/lib/canvas/scenes";
 import { ZERO_WIDTH_SPACE } from "@/lib/canvas/constants";
 import { ELEMENT_CONFIGS } from "@/lib/canvas/elementConfigs";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { resolveElementSchema } from "@/lib/canvas/elementConnector";
-import { useViewMode } from "../ViewModeContext";
 import { OutputPreview } from "./OutputPreview";
 import { DeleteButton } from "./DeleteButton";
-import { CompactElement } from "./CompactElement";
-import { SceneContainer } from "./SceneContainer";
 import { ElementCharacters } from "./ElementCharacters";
 import { AttributeBadge } from "./AttributeBadge";
 import { ElementGenerateButton, ElementStaleIndicator } from "./GenerateButton";
@@ -156,34 +151,3 @@ export function ElementContainer({
 		</ElementGenerationProvider>
 	);
 }
-
-function ContentElement(
-	props: RenderElementProps & { element: CanvasContentElement },
-) {
-	const editor = useSlateStatic();
-	const { isCollapsed, hasCollapsed } = useViewMode();
-
-	if (hasCollapsed) {
-		const path = ReactEditor.findPath(editor, props.element);
-		const sceneId = parentSceneId(editor, path);
-		if (isCollapsed(sceneId)) {
-			return (
-				<CompactElement attributes={props.attributes} element={props.element}>
-					{props.children}
-				</CompactElement>
-			);
-		}
-	}
-	return <ElementContainer {...props} element={props.element} />;
-}
-
-export const renderCanvasElement = (props: RenderElementProps): JSX.Element => {
-	if (isSceneElement(props.element)) {
-		return (
-			<SceneContainer attributes={props.attributes} element={props.element}>
-				{props.children}
-			</SceneContainer>
-		);
-	}
-	return <ContentElement {...props} element={props.element} />;
-};

--- a/app/components/canvas/elements/SceneContainer.tsx
+++ b/app/components/canvas/elements/SceneContainer.tsx
@@ -8,7 +8,6 @@ import type { SceneElement } from "@/lib/canvas/types";
 import { useSceneSequence } from "@/app/components/video/VideoLayoutContext";
 import { isForeground } from "@/lib/canvas/guards";
 import { useDragTransfer } from "../dnd/DragTransferContext";
-import { useSceneIndex } from "../hooks/useSceneIndex";
 import { useViewMode } from "../ViewModeContext";
 import { CollapsibleHeader } from "./CollapsibleHeader";
 import { DeleteButton } from "./DeleteButton";
@@ -23,6 +22,8 @@ const SCENE_FRAME_CLASS =
 interface SceneProps {
 	attributes: RenderElementProps["attributes"];
 	element: SceneElement;
+	/** 1-based position in the document, resolved by whoever mounts the scene. */
+	sceneIndex: number;
 	children: React.ReactNode;
 }
 
@@ -40,7 +41,6 @@ function useSceneState(element: SceneElement) {
 
 	return {
 		childIds,
-		sceneIndex: useSceneIndex(element.id),
 		dropPadding: {
 			paddingBottom:
 				isDropTarget && transfer.atIndex >= childIds.length
@@ -85,8 +85,13 @@ function SceneHeader({
 	);
 }
 
-function CollapsedScene({ attributes, element, children }: SceneProps) {
-	const { sceneIndex, dropPadding } = useSceneState(element);
+function CollapsedScene({
+	attributes,
+	element,
+	sceneIndex,
+	children,
+}: SceneProps) {
+	const { dropPadding } = useSceneState(element);
 	const { toggle } = useViewMode();
 
 	const foregroundElement = useMemo(
@@ -144,8 +149,13 @@ function CollapsedScene({ attributes, element, children }: SceneProps) {
 	);
 }
 
-function ExpandedScene({ attributes, element, children }: SceneProps) {
-	const { childIds, sceneIndex, dropPadding } = useSceneState(element);
+function ExpandedScene({
+	attributes,
+	element,
+	sceneIndex,
+	children,
+}: SceneProps) {
+	const { childIds, dropPadding } = useSceneState(element);
 	const { toggle } = useViewMode();
 
 	return (


### PR DESCRIPTION
## The crash

`throw new Error("Node at [...] is not inside a scene")` on drag, sometimes.

`DragOverlayContent` previews the dragged node in a scratch editor whose entire document is that one node. Drag a content element and it sits at path `[0]` with no parent scene, by construction. The overlay rendered through the canvas renderer, whose `ContentElement` looks up the parent scene to pick compact vs. full.

That lookup was an unchecked cast until #516 swapped it for `parentSceneId`. The cast read `.id` off the `Editor` object, got `undefined`, and `isCollapsed(undefined)` returned false, so the violation was silently absorbed. The helper fails loudly, which is right; it just exposed a real one.

Repro: collapse any scene, drag any element card. The "sometimes" is the `if (hasCollapsed)` guard in `ContentElement` (added in #127 as a perf short-circuit), which is why nothing breaks until something is collapsed.

## Two more overlay bugs from the same cause

- **Scene number.** `SceneContainer` resolved its own index via `useSceneIndex` → `useSlateStatic()`. Inside the overlay's nested `<Slate>` that is the scratch editor, whose only child is the dragged scene, so every dragged scene read as "Scene 1".
- **Collapsed scenes.** `SceneContainer` already picked `CollapsedScene` correctly (it keys off `isCollapsed(element.id)` from the real provider), but its children rendered as full-size element cards inside the 128px collapsed frame, since the compact dispatch depends on the same missing parent-scene lookup.

## The fix

Scene position is now a required prop on `SceneContainer`, resolved by whoever mounts it:

- `SortableItem` resolves it against the canvas editor, as before.
- `DragOverlayContent` resolves it *before* mounting its scratch editor. It renders inside the canvas's own `<Slate>`, so `useSceneIndex` there sees the real document.

The overlay renders its own nodes directly rather than borrowing the canvas renderer's scene-aware dispatch, and takes collapsed state from the scene it was handed. A dragged collapsed scene is now a faithful copy, chips and "+N more" included.

`SceneContainer` stops reading its position off whichever editor happens to be nearest, which is what made this fragile. The `parentSceneId` throw stays, and the invariant it guards is now true everywhere it runs.

## Notes

- The overlay's scene/content dispatch resembles `renderCanvasElement`'s shape. Kept separate: the two encode different policy (canvas asks the document; the overlay is a detached preview), and merging them would mean passing render flags into the canvas renderer to serve one caller.
- `SortableItem` calls `useSceneIndex` for content elements too, where it returns `0` and goes unused. That is `sceneIndexOf`'s existing not-found contract, and it keeps the prop required rather than optional-with-fallback.
- Scenes are only draggable while collapsed, content only while its scene is expanded, so each overlay branch has exactly one real case.

## Testing

Full CI locally: lint, format, typecheck, knip, build, 1086 unit tests, 3 e2e smoke. No unit test added; there is no jsdom/RTL setup in this repo, so this is only reachable through a rendered drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
