### PR TITLE
fix: show an animated image as generating while its still frame renders

### DIFF
--- a/app/components/canvas/hooks/useGenerate.ts
+++ b/app/components/canvas/hooks/useGenerate.ts
@@ -3,7 +3,12 @@ import {
 	useGenerationQueue,
 	useQueueSelector,
 } from "@/lib/generation/GenerationQueueProvider";
-import { forElement, isNodeStale, nodeInputs } from "@/lib/generation/graph";
+import {
+	forElement,
+	isNodeStale,
+	nodeInputs,
+	subtreeProgress,
+} from "@/lib/generation/graph";
 import { useNodeBuilder } from "@/lib/generation/useNodeBuilder";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 
@@ -16,6 +21,7 @@ export function useGenerate(element: CanvasContentElement) {
 		[buildNode, element],
 	);
 	const stale = useQueueSelector((q) => isNodeStale(node, q));
+	const progress = useQueueSelector((q) => subtreeProgress(node, q));
 
 	useEffect(() => {
 		if (!stale) return;
@@ -36,8 +42,8 @@ export function useGenerate(element: CanvasContentElement) {
 
 	return {
 		node,
-		status: snapshot.status,
-		seconds: snapshot.seconds,
+		status: progress.status,
+		seconds: progress.seconds,
 		result: snapshot.result,
 		error: snapshot.error,
 		stale,

--- a/lib/generation/__tests__/graph.test.ts
+++ b/lib/generation/__tests__/graph.test.ts
@@ -7,8 +7,11 @@ import {
 	needsGeneration,
 	nodeInputs,
 	sourceNode,
+	subtreeProgress,
 	type GenerationJob,
 	type GenerationNode,
+	type NodeResult,
+	type NodeResults,
 } from "../graph";
 import { GenerationQueue } from "../queue";
 
@@ -161,5 +164,63 @@ describe("flattenGraph", () => {
 			"left",
 			"right",
 		]);
+	});
+});
+
+describe("subtreeProgress", () => {
+	const IDLE: NodeResult = {
+		status: "idle",
+		seconds: 0,
+		result: null,
+		resultInputs: null,
+		pinned: false,
+	};
+
+	const results = (byId: Record<string, Partial<NodeResult>>): NodeResults => ({
+		getElementSnapshot: (id) => ({ ...IDLE, ...(id ? byId[id] : undefined) }),
+	});
+
+	it("reports a still frame's progress on the animation that depends on it", () => {
+		const still = node("~still:clip");
+		const clip = node("clip", [still]);
+		const progress = subtreeProgress(
+			clip,
+			results({
+				"~still:clip": { status: "generating", seconds: 12 },
+				clip: { status: "queued" },
+			}),
+		);
+
+		expect(progress.status).toBe("generating");
+		expect(progress.seconds).toBe(12);
+	});
+
+	it("stays queued while the whole subtree waits on a slot", () => {
+		const still = node("~still:clip");
+		const clip = node("clip", [still]);
+		const queued = { status: "queued" } as const;
+
+		expect(
+			subtreeProgress(clip, results({ "~still:clip": queued, clip: queued }))
+				.status,
+		).toBe("queued");
+	});
+
+	it("falls back to the node's own snapshot once its dependencies settle", () => {
+		const still = node("~still:clip");
+		const clip = node("clip", [still]);
+		const progress = subtreeProgress(
+			clip,
+			results({ clip: { status: "generating", seconds: 3 } }),
+		);
+
+		expect(progress.status).toBe("generating");
+		expect(progress.seconds).toBe(3);
+	});
+
+	it("leaves a single-node element unchanged", () => {
+		expect(
+			subtreeProgress(node("image"), results({ image: { status: "queued" } })),
+		).toEqual({ ...IDLE, status: "queued" });
 	});
 });

--- a/lib/generation/graph.ts
+++ b/lib/generation/graph.ts
@@ -15,6 +15,7 @@ import {
 	type GenerationInputs,
 	type NodeInputs,
 } from "./inputs";
+import type { GenerationStatus } from "./snapshots";
 
 export type NodeId = string;
 
@@ -64,8 +65,10 @@ export const forElement =
 	(element: CanvasContentElement): NodeSpec =>
 	() => ({ element });
 
-/** What the graph reads back about a node the queue has settled. */
+/** What the graph reads back about a node the queue is running or has settled. */
 export type NodeResult = {
+	status: GenerationStatus;
+	seconds: number;
 	result: AssetResult | null;
 	resultInputs: GenerationInputs | null;
 	/** The result was supplied rather than generated, so it is never regenerated. */
@@ -159,4 +162,26 @@ export function flattenGraph(roots: GenerationNode[]): GenerationNode[] {
 	};
 	for (const root of roots) visit(root);
 	return ordered;
+}
+
+/**
+ * What a node's subtree is doing, as one snapshot: whatever is running in it,
+ * else whatever is waiting, else the node's own. A node with dependencies is
+ * already working while they run, so its own status alone would read "queued"
+ * for as long as they take. Dependencies come first, so the snapshot belongs to
+ * the earliest stage still in flight.
+ */
+export function subtreeProgress(
+	node: GenerationNode,
+	results: NodeResults,
+): NodeResult {
+	const own = results.getElementSnapshot(node.id);
+	const snapshots = flattenGraph([node]).map((dep) =>
+		results.getElementSnapshot(dep.id),
+	);
+	return (
+		snapshots.find((snap) => snap.status === "generating") ??
+		snapshots.find((snap) => snap.status === "queued") ??
+		own
+	);
 }


### PR DESCRIPTION
## Summary

An `animated_image` is two nodes under the dependency graph: a still-image node feeding the animation node. The card only ever read the animation's snapshot, which stays `"queued"` until the still settles. So the element type that does the most work looked idle for most of it, and the elapsed counter did not start until the animation itself began.

`subtreeProgress` joins the other graph walkers in `lib/generation/graph.ts` and returns whichever snapshot in a node's subtree is running, else whichever is waiting, else the node's own. `flattenGraph` already orders dependencies before dependents, so the snapshot belongs to the earliest stage still in flight. `useGenerate` reports that instead of the raw snapshot status.

There is one `useGenerate` per card, so `GenerationIndicator`, the shimmer, and the disabled state all inherit the fix with no change of their own. Nothing is special-cased to `animated_image`: any element that grows a derived node gets an honest status for free.

`result` and `error` still come from the element's own snapshot; only `status` and `seconds` aggregate. `NodeResult` gains `status` and `seconds`, which `ElementSnapshot` already had.

For elapsed seconds this takes the simpler of the two options the issue offers: surface the elapsed time of the node that is running. The counter now runs through the still instead of sitting at nothing, though it does restart when the animation takes over. Accumulating across the subtree would mean retaining per-node elapsed past commit, which changes snapshot semantics for every element to fix one label.

Out of scope, per the issue: showing *which* stage is running.

## Selected issue

#506, `size: S`, `bug`. It names the change point, the fix is one pure helper plus a two-line hook change, and it is validated at the graph seam rather than through the UI. The only `size: xs` issue open (#529) is already covered by PR #534.

## Validation

- `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run knip` — clean
- `npm run build` — passes
- `npm test` — 1115 passed / 128 files, including 4 new `subtreeProgress` cases
- `npm run test:e2e` — 3 passed

## Open-PR overlap check

Checked #531, #532, #533, #534, #538, #539 with `gh pr diff --name-only`. None touches `lib/generation/graph.ts`, `lib/generation/__tests__/graph.test.ts`, or `app/components/canvas/hooks/useGenerate.ts`. #533 touches `lib/generation/__tests__/resolveGraph.test.ts`, a different file in the same directory.

## Skipped candidates

Everything else open is `size: M` or larger, or turns on product direction (art-style editing, YOLO mode, publishing kit, BYOK, i18n). `size: S` issues #461, #332, and #254 all need a design call on new surface or on audio defaults.

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)