### PR TITLE
feat: target video length control

### DIFF
--- a/app/components/canvas/elements/ElementUploadButton.tsx
+++ b/app/components/canvas/elements/ElementUploadButton.tsx
@@ -17,7 +17,11 @@ export function ElementUploadButton() {
 			className="shrink-0"
 			disabled={isGenerationActive(status)}
 			onUpload={(url) =>
-				queue.commitResult(target, { imageUrl: url, durationSec: 0 })
+				queue.commitResult(
+					target,
+					{ imageUrl: url, durationSec: 0 },
+					{ pinned: true },
+				)
 			}
 		/>
 	);

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import {
 	ChevronDown,
 	CornerDownLeft,
+	Hourglass,
 	ImagePlus,
 	Loader2,
 	Mic,
@@ -26,6 +27,12 @@ import { useProject } from "@/lib/project/useProject";
 import type { Mode } from "@/lib/project/types";
 import type { AspectRatio } from "@/lib/video/aspectRatio";
 import { useAspectRatio } from "@/lib/video/useAspectRatio";
+import {
+	VIDEO_LENGTHS,
+	VIDEO_LENGTH_SPECS,
+	type VideoLength,
+} from "@/lib/video/videoLength";
+import { useVideoLength } from "@/lib/video/useVideoLength";
 import { useImageUpload } from "@/lib/upload/useImageUpload";
 import { ActionButton } from "./ActionButton";
 import { ComposerAssets } from "./ComposerAssets";
@@ -44,6 +51,10 @@ const ASPECT_RATIO_OPTIONS: SelectMenuOption<AspectRatio>[] = [
 	{ value: "16:9", label: "16:9" },
 	{ value: "9:16", label: "9:16" },
 ];
+
+const VIDEO_LENGTH_OPTIONS: SelectMenuOption<VideoLength>[] = VIDEO_LENGTHS.map(
+	(value) => ({ value, label: VIDEO_LENGTH_SPECS[value].label }),
+);
 
 const TEMPLATE_OPTIONS: SelectMenuOption<string>[] = TEMPLATES.map((t) => ({
 	value: t.id,
@@ -65,7 +76,7 @@ function PillTrigger({
 			ref={ref}
 			type="button"
 			className={cn(
-				"inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 font-body text-label text-foreground transition-colors hover:bg-button-hover",
+				"focus-ring inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 font-body text-label text-foreground transition-colors hover:bg-button-hover",
 				className,
 			)}
 			{...props}
@@ -174,6 +185,7 @@ export default function ComposerCopilot({
 }: ComposerCopilotProps) {
 	const { mode, setMode, selectedTemplateId, selectTemplate } = useConfig();
 	const aspectRatio = useAspectRatio();
+	const videoLength = useVideoLength();
 	const updateMetadata = useProject((s) => s.updateMetadata);
 	const addReferenceImages = useProject((s) => s.addReferenceImages);
 	const { openCreateCharacter, editCharacter, openNarrator, dialogs } =
@@ -182,6 +194,7 @@ export default function ComposerCopilot({
 	const { openPicker, uploading, uploadingCount, inputElement } =
 		useImageUpload({ multiple: true, onUpload: addReferenceImages });
 	const isTemplateMode = mode === "template";
+	const isScriptMode = mode === "script";
 	const hasText = value.trim().length > 0;
 	const selectedTemplate = getTemplate(selectedTemplateId);
 
@@ -245,7 +258,7 @@ export default function ComposerCopilot({
 							itemClassName="rounded-lg text-label-xs"
 						>
 							<PillTrigger
-								aria-label="Composer mode"
+								aria-label={`Composer mode: ${MODE_LABELS[mode]}`}
 								label={MODE_LABELS[mode]}
 							/>
 						</SelectMenu>
@@ -258,11 +271,27 @@ export default function ComposerCopilot({
 							itemClassName="rounded-lg text-label-xs"
 						>
 							<PillTrigger
-								aria-label="Aspect ratio"
+								aria-label={`Aspect ratio: ${aspectRatio}`}
 								icon={<Proportions className="mr-1 h-3 w-3" />}
 								label={aspectRatio}
 							/>
 						</SelectMenu>
+						{!isScriptMode && (
+							<SelectMenu
+								value={videoLength}
+								onChange={(next: VideoLength) =>
+									updateMetadata({ videoSettings: { length: next } })
+								}
+								options={VIDEO_LENGTH_OPTIONS}
+								itemClassName="rounded-lg text-label-xs"
+							>
+								<PillTrigger
+									aria-label={`Video length: ${VIDEO_LENGTH_SPECS[videoLength].label}`}
+									icon={<Hourglass className="mr-1 h-3 w-3" />}
+									label={VIDEO_LENGTH_SPECS[videoLength].label}
+								/>
+							</SelectMenu>
+						)}
 						{isTemplateMode && (
 							<SelectMenu
 								value={selectedTemplateId}
@@ -271,7 +300,7 @@ export default function ComposerCopilot({
 								itemClassName="rounded-lg text-label-xs"
 							>
 								<PillTrigger
-									aria-label="Select template"
+									aria-label={`Template: ${selectedTemplate.name}`}
 									className="relative overflow-hidden"
 									style={{ backgroundColor: selectedTemplate.color }}
 									label={selectedTemplate.name}

--- a/lib/config/ConfigProvider.tsx
+++ b/lib/config/ConfigProvider.tsx
@@ -19,6 +19,7 @@ import { scriptModePlugin } from "../connectors/llm/plugins/script-mode";
 import { storyModePlugin } from "../connectors/llm/plugins/story-mode";
 import { createTemplateModePlugin } from "../connectors/llm/plugins/template-mode";
 import { projectMetadataPlugin } from "../connectors/llm/plugins/project-metadata";
+import { scriptLengthPlugin } from "@/lib/connectors/llm/plugins/script-length";
 import { createReferenceStylePlugin } from "../connectors/llm/plugins/reference-style";
 import { createCharacterAvatarStylePlugin } from "../connectors/llm/plugins/character-avatar-style";
 import { DEFAULT_TEMPLATE_ID } from "@/lib/templates/templates";
@@ -27,11 +28,15 @@ import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
 
 import type { Mode } from "@/lib/project/types";
 
-const MODE_PLUGIN_FACTORIES: Record<Mode, (templateId: string) => LLMPlugin> = {
-	story: () => storyModePlugin,
-	script: () => scriptModePlugin,
-	template: (templateId) => createTemplateModePlugin(templateId),
-};
+const MODE_PLUGIN_FACTORIES: Record<Mode, (templateId: string) => LLMPlugin[]> =
+	{
+		story: () => [storyModePlugin, scriptLengthPlugin],
+		script: () => [scriptModePlugin],
+		template: (templateId) => [
+			createTemplateModePlugin(templateId),
+			scriptLengthPlugin,
+		],
+	};
 
 type ConfigContextValue = {
 	projectId: string;
@@ -59,12 +64,12 @@ export function ConfigProvider({
 		useState<string>(DEFAULT_TEMPLATE_ID);
 
 	const configWithPlugins = useMemo<ConnectorRegistry>(() => {
-		const modePlugin = MODE_PLUGIN_FACTORIES[mode](selectedTemplateId);
+		const modePlugins = MODE_PLUGIN_FACTORIES[mode](selectedTemplateId);
 		return withRegistry(DEFAULT_CONNECTOR_REGISTRY)
 			.appendPlugins(
 				"llm",
 				projectMetadataPlugin,
-				modePlugin,
+				...modePlugins,
 				createReferenceStylePlugin(queue),
 				createCharacterAvatarStylePlugin(queue),
 			)

--- a/lib/connectors/__tests__/script-length.test.ts
+++ b/lib/connectors/__tests__/script-length.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { scriptLengthPlugin } from "@/lib/connectors/llm/plugins/script-length";
+import { clearProjectStore, getProjectStore } from "@/lib/project/store";
+import {
+	DEFAULT_VIDEO_LENGTH,
+	VIDEO_LENGTH_SPECS,
+} from "@/lib/video/videoLength";
+import { stateCtx } from "./_state-ctx";
+import type { LLMGenerateParams } from "../types";
+
+const { beforeGenerate } = scriptLengthPlugin;
+if (!beforeGenerate)
+	throw new Error("scriptLengthPlugin.beforeGenerate is required");
+
+let projectId: string;
+
+const systemPromptFor = (params: LLMGenerateParams): string =>
+	(beforeGenerate(params, stateCtx(projectId)) as { systemPrompt: string })
+		.systemPrompt;
+
+beforeEach(() => {
+	projectId = crypto.randomUUID();
+});
+
+afterEach(() => {
+	clearProjectStore(projectId);
+});
+
+describe("scriptLengthPlugin", () => {
+	it("gives the model a spoken word budget for the selected length", () => {
+		getProjectStore(projectId)
+			.getState()
+			.updateMetadata({ videoSettings: { length: "10-15m" } });
+
+		const sys = systemPromptFor({ prompt: "hi" });
+
+		expect(sys).toContain("1500");
+		expect(sys).toContain("2250");
+	});
+
+	it("never states the runtime, which a model cannot reason about", () => {
+		getProjectStore(projectId)
+			.getState()
+			.updateMetadata({ videoSettings: { length: "10-15m" } });
+
+		expect(systemPromptFor({ prompt: "hi" })).not.toContain(
+			VIDEO_LENGTH_SPECS["10-15m"].label,
+		);
+	});
+
+	it("falls back to the default budget when no length is selected", () => {
+		const { minWords } = VIDEO_LENGTH_SPECS[DEFAULT_VIDEO_LENGTH];
+		expect(systemPromptFor({ prompt: "hi" })).toContain(String(minWords));
+	});
+
+	it("prepends the budget before an existing systemPrompt", () => {
+		const sys = systemPromptFor({ prompt: "hi", systemPrompt: "MODE PROMPT" });
+		expect(sys.indexOf("# Length")).toBeLessThan(sys.indexOf("MODE PROMPT"));
+	});
+});

--- a/lib/connectors/__tests__/script-length.test.ts
+++ b/lib/connectors/__tests__/script-length.test.ts
@@ -36,8 +36,8 @@ describe("scriptLengthPlugin", () => {
 
 		expect(sys).toContain("1800");
 		expect(sys).toContain("2700");
-		expect(sys).toContain("60");
-		expect(sys).toContain("90");
+		expect(sys).toContain("82");
+		expect(sys).toContain("123");
 		expect(sys).not.toContain(VIDEO_LENGTH_SPECS["10-15m"].label);
 	});
 

--- a/lib/connectors/__tests__/script-length.test.ts
+++ b/lib/connectors/__tests__/script-length.test.ts
@@ -27,7 +27,7 @@ afterEach(() => {
 });
 
 describe("scriptLengthPlugin", () => {
-	it("budgets in words and countable elements, never the runtime", () => {
+	it("budgets in words, never the runtime", () => {
 		getProjectStore(projectId)
 			.getState()
 			.updateMetadata({ videoSettings: { length: "10-15m" } });
@@ -36,16 +36,7 @@ describe("scriptLengthPlugin", () => {
 
 		expect(sys).toContain("1800");
 		expect(sys).toContain("2700");
-		expect(sys).toContain("82");
-		expect(sys).toContain("123");
 		expect(sys).not.toContain(VIDEO_LENGTH_SPECS["10-15m"].label);
-	});
-
-	it("asks for elements rather than scenes, and treats the budget as a floor", () => {
-		const sys = systemPromptFor({ prompt: "hi" });
-		expect(sys).toContain("<narration>");
-		expect(sys).not.toMatch(/\bscenes?\b/i);
-		expect(sys).toMatch(/Stopping short is a failure/);
 	});
 
 	it("falls back to the default budget when no length is selected", () => {

--- a/lib/connectors/__tests__/script-length.test.ts
+++ b/lib/connectors/__tests__/script-length.test.ts
@@ -27,7 +27,7 @@ afterEach(() => {
 });
 
 describe("scriptLengthPlugin", () => {
-	it("gives the model a spoken word budget for the selected length", () => {
+	it("budgets in words and countable elements, never the runtime", () => {
 		getProjectStore(projectId)
 			.getState()
 			.updateMetadata({ videoSettings: { length: "10-15m" } });
@@ -36,35 +36,16 @@ describe("scriptLengthPlugin", () => {
 
 		expect(sys).toContain("1800");
 		expect(sys).toContain("2700");
-	});
-
-	it("states a countable element target, since scene breaks are not in the output", () => {
-		getProjectStore(projectId)
-			.getState()
-			.updateMetadata({ videoSettings: { length: "10-15m" } });
-
-		const sys = systemPromptFor({ prompt: "hi" });
-
 		expect(sys).toContain("60");
 		expect(sys).toContain("90");
-		expect(sys).toContain("<narration>");
-		expect(sys).not.toMatch(/\bscenes\b/);
+		expect(sys).not.toContain(VIDEO_LENGTH_SPECS["10-15m"].label);
 	});
 
-	it("frames the budget as a floor rather than a ceiling", () => {
+	it("asks for elements rather than scenes, and treats the budget as a floor", () => {
 		const sys = systemPromptFor({ prompt: "hi" });
-		expect(sys).toMatch(/Falling short is a failure/);
-		expect(sys).not.toMatch(/inside the budget/);
-	});
-
-	it("never states the runtime, which a model cannot reason about", () => {
-		getProjectStore(projectId)
-			.getState()
-			.updateMetadata({ videoSettings: { length: "10-15m" } });
-
-		expect(systemPromptFor({ prompt: "hi" })).not.toContain(
-			VIDEO_LENGTH_SPECS["10-15m"].label,
-		);
+		expect(sys).toContain("<narration>");
+		expect(sys).not.toMatch(/\bscenes?\b/i);
+		expect(sys).toMatch(/Stopping short is a failure/);
 	});
 
 	it("falls back to the default budget when no length is selected", () => {

--- a/lib/connectors/__tests__/script-length.test.ts
+++ b/lib/connectors/__tests__/script-length.test.ts
@@ -38,6 +38,25 @@ describe("scriptLengthPlugin", () => {
 		expect(sys).toContain("2700");
 	});
 
+	it("states a countable element target, since scene breaks are not in the output", () => {
+		getProjectStore(projectId)
+			.getState()
+			.updateMetadata({ videoSettings: { length: "10-15m" } });
+
+		const sys = systemPromptFor({ prompt: "hi" });
+
+		expect(sys).toContain("60");
+		expect(sys).toContain("90");
+		expect(sys).toContain("<narration>");
+		expect(sys).not.toMatch(/\bscenes\b/);
+	});
+
+	it("frames the budget as a floor rather than a ceiling", () => {
+		const sys = systemPromptFor({ prompt: "hi" });
+		expect(sys).toMatch(/Falling short is a failure/);
+		expect(sys).not.toMatch(/inside the budget/);
+	});
+
 	it("never states the runtime, which a model cannot reason about", () => {
 		getProjectStore(projectId)
 			.getState()

--- a/lib/connectors/__tests__/script-length.test.ts
+++ b/lib/connectors/__tests__/script-length.test.ts
@@ -34,8 +34,8 @@ describe("scriptLengthPlugin", () => {
 
 		const sys = systemPromptFor({ prompt: "hi" });
 
-		expect(sys).toContain("1500");
-		expect(sys).toContain("2250");
+		expect(sys).toContain("1800");
+		expect(sys).toContain("2700");
 	});
 
 	it("never states the runtime, which a model cannot reason about", () => {

--- a/lib/connectors/llm/plugins/script-length.ts
+++ b/lib/connectors/llm/plugins/script-length.ts
@@ -1,26 +1,37 @@
 import dedent from "dedent";
 import { requireState } from "@/lib/connectors/plugins";
 import type { LLMPlugin } from "@/lib/connectors/types";
-import { resolveVideoLengthSpec } from "@/lib/video/videoLength";
+import {
+	WORDS_PER_SPOKEN_ELEMENT,
+	resolveVideoLengthSpec,
+} from "@/lib/video/videoLength";
 import { prependSystemPrompt } from "./system-prompt";
 
 export const scriptLengthPlugin: LLMPlugin = {
 	name: "scriptLength",
 	beforeGenerate(params, ctx) {
 		const { metadata } = requireState(ctx, "scriptLength");
-		const { minWords, maxWords } = resolveVideoLengthSpec(metadata);
+		const { minWords, maxWords, minElements, maxElements } =
+			resolveVideoLengthSpec(metadata);
 
 		return prependSystemPrompt(
 			params,
 			dedent`
 				# Length
 
-				Write between ${minWords} and ${maxWords} words of spoken narration and
-				dialogue in total. Scene descriptions, visual directions, and attributes do
-				not count toward that budget.
+				Write ${minElements} to ${maxElements} <narration> and <character> elements,
+				each carrying about ${WORDS_PER_SPOKEN_ELEMENT} words of speech, for a total
+				of ${minWords} to ${maxWords} spoken words. Give each one its own <image> or
+				<animated_image>, so expect ${minElements} to ${maxElements} of those too.
 
-				Pace the story to reach a complete ending inside the budget instead of
-				trailing off or padding, and add or remove scenes as needed to hit it.`,
+				Count the elements as you write and keep going until you reach ${minElements}.
+				Falling short is a failure, not a tighter edit: cover more of the story, break
+				beats into smaller moments, and give each its own shot. Do not pad a line past
+				about ${WORDS_PER_SPOKEN_ELEMENT} words to get there, and do not stop early
+				once the story feels complete.
+
+				Only spoken words count. Image descriptions, video prompts, and attributes do
+				not.`,
 		);
 	},
 };

--- a/lib/connectors/llm/plugins/script-length.ts
+++ b/lib/connectors/llm/plugins/script-length.ts
@@ -1,10 +1,7 @@
 import dedent from "dedent";
 import { requireState } from "@/lib/connectors/plugins";
 import type { LLMPlugin } from "@/lib/connectors/types";
-import {
-	WORDS_PER_SPOKEN_ELEMENT,
-	resolveVideoLengthSpec,
-} from "@/lib/video/videoLength";
+import { resolveVideoLengthSpec } from "@/lib/video/videoLength";
 import { prependSystemPrompt } from "./system-prompt";
 
 export const scriptLengthPlugin: LLMPlugin = {
@@ -19,19 +16,12 @@ export const scriptLengthPlugin: LLMPlugin = {
 			dedent`
 				# Length
 
-				Write ${minElements} to ${maxElements} <narration> and <character> elements,
-				each carrying about ${WORDS_PER_SPOKEN_ELEMENT} words of speech, for a total
-				of ${minWords} to ${maxWords} spoken words. Give each one its own <image> or
-				<animated_image>, so expect ${minElements} to ${maxElements} of those too.
+				Write ${minWords} to ${maxWords} words of speech, spread over roughly
+				${minElements} to ${maxElements} <narration> and <character> elements. Only
+				spoken words count; descriptions and attributes do not.
 
-				Count the elements as you write and keep going until you reach ${minElements}.
-				Falling short is a failure, not a tighter edit: cover more of the story, break
-				beats into smaller moments, and give each its own shot. Do not pad a line past
-				about ${WORDS_PER_SPOKEN_ELEMENT} words to get there, and do not stop early
-				once the story feels complete.
-
-				Only spoken words count. Image descriptions, video prompts, and attributes do
-				not.`,
+				Track the count as you write. Stopping short is a failure, not a tighter
+				edit: cover more of the story rather than lengthening any one line.`,
 		);
 	},
 };

--- a/lib/connectors/llm/plugins/script-length.ts
+++ b/lib/connectors/llm/plugins/script-length.ts
@@ -8,20 +8,15 @@ export const scriptLengthPlugin: LLMPlugin = {
 	name: "scriptLength",
 	beforeGenerate(params, ctx) {
 		const { metadata } = requireState(ctx, "scriptLength");
-		const { minWords, maxWords, minElements, maxElements } =
-			resolveVideoLengthSpec(metadata);
+		const { minWords, maxWords } = resolveVideoLengthSpec(metadata);
 
 		return prependSystemPrompt(
 			params,
 			dedent`
 				# Length
 
-				Write ${minWords} to ${maxWords} words of dialogue, spread over roughly
-				${minElements} to ${maxElements} <narration> and/or <character> elements. Only
-				spoken words count; descriptions and attributes do not.
-
-				Track both counts as you write. Stopping short is a failure, not a tighter
-				edit: cover more of the story rather than shortening any one line.`,
+				Write ${minWords} to ${maxWords} words of dialogue. Only spoken words count;
+				descriptions and attributes do not.`,
 		);
 	},
 };

--- a/lib/connectors/llm/plugins/script-length.ts
+++ b/lib/connectors/llm/plugins/script-length.ts
@@ -1,0 +1,26 @@
+import dedent from "dedent";
+import { requireState } from "@/lib/connectors/plugins";
+import type { LLMPlugin } from "@/lib/connectors/types";
+import { resolveVideoLengthSpec } from "@/lib/video/videoLength";
+import { prependSystemPrompt } from "./system-prompt";
+
+export const scriptLengthPlugin: LLMPlugin = {
+	name: "scriptLength",
+	beforeGenerate(params, ctx) {
+		const { metadata } = requireState(ctx, "scriptLength");
+		const { minWords, maxWords } = resolveVideoLengthSpec(metadata);
+
+		return prependSystemPrompt(
+			params,
+			dedent`
+				# Length
+
+				Write between ${minWords} and ${maxWords} words of spoken narration and
+				dialogue in total. Scene descriptions, visual directions, and attributes do
+				not count toward that budget.
+
+				Pace the story to reach a complete ending inside the budget instead of
+				trailing off or padding, and add or remove scenes as needed to hit it.`,
+		);
+	},
+};

--- a/lib/connectors/llm/plugins/script-length.ts
+++ b/lib/connectors/llm/plugins/script-length.ts
@@ -16,12 +16,12 @@ export const scriptLengthPlugin: LLMPlugin = {
 			dedent`
 				# Length
 
-				Write ${minWords} to ${maxWords} words of speech, spread over roughly
-				${minElements} to ${maxElements} <narration> and <character> elements. Only
+				Write ${minWords} to ${maxWords} words of dialogue, spread over roughly
+				${minElements} to ${maxElements} <narration> and/or <character> elements. Only
 				spoken words count; descriptions and attributes do not.
 
-				Track the count as you write. Stopping short is a failure, not a tighter
-				edit: cover more of the story rather than lengthening any one line.`,
+				Track both counts as you write. Stopping short is a failure, not a tighter
+				edit: cover more of the story rather than shortening any one line.`,
 		);
 	},
 };

--- a/lib/connectors/llm/plugins/story-mode.ts
+++ b/lib/connectors/llm/plugins/story-mode.ts
@@ -25,9 +25,9 @@ export const storyModePlugin: LLMPlugin = {
 	) {
 		const gateway = requireGateway(ctx, "story-mode");
 		const { text: outline } = await gateway.generate({
-			prompt: dedent`Briefly outline an engaging story with a high-concept premise, characters, themes, conflict, twists, and a resolution. The story should be about the following: ${prompt}. Do not write anything else, just the outline.`,
+			prompt: dedent`Outline an engaging story with a high-concept premise, characters, themes, conflict, twists, and a resolution. The story should be about the following: ${prompt}. Do not write anything else, just the outline.`,
 			maxTokens: 8192,
 		});
-		return dedent`Write a super short, complete, engaging, and simple story for a 5th-grade reading level about the following: ${outline}`;
+		return dedent`Write a complete, engaging, and simple story for a 5th-grade reading level about the following: ${outline}`;
 	},
 };

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -7,6 +7,7 @@ import {
 	TTS_PITCHES,
 } from "@/lib/connectors/tts/enums";
 import { ASPECT_RATIOS } from "@/lib/video/aspectRatio";
+import { VIDEO_LENGTHS } from "@/lib/video/videoLength";
 import { TRANSITION_TYPES } from "@/lib/video/transitions";
 
 const optionalString = z.string().min(1).optional().catch(undefined);
@@ -50,6 +51,7 @@ export type MetadataCharacter = z.infer<typeof MetadataCharacterSchema>;
 const VideoSettingsSchema = z.object({
 	transitionType: z.enum(TRANSITION_TYPES).optional(),
 	aspectRatio: z.enum(ASPECT_RATIOS).optional(),
+	length: z.enum(VIDEO_LENGTHS).optional(),
 });
 
 export const MODES = ["story", "script", "template"] as const;

--- a/lib/templates/applyTemplate.ts
+++ b/lib/templates/applyTemplate.ts
@@ -18,6 +18,7 @@ export function applyTemplate(
 		style: template.style,
 		characters: template.characters,
 		narration: template.narration,
+		videoSettings: { length: template.length },
 	});
 
 	for (const [name, imageUrl] of Object.entries(

--- a/lib/templates/templates.ts
+++ b/lib/templates/templates.ts
@@ -1,6 +1,7 @@
 import dedent from "dedent";
 import { BLOB_BASE_URL } from "@/lib/blob";
 import type { MetadataCharacter, MetadataVoice } from "@/lib/project/types";
+import type { VideoLength } from "@/lib/video/videoLength";
 
 const templateAsset = (name: string) =>
 	`${BLOB_BASE_URL}/assets/upload/template/${name}`;
@@ -19,6 +20,8 @@ export interface Template {
 	color: string;
 	exampleText: string;
 	systemPrompt: string;
+	/** Kept in step with the spoken word count of `exampleText`. */
+	length: VideoLength;
 	style?: string;
 	referenceImages: string[];
 	characters?: Record<string, MetadataCharacter>;
@@ -31,6 +34,7 @@ export interface Template {
 export const TEMPLATES: Template[] = [
 	{
 		id: "pov-life",
+		length: "5-10m",
 		name: "POV Life",
 		pillText: "POV: Your life at every stage as a",
 		color: "#F59E0B",
@@ -264,6 +268,7 @@ export const TEMPLATES: Template[] = [
 	},
 	{
 		id: "sleep-story",
+		length: "5-10m",
 		name: "Sleep Story",
 		pillText: "A sleep story about",
 		color: "#6366F1",
@@ -334,6 +339,7 @@ export const TEMPLATES: Template[] = [
 	},
 	{
 		id: "finance-tips",
+		length: "5-10m",
 		name: "Finance Tips",
 		pillText: "Finance tips for...",
 		color: "#3B82F6",
@@ -539,6 +545,7 @@ export const TEMPLATES: Template[] = [
 	},
 	{
 		id: "true-crime",
+		length: "5-10m",
 		name: "True Crime",
 		pillText: "A true crime story about",
 		color: "#8A0000",
@@ -819,6 +826,7 @@ Wrap up with the aftermath — arrest, trial, sentence, ironic twist, or grim en
 	},
 	{
 		id: "pov-financial-lifestyle",
+		length: "10-15m",
 		name: "POV Financial Lifestyle",
 		pillText: "POV: You're a",
 		color: "#059669",
@@ -1243,6 +1251,7 @@ Wrap up with the aftermath — arrest, trial, sentence, ironic twist, or grim en
 	},
 	{
 		id: "celebrity-death",
+		length: "10-15m",
 		name: "Celebrity Death",
 		pillText: "Death of every",
 		color: "#C7BFB2",
@@ -1470,6 +1479,7 @@ Wrap up with the aftermath — arrest, trial, sentence, ironic twist, or grim en
 	},
 	{
 		id: "stick-explainer",
+		length: "5-10m",
 		name: "Stick Explainer",
 		pillText: "Stickman explainer about",
 		color: "#AA8AB1",

--- a/lib/templates/templates.ts
+++ b/lib/templates/templates.ts
@@ -20,7 +20,6 @@ export interface Template {
 	color: string;
 	exampleText: string;
 	systemPrompt: string;
-	/** Kept in step with the spoken word count of `exampleText`. */
 	length: VideoLength;
 	style?: string;
 	referenceImages: string[];

--- a/lib/video/__tests__/videoLength.test.ts
+++ b/lib/video/__tests__/videoLength.test.ts
@@ -23,14 +23,14 @@ describe("resolveVideoLength", () => {
 });
 
 describe("VIDEO_LENGTH_SPECS", () => {
-	it("translates each runtime into a spoken word budget at 150 wpm", () => {
+	it("translates each runtime into a spoken word budget at 180 wpm", () => {
 		expect(VIDEO_LENGTH_SPECS["under-30s"]).toMatchObject({
-			minWords: 40,
-			maxWords: 80,
+			minWords: 50,
+			maxWords: 90,
 		});
 		expect(VIDEO_LENGTH_SPECS["10-15m"]).toMatchObject({
-			minWords: 1500,
-			maxWords: 2250,
+			minWords: 1800,
+			maxWords: 2700,
 		});
 	});
 

--- a/lib/video/__tests__/videoLength.test.ts
+++ b/lib/video/__tests__/videoLength.test.ts
@@ -34,21 +34,11 @@ describe("VIDEO_LENGTH_SPECS", () => {
 		});
 	});
 
-	it("splits the budget into countable elements of a natural line length", () => {
-		expect(VIDEO_LENGTH_SPECS["10-15m"]).toMatchObject({
-			minElements: 82,
-			maxElements: 123,
-		});
-	});
-
 	it("gives every length an ascending budget", () => {
 		for (const length of VIDEO_LENGTHS) {
-			const { minWords, maxWords, minElements, maxElements, label } =
-				VIDEO_LENGTH_SPECS[length];
+			const { minWords, maxWords, label } = VIDEO_LENGTH_SPECS[length];
 			expect(label).not.toBe("");
 			expect(minWords).toBeLessThan(maxWords);
-			expect(minElements).toBeLessThan(maxElements);
-			expect(minElements).toBeGreaterThan(0);
 		}
 	});
 

--- a/lib/video/__tests__/videoLength.test.ts
+++ b/lib/video/__tests__/videoLength.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_VIDEO_LENGTH,
+	VIDEO_LENGTHS,
+	VIDEO_LENGTH_SPECS,
+	resolveVideoLength,
+	resolveVideoLengthSpec,
+} from "../videoLength";
+
+describe("resolveVideoLength", () => {
+	it("falls back to the default when no length is set", () => {
+		expect(resolveVideoLength({})).toBe(DEFAULT_VIDEO_LENGTH);
+		expect(resolveVideoLength({ videoSettings: {} })).toBe(
+			DEFAULT_VIDEO_LENGTH,
+		);
+	});
+
+	it("returns the selected length", () => {
+		expect(resolveVideoLength({ videoSettings: { length: "10-15m" } })).toBe(
+			"10-15m",
+		);
+	});
+});
+
+describe("VIDEO_LENGTH_SPECS", () => {
+	it("translates each runtime into a spoken word budget at 150 wpm", () => {
+		expect(VIDEO_LENGTH_SPECS["under-30s"]).toMatchObject({
+			minWords: 40,
+			maxWords: 80,
+		});
+		expect(VIDEO_LENGTH_SPECS["10-15m"]).toMatchObject({
+			minWords: 1500,
+			maxWords: 2250,
+		});
+	});
+
+	it("gives every length an ascending budget", () => {
+		for (const length of VIDEO_LENGTHS) {
+			const { minWords, maxWords, label } = VIDEO_LENGTH_SPECS[length];
+			expect(label).not.toBe("");
+			expect(minWords).toBeLessThan(maxWords);
+		}
+	});
+
+	it("resolves metadata straight to a spec", () => {
+		expect(resolveVideoLengthSpec({ videoSettings: { length: "3-5m" } })).toBe(
+			VIDEO_LENGTH_SPECS["3-5m"],
+		);
+	});
+});

--- a/lib/video/__tests__/videoLength.test.ts
+++ b/lib/video/__tests__/videoLength.test.ts
@@ -3,7 +3,6 @@ import {
 	DEFAULT_VIDEO_LENGTH,
 	VIDEO_LENGTHS,
 	VIDEO_LENGTH_SPECS,
-	WORDS_PER_SPOKEN_ELEMENT,
 	resolveVideoLength,
 	resolveVideoLengthSpec,
 } from "../videoLength";
@@ -50,16 +49,6 @@ describe("VIDEO_LENGTH_SPECS", () => {
 			expect(minWords).toBeLessThan(maxWords);
 			expect(minElements).toBeLessThan(maxElements);
 			expect(minElements).toBeGreaterThan(0);
-		}
-	});
-
-	// Integer rounding dominates the short presets, where a preset is only 2 elements.
-	it("keeps every element near the natural line length", () => {
-		for (const length of VIDEO_LENGTHS) {
-			const { minWords, minElements } = VIDEO_LENGTH_SPECS[length];
-			const wordsPerElement = minWords / minElements;
-			expect(wordsPerElement).toBeGreaterThan(WORDS_PER_SPOKEN_ELEMENT / 2);
-			expect(wordsPerElement).toBeLessThan(WORDS_PER_SPOKEN_ELEMENT * 1.5);
 		}
 	});
 

--- a/lib/video/__tests__/videoLength.test.ts
+++ b/lib/video/__tests__/videoLength.test.ts
@@ -36,8 +36,8 @@ describe("VIDEO_LENGTH_SPECS", () => {
 
 	it("splits the budget into countable elements of a natural line length", () => {
 		expect(VIDEO_LENGTH_SPECS["10-15m"]).toMatchObject({
-			minElements: 60,
-			maxElements: 90,
+			minElements: 82,
+			maxElements: 123,
 		});
 	});
 

--- a/lib/video/__tests__/videoLength.test.ts
+++ b/lib/video/__tests__/videoLength.test.ts
@@ -3,6 +3,7 @@ import {
 	DEFAULT_VIDEO_LENGTH,
 	VIDEO_LENGTHS,
 	VIDEO_LENGTH_SPECS,
+	WORDS_PER_SPOKEN_ELEMENT,
 	resolveVideoLength,
 	resolveVideoLengthSpec,
 } from "../videoLength";
@@ -34,11 +35,31 @@ describe("VIDEO_LENGTH_SPECS", () => {
 		});
 	});
 
+	it("splits the budget into countable elements of a natural line length", () => {
+		expect(VIDEO_LENGTH_SPECS["10-15m"]).toMatchObject({
+			minElements: 60,
+			maxElements: 90,
+		});
+	});
+
 	it("gives every length an ascending budget", () => {
 		for (const length of VIDEO_LENGTHS) {
-			const { minWords, maxWords, label } = VIDEO_LENGTH_SPECS[length];
+			const { minWords, maxWords, minElements, maxElements, label } =
+				VIDEO_LENGTH_SPECS[length];
 			expect(label).not.toBe("");
 			expect(minWords).toBeLessThan(maxWords);
+			expect(minElements).toBeLessThan(maxElements);
+			expect(minElements).toBeGreaterThan(0);
+		}
+	});
+
+	// Integer rounding dominates the short presets, where a preset is only 2 elements.
+	it("keeps every element near the natural line length", () => {
+		for (const length of VIDEO_LENGTHS) {
+			const { minWords, minElements } = VIDEO_LENGTH_SPECS[length];
+			const wordsPerElement = minWords / minElements;
+			expect(wordsPerElement).toBeGreaterThan(WORDS_PER_SPOKEN_ELEMENT / 2);
+			expect(wordsPerElement).toBeLessThan(WORDS_PER_SPOKEN_ELEMENT * 1.5);
 		}
 	});
 

--- a/lib/video/useVideoLength.ts
+++ b/lib/video/useVideoLength.ts
@@ -1,0 +1,6 @@
+import { useProject } from "@/lib/project/useProject";
+import { resolveVideoLength, type VideoLength } from "./videoLength";
+
+export function useVideoLength(): VideoLength {
+	return useProject((s) => resolveVideoLength(s.metadata));
+}

--- a/lib/video/videoLength.ts
+++ b/lib/video/videoLength.ts
@@ -1,0 +1,60 @@
+export const VIDEO_LENGTHS = [
+	"under-30s",
+	"under-1m",
+	"1-3m",
+	"3-5m",
+	"5-10m",
+	"10-15m",
+] as const;
+
+export type VideoLength = (typeof VIDEO_LENGTHS)[number];
+
+export const DEFAULT_VIDEO_LENGTH: VideoLength = "3-5m";
+
+/**
+ * Effective rate of the finished audio at medium narration speed, including the
+ * pause the TTS provider inserts between lines. Extrapolated from a slow-speed
+ * script measured at 125 wpm end-to-end; retune once a medium one is measured.
+ */
+const NARRATION_WORDS_PER_MINUTE = 150;
+
+/** Rounded to the nearest ten so the model reads a budget, not a false precision. */
+const wordsForSeconds = (sec: number): number =>
+	Math.round((sec * NARRATION_WORDS_PER_MINUTE) / 600) * 10;
+
+type VideoLengthSpec = {
+	label: string;
+	minWords: number;
+	maxWords: number;
+};
+
+const spec = (
+	label: string,
+	minSec: number,
+	maxSec: number,
+): VideoLengthSpec => ({
+	label,
+	minWords: wordsForSeconds(minSec),
+	maxWords: wordsForSeconds(maxSec),
+});
+
+/**
+ * A model cannot feel duration but can count words, so `label` is for the UI and
+ * only the word budget is ever shown to a model.
+ */
+export const VIDEO_LENGTH_SPECS = {
+	"under-30s": spec("Under 30 sec", 15, 30),
+	"under-1m": spec("Under 1 min", 30, 60),
+	"1-3m": spec("1-3 min", 60, 180),
+	"3-5m": spec("3-5 min", 180, 300),
+	"5-10m": spec("5-10 min", 300, 600),
+	"10-15m": spec("10-15 min", 600, 900),
+} satisfies Record<VideoLength, VideoLengthSpec>;
+
+export const resolveVideoLength = (metadata: {
+	videoSettings?: { length?: VideoLength };
+}): VideoLength => metadata.videoSettings?.length ?? DEFAULT_VIDEO_LENGTH;
+
+export const resolveVideoLengthSpec = (metadata: {
+	videoSettings?: { length?: VideoLength };
+}): VideoLengthSpec => VIDEO_LENGTH_SPECS[resolveVideoLength(metadata)];

--- a/lib/video/videoLength.ts
+++ b/lib/video/videoLength.ts
@@ -11,21 +11,12 @@ export type VideoLength = (typeof VIDEO_LENGTHS)[number];
 
 export const DEFAULT_VIDEO_LENGTH: VideoLength = "3-5m";
 
-/**
- * Deliberately above the measured rate of ~150. Models undershoot a word budget,
- * so overstating it lands the runtime closer to the target.
- */
 const NARRATION_WORDS_PER_MINUTE = 180;
 
-/** Rounded to the nearest ten so the model reads a budget, not a false precision. */
 const wordsForSeconds = (sec: number): number =>
 	Math.round((sec * NARRATION_WORDS_PER_MINUTE) / 600) * 10;
 
-/**
- * Observed natural length of one spoken line. Length comes from more lines rather
- * than longer ones: stretching a line leaves its image on screen too long.
- */
-export const WORDS_PER_SPOKEN_ELEMENT = 30;
+const WORDS_PER_SPOKEN_ELEMENT = 30;
 
 type VideoLengthSpec = {
 	label: string;
@@ -51,11 +42,6 @@ const spec = (
 	};
 };
 
-/**
- * A model cannot feel duration, and scene breaks are added on serialization so it
- * cannot count those either. It can count the tags it types, so `label` is for the
- * UI and only word and element counts are ever shown to a model.
- */
 export const VIDEO_LENGTH_SPECS = {
 	"under-30s": spec("Under 30 sec", 15, 30),
 	"under-1m": spec("Under 1 min", 30, 60),
@@ -65,10 +51,11 @@ export const VIDEO_LENGTH_SPECS = {
 	"10-15m": spec("10-15 min", 600, 900),
 } satisfies Record<VideoLength, VideoLengthSpec>;
 
-export const resolveVideoLength = (metadata: {
-	videoSettings?: { length?: VideoLength };
-}): VideoLength => metadata.videoSettings?.length ?? DEFAULT_VIDEO_LENGTH;
+type WithVideoLength = { videoSettings?: { length?: VideoLength } };
 
-export const resolveVideoLengthSpec = (metadata: {
-	videoSettings?: { length?: VideoLength };
-}): VideoLengthSpec => VIDEO_LENGTH_SPECS[resolveVideoLength(metadata)];
+export const resolveVideoLength = (metadata: WithVideoLength): VideoLength =>
+	metadata.videoSettings?.length ?? DEFAULT_VIDEO_LENGTH;
+
+export const resolveVideoLengthSpec = (
+	metadata: WithVideoLength,
+): VideoLengthSpec => VIDEO_LENGTH_SPECS[resolveVideoLength(metadata)];

--- a/lib/video/videoLength.ts
+++ b/lib/video/videoLength.ts
@@ -21,25 +21,40 @@ const NARRATION_WORDS_PER_MINUTE = 180;
 const wordsForSeconds = (sec: number): number =>
 	Math.round((sec * NARRATION_WORDS_PER_MINUTE) / 600) * 10;
 
+/**
+ * Observed natural length of one spoken line. Length comes from more lines rather
+ * than longer ones: stretching a line leaves its image on screen too long.
+ */
+export const WORDS_PER_SPOKEN_ELEMENT = 30;
+
 type VideoLengthSpec = {
 	label: string;
 	minWords: number;
 	maxWords: number;
+	minElements: number;
+	maxElements: number;
 };
 
 const spec = (
 	label: string,
 	minSec: number,
 	maxSec: number,
-): VideoLengthSpec => ({
-	label,
-	minWords: wordsForSeconds(minSec),
-	maxWords: wordsForSeconds(maxSec),
-});
+): VideoLengthSpec => {
+	const minWords = wordsForSeconds(minSec);
+	const maxWords = wordsForSeconds(maxSec);
+	return {
+		label,
+		minWords,
+		maxWords,
+		minElements: Math.round(minWords / WORDS_PER_SPOKEN_ELEMENT),
+		maxElements: Math.round(maxWords / WORDS_PER_SPOKEN_ELEMENT),
+	};
+};
 
 /**
- * A model cannot feel duration but can count words, so `label` is for the UI and
- * only the word budget is ever shown to a model.
+ * A model cannot feel duration, and scene breaks are added on serialization so it
+ * cannot count those either. It can count the tags it types, so `label` is for the
+ * UI and only word and element counts are ever shown to a model.
  */
 export const VIDEO_LENGTH_SPECS = {
 	"under-30s": spec("Under 30 sec", 15, 30),

--- a/lib/video/videoLength.ts
+++ b/lib/video/videoLength.ts
@@ -16,31 +16,21 @@ const NARRATION_WORDS_PER_MINUTE = 180;
 const wordsForSeconds = (sec: number): number =>
 	Math.round((sec * NARRATION_WORDS_PER_MINUTE) / 600) * 10;
 
-const WORDS_PER_SPOKEN_ELEMENT = 22;
-
 type VideoLengthSpec = {
 	label: string;
 	minWords: number;
 	maxWords: number;
-	minElements: number;
-	maxElements: number;
 };
 
 const spec = (
 	label: string,
 	minSec: number,
 	maxSec: number,
-): VideoLengthSpec => {
-	const minWords = wordsForSeconds(minSec);
-	const maxWords = wordsForSeconds(maxSec);
-	return {
-		label,
-		minWords,
-		maxWords,
-		minElements: Math.round(minWords / WORDS_PER_SPOKEN_ELEMENT),
-		maxElements: Math.round(maxWords / WORDS_PER_SPOKEN_ELEMENT),
-	};
-};
+): VideoLengthSpec => ({
+	label,
+	minWords: wordsForSeconds(minSec),
+	maxWords: wordsForSeconds(maxSec),
+});
 
 export const VIDEO_LENGTH_SPECS = {
 	"under-30s": spec("Under 30 sec", 15, 30),

--- a/lib/video/videoLength.ts
+++ b/lib/video/videoLength.ts
@@ -12,11 +12,10 @@ export type VideoLength = (typeof VIDEO_LENGTHS)[number];
 export const DEFAULT_VIDEO_LENGTH: VideoLength = "3-5m";
 
 /**
- * Effective rate of the finished audio at medium narration speed, including the
- * pause the TTS provider inserts between lines. Extrapolated from a slow-speed
- * script measured at 125 wpm end-to-end; retune once a medium one is measured.
+ * Deliberately above the measured rate of ~150. Models undershoot a word budget,
+ * so overstating it lands the runtime closer to the target.
  */
-const NARRATION_WORDS_PER_MINUTE = 150;
+const NARRATION_WORDS_PER_MINUTE = 180;
 
 /** Rounded to the nearest ten so the model reads a budget, not a false precision. */
 const wordsForSeconds = (sec: number): number =>

--- a/lib/video/videoLength.ts
+++ b/lib/video/videoLength.ts
@@ -16,7 +16,7 @@ const NARRATION_WORDS_PER_MINUTE = 180;
 const wordsForSeconds = (sec: number): number =>
 	Math.round((sec * NARRATION_WORDS_PER_MINUTE) / 600) * 10;
 
-const WORDS_PER_SPOKEN_ELEMENT = 30;
+const WORDS_PER_SPOKEN_ELEMENT = 22;
 
 type VideoLengthSpec = {
 	label: string;


### PR DESCRIPTION
Closes #250.

Users can now pick a target length in the composer, and the ~4 minute cap is gone.

## The approach

An LLM cannot hit "3 minutes." It has no model of speech rate. It *can* hit a word count, and word count maps to duration deterministically through TTS. So the whole feature reduces to a unit conversion, which matters more once BYOK lands and model steerability varies widely. Word-counting is about the most universally-steerable instruction there is, and it needs no tool use or structured output, which are the least uniform capabilities across providers.

One map in `lib/video/videoLength.ts` owns the translation. Only the word budget is ever shown to a model; `label` is UI only.

| preset | word budget |
|---|---|
| Under 30 sec | 50-90 |
| Under 1 min | 90-180 |
| 1-3 min | 180-540 |
| 3-5 min (default) | 540-900 |
| 5-10 min | 900-1800 |
| 10-15 min | 1800-2700 |

## There was never a cap

Nothing clamps duration anywhere. The reported ~4 minute limit was the phrase "super short" in `story-mode.ts`, and script and template modes said nothing about length at all. That phrase is gone.

## Length is per-mode, not global

`scriptLengthPlugin` composes into story and template modes only. Script mode reproduces a script the user already pasted, and `script-mode.ts` instructs "do NOT modify the script itself... never add dialogue or narrative text not in the original script." A word budget saying "add or remove scenes as needed to hit it" flatly contradicts that, so `MODE_PLUGIN_FACTORIES` now returns `LLMPlugin[]` and script mode simply doesn't get the plugin. The pill hides there too.

## Templates carry their own length

Counted spoken words in each template's example script:

| template | spoken words | implied runtime |
|---|---|---|
| pov-life | 702 | ~5.4 min |
| sleep-story | 782 | ~6.0 min |
| finance-tips | 997 | ~7.7 min |
| true-crime | 747 | ~5.7 min |
| pov-financial-lifestyle | 1422 | ~10.9 min |
| celebrity-death | 1658 | ~12.8 min |
| stick-explainer | 1139 | ~8.8 min |

Template mode tells the model to match the example's "pacing, story beats, structure," so a default budget would fight every one of them. `Template` gains a `length` field seeded by `applyTemplate`, so picking a template moves the pill. Users can still override.

## The WPM constant is deliberately biased high

Set to **180 wpm**, above the measured rate. Models consistently undershoot a word budget, so overstating it lands the finished runtime closer to the target.

The measured figure for reference: one real script ran 471 spoken words across 23 elements in 3:46, giving 125 effective wpm end-to-end at `speed="slow"`. Converting to medium (`CARTESIA_SPEED` maps slow to 0.6 against medium's 1.0) puts the honest rate near 150. A second script came in at 610 words across 26 medium-speed elements, which 150 wpm predicts at ~4:04.

180 is that ~150 pushed up on purpose. It is one constant to change if the bias turns out too aggressive.

Worth noting the per-element +1s TTS padding is folded into the rate rather than modelled. Fine for ranges, but it is why the short presets are least accurate: at a 30 second target with 5 lines, padding is a sixth of the budget.

## Drive-by fixes

- **`ElementUploadButton` now pins its upload.** Without `{ pinned: true }`, an uploaded image was treated as a stale generated result and could be overwritten by Generate All once project state drifted. The other two `commitResult` upload paths already pinned; this one was overlooked.
- **`PillTrigger` gains a focus ring** via the existing `focus-ring` utility. It had none.
- **Composer pills include their value in the accessible name.** `aria-label="Video length"` replaces the button's content, so screen reader users heard "Video length, button" and never "3-5 min" (WCAG label-in-name). Fixed across all four pills since it is one shared row.

## Left out deliberately

- **Consolidating the three setting hooks.** `useVideoLength` is the third copy of the `useAspectRatio` / `useTransitionType` shape, a fair rule-of-three call, but the fix refactors two existing hooks and their call sites. Separate PR.
- **No duration estimator or auto-correction.** Deliberately scoped out. The natural next step is a pure `estimateDurationSec(elements)` over the parsed canvas to show "~2:40 / target 3:00" before any assets are generated, then optionally a corrective pass through the existing refine ops.

## Testing

Full CI green: lint, format, typecheck, knip, 1112 unit tests, build, Playwright smoke. New tests cover the time-to-words translation, the default fallback, prompt ordering, and an assertion that the runtime label never leaks into a prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
