### PR TITLE
feat: write scripts in the language the user typed in

### DIFF
--- a/lib/connectors/__tests__/osml.test.ts
+++ b/lib/connectors/__tests__/osml.test.ts
@@ -23,6 +23,23 @@ describe("osmlPlugin", () => {
 		);
 	});
 
+	it("writes spoken text in the user's language while pinning descriptions to English", () => {
+		const { systemPrompt } = beforeGenerate({ prompt: "hello" }) as {
+			systemPrompt: string;
+		};
+		expect(systemPrompt).toContain(
+			"the same language the user wrote their input in",
+		);
+		expect(systemPrompt).toMatch(/descriptions in English/);
+	});
+
+	it("derives the voice language attribute from the script rather than defaulting to English", () => {
+		const { systemPrompt } = beforeGenerate({ prompt: "hello" }) as {
+			systemPrompt: string;
+		};
+		expect(systemPrompt).not.toContain('Default to "en"');
+	});
+
 	it("deters motion on animated_image, which competes with the videoPrompt animation", () => {
 		const { systemPrompt } = beforeGenerate({ prompt: "hello" }) as {
 			systemPrompt: string;

--- a/lib/connectors/__tests__/refine.test.ts
+++ b/lib/connectors/__tests__/refine.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { createRefinePlugin } from "@/lib/connectors/llm/plugins/refine";
+
+async function systemPromptOf(osml: string): Promise<string> {
+	const { beforeGenerate } = createRefinePlugin(osml);
+	if (!beforeGenerate)
+		throw new Error("refinePlugin.beforeGenerate is required");
+	const { systemPrompt } = await beforeGenerate({ prompt: "make it funnier" });
+	if (!systemPrompt) throw new Error("refinePlugin must set a systemPrompt");
+	return systemPrompt;
+}
+
+describe("createRefinePlugin", () => {
+	it("keeps edits in the script's language even when the request is in another one", async () => {
+		const systemPrompt = await systemPromptOf("<narration>Bonjour</narration>");
+		expect(systemPrompt).toContain(
+			"the same language as the script you are editing",
+		);
+	});
+
+	it("keeps media descriptions in English regardless of the script's language", async () => {
+		expect(await systemPromptOf("<narration>Bonjour</narration>")).toMatch(
+			/descriptions in English/,
+		);
+	});
+});

--- a/lib/connectors/__tests__/story-kernel.test.ts
+++ b/lib/connectors/__tests__/story-kernel.test.ts
@@ -11,11 +11,22 @@ class MockLLMGateway extends GatewayClient<
 	LLMGenerateParams,
 	LLMGenerateResult
 > {
-	async generate(): Promise<LLMGenerateResult> {
+	async generate(_params: LLMGenerateParams): Promise<LLMGenerateResult> {
 		return {
 			text: "A brave knight rescues a dragon who turns out to be friendly.",
 			model: "test",
 		};
+	}
+}
+
+class RecordingLLMGateway extends MockLLMGateway {
+	readonly prompts: string[] = [];
+
+	override async generate(
+		params: LLMGenerateParams,
+	): Promise<LLMGenerateResult> {
+		this.prompts.push(params.prompt);
+		return super.generate(params);
 	}
 }
 
@@ -36,6 +47,16 @@ describe("storyModePlugin", () => {
 			"A brave knight rescues a dragon who turns out to be friendly.",
 		);
 		expect(result).toContain("5th-grade reading level");
+	});
+
+	it("carries the input language across the outline hop, the only place it can survive", async () => {
+		const gateway = new RecordingLLMGateway();
+		const result = await transformPrompt("un chevalier et un dragon", {
+			gateway,
+		});
+
+		expect(gateway.prompts.at(0)).toContain("same language as that input");
+		expect(result).toContain("same language as the following outline");
 	});
 
 	it("throws when no context is provided", async () => {

--- a/lib/connectors/__tests__/template-mode.test.ts
+++ b/lib/connectors/__tests__/template-mode.test.ts
@@ -66,6 +66,13 @@ describe("createTemplateModePlugin", () => {
 			expect(result).toContain(realTemplate.exampleText.slice(0, 64));
 		});
 
+		it("pastiches the example's form without inheriting its language", async () => {
+			const { transformPrompt } = createTemplateModePlugin(realTemplate.id);
+			const result = await transformPrompt?.("un PDG de la tech", fakeCtx);
+			expect(result).toContain("language of the user_input");
+			expect(result).not.toContain("tone, language, pacing");
+		});
+
 		it("rejects when templateId is unknown", async () => {
 			const { transformPrompt } = createTemplateModePlugin("does-not-exist");
 			await expect(transformPrompt?.("anything", fakeCtx)).rejects.toThrow(

--- a/lib/connectors/llm/plugins/osml.ts
+++ b/lib/connectors/llm/plugins/osml.ts
@@ -14,12 +14,24 @@ import {
 } from "@/lib/connectors/tts/enums";
 import type { LLMPlugin } from "@/lib/connectors/types";
 
+export function osmlLanguagePrompt(spokenLanguage: string): string {
+	return dedent`
+		## **Language**
+		- Write all narration text and character dialogue in ${spokenLanguage}.
+		- Always write image, animated_image (including videoPrompt), sound, and music descriptions in English, whatever language the spoken text is in.`;
+}
+
 const OSML_SYSTEM_PROMPT = dedent`
-	The story script must be written in a special XML format that strictly follows these rules: 
+	The story script must be written in a special XML format that strictly follows these rules:
 
   ## **General Guidelines**
   - Never write words in ALL CAPS in narration or dialogue — the TTS engine mispronounces them. Acronyms (USA, FBI, NASA) stay capitalized; convey emphasis through word choice or punctuation.
   - Descriptions in image tags are opaque to the reader, so the narrative prose should include some details that are only in the image tags.
+
+${osmlLanguagePrompt(
+	"the same language the user wrote their input in, ignoring the language of any example, reference, or instruction text",
+)}
+- Write the metadata_title in that same language, and the metadata_style description in English.
 
   ## **XML Tagging**
 
@@ -132,7 +144,7 @@ const OSML_SYSTEM_PROMPT = dedent`
   - pitch: ${TTS_PITCHES.join(", ")}.
   - accent: ${TTS_ACCENTS.join(", ")}.
   - description: A simple descriptor of the voice. Examples: Charming, Confident, Approachable, Friendly, Energetic, Casual, Mature, Warm, Clear, Upbeat, Deep, Soft, etc.
-  - language: ISO 639-1 code of the spoken language. Allowed values: ${TTS_LANGUAGES.join(", ")}. Default to "en" when unspecified.
+  - language: ISO 639-1 code of the language the narration and dialogue are written in, per the Language rules above. Allowed values: ${TTS_LANGUAGES.join(", ")}.
 
   ### General XML Tag Rules
   - NEVER nest XML tags within other XML tags.

--- a/lib/connectors/llm/plugins/refine.ts
+++ b/lib/connectors/llm/plugins/refine.ts
@@ -3,6 +3,7 @@ import { CANVAS_ELEMENT_TYPES, DURATION_OPTIONS } from "@/lib/canvas/types";
 import { MOTION_EFFECTS } from "@/lib/video/motionEffects";
 import { MusicLength } from "@/lib/connectors/music/enums";
 import type { LLMPlugin } from "@/lib/connectors/types";
+import { osmlLanguagePrompt } from "./osml";
 
 const ELEMENT_TYPE_LIST = [...CANVAS_ELEMENT_TYPES].join(", ");
 const vals = (e: Record<string, string>) => Object.values(e).join(", ");
@@ -52,6 +53,10 @@ const REFINE_SYSTEM_PROMPT = dedent`
   - Emit all operations for a given location consecutively before moving to the next location.
   - Minimize the number of operations. Only output what is necessary to fulfill the request.
   - Preserve existing element IDs — reference them, do not invent new ones.
+
+${osmlLanguagePrompt(
+	"the same language as the script you are editing, even when the refinement request is written in another language",
+)}
 `;
 
 export function createRefinePlugin(osml: string): LLMPlugin {

--- a/lib/connectors/llm/plugins/story-mode.ts
+++ b/lib/connectors/llm/plugins/story-mode.ts
@@ -25,9 +25,9 @@ export const storyModePlugin: LLMPlugin = {
 	) {
 		const gateway = requireGateway(ctx, "story-mode");
 		const { text: outline } = await gateway.generate({
-			prompt: dedent`Outline an engaging story with a high-concept premise, characters, themes, conflict, twists, and a resolution. The story should be about the following: ${prompt}. Do not write anything else, just the outline.`,
+			prompt: dedent`Outline an engaging story with a high-concept premise, characters, themes, conflict, twists, and a resolution. The story should be about the following: ${prompt}. Write the outline in the same language as that input. Do not write anything else, just the outline.`,
 			maxTokens: 8192,
 		});
-		return dedent`Write a complete, engaging, and simple story for a 5th-grade reading level about the following: ${outline}`;
+		return dedent`Write a complete, engaging, and simple story for a 5th-grade reading level, in the same language as the following outline: ${outline}`;
 	},
 };

--- a/lib/connectors/llm/plugins/template-mode.ts
+++ b/lib/connectors/llm/plugins/template-mode.ts
@@ -10,7 +10,7 @@ export function createTemplateModePlugin(templateId: string): LLMPlugin {
 			return prependSystemPrompt(params, getTemplate(templateId).systemPrompt);
 		},
 		async transformPrompt(prompt: string) {
-			return dedent`Pastiche this story format (with tone, language, pacing, imagery, plot techniques, story beats, structure, etc.) and reframe it to be about the following topic: <user_input>${prompt}</user_input>.
+			return dedent`Pastiche this story format (with tone, pacing, imagery, plot techniques, story beats, structure, etc.) and reframe it to be about the following topic: <user_input>${prompt}</user_input>. Write the story in the language of the user_input, not the language of the example.
 
 				Example story: ${getTemplate(templateId).exampleText}`;
 		},


### PR DESCRIPTION
## Summary

- Narration and character dialogue now follow the language of the user's own composer input, in story, script and template mode. Image, animated_image, videoPrompt, sound and music descriptions stay in English always.
- Fixes the voice bug: the OSML prompt told the model to default the voice `language` attribute to `"en"`, and that attribute feeds voice selection in `voice-search.ts`, so even a non-English script got an English voice. It is now derived from the script.
- Fixes story mode, where the language was lost in code rather than prompting: the outline is generated in a separate call and the final prompt is built from the outline alone, so the user's text never reached the generation call. The outline now carries the input's language.
- Drops "language" from template mode's pastiche list, which had been instructing the model to copy the English example's language.
- The rule lives in one shared `osmlLanguagePrompt` helper, used by both OSML and refine. Refine is keyed off the script being edited, so an English refinement request does not flip a French script to English.

No composer UI change. Closes #319 in favour of taking the language from what the user typed; a user wanting a language other than the one they are writing in still asks for it in the prompt.

## Test plan

- [x] `npm run lint`, `format:check`, `typecheck`, `knip`, `build` all clean
- [x] Full suite green (1129 tests), including new prompt-pinning tests in `osml.test.ts`, `refine.test.ts` (new file, plugin had none), `story-kernel.test.ts` and `template-mode.test.ts`
- [x] Rendered both system prompts through `dedent` to confirm the interpolated blocks do not break the surrounding indentation
- [ ] Manual: type a prompt in French in the composer in each of story / script / template mode; narration and dialogue should come out French with a French voice, while image and music descriptions stay English
- [ ] Manual: refine that French script with an English instruction; new narration should stay French

🤖 Generated with [Claude Code](https://claude.com/claude-code)