### PR TITLE
fix: defer the play one frame past the seek on "play from here"

### DIFF
--- a/app/components/canvas/elements/PlayFromHereButton.tsx
+++ b/app/components/canvas/elements/PlayFromHereButton.tsx
@@ -23,8 +23,8 @@ export function PlayFromHereButton({ scene }: { scene: SceneElement }) {
 			className="bg-muted"
 			disabled={disabled}
 			onMouseDown={(e) => e.preventDefault()}
-			onClick={(e) => {
-				if (startFrame != null) playFromFrame(startFrame, e);
+			onClick={() => {
+				if (startFrame != null) playFromFrame(startFrame);
 			}}
 		>
 			<Play className="h-4 w-4" />

--- a/app/components/canvas/elements/PlayFromHereButton.tsx
+++ b/app/components/canvas/elements/PlayFromHereButton.tsx
@@ -23,8 +23,8 @@ export function PlayFromHereButton({ scene }: { scene: SceneElement }) {
 			className="bg-muted"
 			disabled={disabled}
 			onMouseDown={(e) => e.preventDefault()}
-			onClick={() => {
-				if (startFrame != null) playFromFrame(startFrame);
+			onClick={(e) => {
+				if (startFrame != null) playFromFrame(startFrame, e);
 			}}
 		>
 			<Play className="h-4 w-4" />

--- a/app/components/video/PlayerControlContext.tsx
+++ b/app/components/video/PlayerControlContext.tsx
@@ -13,6 +13,8 @@ import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { usePlayerPosition } from "./PlayerPositionContext";
 import { startPlaybackAt } from "./startPlaybackAt";
 
+type PlaybackRequest = { frame: number; event?: SyntheticEvent };
+
 type PlayerControl = {
 	player: PlayerRef | null;
 	registerPlayer: (player: PlayerRef | null) => void;
@@ -29,22 +31,22 @@ export function PlayerControlProvider({ children }: { children: ReactNode }) {
 	// only copy of the handle — nothing downstream mirrors it.
 	const [player, setPlayer] = useState<PlayerRef | null>(null);
 	const { showPlayer } = usePlayerPosition();
-	// `showPlayer()` only schedules the mount, so a play requested while the
+	// `showPlayer()` only schedules the mount, so a request made while the
 	// player is hidden has nothing to run against until the ref arrives.
-	const pendingFrameRef = useRef<number | null>(null);
+	const pendingRef = useRef<PlaybackRequest | null>(null);
 
 	const registerPlayer = useCallback((next: PlayerRef | null) => {
 		setPlayer(next);
-		const frame = pendingFrameRef.current;
-		pendingFrameRef.current = null;
-		if (next && frame != null) startPlaybackAt(next, frame);
+		const pending = pendingRef.current;
+		pendingRef.current = null;
+		if (next && pending) startPlaybackAt(next, pending.frame, pending.event);
 	}, []);
 
 	const playFromFrame = useCallback(
 		(frame: number, event?: SyntheticEvent) => {
 			showPlayer();
 			if (player) startPlaybackAt(player, frame, event);
-			else pendingFrameRef.current = frame;
+			else pendingRef.current = { frame, event };
 		},
 		[showPlayer, player],
 	);

--- a/app/components/video/PlayerControlContext.tsx
+++ b/app/components/video/PlayerControlContext.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import type { PlayerRef } from "@remotion/player";
-import { useCallback, useMemo, useState, type ReactNode } from "react";
+import {
+	useCallback,
+	useMemo,
+	useRef,
+	useState,
+	type ReactNode,
+	type SyntheticEvent,
+} from "react";
 import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { usePlayerPosition } from "./PlayerPositionContext";
 import { startPlaybackAt } from "./startPlaybackAt";
@@ -9,7 +16,7 @@ import { startPlaybackAt } from "./startPlaybackAt";
 type PlayerControl = {
 	player: PlayerRef | null;
 	registerPlayer: (player: PlayerRef | null) => void;
-	playFromFrame: (frame: number) => void;
+	playFromFrame: (frame: number, event?: SyntheticEvent) => void;
 };
 
 const [Ctx, usePlayerControl] = createRequiredContext<PlayerControl>(
@@ -20,20 +27,31 @@ export { usePlayerControl };
 export function PlayerControlProvider({ children }: { children: ReactNode }) {
 	// `registerPlayer` is the mounted player's ref callback, so this state is the
 	// only copy of the handle — nothing downstream mirrors it.
-	const [player, registerPlayer] = useState<PlayerRef | null>(null);
+	const [player, setPlayer] = useState<PlayerRef | null>(null);
 	const { showPlayer } = usePlayerPosition();
+	// `showPlayer()` only schedules the mount, so a play requested while the
+	// player is hidden has nothing to run against until the ref arrives.
+	const pendingFrameRef = useRef<number | null>(null);
+
+	const registerPlayer = useCallback((next: PlayerRef | null) => {
+		setPlayer(next);
+		const frame = pendingFrameRef.current;
+		pendingFrameRef.current = null;
+		if (next && frame != null) startPlaybackAt(next, frame);
+	}, []);
 
 	const playFromFrame = useCallback(
-		(frame: number) => {
+		(frame: number, event?: SyntheticEvent) => {
 			showPlayer();
-			startPlaybackAt(player, frame);
+			if (player) startPlaybackAt(player, frame, event);
+			else pendingFrameRef.current = frame;
 		},
 		[showPlayer, player],
 	);
 
 	const value = useMemo(
 		() => ({ player, registerPlayer, playFromFrame }),
-		[player, playFromFrame],
+		[player, registerPlayer, playFromFrame],
 	);
 
 	return <Ctx value={value}>{children}</Ctx>;

--- a/app/components/video/PlayerControlContext.tsx
+++ b/app/components/video/PlayerControlContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { PlayerRef } from "@remotion/player";
-import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
 import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { usePlayerPosition } from "./PlayerPositionContext";
 import { startPlaybackAt } from "./startPlaybackAt";
@@ -20,31 +20,20 @@ export { usePlayerControl };
 export function PlayerControlProvider({ children }: { children: ReactNode }) {
 	// `registerPlayer` is the mounted player's ref callback, so this state is the
 	// only copy of the handle — nothing downstream mirrors it.
-	const [player, setPlayer] = useState<PlayerRef | null>(null);
+	const [player, registerPlayer] = useState<PlayerRef | null>(null);
 	const { showPlayer } = usePlayerPosition();
-	// `showPlayer()` only schedules the mount, so a frame requested while the
-	// player is hidden has nothing to run against until the ref arrives.
-	const pendingFrameRef = useRef<number | null>(null);
-
-	const registerPlayer = useCallback((next: PlayerRef | null) => {
-		setPlayer(next);
-		const frame = pendingFrameRef.current;
-		pendingFrameRef.current = null;
-		if (next && frame != null) startPlaybackAt(next, frame);
-	}, []);
 
 	const playFromFrame = useCallback(
 		(frame: number) => {
 			showPlayer();
 			if (player) startPlaybackAt(player, frame);
-			else pendingFrameRef.current = frame;
 		},
 		[showPlayer, player],
 	);
 
 	const value = useMemo(
 		() => ({ player, registerPlayer, playFromFrame }),
-		[player, registerPlayer, playFromFrame],
+		[player, playFromFrame],
 	);
 
 	return <Ctx value={value}>{children}</Ctx>;

--- a/app/components/video/PlayerControlContext.tsx
+++ b/app/components/video/PlayerControlContext.tsx
@@ -1,24 +1,15 @@
 "use client";
 
 import type { PlayerRef } from "@remotion/player";
-import {
-	useCallback,
-	useMemo,
-	useRef,
-	useState,
-	type ReactNode,
-	type SyntheticEvent,
-} from "react";
+import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
 import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { usePlayerPosition } from "./PlayerPositionContext";
 import { startPlaybackAt } from "./startPlaybackAt";
 
-type PlaybackRequest = { frame: number; event?: SyntheticEvent };
-
 type PlayerControl = {
 	player: PlayerRef | null;
 	registerPlayer: (player: PlayerRef | null) => void;
-	playFromFrame: (frame: number, event?: SyntheticEvent) => void;
+	playFromFrame: (frame: number) => void;
 };
 
 const [Ctx, usePlayerControl] = createRequiredContext<PlayerControl>(
@@ -31,22 +22,22 @@ export function PlayerControlProvider({ children }: { children: ReactNode }) {
 	// only copy of the handle — nothing downstream mirrors it.
 	const [player, setPlayer] = useState<PlayerRef | null>(null);
 	const { showPlayer } = usePlayerPosition();
-	// `showPlayer()` only schedules the mount, so a request made while the
+	// `showPlayer()` only schedules the mount, so a frame requested while the
 	// player is hidden has nothing to run against until the ref arrives.
-	const pendingRef = useRef<PlaybackRequest | null>(null);
+	const pendingFrameRef = useRef<number | null>(null);
 
 	const registerPlayer = useCallback((next: PlayerRef | null) => {
 		setPlayer(next);
-		const pending = pendingRef.current;
-		pendingRef.current = null;
-		if (next && pending) startPlaybackAt(next, pending.frame, pending.event);
+		const frame = pendingFrameRef.current;
+		pendingFrameRef.current = null;
+		if (next && frame != null) startPlaybackAt(next, frame);
 	}, []);
 
 	const playFromFrame = useCallback(
-		(frame: number, event?: SyntheticEvent) => {
+		(frame: number) => {
 			showPlayer();
-			if (player) startPlaybackAt(player, frame, event);
-			else pendingRef.current = { frame, event };
+			if (player) startPlaybackAt(player, frame);
+			else pendingFrameRef.current = frame;
 		},
 		[showPlayer, player],
 	);

--- a/app/components/video/__tests__/startPlaybackAt.test.ts
+++ b/app/components/video/__tests__/startPlaybackAt.test.ts
@@ -2,7 +2,7 @@ import type { SyntheticEvent } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { startPlaybackAt, type PlaybackTarget } from "../startPlaybackAt";
 
-function makePlayer(containerNode: HTMLElement | null = null) {
+function makePlayer(containerNode: HTMLDivElement | null = null) {
 	const calls: string[] = [];
 	const player: PlaybackTarget = {
 		play: vi.fn(() => {
@@ -15,15 +15,13 @@ function makePlayer(containerNode: HTMLElement | null = null) {
 			calls.push("getContainerNode");
 			return containerNode;
 		}),
-	} as unknown as PlaybackTarget;
+	};
 	return { player, calls };
 }
 
 describe("startPlaybackAt", () => {
-	// Regression for #425. The player has to be playing when the seek lands, so
-	// that Remotion owns the pause/seek/replay and defers the replay past the
-	// buffering its own seek triggers. Playing after the seek instead leaves the
-	// shared audio tags running against a parked frame driver.
+	// Regression for #425: playing after the seek leaves the shared audio tags
+	// running against a parked frame driver.
 	it("plays before seeking, so the seek resumes rather than starts playback", () => {
 		const { player, calls } = makePlayer();
 
@@ -32,16 +30,6 @@ describe("startPlaybackAt", () => {
 		expect(calls).toEqual(["play", "seekTo:120", "getContainerNode"]);
 	});
 
-	it("seeks to the requested frame", () => {
-		const { player } = makePlayer();
-
-		startPlaybackAt(player, 42);
-
-		expect(player.seekTo).toHaveBeenCalledWith(42);
-	});
-
-	// Remotion only warms the shared audio tag pool for autoplay when play() is
-	// given the event, so the originating click has to reach it.
 	it("forwards the originating event to play", () => {
 		const { player } = makePlayer();
 		const event = {} as SyntheticEvent;
@@ -51,24 +39,10 @@ describe("startPlaybackAt", () => {
 		expect(player.play).toHaveBeenCalledWith(event);
 	});
 
-	it("silences stray media only once the seek has landed", () => {
-		const { player, calls } = makePlayer();
-
-		startPlaybackAt(player, 3);
-
-		expect(calls.indexOf("getContainerNode")).toBeGreaterThan(
-			calls.indexOf("seekTo:3"),
-		);
-	});
-
 	it("tolerates a player with no container node yet", () => {
 		const { player } = makePlayer(null);
 
 		expect(() => startPlaybackAt(player, 0)).not.toThrow();
 		expect(player.play).toHaveBeenCalledOnce();
-	});
-
-	it("no-ops when the player has not mounted", () => {
-		expect(() => startPlaybackAt(null, 120)).not.toThrow();
 	});
 });

--- a/app/components/video/__tests__/startPlaybackAt.test.ts
+++ b/app/components/video/__tests__/startPlaybackAt.test.ts
@@ -39,8 +39,7 @@ function makePlayer(containerNode: HTMLDivElement | null = null) {
 }
 
 describe("startPlaybackAt", () => {
-	// Regression for #425: playing in the same tick as the seek runs the shared
-	// audio tags against a frame driver parked on the seek's buffering block.
+	// Regression for #425: playing in the seek's tick freezes the frame driver.
 	it("holds the play back until the frame after the seek", () => {
 		const { player, calls } = makePlayer();
 

--- a/app/components/video/__tests__/startPlaybackAt.test.ts
+++ b/app/components/video/__tests__/startPlaybackAt.test.ts
@@ -1,17 +1,15 @@
+import type { SyntheticEvent } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { startPlaybackAt, type PlaybackTarget } from "../startPlaybackAt";
 
 function makePlayer(containerNode: HTMLElement | null = null) {
 	const calls: string[] = [];
 	const player: PlaybackTarget = {
-		pause: vi.fn(() => {
-			calls.push("pause");
+		play: vi.fn(() => {
+			calls.push("play");
 		}),
 		seekTo: vi.fn((frame: number) => {
 			calls.push(`seekTo:${frame}`);
-		}),
-		play: vi.fn(() => {
-			calls.push("play");
 		}),
 		getContainerNode: vi.fn(() => {
 			calls.push("getContainerNode");
@@ -22,14 +20,16 @@ function makePlayer(containerNode: HTMLElement | null = null) {
 }
 
 describe("startPlaybackAt", () => {
-	// Regression for #425: firing seekTo + play in one tick without pausing let
-	// the shared audio tags run while the frame driver stayed frozen.
-	it("pauses and seeks before playing", () => {
+	// Regression for #425. The player has to be playing when the seek lands, so
+	// that Remotion owns the pause/seek/replay and defers the replay past the
+	// buffering its own seek triggers. Playing after the seek instead leaves the
+	// shared audio tags running against a parked frame driver.
+	it("plays before seeking, so the seek resumes rather than starts playback", () => {
 		const { player, calls } = makePlayer();
 
 		startPlaybackAt(player, 120);
 
-		expect(calls).toEqual(["pause", "seekTo:120", "getContainerNode", "play"]);
+		expect(calls).toEqual(["play", "seekTo:120", "getContainerNode"]);
 	});
 
 	it("seeks to the requested frame", () => {
@@ -40,22 +40,25 @@ describe("startPlaybackAt", () => {
 		expect(player.seekTo).toHaveBeenCalledWith(42);
 	});
 
-	it("never plays before seeking", () => {
-		const { player, calls } = makePlayer();
+	// Remotion only warms the shared audio tag pool for autoplay when play() is
+	// given the event, so the originating click has to reach it.
+	it("forwards the originating event to play", () => {
+		const { player } = makePlayer();
+		const event = {} as SyntheticEvent;
 
-		startPlaybackAt(player, 7);
+		startPlaybackAt(player, 7, event);
 
-		expect(calls.indexOf("play")).toBeGreaterThan(calls.indexOf("seekTo:7"));
+		expect(player.play).toHaveBeenCalledWith(event);
 	});
 
-	it("silences stray media between the seek and the play", () => {
+	it("silences stray media only once the seek has landed", () => {
 		const { player, calls } = makePlayer();
 
 		startPlaybackAt(player, 3);
 
-		const silenced = calls.indexOf("getContainerNode");
-		expect(silenced).toBeGreaterThan(calls.indexOf("seekTo:3"));
-		expect(silenced).toBeLessThan(calls.indexOf("play"));
+		expect(calls.indexOf("getContainerNode")).toBeGreaterThan(
+			calls.indexOf("seekTo:3"),
+		);
 	});
 
 	it("tolerates a player with no container node yet", () => {

--- a/app/components/video/__tests__/startPlaybackAt.test.ts
+++ b/app/components/video/__tests__/startPlaybackAt.test.ts
@@ -1,15 +1,34 @@
-import type { SyntheticEvent } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startPlaybackAt, type PlaybackTarget } from "../startPlaybackAt";
+
+let frameCallbacks: FrameRequestCallback[] = [];
+
+beforeEach(() => {
+	frameCallbacks = [];
+	vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) =>
+		frameCallbacks.push(cb),
+	);
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+function nextFrame() {
+	const due = frameCallbacks;
+	frameCallbacks = [];
+	for (const cb of due) cb(0);
+}
 
 function makePlayer(containerNode: HTMLDivElement | null = null) {
 	const calls: string[] = [];
 	const player: PlaybackTarget = {
-		play: vi.fn(() => {
-			calls.push("play");
+		pause: vi.fn(() => {
+			calls.push("pause");
 		}),
 		seekTo: vi.fn((frame: number) => {
 			calls.push(`seekTo:${frame}`);
+		}),
+		play: vi.fn(() => {
+			calls.push("play");
 		}),
 		getContainerNode: vi.fn(() => {
 			calls.push("getContainerNode");
@@ -20,29 +39,25 @@ function makePlayer(containerNode: HTMLDivElement | null = null) {
 }
 
 describe("startPlaybackAt", () => {
-	// Regression for #425: playing after the seek leaves the shared audio tags
-	// running against a parked frame driver.
-	it("plays before seeking, so the seek resumes rather than starts playback", () => {
+	// Regression for #425: playing in the same tick as the seek runs the shared
+	// audio tags against a frame driver parked on the seek's buffering block.
+	it("holds the play back until the frame after the seek", () => {
 		const { player, calls } = makePlayer();
 
 		startPlaybackAt(player, 120);
 
-		expect(calls).toEqual(["play", "seekTo:120", "getContainerNode"]);
-	});
+		expect(calls).toEqual(["pause", "seekTo:120", "getContainerNode"]);
 
-	it("forwards the originating event to play", () => {
-		const { player } = makePlayer();
-		const event = {} as SyntheticEvent;
+		nextFrame();
 
-		startPlaybackAt(player, 7, event);
-
-		expect(player.play).toHaveBeenCalledWith(event);
+		expect(calls).toEqual(["pause", "seekTo:120", "getContainerNode", "play"]);
 	});
 
 	it("tolerates a player with no container node yet", () => {
 		const { player } = makePlayer(null);
 
 		expect(() => startPlaybackAt(player, 0)).not.toThrow();
+		nextFrame();
 		expect(player.play).toHaveBeenCalledOnce();
 	});
 });

--- a/app/components/video/startPlaybackAt.ts
+++ b/app/components/video/startPlaybackAt.ts
@@ -1,27 +1,24 @@
 import type { PlayerRef } from "@remotion/player";
-import type { SyntheticEvent } from "react";
 import { silenceMediaIn } from "./silenceMedia";
 
 export type PlaybackTarget = Pick<
 	PlayerRef,
-	"play" | "seekTo" | "getContainerNode"
+	"pause" | "seekTo" | "play" | "getContainerNode"
 >;
 
 /**
- * Seeking mid-playback is what defers the resume: the Player pauses, seeks, and
- * replays from an effect once the new frame has committed. Playing after the
- * seek instead runs the shared audio tags against a frame driver still parked
- * on the seek's buffering block (#425).
+ * Playing in the same tick as the seek freezes the picture (#425): the seek
+ * makes the media elements buffer, the Player parks its frame driver while any
+ * buffering block is held, and `play()` starts the shared audio tags directly,
+ * so audio runs on against a still frame. One frame of separation lets the seek
+ * commit first, which is what makes the scrub bar's play-on-pointerup work.
  *
- * `play()` needs the originating event: Remotion only warms the shared audio
- * tags for autoplay when it gets one.
+ * `pause()` is load-bearing when the player is already playing: it stops
+ * `seekTo` taking its own pause-and-resume path, which freezes the same way.
  */
-export function startPlaybackAt(
-	player: PlaybackTarget,
-	frame: number,
-	event?: SyntheticEvent,
-) {
-	player.play(event);
+export function startPlaybackAt(player: PlaybackTarget, frame: number) {
+	player.pause();
 	player.seekTo(frame);
 	silenceMediaIn(player.getContainerNode());
+	requestAnimationFrame(() => player.play());
 }

--- a/app/components/video/startPlaybackAt.ts
+++ b/app/components/video/startPlaybackAt.ts
@@ -7,14 +7,11 @@ export type PlaybackTarget = Pick<
 >;
 
 /**
- * Playing in the same tick as the seek freezes the picture (#425): the seek
- * makes the media elements buffer, the Player parks its frame driver while any
- * buffering block is held, and `play()` starts the shared audio tags directly,
- * so audio runs on against a still frame. One frame of separation lets the seek
- * commit first, which is what makes the scrub bar's play-on-pointerup work.
- *
- * `pause()` is load-bearing when the player is already playing: it stops
- * `seekTo` taking its own pause-and-resume path, which freezes the same way.
+ * The play has to land a whole frame after the seek. In the same tick the
+ * Player parks its frame driver on the seek's buffering block while `play()`
+ * starts the shared audio tags anyway, so audio runs against a frozen picture
+ * (#425); a `setTimeout` fires too early and freezes the same way. `pause()`
+ * keeps `seekTo` off its own pause-and-resume path, which also stalls.
  */
 export function startPlaybackAt(player: PlaybackTarget, frame: number) {
 	player.pause();

--- a/app/components/video/startPlaybackAt.ts
+++ b/app/components/video/startPlaybackAt.ts
@@ -1,16 +1,31 @@
 import type { PlayerRef } from "@remotion/player";
+import type { SyntheticEvent } from "react";
 import { silenceMediaIn } from "./silenceMedia";
 
 export type PlaybackTarget = Pick<
 	PlayerRef,
-	"pause" | "seekTo" | "play" | "getContainerNode"
+	"play" | "seekTo" | "getContainerNode"
 >;
 
-export function startPlaybackAt(player: PlaybackTarget | null, frame: number) {
-	// Pause before seeking, or the shared audio tags keep running on their own
-	// media clock from the old position.
-	player?.pause();
-	player?.seekTo(frame);
-	silenceMediaIn(player?.getContainerNode() ?? null);
-	player?.play();
+/**
+ * Start playback at a frame by seeking while the player is already playing.
+ *
+ * The play cannot follow the seek in the same tick: Remotion parks its frame
+ * driver while any media element holds a buffering block, but `play()` starts
+ * the shared audio tags directly, so audio runs against a frozen picture
+ * (#425). Seeking while playing hands that ordering to the Player, which
+ * pauses, seeks, and replays from an effect once the new frame has committed.
+ *
+ * The originating click has to reach `play()`: Remotion only warms the shared
+ * audio tag pool for autoplay when it is passed one.
+ */
+export function startPlaybackAt(
+	player: PlaybackTarget | null,
+	frame: number,
+	event?: SyntheticEvent,
+) {
+	if (!player) return;
+	player.play(event);
+	player.seekTo(frame);
+	silenceMediaIn(player.getContainerNode());
 }

--- a/app/components/video/startPlaybackAt.ts
+++ b/app/components/video/startPlaybackAt.ts
@@ -8,23 +8,19 @@ export type PlaybackTarget = Pick<
 >;
 
 /**
- * Start playback at a frame by seeking while the player is already playing.
+ * Seeking mid-playback is what defers the resume: the Player pauses, seeks, and
+ * replays from an effect once the new frame has committed. Playing after the
+ * seek instead runs the shared audio tags against a frame driver still parked
+ * on the seek's buffering block (#425).
  *
- * The play cannot follow the seek in the same tick: Remotion parks its frame
- * driver while any media element holds a buffering block, but `play()` starts
- * the shared audio tags directly, so audio runs against a frozen picture
- * (#425). Seeking while playing hands that ordering to the Player, which
- * pauses, seeks, and replays from an effect once the new frame has committed.
- *
- * The originating click has to reach `play()`: Remotion only warms the shared
- * audio tag pool for autoplay when it is passed one.
+ * `play()` needs the originating event: Remotion only warms the shared audio
+ * tags for autoplay when it gets one.
  */
 export function startPlaybackAt(
-	player: PlaybackTarget | null,
+	player: PlaybackTarget,
 	frame: number,
 	event?: SyntheticEvent,
 ) {
-	if (!player) return;
 	player.play(event);
 	player.seekTo(frame);
 	silenceMediaIn(player.getContainerNode());


### PR DESCRIPTION
Reopens and fixes #425. The original fix (#430) was a no-op for the case it targeted.

Verified in a real browser against a real project. Earlier revisions of this PR were wrong; the measurements are below.

## The bug

`startPlaybackAt` did `pause; seekTo; silence; play` in one tick. The seek makes the media elements buffer, `useMediaBuffering` takes a `buffer.delayPlayback()` block, and the Player stops scheduling animation frames while any block is held. But `play()` starts the shared audio tags directly, so they advance on their own media clock against a frozen picture.

## The fix

One line: defer the play to the next animation frame, so the seek commits first.

```
player.pause();
player.seekTo(frame);
silenceMediaIn(player.getContainerNode());
requestAnimationFrame(() => player.play());
```

That is the same separation `SegmentedSeekBar` gets for free by playing from `onScrubEnd` (pointerup), which is why the scrub bar never had this bug.

Two things that look removable but are not:

- **`pause()`** is what stops `seekTo` taking its own pause-and-resume path (`hasPausedToResume`), which freezes identically when the player is already playing. An earlier revision of this PR dropped it and reintroduced the bug.
- **`requestAnimationFrame`, not `setTimeout`.** A macrotask fires too early and freezes exactly like the unfixed code. Measured, see below.

## What the browser showed

Chrome, 9-scene project with generated audio. The frame clock is the seek bar fill, driven by the Player's `frameupdate` event, so it reads the frame driver directly. Sampled every 200ms.

Before, clicking "Play from here" on scene 7:

```
 0.0s prog=2043 state=Pause playing=0 audio= 0.00
 3.9s prog=2043 state=Pause playing=1 audio= 3.71
 7.9s prog=2043 state=Pause playing=1 audio= 7.73
11.9s prog=2043 state=Pause playing=1 audio=11.74
```

The button reads "Pause", so the Player believes it is playing. The frame clock never moves. Audio climbs to 11.7s. That is the reported bug.

After:

```
 0.0s prog=2139 playing=0 audio= 0.00
 3.1s prog=2153 playing=3 audio=13.26
 5.1s prog=2160 playing=3 audio=15.26
 7.0s prog=2168 playing=3 audio=17.20
```

Picture and audio advance in lockstep. Reproduced on scenes 2, 4, 6, 8 and 9.

With `setTimeout(..., 0)` instead of `requestAnimationFrame`:

```
 0.0s prog=1776 state=Pause playing=0 audio= 0.00
 7.8s prog=1776 state=Pause playing=0 audio= 0.00
```

Frozen. This is why the deferral is a frame and not a task.

Also checked:

- **Jumping while already playing** — frame clock advances, no media element keeps running from the old position.
- **Control: plain Play with no seek** — advances normally, so the freeze is specific to the seek path and not a loading problem.
- **Master's ordering, same probe** — frozen, so the probe reproduces the original bug rather than just agreeing with the fix.

## Tests

The old tests asserted mock call order within one tick, which was never the failing property, so they were green throughout the bug. They now stub `requestAnimationFrame` and pin that the play does *not* happen until the frame after the seek.

## Deliberately not included

- **Threading the originating click into `play()`.** Remotion only warms the shared audio tag pool for autoplay when `play()` is passed an event. I could not measure any difference in Chrome with or without it, and master never passed one, so it is an unproven enhancement rather than part of this fix.
- **Holding the frame while the player is hidden.** `showPlayer()` only schedules the mount, so a click made while the player is hidden is dropped. Not worth machinery for that path.

Known behaviour: `requestAnimationFrame` does not fire in a background tab, so a click made just before switching tabs starts playing when the tab is next visible.

## Verification

Lint, format, typecheck, knip, build, 1102 unit tests. Verified against `@remotion/player` 4.0.481.

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
