### PR TITLE
refactor: nightly maintainability 2026-08-09

### DIFF
--- a/lib/api/asset-bundle.ts
+++ b/lib/api/asset-bundle.ts
@@ -78,8 +78,7 @@ export class AssetBundle {
 	}
 
 	static buildUrl(type: string, provider: string, id: string): string {
-		const base = AssetBundle.baseUrl || "";
-		return `${base}/assets/${type}/${provider}/${id}`;
+		return `${AssetBundle.baseUrl}/assets/${type}/${provider}/${id}`;
 	}
 
 	static fromResponse(response: BundleResponse): AssetBundle {

--- a/lib/api/handlers/__tests__/video.test.ts
+++ b/lib/api/handlers/__tests__/video.test.ts
@@ -36,7 +36,10 @@ function job(overrides: Partial<VideoJobRow> = {}): VideoJobRow {
 describe("videoHandler.process", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		poll.mockResolvedValue({ result: {}, metadata: { status: "processing" } });
+		poll.mockResolvedValue({
+			kind: "pending",
+			metadata: { status: "processing" },
+		});
 	});
 
 	it("submits upstream without polling a job it just created", async () => {
@@ -68,18 +71,18 @@ describe("videoHandler.process", () => {
 	});
 
 	it("completes with the re-hosted bundle once upstream reports a video", async () => {
-		const completed = { ...bundle, result: { video: "output.mp4" } };
-		poll.mockResolvedValue(completed);
+		const asset = { ...bundle, result: { video: "output.mp4" } };
+		poll.mockResolvedValue({ kind: "ready", asset });
 
 		await expect(videoHandler.process(job())).resolves.toEqual({
 			kind: "completed",
-			result: completed,
+			result: asset,
 		});
 	});
 
 	it("throws the upstream error message on failure", async () => {
 		poll.mockResolvedValue({
-			result: {},
+			kind: "pending",
 			metadata: { status: "failed", error: "content policy" },
 		});
 
@@ -87,7 +90,7 @@ describe("videoHandler.process", () => {
 	});
 
 	it("throws a fallback message when upstream fails without one", async () => {
-		poll.mockResolvedValue({ result: {}, metadata: { status: "failed" } });
+		poll.mockResolvedValue({ kind: "pending", metadata: { status: "failed" } });
 
 		await expect(videoHandler.process(job())).rejects.toThrow(
 			"Video generation failed",

--- a/lib/api/handlers/video.ts
+++ b/lib/api/handlers/video.ts
@@ -22,8 +22,8 @@ export const videoHandler: JobHandler<VideoGenerateParams, VideoMetadata> = {
 		}
 
 		const upstream = await provider.poll(providerJobId);
-		if (upstream.result.video) {
-			return { kind: "completed", result: upstream };
+		if (upstream.kind === "ready") {
+			return { kind: "completed", result: upstream.asset };
 		}
 		if (upstream.metadata?.status === "failed") {
 			throw new Error(upstream.metadata.error ?? "Video generation failed");

--- a/lib/api/job-handlers.ts
+++ b/lib/api/job-handlers.ts
@@ -15,9 +15,9 @@ import {
 	getTTSProvider,
 } from "./providers";
 
-export type ProcessOutcome =
+export type ProcessOutcome<TMeta = Record<string, unknown>> =
 	| { kind: "completed"; result: BundleResponse }
-	| { kind: "pending"; metadata: Record<string, unknown> };
+	| { kind: "pending"; metadata: TMeta };
 
 export type TypedJobRow<TReq, TMeta> = Omit<JobRow, "request" | "metadata"> & {
 	request: TReq;
@@ -28,7 +28,7 @@ export interface JobHandler<
 	TReq = Record<string, unknown>,
 	TMeta = Record<string, unknown>,
 > {
-	process(job: TypedJobRow<TReq, TMeta>): Promise<ProcessOutcome>;
+	process(job: TypedJobRow<TReq, TMeta>): Promise<ProcessOutcome<TMeta>>;
 }
 
 function assetHandler<TReq extends Record<string, unknown>>(

--- a/lib/providers/__tests__/runware-video.test.ts
+++ b/lib/providers/__tests__/runware-video.test.ts
@@ -142,7 +142,7 @@ describe("RunwareVideo", () => {
 	});
 
 	describe("poll", () => {
-		it("returns BundleResponse when job is completed", async () => {
+		it("returns the stored asset when the job is completed", async () => {
 			mockGetResponse.mockResolvedValue([
 				{
 					taskUUID: "job-1",
@@ -154,11 +154,14 @@ describe("RunwareVideo", () => {
 			const provider = new RunwareVideo("test-key");
 			const result = await provider.poll("job-1");
 
-			expect(result.result.video).toBe("https://result.mp4");
+			expect(result).toMatchObject({
+				kind: "ready",
+				asset: { result: { video: "https://result.mp4" } },
+			});
 			expect(mockDisconnect).toHaveBeenCalled();
 		});
 
-		it("returns empty BundleResponse when job is pending", async () => {
+		it("reports pending with the upstream status while the job runs", async () => {
 			mockGetResponse.mockResolvedValue([
 				{
 					taskUUID: "job-1",
@@ -169,8 +172,10 @@ describe("RunwareVideo", () => {
 			const provider = new RunwareVideo("test-key");
 			const result = await provider.poll("job-1");
 
-			expect(result.id).toBe("");
-			expect(result.result).toEqual({});
+			expect(result).toEqual({
+				kind: "pending",
+				metadata: { jobId: "job-1", status: "processing" },
+			});
 		});
 
 		it("throws when job not found", async () => {

--- a/lib/providers/video/base.ts
+++ b/lib/providers/video/base.ts
@@ -21,6 +21,11 @@ export type VideoProviderResponse = BundleResponse & {
 	metadata?: VideoJobMetadata;
 };
 
+/** A provider that is still working has no asset to hand back yet. */
+export type VideoPoll =
+	| { kind: "pending"; metadata?: VideoJobMetadata }
+	| { kind: "ready"; asset: VideoProviderResponse };
+
 export abstract class BaseVideoProvider extends BaseProvider<
 	VideoGenerateParams,
 	VideoJob,
@@ -41,17 +46,11 @@ export abstract class BaseVideoProvider extends BaseProvider<
 
 	protected abstract _poll(jobId: string): Promise<VideoJob>;
 
-	async poll(jobId: string): Promise<VideoProviderResponse> {
+	async poll(jobId: string): Promise<VideoPoll> {
 		const result = await this._poll(jobId);
 		if (this.toFiles(result).length === 0) {
-			return {
-				id: "",
-				type: this.blobConfig.type,
-				provider: this.blobConfig.provider,
-				result: {},
-				metadata: result.metadata,
-			};
+			return { kind: "pending", metadata: result.metadata };
 		}
-		return this.store(result);
+		return { kind: "ready", asset: await this.store(result) };
 	}
 }


### PR DESCRIPTION
## Async video polling is now an explicit contract

`BaseVideoProvider.poll` used to fabricate a hollow `VideoProviderResponse` (`id: ""`, `result: {}`) to signal "the provider is still working", and `lib/api/handlers/video.ts` recovered that state by sniffing `upstream.result.video`. The pending case was encoded in the *absence* of data, so the type said "here is an asset" while the value said otherwise.

`poll` now returns a `VideoPoll` discriminated union:

```ts
export type VideoPoll =
  | { kind: "pending"; metadata?: VideoJobMetadata }
  | { kind: "ready"; asset: VideoProviderResponse };
```

The handler branches on `kind`. This matches every other async surface in the repo (`ProcessOutcome`'s `pending | completed`, `graph.ts`'s `SourceNode | JobNode`), and removes the only place a provider hands back an asset envelope that isn't one.

## Also

- `ProcessOutcome<TMeta>` is parameterized by the handler's metadata type, so a `pending` outcome must carry that handler's shape instead of an untyped `Record<string, unknown>`. `videoHandler`'s pending metadata is now checked against `VideoMetadata`.
- `AssetBundle.buildUrl` dropped `const base = AssetBundle.baseUrl || ""` — `baseUrl` is already declared `?? ""`, so the second default was unreachable. One decision, one default.

No behavior change: the pending / ready / failed branches fire on exactly the same conditions as before. Tests updated to the new contract.

## Validation

`npm run build`, `npm run typecheck`, `npm run lint`, `npm run knip`, and `npm test` (128 files / 1111 tests) all pass.

## Open PR overlap check

Considered open PRs #538 (art style), #534 (transport bar), #533 (architecture rethink), #532 (template mode), #531 (ARCHITECTURE.md). None touch `lib/providers/video/**`, `lib/api/handlers/**`, `lib/api/job-handlers.ts` or `lib/api/asset-bundle.ts`. This PR is non-overlapping.

## Skipped

- `lib/api/sse.ts`'s unused `createSSEResponse` — reusable surface, not dead code; wants a human call.
- Returning `stringifyError` to clients (`with-auth.ts`, `process-job.ts`) — API contract change.
- `Waveform` silent peaks-decode failure, `lib/supabase/env.ts` empty-string env defaults — behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)