### PR TITLE
refactor: nightly maintainability 2026-08-08

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,9 @@ The prompt goes through the LLM connector to `POST /api/v1/llm`, which streams O
 
 ### 2. Generate
 
-Generate resolves the element into a dependency graph (see [Generation graph](#generation-graph)) and queues the stale nodes client-side, dependencies first and up to a per-media-type concurrency limit at a time. Each job is submitted to `POST /api/v1/{asset}`, which records a `jobs` row and enqueues to the Vercel Queue. Workers call the provider, upload results to Vercel Blob, and mark the job complete. The client polls until the asset URL arrives and the preview updates. Music and sfx check a Pinecone similarity cache first.
+Generate resolves the element into a dependency graph (see [Generation graph](#generation-graph)) and queues the stale nodes client-side, dependencies first and up to a per-media-type concurrency limit at a time. Each job is submitted to `POST /api/v1/{asset}`, which records a `jobs` row and enqueues to the Vercel Queue. The client polls until the asset URL arrives and the preview updates. Music and sfx check a Pinecone similarity cache first.
+
+Each delivery runs `lib/api/process-job.ts`, which hands the job to the `JobHandler` registered for its type (`lib/api/job-handlers.ts`) and gets back `completed` or `pending`. Image, tts, music and sfx complete on the first delivery. Video is slow enough to outlive one invocation, so its handler submits to the provider, records the provider's job id on the row, and reports `pending`; the job then redelivers itself every 5s to poll, and fails once it outlives `JOB_TIMEOUT_MS`. Results upload to Vercel Blob. Bytes a provider only exposes at its own URL are streamed across rather than linked, so every asset we serve is our own.
 
 ### 3. Save / restore
 


### PR DESCRIPTION
Docs-only night. The code surface swept clean, so the one change worth making is a correction to `ARCHITECTURE.md`.

## What changed

Flow 2 described only the synchronous worker path:

> Workers call the provider, upload results to Vercel Blob, and mark the job complete.

That stopped being true when video generation moved to a redelivered job. A reader would not guess from the old text that a single `jobs` row is delivered to the worker many times. Now documented:

- `lib/api/process-job.ts` hands each delivery to the `JobHandler` registered in `lib/api/job-handlers.ts`, which returns `completed` or `pending`.
- Image, tts, music and sfx complete on the first delivery; video submits, records `providerJobId`, and reports `pending`.
- Pending jobs re-enqueue themselves every 5s to poll, and fail once they outlive `JOB_TIMEOUT_MS`.
- Provider-hosted bytes are streamed into our own blob rather than linked (`BundleFileRemote`, PR #526).

Referenced by constant name rather than literal so the doc doesn't drift when the timeout changes.

## Open PR overlap check

There were **zero open PRs** at the time of this run, so this is trivially non-overlapping.

## Maintainability sweep: no code changes

Swept for the architecture/simplification passes and found nothing meeting the "substantial, not marginal churn" bar. Read in full and confirmed clean this pass: `lib/video/{videoLength,useVideoLength,scene-builder,motionEffects}`, `lib/api/{process-job,asset-bundle,job-handlers,route-handler,handlers/video}`, `lib/providers/{cache,video/base,tts/cartesia}`, `lib/generation/{graph,queue,concurrency}`, `lib/connectors/llm/plugins/{script-length,osml}`, and the character-editing cluster (`CharacterEditModal`, `fields`, `VoiceMetadataFields`, `VoicePicker`, `useAssetEditDialogs`, `CharactersPicker`, `ExportButton`). `npx knip` is clean.

Two standing architecture items are now **resolved** and can be dropped from the backlog:

1. The `graph.ts` ↔ `queue.ts` type cycle is gone — `graph.ts` owns `GenerationJob` and imports nothing from `queue.ts`.
2. The dual plugin state-read paths were unified by #516; every LLM plugin now uses `requireState(ctx)`.

## Tried and reverted

Extracted a `SelectPill` from the four repeated `SelectMenu` + `PillTrigger` blocks in `ComposerCopilot` (the repo's largest hand-written component). It typechecked and lint-passed with no visual change, but came out at **net +3 lines** — the shared component costs about what the four call sites save. Reverted as churn rather than shipping it.

## Flagged for a human, not taken

- **`lib/project/store.ts` global `Map<projectId, store>`** — the last open architecture item, and unblocked for the first time in weeks now that the PR queue is empty. `clearProjectStore` has no callers, so every visited project's store leaks for the session, and `projectId` is threaded through ~12 modules purely as a lookup key. The fix (create the store in `ProjectEditor`, pass the handle) changes store lifecycle, which is out of scope for a no-behavior-change nightly.
- **`EnumField` in `canvas/elements/character/fields.tsx` bypasses the design system.** It hand-rolls the `DropdownMenu` wiring and the selected-check column that `components/ui/select-menu.tsx` already owns, and overrides `DropdownMenuContent`'s chrome with one-off Tailwind (`rounded-xl ... bg-card p-0.5 shadow-md shadow-black/40` in place of the shipped `rounded-md ... bg-popover p-1 shadow-elevation-3`). `CharactersPicker.ProjectCharactersMenu` hand-rolls the same check column a third time. Routing these through `SelectMenu` would be the right call, but the three copies disagree on the check color (`text-accent` vs `text-foreground`), so unifying them changes pixels — a DESIGN.md decision, not a nightly one.

## Validation

`npm run build`, `npm test` (128 files, 1111 tests), and `prettier --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)