### PR TITLE
feat: per-media-type generation concurrency limits

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,7 @@ The prompt goes through the LLM connector to `POST /api/v1/llm`, which streams O
 
 ### 2. Generate
 
-Generate resolves the element into a dependency graph (see [Generation graph](#generation-graph)) and queues the stale nodes client-side, dependencies first, `DEFAULT_BATCH_SIZE` at a time. Each job is submitted to `POST /api/v1/{asset}`, which records a `jobs` row and enqueues to the Vercel Queue. Workers call the provider, upload results to Vercel Blob, and mark the job complete. The client polls until the asset URL arrives and the preview updates. Music and sfx check a Pinecone similarity cache first.
+Generate resolves the element into a dependency graph (see [Generation graph](#generation-graph)) and queues the stale nodes client-side, dependencies first and up to a per-media-type concurrency limit at a time. Each job is submitted to `POST /api/v1/{asset}`, which records a `jobs` row and enqueues to the Vercel Queue. Workers call the provider, upload results to Vercel Blob, and mark the job complete. The client polls until the asset URL arrives and the preview updates. Music and sfx check a Pinecone similarity cache first.
 
 ### 3. Save / restore
 
@@ -48,10 +48,11 @@ A generation is a small dependency graph, not a lone job. `lib/generation/graph.
 
 Staleness falls out of the graph: a node needs generating when it has no result, when a dependency does, or when its current inputs differ from the inputs its result was made from. One element (`useGenerate`) and Generate All (`useGenerateAll`) run the same check. A result the user supplied is `pinned` and never regenerated.
 
-`queue.ts` runs the graph. It flattens roots dependencies-first, skips nodes that are already fresh, and holds only what is in flight: the pending nodes, the abort controllers, and the batch limit. Everything that outlives a run lives beside it:
+`queue.ts` runs the graph. It flattens roots dependencies-first, skips nodes that are already fresh, and holds only what is in flight: the pending nodes and the jobs currently running, each with its abort controller. Everything that outlives a run lives beside it:
 
 - `snapshots.ts` is the per-element record (status, elapsed seconds, result, error, the inputs that result was made from) plus a result history keyed by serialized inputs, so undoing an edit restores the earlier result instead of regenerating it. It is also the subscription observers read through; mutators leave notifying to the caller so a batch of edits lands as one update.
 - `elapsedTicker.ts` counts whole seconds for running jobs and keeps its interval alive only while something is running.
+- `concurrency.ts` is how many jobs of each media type may run at once, so a pair of slow videos never stalls the sound effects behind them. The limits are hardcoded until BYOK makes them a user setting.
 
 ## Editor state
 

--- a/app/components/canvas/__tests__/useGenerateAll.test.ts
+++ b/app/components/canvas/__tests__/useGenerateAll.test.ts
@@ -128,7 +128,7 @@ let enqueueGraphSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
 	vi.clearAllMocks();
-	queue = new GenerationQueue({ batchSize: 3 });
+	queue = new GenerationQueue();
 	enqueueGraphSpy = vi
 		.spyOn(queue, "enqueueGraph")
 		.mockImplementation(() => {});

--- a/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
@@ -98,7 +98,7 @@ describe("stillFrameUrl", () => {
 	// Regression: the preview used to read the animation's own result, so an
 	// uploaded still stayed invisible until the animation re-rendered.
 	it("reads the still node rather than the animation's own result", () => {
-		const queue = new GenerationQueue({ batchSize: 1 });
+		const queue = new GenerationQueue();
 		const node = nodeBuilder(registry, state)(forElement(animated));
 		const still = node.dependsOn.find(
 			(dep) => dep.id === stillElementId(ELEMENT_ID),
@@ -122,7 +122,7 @@ describe("stillFrameUrl", () => {
 	});
 
 	it("has no still frame before one exists", () => {
-		const queue = new GenerationQueue({ batchSize: 1 });
+		const queue = new GenerationQueue();
 		const node = nodeBuilder(registry, state)(forElement(animated));
 		expect(stillFrameUrl(node, queue)).toBeUndefined();
 	});
@@ -148,7 +148,7 @@ describe("uploaded still lifetime", () => {
 
 	/** Upload a still, then read back both nodes against a possibly-edited element. */
 	const afterUpload = (text: string, videoPrompt: string) => {
-		const queue = new GenerationQueue({ batchSize: 1 });
+		const queue = new GenerationQueue();
 		const build = nodeBuilder(registry, state);
 		const original = build(forElement(animated("a forest", "slow pan")));
 		const still = original.dependsOn.find(

--- a/lib/generation/GenerationQueueProvider.tsx
+++ b/lib/generation/GenerationQueueProvider.tsx
@@ -7,7 +7,7 @@ import {
 	type ReactNode,
 } from "react";
 import { createRequiredContext } from "@/lib/components/createRequiredContext";
-import { DEFAULT_BATCH_SIZE, GenerationQueue } from "./queue";
+import { GenerationQueue } from "./queue";
 import type { ElementSnapshot } from "./snapshots";
 
 const [GenerationQueueContext, useGenerationQueue] =
@@ -32,13 +32,7 @@ export function GenerationQueueProvider({
 	initialState: Record<string, ElementSnapshot>;
 	children: ReactNode;
 }) {
-	const [queue] = useState(
-		() =>
-			new GenerationQueue({
-				batchSize: DEFAULT_BATCH_SIZE,
-				initialState,
-			}),
-	);
+	const [queue] = useState(() => new GenerationQueue({ initialState }));
 	useEffect(() => () => queue.cancelAll(), [queue]);
 	return (
 		<GenerationQueueContext value={queue}>{children}</GenerationQueueContext>

--- a/lib/generation/__tests__/graph.test.ts
+++ b/lib/generation/__tests__/graph.test.ts
@@ -49,7 +49,7 @@ const commit = (queue: GenerationQueue, target: GenerationNode, url: string) =>
 
 describe("nodeInputs", () => {
 	it("records what each dependency resolved to", () => {
-		const queue = new GenerationQueue({ batchSize: 1 });
+		const queue = new GenerationQueue();
 		const avatar = node("avatar");
 		const image = node("image", [
 			avatar,
@@ -70,12 +70,12 @@ describe("nodeInputs", () => {
 
 describe("isNodeStale", () => {
 	it("is false for a node with no result yet", () => {
-		const queue = new GenerationQueue({ batchSize: 1 });
+		const queue = new GenerationQueue();
 		expect(isNodeStale(node("a"), queue)).toBe(false);
 	});
 
 	it("is false right after a result is committed", () => {
-		const queue = new GenerationQueue({ batchSize: 1 });
+		const queue = new GenerationQueue();
 		const avatar = node("avatar");
 		const image = node("image", [avatar]);
 		commit(queue, avatar, "avatar.png");
@@ -85,7 +85,7 @@ describe("isNodeStale", () => {
 	});
 
 	it("is true once a dependency resolves to a different output", () => {
-		const queue = new GenerationQueue({ batchSize: 1 });
+		const queue = new GenerationQueue();
 		const avatar = node("avatar");
 		const image = node("image", [avatar]);
 		commit(queue, avatar, "avatar.png");
@@ -96,7 +96,7 @@ describe("isNodeStale", () => {
 	});
 
 	it("is true when a source node's inputs change, without regenerating anything", () => {
-		const queue = new GenerationQueue({ batchSize: 1 });
+		const queue = new GenerationQueue();
 		const withRefs = (urls: string) =>
 			node("image", [sourceNode("project:refs", { urls })]);
 		commit(queue, withRefs("a.png"), "image.png");
@@ -106,7 +106,7 @@ describe("isNodeStale", () => {
 	});
 
 	it("propagates through a dependency that itself needs regenerating", () => {
-		const queue = new GenerationQueue({ batchSize: 1 });
+		const queue = new GenerationQueue();
 		const refs = (urls: string) => sourceNode("project:refs", { urls });
 		const avatar = (urls: string) => node("avatar", [refs(urls)]);
 		const image = (urls: string) => node("image", [avatar(urls)]);
@@ -123,7 +123,7 @@ describe("isNodeStale", () => {
 	// commitResult is the "the queue did not generate this" path: uploads and
 	// template seeds. It pins, so project state drifting cannot overwrite them.
 	it("never marks a committed upload stale, however far its inputs drift", () => {
-		const queue = new GenerationQueue({ batchSize: 1 });
+		const queue = new GenerationQueue();
 		const uploaded = (style: string) =>
 			node("el", [sourceNode("project:artStyle", { style })]);
 		queue.commitResult(
@@ -137,13 +137,13 @@ describe("isNodeStale", () => {
 	});
 
 	it("still generates a pinned node that has no result yet", () => {
-		const queue = new GenerationQueue({ batchSize: 1 });
+		const queue = new GenerationQueue();
 		queue.discard("el");
 		expect(needsGeneration(node("el"), queue)).toBe(true);
 	});
 
 	it("never marks a source node stale", () => {
-		const queue = new GenerationQueue({ batchSize: 1 });
+		const queue = new GenerationQueue();
 		expect(isNodeStale(sourceNode("project:refs", { urls: "a" }), queue)).toBe(
 			false,
 		);

--- a/lib/generation/__tests__/queue.test.ts
+++ b/lib/generation/__tests__/queue.test.ts
@@ -57,7 +57,7 @@ describe("GenerationQueue", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
 		generateMock = vi.fn();
-		generationQueue = new GenerationQueue({ batchSize: 3 });
+		generationQueue = new GenerationQueue({ limits: { image: 3 } });
 	});
 
 	afterEach(() => {
@@ -139,6 +139,25 @@ describe("GenerationQueue", () => {
 			generationQueue.discard("b2");
 			generationQueue.discard("b3");
 			generationQueue.discard("b4");
+		});
+
+		it("limits each connector type independently", () => {
+			generateMock.mockReturnValue(new Promise(() => {}));
+			const queue = new GenerationQueue({ limits: { image: 1, tts: 2 } });
+
+			queue.enqueueGraph([
+				makeJob("i1"),
+				makeJob("i2"),
+				makeJob("t1", { connectorType: "tts" }),
+				makeJob("t2", { connectorType: "tts" }),
+			]);
+
+			expect(queue.getElementSnapshot("i1").status).toBe("generating");
+			expect(queue.getElementSnapshot("i2").status).toBe("queued");
+			expect(queue.getElementSnapshot("t1").status).toBe("generating");
+			expect(queue.getElementSnapshot("t2").status).toBe("generating");
+
+			queue.cancelAll();
 		});
 
 		it("does not re-enqueue an element already in the queue", () => {
@@ -689,7 +708,6 @@ describe("GenerationQueue", () => {
 
 		it("populates entries from the constructor", () => {
 			const q = new GenerationQueue({
-				batchSize: 3,
 				initialState: { h1: idleEntry },
 			});
 			expect(q.getElementSnapshot("h1")).toEqual(idleEntry);
@@ -697,7 +715,6 @@ describe("GenerationQueue", () => {
 
 		it("normalizes stale 'generating' status back to idle", () => {
 			const q = new GenerationQueue({
-				batchSize: 3,
 				initialState: {
 					h2: { ...idleEntry, status: "generating", seconds: 42 },
 				},
@@ -710,7 +727,6 @@ describe("GenerationQueue", () => {
 		it("keeps staleness correct after rehydration", async () => {
 			const { isNodeStale } = await import("../graph");
 			const q = new GenerationQueue({
-				batchSize: 3,
 				initialState: { h3: idleEntry },
 			});
 

--- a/lib/generation/__tests__/queue.test.ts
+++ b/lib/generation/__tests__/queue.test.ts
@@ -102,7 +102,7 @@ describe("GenerationQueue", () => {
 	});
 
 	describe("enqueue", () => {
-		it("sets element status to generating when under batch limit", () => {
+		it("sets element status to generating when under the concurrency limit", () => {
 			generateMock.mockReturnValue(new Promise(() => {}));
 			generationQueue.enqueueGraph([makeJob("e1")]);
 
@@ -112,10 +112,10 @@ describe("GenerationQueue", () => {
 			generationQueue.discard("e1");
 		});
 
-		it("sets element status to queued when at batch limit", () => {
+		it("sets element status to queued when at the concurrency limit", () => {
 			generateMock.mockReturnValue(new Promise(() => {}));
 
-			// Fill up the batch (size 3)
+			// Fill the image limit (3)
 			generationQueue.enqueueGraph([
 				makeJob("b1"),
 				makeJob("b2"),

--- a/lib/generation/__tests__/queueDependencies.test.ts
+++ b/lib/generation/__tests__/queueDependencies.test.ts
@@ -45,7 +45,7 @@ beforeEach(() => {
 	vi.useFakeTimers();
 	generateMock = vi.fn();
 	// The batch size from the issue's repro: two avatars can fill it.
-	queue = new GenerationQueue({ batchSize: 2 });
+	queue = new GenerationQueue({ limits: { image: 2 } });
 });
 
 afterEach(() => vi.useRealTimers());

--- a/lib/generation/__tests__/resolveGraph.test.ts
+++ b/lib/generation/__tests__/resolveGraph.test.ts
@@ -198,7 +198,7 @@ describe("resolveGraph", () => {
 		);
 		if (!still) throw new Error("expected a still dependency");
 
-		const queue = new GenerationQueue({ batchSize: 1 });
+		const queue = new GenerationQueue();
 		const commit = (node: typeof anim, url: string) =>
 			queue.commitResult(node, { imageUrl: url, durationSec: 0 });
 
@@ -213,7 +213,7 @@ describe("resolveGraph", () => {
 	// An upload replaces a generated result with the user's own image. Project
 	// state drifting underneath it must not let Generate All overwrite it.
 	it("regenerates a generated image when the art style changes", () => {
-		const queue = new GenerationQueue({ batchSize: 1 });
+		const queue = new GenerationQueue();
 		const img = element("img", "image");
 
 		queue.commitResult(resolve(img), {

--- a/lib/generation/concurrency.ts
+++ b/lib/generation/concurrency.ts
@@ -1,0 +1,22 @@
+import type { AssetConnectorType } from "../connectors/types";
+
+/** How many jobs of a given media type may be in flight at once. */
+export type ConcurrencyLimits = Record<AssetConnectorType, number>;
+
+/**
+ * Hardcoded until BYOK, where these become per-user settings: the limits exist
+ * to keep our shared provider keys under their rate limits, so heavier media
+ * gets a smaller share.
+ */
+const DEFAULT_CONCURRENCY_LIMITS: ConcurrencyLimits = {
+	video: 3,
+	image: 3,
+	animated_image: 3,
+	tts: 2,
+	music: 5,
+	sfx: 5,
+};
+
+export const resolveConcurrencyLimits = (
+	overrides: Partial<ConcurrencyLimits> = {},
+): ConcurrencyLimits => ({ ...DEFAULT_CONCURRENCY_LIMITS, ...overrides });

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -1,5 +1,9 @@
-import type { AssetResult } from "../connectors/types";
+import type { AssetConnectorType, AssetResult } from "../connectors/types";
 import { errorMessage } from "../errors";
+import {
+	resolveConcurrencyLimits,
+	type ConcurrencyLimits,
+} from "./concurrency";
 import { ElapsedTicker } from "./elapsedTicker";
 import { generateForElement } from "./generateForElement";
 import type { GenerationInputs } from "./inputs";
@@ -15,12 +19,15 @@ import {
 	type NodeId,
 } from "./graph";
 
-export const DEFAULT_BATCH_SIZE = 2;
+type ActiveJob = {
+	controller: AbortController;
+	connectorType: AssetConnectorType;
+};
 
 /**
- * Runs generation nodes, at most `batchSize` at a time and never before their
- * dependencies have settled. All per-element state lives in the snapshot store;
- * the queue owns only what is in flight.
+ * Runs generation nodes, at most `limits[connectorType]` of each media type at a
+ * time and never before their dependencies have settled. All per-element state
+ * lives in the snapshot store; the queue owns only what is in flight.
  */
 export class GenerationQueue {
 	private readonly snapshots: SnapshotStore;
@@ -28,17 +35,17 @@ export class GenerationQueue {
 		this.onTick(elapsed),
 	);
 	private pending: JobNode[] = [];
-	private controllers = new Map<string, AbortController>();
-	private readonly batchSize: number;
+	private active = new Map<string, ActiveJob>();
+	private readonly limits: ConcurrencyLimits;
 
 	constructor({
-		batchSize,
+		limits,
 		initialState,
 	}: {
-		batchSize: number;
+		limits?: Partial<ConcurrencyLimits>;
 		initialState?: Record<string, ElementSnapshot>;
-	}) {
-		this.batchSize = batchSize;
+	} = {}) {
+		this.limits = resolveConcurrencyLimits(limits);
 		this.snapshots = new SnapshotStore(initialState);
 	}
 
@@ -91,11 +98,11 @@ export class GenerationQueue {
 	}
 
 	cancelAll() {
-		for (const [id, controller] of this.controllers) {
+		for (const [id, { controller }] of this.active) {
 			controller.abort();
 			this.ticker.stop(id);
 		}
-		this.controllers.clear();
+		this.active.clear();
 		this.pending = [];
 		for (const id of this.snapshots.ids()) {
 			this.snapshots.resetToIdle(id);
@@ -156,8 +163,8 @@ export class GenerationQueue {
 	}
 
 	private abortJob(id: string) {
-		this.controllers.get(id)?.abort();
-		this.controllers.delete(id);
+		this.active.get(id)?.controller.abort();
+		this.active.delete(id);
 		this.ticker.stop(id);
 		this.pending = this.pending.filter((node) => node.id !== id);
 	}
@@ -171,10 +178,19 @@ export class GenerationQueue {
 		);
 	}
 
+	private hasCapacity(connectorType: AssetConnectorType) {
+		const running = [...this.active.values()].filter(
+			(job) => job.connectorType === connectorType,
+		).length;
+		return running < this.limits[connectorType];
+	}
+
 	private processQueue() {
-		while (this.controllers.size < this.batchSize) {
+		for (;;) {
 			const index = this.pending.findIndex(
-				(node) => !this.blockingDependency(node),
+				(node) =>
+					this.hasCapacity(node.job.connectorType) &&
+					!this.blockingDependency(node),
 			);
 			if (index === -1) break;
 			const [node] = this.pending.splice(index, 1);
@@ -197,7 +213,7 @@ export class GenerationQueue {
 	 * its own, so its error would otherwise never reach anyone.
 	 */
 	private releaseBlocked() {
-		if (this.controllers.size > 0 || this.pending.length === 0) return;
+		if (this.active.size > 0 || this.pending.length === 0) return;
 		const blocked = this.pending;
 		this.pending = [];
 		for (const node of blocked) {
@@ -220,7 +236,10 @@ export class GenerationQueue {
 		const { job } = node;
 		const { elementId } = job;
 		const controller = new AbortController();
-		this.controllers.set(elementId, controller);
+		this.active.set(elementId, {
+			controller,
+			connectorType: job.connectorType,
+		});
 
 		this.snapshots.update(elementId, { status: "generating", seconds: 0 });
 		this.snapshots.notify();
@@ -264,7 +283,7 @@ export class GenerationQueue {
 	private finalizeJob(elementId: string, controller: AbortController) {
 		if (controller.signal.aborted) return;
 		this.ticker.stop(elementId);
-		this.controllers.delete(elementId);
+		this.active.delete(elementId);
 		this.processQueue();
 	}
 }

--- a/lib/project/__tests__/applyTemplate.test.ts
+++ b/lib/project/__tests__/applyTemplate.test.ts
@@ -19,7 +19,7 @@ const apply = (templateId: string) =>
 describe("applyTemplate", () => {
 	beforeEach(() => {
 		clearProjectStore(PROJECT_ID);
-		queue = new GenerationQueue({ batchSize: 1 });
+		queue = new GenerationQueue();
 	});
 
 	it("does not leak characters from a previous template", () => {


### PR DESCRIPTION
Closes #259.

## Problem

The generation queue admitted at most `DEFAULT_BATCH_SIZE = 2` jobs at a time, regardless of what those jobs were. Two slow video renders would stall every sound effect and TTS clip waiting behind them, even though those cost us almost nothing to run in parallel.

## Change

Concurrency is now a per-connector-type budget rather than one global count:

| type | limit |
| --- | --- |
| `video`, `image`, `animated_image` | 3 |
| `tts` | 2 |
| `music`, `sfx` | 5 |

- **`lib/generation/concurrency.ts`** (new) — the limits as one declarative table, plus `resolveConcurrencyLimits(overrides)`.
- **`lib/generation/queue.ts`** — `controllers: Map<string, AbortController>` becomes `active: Map<string, {controller, connectorType}>` so the queue knows the type of each in-flight job. `processQueue` admits any pending node whose type has headroom *and* whose dependencies have settled, instead of stopping at a single global count.
- **`GenerationQueueProvider`** — constructs the queue with no arguments; defaults come from the table.

Dependency ordering, cancellation, and the blocked-node release path are unchanged.

## Post-BYOK

The seam is `resolveConcurrencyLimits`, which merges a `Partial<ConcurrencyLimits>` over the defaults. When user-adjustable limits land, the provider passes the user's overrides in and nothing in the queue changes. Nothing is exported ahead of that need.

## Notes

- `animated_image` sits with video/image at 3 — same class of heavy job.
- The old default was 2 for *everything*, so this does raise real throughput against our shared provider keys. `tts` is the only type that didn't go up.

## Testing

New test covers the core behavior: a saturated `image` pool no longer blocks `tts` jobs. Existing queue tests that relied on `batchSize` now pin the specific limit they exercise. Full CI green locally — lint, format, typecheck, knip, build, 1107 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)