### PR TITLE
fix: reserve the transport bar seek row height

### DIFF
--- a/app/components/video/BottomTransportBar.tsx
+++ b/app/components/video/BottomTransportBar.tsx
@@ -3,12 +3,14 @@
 import { memo } from "react";
 import { ChevronsLeft, ChevronsRight, Pause, Play } from "@/components/ui/icon";
 import { TooltipIconButton } from "@/components/ui/icon-button";
+import { cn } from "@/lib/utils";
 import { toFrames } from "@/lib/video/frames";
 import { usePlayerControl } from "./PlayerControlContext";
 import { usePlayerPosition } from "./PlayerPositionContext";
 import { useLayout } from "./VideoLayoutContext";
 import { findSegmentIndexAtFrame } from "./useSceneSegments";
 import { usePlayerPlaying } from "./usePlayerState";
+import { SCRUB_BAR_HEIGHT } from "./ScrubBar";
 import { SegmentedSeekBar } from "./SegmentedSeekBar";
 import {
 	FullscreenButton,
@@ -38,11 +40,15 @@ function BottomTransportBarComponent() {
 
 	return (
 		<div className="@container relative z-20 flex w-full shrink-0 flex-col gap-1.5 border-t border-border px-4 py-2 text-body text-foreground">
-			{ready ? (
-				<SegmentedSeekBar player={player} layout={layout} segments={segments} />
-			) : (
-				<div className="h-3 w-full" aria-hidden />
-			)}
+			<div className={cn("flex w-full items-center", SCRUB_BAR_HEIGHT)}>
+				{ready && (
+					<SegmentedSeekBar
+						player={player}
+						layout={layout}
+						segments={segments}
+					/>
+				)}
+			</div>
 			<div className="flex items-center gap-2">
 				<div className="flex flex-1 items-center gap-2">
 					{ready && <TimeDisplay player={player} layout={layout} />}

--- a/app/components/video/ScrubBar.tsx
+++ b/app/components/video/ScrubBar.tsx
@@ -42,6 +42,9 @@ interface ScrubBarProps {
 	children?: ReactNode;
 }
 
+/** Height of the interactive track; callers reserve this to avoid layout shift. */
+export const SCRUB_BAR_HEIGHT = "h-5";
+
 const SINGLE: ScrubSegment[] = [{ id: "_", basis: 1 }];
 
 /**
@@ -168,7 +171,8 @@ export function ScrubBar({
 			ref={trackRef}
 			aria-label={ariaLabel}
 			className={cn(
-				"group relative flex h-5 cursor-pointer items-center",
+				"group relative flex cursor-pointer items-center",
+				SCRUB_BAR_HEIGHT,
 				className,
 			)}
 			style={


### PR DESCRIPTION
## Summary

The bottom transport bar had no stable height. Its seek-bar row rendered `SegmentedSeekBar` (a `ScrubBar`, `h-5`) when the player was ready and an `h-3` placeholder otherwise, and the container inferred its height from children. The bar and the canvas above it jumped 8px the moment the video became playable.

The seek row now owns its height: a wrapper reserves `SCRUB_BAR_HEIGHT` unconditionally and renders the seek bar into that space when ready. The height is defined once, in `ScrubBar.tsx`, and consumed by both the control and the reserved row, so the two can't drift apart.

This also makes `SegmentedSeekBar`'s redundant `segments.length === 0` early return harmless: if it ever fired, the row keeps its height instead of collapsing to 0.

`TimeDisplay` and `ScenePill` sit in the controls row, whose height is set by the always-rendered play buttons, so they can't move the bar. Left as-is rather than adding a second reserved height.

## Why this issue was safe and small

Two-file, presentation-only change with explicit acceptance criteria and named code locations in the issue. No behavior, state, or API changes.

## Validation

- `npm run lint` — pass
- `npm run format:check` — pass
- `npm run typecheck` — pass
- `npm run knip` — pass
- `npm run build` — pass
- `npm run test:coverage` — 128 files, 1111 tests passed
- `npm run test:e2e` — 3 passed

No test added: the change is Tailwind class placement with no logic to assert; a class-string test would be brittle.

## Open PR overlap check

Open PRs at selection time: #531 (`ARCHITECTURE.md`), #532 (`lib/connectors`, `lib/templates`), #533 (`lib/project`, `lib/connectors`, canvas hooks). None touch `app/components/video/`. No overlap.

## Candidates skipped

Issue #529 was the only open `size: XS` issue. Everything else open is S/M/L/XL and product-, design-, or architecture-heavy (model selection UX, BYOK, i18n, publishing kit, a11y audit), which the runbook excludes from unattended runs.

Closes #529