### PR TITLE
perf: nightly performance optimizations 2026-08-07

### DIFF
--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -29,7 +29,7 @@ export default function Canvas({
 	const {
 		activeId,
 		sceneItems,
-		dragTransfer,
+		dragTransferStore,
 		sensors,
 		handleDragStart,
 		handleDragOver,
@@ -64,7 +64,7 @@ export default function Canvas({
 	);
 
 	return (
-		<DragTransferContext value={dragTransfer}>
+		<DragTransferContext value={dragTransferStore}>
 			<DndContext
 				sensors={sensors}
 				collisionDetection={pointerWithin}

--- a/app/components/canvas/__tests__/dragTransfer.test.ts
+++ b/app/components/canvas/__tests__/dragTransfer.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	createDragTransferStore,
+	dropIndexIn,
+	type DragTransfer,
+} from "../dnd/DragTransferContext";
+
+const transfer = (
+	overrides: Partial<NonNullable<DragTransfer>> = {},
+): DragTransfer => ({
+	itemId: "item-1",
+	fromSceneId: "scene-1",
+	toSceneId: "scene-2",
+	atIndex: 3,
+	...overrides,
+});
+
+describe("dropIndexIn", () => {
+	it("reports the landing index for the receiving scene", () => {
+		expect(dropIndexIn(transfer(), "scene-2")).toBe(3);
+	});
+
+	it("reports nothing while no drag is in flight", () => {
+		expect(dropIndexIn(null, "scene-2")).toBeNull();
+	});
+
+	it("reports nothing for scenes the drag is not over", () => {
+		expect(dropIndexIn(transfer(), "scene-9")).toBeNull();
+	});
+
+	it("reports nothing when the item is being reordered within its own scene", () => {
+		expect(
+			dropIndexIn(transfer({ toSceneId: "scene-1" }), "scene-1"),
+		).toBeNull();
+	});
+});
+
+describe("createDragTransferStore", () => {
+	it("starts empty", () => {
+		expect(createDragTransferStore().get()).toBeNull();
+	});
+
+	it("notifies subscribers on every write", () => {
+		const store = createDragTransferStore();
+		const listener = vi.fn();
+		store.subscribe(listener);
+
+		store.set(transfer());
+		expect(store.get()).toEqual(transfer());
+
+		store.set(null);
+		expect(store.get()).toBeNull();
+		expect(listener).toHaveBeenCalledTimes(2);
+	});
+
+	it("stops notifying once unsubscribed", () => {
+		const store = createDragTransferStore();
+		const listener = vi.fn();
+		store.subscribe(listener)();
+
+		store.set(transfer());
+		expect(listener).not.toHaveBeenCalled();
+	});
+});

--- a/app/components/canvas/dnd/DragTransferContext.tsx
+++ b/app/components/canvas/dnd/DragTransferContext.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useSyncExternalStore } from "react";
 import { createRequiredContext } from "@/lib/components/createRequiredContext";
 
 export type DragTransfer = {
@@ -7,6 +8,58 @@ export type DragTransfer = {
 	atIndex: number;
 } | null;
 
-const [DragTransferContext, useDragTransfer] =
-	createRequiredContext<DragTransfer>("DragTransferContext");
-export { DragTransferContext, useDragTransfer };
+export type DragTransferStore = {
+	get: () => DragTransfer;
+	set: (next: DragTransfer) => void;
+	subscribe: (onChange: () => void) => () => void;
+};
+
+/**
+ * Every element card watches the drag transfer, but it drives a gap above
+ * exactly one of them. Holding the value in the context would re-render all of
+ * them on every drag-over; holding a store lets each card subscribe and
+ * re-render only when its own answer flips.
+ */
+export function createDragTransferStore(): DragTransferStore {
+	let transfer: DragTransfer = null;
+	const listeners = new Set<() => void>();
+	return {
+		get: () => transfer,
+		set: (next) => {
+			transfer = next;
+			for (const listener of listeners) listener();
+		},
+		subscribe: (onChange) => {
+			listeners.add(onChange);
+			return () => {
+				listeners.delete(onChange);
+			};
+		},
+	};
+}
+
+export function dropIndexIn(
+	transfer: DragTransfer,
+	sceneId: string,
+): number | null {
+	if (!transfer) return null;
+	if (transfer.toSceneId !== sceneId) return null;
+	if (transfer.fromSceneId === sceneId) return null;
+	return transfer.atIndex;
+}
+
+const [DragTransferContext, useDragTransferStore] =
+	createRequiredContext<DragTransferStore>("DragTransferContext");
+export { DragTransferContext };
+
+const noDrop = () => null;
+
+/** Where an incoming cross-scene drag would land in this scene, if anywhere. */
+export function useDropIndex(sceneId: string): number | null {
+	const store = useDragTransferStore();
+	const getSnapshot = useCallback(
+		() => dropIndexIn(store.get(), sceneId),
+		[store, sceneId],
+	);
+	return useSyncExternalStore(store.subscribe, getSnapshot, noDrop);
+}

--- a/app/components/canvas/dnd/SortableContent.tsx
+++ b/app/components/canvas/dnd/SortableContent.tsx
@@ -13,7 +13,7 @@ import { useViewMode } from "../ViewModeContext";
 import { CompactElement } from "../elements/CompactElement";
 import { ElementContainer } from "../elements/ElementContainer";
 import { SortableItem } from "./SortableItem";
-import { useDragTransfer } from "./DragTransferContext";
+import { useDropIndex } from "./DragTransferContext";
 import { InsertMenu, type InsertOption } from "./SortableActions";
 
 const INSERT_OPTIONS: InsertOption<CanvasElementType>[] = ELEMENT_LIST.map(
@@ -38,7 +38,6 @@ export function SortableContent({
 	const [isMenuOpen, setIsMenuOpen] = useState(false);
 	const editor = useSlateStatic();
 	const { connectorConfig } = useConfig();
-	const transfer = useDragTransfer();
 	const { isCollapsed } = useViewMode();
 
 	const path = ReactEditor.findPath(editor, element);
@@ -46,10 +45,7 @@ export function SortableContent({
 	const collapsed = isCollapsed(sceneId);
 	const Content = collapsed ? CompactElement : ElementContainer;
 
-	const insertGap =
-		sceneId === transfer?.toSceneId &&
-		sceneId !== transfer?.fromSceneId &&
-		path[path.length - 1] === transfer?.atIndex;
+	const insertGap = useDropIndex(sceneId) === path[path.length - 1];
 
 	const wrapperStyle = useMemo(
 		() => ({

--- a/app/components/canvas/dnd/useDragAndDrop.ts
+++ b/app/components/canvas/dnd/useDragAndDrop.ts
@@ -13,13 +13,13 @@ import { Descendant, Editor } from "slate";
 import { moveDraggedElement } from "@/lib/canvas/dragOps";
 import { findElementById } from "@/lib/canvas/editorOps";
 import { isSceneElement } from "@/lib/canvas/scenes";
-import type { DragTransfer } from "./DragTransferContext";
+import { createDragTransferStore } from "./DragTransferContext";
 
 const SCENE_ID_SEPARATOR = ",";
 
 export function useDragAndDrop(editor: Editor, value: Descendant[]) {
 	const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
-	const [dragTransfer, setDragTransfer] = useState<DragTransfer>(null);
+	const [dragTransferStore] = useState(createDragTransferStore);
 
 	const sensors = useSensors(useSensor(PointerSensor), useSensor(TouchSensor));
 
@@ -50,7 +50,7 @@ export function useDragAndDrop(editor: Editor, value: Descendant[]) {
 			if (!fromSceneId || !toSceneId) return;
 
 			if (fromSceneId === toSceneId) {
-				setDragTransfer(null);
+				dragTransferStore.set(null);
 				return;
 			}
 
@@ -61,38 +61,38 @@ export function useDragAndDrop(editor: Editor, value: Descendant[]) {
 			const atIndex = isSceneElement(overNode)
 				? overNode.children.length
 				: overPath[overPath.length - 1];
-			setDragTransfer({
+			dragTransferStore.set({
 				itemId: active.id as string,
 				fromSceneId,
 				toSceneId,
 				atIndex,
 			});
 		},
-		[editor],
+		[dragTransferStore, editor],
 	);
 
 	const handleDragEnd = useCallback(
 		(event: DragEndEvent) => {
 			const { active, over } = event;
 			setActiveId(null);
-			setDragTransfer(null);
+			dragTransferStore.set(null);
 
 			if (!over?.id || active.id === over.id) return;
 
 			moveDraggedElement(editor, String(active.id), String(over.id));
 		},
-		[editor],
+		[dragTransferStore, editor],
 	);
 
 	const handleDragCancel = useCallback(() => {
 		setActiveId(null);
-		setDragTransfer(null);
-	}, []);
+		dragTransferStore.set(null);
+	}, [dragTransferStore]);
 
 	return {
 		activeId,
 		sceneItems,
-		dragTransfer,
+		dragTransferStore,
 		sensors,
 		handleDragStart,
 		handleDragOver,

--- a/app/components/canvas/elements/SceneContainer.tsx
+++ b/app/components/canvas/elements/SceneContainer.tsx
@@ -7,7 +7,7 @@ import {
 import type { SceneElement } from "@/lib/canvas/types";
 import { useSceneSequence } from "@/app/components/video/VideoLayoutContext";
 import { isForeground } from "@/lib/canvas/guards";
-import { useDragTransfer } from "../dnd/DragTransferContext";
+import { useDropIndex } from "../dnd/DragTransferContext";
 import { useViewMode } from "../ViewModeContext";
 import { CollapsibleHeader } from "./CollapsibleHeader";
 import { DeleteButton } from "./DeleteButton";
@@ -33,19 +33,13 @@ function useSceneState(element: SceneElement) {
 		[element.children],
 	);
 
-	const transfer = useDragTransfer();
-	const isDropTarget =
-		transfer &&
-		element.id === transfer.toSceneId &&
-		element.id !== transfer.fromSceneId;
+	const dropIndex = useDropIndex(element.id);
 
 	return {
 		childIds,
 		dropPadding: {
 			paddingBottom:
-				isDropTarget && transfer.atIndex >= childIds.length
-					? "3rem"
-					: undefined,
+				dropIndex !== null && dropIndex >= childIds.length ? "3rem" : undefined,
 			transition: "padding-bottom 200ms ease",
 		} as React.CSSProperties,
 	};


### PR DESCRIPTION
## What

Dragging an element into another scene re-rendered **every** element card on **every** pointer move.

`setDragTransfer` fires from `onDragOver`, so it runs repeatedly through a cross-scene drag. The transfer sat in `DragTransferContext`, and context updates bypass `React.memo` and Slate's element memoization — so each pointer move re-rendered all 200 `SortableContent` cards and rebuilt their `ElementContainer` subtrees (settings popover, tooltips, the 11-item insert menu) to move a single `3rem` gap.

This is item 3 of #510, and the same shape as the drag-start fanout fixed in #520.

- **`DragTransferContext`** now carries a store (`get` / `set` / `subscribe`) instead of the value. Cards subscribe via `useSyncExternalStore` and re-render only when their own answer flips.
- **`useDropIndex(sceneId)`** is the entire consumer surface: `SortableContent` compares it against its own index, `SceneContainer` against its child count. Both call sites keep their exact previous conditions, so the gap and the scene's trailing pad appear where they always did.
- The transfer no longer lives in React state, so `Canvas` stops re-rendering during a drag too.

## Measurements

Production build, a 40-scene / 200-element fixture, one cross-scene drag of 12–13 pointer moves, 2–3 runs per side. Render counts came from counters compiled into the build; task times from a `longtask` PerformanceObserver.

| | before | after |
|---|---|---|
| card re-renders per pointer move | 200 | 10 |
| `ElementContainer` rebuilds over the drag | 2400–2800 | 120–125 |
| long-task time over the drag | 3.8–3.9s | 0.79–0.95s |
| longest task | 435–440ms | 102–123ms |

The remaining per-move cost is dnd-kit's own `useSortable` re-render on every consumer, which #520 measured and deliberately left alone. Those renders no longer rebuild anything, because the card subtrees are stable props.

Behavior verified in the same build: one insert gap appears during a cross-scene drag (never zero, never two), it clears on drop, and the element lands in the target scene.

## Also

`app/components/canvas/__tests__/dragTransfer.test.ts` covers the new seam: `dropIndexIn` for the four transfer cases, and the store's notify/unsubscribe semantics.

## Skipped

- **`ViewModeContext` identity churn** (#510 item 5) — same fix shape, but collapse-toggle is a rare interaction next to a drag, and bundling it would double the diff for a fraction of the win. Left for its own measured PR.
- **`pointerWithin` over every droppable** (#510 item 5) — cutting droppable count risks cross-scene drop correctness; it needs its own measurement, as #520 noted.
- Player/Remotion/Slate render paths were profiled and left alone: `ScrubBar` already drives the playhead through CSS variables, `usePlayerValue` already selects per-consumer, and `VideoComposition` already memoizes its sequence nodes.

## Validation

`lint`, `format:check`, `typecheck`, `knip`, `build` all clean. Full suite: 125 files / 1093 tests passing.

## Open PR overlap check

One open PR at the time of the run: **#522** (nightly maintainability — `lib/generation/*`, `lib/project/*`, `lib/video/resolve.ts`, `app/components/canvas/elements/{AssetTile,GenerateButton,GenerationIndicator,ElementUploadButton,preview/*}`, `ProjectEditor.tsx`, `ARCHITECTURE.md`). This PR touches `app/components/canvas/{Canvas.tsx,dnd/*,elements/SceneContainer.tsx}` and one new test file — no file or theme overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)