### PR TITLE
feat: per-element reference images on visual elements

### DIFF
--- a/app/components/canvas/elements/AssetTiles.tsx
+++ b/app/components/canvas/elements/AssetTiles.tsx
@@ -70,16 +70,28 @@ function CharacterAssetTile({
 	);
 }
 
-export function ReferenceAssetTiles() {
-	const referenceImages = useProject((s) => s.referenceImages);
-	const removeReferenceImage = useProject((s) => s.removeReferenceImage);
-	return referenceImages.map((url, index) => (
+export function ReferenceTiles({
+	urls,
+	onRemove,
+}: {
+	urls: string[];
+	onRemove: (index: number) => void;
+}) {
+	return urls.map((url, index) => (
 		<AssetTile
-			key={`reference:${url}`}
+			key={`reference:${index}:${url}`}
 			name={`Reference ${index + 1}`}
 			previewUrl={url}
 			Icon={Image}
-			onRemove={() => removeReferenceImage(index)}
+			onRemove={() => onRemove(index)}
 		/>
 	));
+}
+
+export function ReferenceAssetTiles() {
+	const referenceImages = useProject((s) => s.referenceImages);
+	const removeReferenceImage = useProject((s) => s.removeReferenceImage);
+	return (
+		<ReferenceTiles urls={referenceImages} onRemove={removeReferenceImage} />
+	);
 }

--- a/app/components/canvas/elements/AttributeBadge.tsx
+++ b/app/components/canvas/elements/AttributeBadge.tsx
@@ -4,6 +4,7 @@ import { SelectMenu } from "@/components/ui/select-menu";
 import { updateElementAttrs } from "@/app/components/canvas/utils/nodeOps";
 import type { AttributeSpec } from "@/lib/connectors/attributes/schema";
 import type { CanvasContentElement } from "@/lib/canvas/types";
+import { ReferenceImagesPopover } from "./attributes/ReferenceImagesPopover";
 import { TextAttributePopover } from "./attributes/TextAttributePopover";
 
 const UNSET = "—";
@@ -59,6 +60,17 @@ export function AttributeBadge({
 			<span className={PILL} title={tooltip}>
 				{labeled}
 			</span>
+		);
+	}
+
+	if (spec.edit.kind === "images") {
+		return (
+			<ReferenceImagesPopover
+				element={element}
+				attrKey={attrKey}
+				label={spec.label}
+				hideLabel={hideLabel}
+			/>
 		);
 	}
 

--- a/app/components/canvas/elements/CharactersPicker.tsx
+++ b/app/components/canvas/elements/CharactersPicker.tsx
@@ -10,7 +10,10 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { SimpleTooltip } from "@/components/ui/tooltip";
-import { getElementCharacterNames } from "@/lib/canvas/characterNames";
+import {
+	CHARACTERS_ATTR,
+	getElementCharacterNames,
+} from "@/lib/canvas/characterNames";
 import { updateElementAttrs } from "@/app/components/canvas/utils/nodeOps";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { useProject } from "@/lib/project/useProject";
@@ -27,7 +30,7 @@ function writeCharacters(
 	names: string[],
 ): void {
 	const joined = names.join(", ");
-	updateElementAttrs(editor, element, { characters: joined || null });
+	updateElementAttrs(editor, element, { [CHARACTERS_ATTR]: joined || null });
 }
 
 export function toggleCharacter(

--- a/app/components/canvas/elements/ReferenceImages.tsx
+++ b/app/components/canvas/elements/ReferenceImages.tsx
@@ -4,19 +4,26 @@ import { ImagePlus } from "@/components/ui/icon";
 import { useProject } from "@/lib/project/useProject";
 import { useImageUpload } from "@/lib/upload/useImageUpload";
 import { AddAssetTile } from "./AddAssetTile";
-import { ReferenceAssetTiles } from "./AssetTiles";
+import { ReferenceTiles } from "./AssetTiles";
 
-/** The project's reference images, plus the tile that adds more. */
-export function ReferenceImages() {
-	const addReferenceImages = useProject((s) => s.addReferenceImages);
+/** Reference image tiles for a caller-owned list, plus the tile that uploads more. */
+export function ReferenceImagePicker({
+	urls,
+	onAdd,
+	onRemove,
+}: {
+	urls: string[];
+	onAdd: (urls: string[]) => void;
+	onRemove: (index: number) => void;
+}) {
 	const { openPicker, uploading, inputElement } = useImageUpload({
 		multiple: true,
-		onUpload: addReferenceImages,
+		onUpload: onAdd,
 	});
 
 	return (
 		<>
-			<ReferenceAssetTiles />
+			<ReferenceTiles urls={urls} onRemove={onRemove} />
 			<AddAssetTile
 				label="Reference"
 				ariaLabel="Add reference image"
@@ -27,5 +34,20 @@ export function ReferenceImages() {
 			/>
 			{inputElement}
 		</>
+	);
+}
+
+/** The project's reference images, plus the tile that adds more. */
+export function ReferenceImages() {
+	const referenceImages = useProject((s) => s.referenceImages);
+	const addReferenceImages = useProject((s) => s.addReferenceImages);
+	const removeReferenceImage = useProject((s) => s.removeReferenceImage);
+
+	return (
+		<ReferenceImagePicker
+			urls={referenceImages}
+			onAdd={addReferenceImages}
+			onRemove={removeReferenceImage}
+		/>
 	);
 }

--- a/app/components/canvas/elements/attributes/AttributeTrigger.tsx
+++ b/app/components/canvas/elements/attributes/AttributeTrigger.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { ChevronDown } from "@/components/ui/icon";
+import { PopoverTrigger } from "@/components/ui/popover";
+
+/** The pill that opens an attribute's editor. */
+export function AttributeTrigger({
+	tooltip,
+	children,
+}: {
+	tooltip: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<PopoverTrigger asChild>
+			<button
+				type="button"
+				aria-label={tooltip}
+				title={tooltip}
+				onMouseDown={(e) => e.preventDefault()}
+				className="bg-secondary text-secondary-foreground text-label px-2 py-1 rounded-md max-w-[140px] inline-flex items-center gap-1.5 cursor-pointer ring-1 ring-inset ring-border hover:bg-button-hover hover:text-foreground transition-colors"
+			>
+				<span className="truncate min-w-0">{children}</span>
+				<ChevronDown className="w-3 h-3 shrink-0 text-foreground" />
+			</button>
+		</PopoverTrigger>
+	);
+}

--- a/app/components/canvas/elements/attributes/ReferenceImagesPopover.tsx
+++ b/app/components/canvas/elements/attributes/ReferenceImagesPopover.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useSlateStatic } from "slate-react";
+import { updateElementAttrs } from "@/app/components/canvas/utils/nodeOps";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent } from "@/components/ui/popover";
+import type { CanvasContentElement } from "@/lib/canvas/types";
+import {
+	parseReferenceImages,
+	serializeReferenceImages,
+} from "@/lib/connectors/attributes/referenceImages";
+import { useProject } from "@/lib/project/useProject";
+import { ReferenceImagePicker } from "../ReferenceImages";
+import { AttributeTrigger } from "./AttributeTrigger";
+
+const summarize = (override: string[] | undefined, projectCount: number) => {
+	if (!override) return `Project (${projectCount})`;
+	return override.length ? `${override.length} custom` : "None";
+};
+
+interface ReferenceImagesPopoverProps {
+	element: CanvasContentElement;
+	attrKey: string;
+	label: string;
+	hideLabel?: boolean;
+}
+
+/**
+ * This element's reference images. With no override it shows the project's and
+ * says so; the first add or remove copies them onto the element, from where they
+ * stop tracking the project until reset.
+ */
+export function ReferenceImagesPopover({
+	element,
+	attrKey,
+	label,
+	hideLabel = false,
+}: ReferenceImagesPopoverProps) {
+	const editor = useSlateStatic();
+	const projectImages = useProject((s) => s.referenceImages);
+	const override = parseReferenceImages(element.customAttributes?.[attrKey]);
+	const urls = override ?? projectImages;
+
+	const setOverride = (next: string[]) =>
+		updateElementAttrs(editor, element, {
+			[attrKey]: serializeReferenceImages(next),
+		});
+
+	const summary = summarize(override, projectImages.length);
+	const tooltip = `${label}: ${summary}`;
+
+	return (
+		<Popover>
+			<AttributeTrigger tooltip={tooltip}>
+				{!hideLabel && <span className="opacity-70 mr-1">{label}</span>}
+				{summary}
+			</AttributeTrigger>
+			<PopoverContent align="start" className="w-72">
+				<div className="mb-2 flex items-baseline justify-between gap-2">
+					<span className="text-label text-muted-foreground">
+						{override ? "Custom for this element" : "Using project references"}
+					</span>
+					{override && (
+						<Button
+							variant="link"
+							size="sm"
+							className="h-auto p-0"
+							tooltip="Use the project's reference images"
+							onClick={() =>
+								updateElementAttrs(editor, element, { [attrKey]: null })
+							}
+						>
+							Reset
+						</Button>
+					)}
+				</div>
+				<div className="flex flex-wrap gap-2">
+					<ReferenceImagePicker
+						urls={urls}
+						onAdd={(added) => setOverride([...urls, ...added])}
+						onRemove={(index) =>
+							setOverride(urls.filter((_, i) => i !== index))
+						}
+					/>
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/app/components/canvas/elements/attributes/TextAttributePopover.tsx
+++ b/app/components/canvas/elements/attributes/TextAttributePopover.tsx
@@ -1,15 +1,11 @@
 "use client";
 
-import { ChevronDown } from "@/components/ui/icon";
 import { useCallback, useRef, useState } from "react";
 import { useSlateStatic } from "slate-react";
-import {
-	Popover,
-	PopoverContent,
-	PopoverTrigger,
-} from "@/components/ui/popover";
+import { Popover, PopoverContent } from "@/components/ui/popover";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { updateElementAttrs } from "@/app/components/canvas/utils/nodeOps";
+import { AttributeTrigger } from "./AttributeTrigger";
 
 interface TextAttributePopoverProps {
 	element: CanvasContentElement;
@@ -59,24 +55,14 @@ export function TextAttributePopover({
 
 	return (
 		<Popover open={open} onOpenChange={handleOpenChange}>
-			<PopoverTrigger asChild>
-				<button
-					type="button"
-					aria-label={tooltip}
-					title={tooltip}
-					className="bg-secondary text-secondary-foreground text-label px-2 py-1 rounded-md max-w-[140px] inline-flex items-center gap-1.5 cursor-pointer ring-1 ring-inset ring-border hover:bg-button-hover hover:text-foreground transition-colors"
-				>
-					<span className="truncate min-w-0">
-						{!hideLabel && (
-							<span className={value ? "opacity-70 mr-1" : "opacity-90"}>
-								{label}
-							</span>
-						)}
-						{value ? value : <span className="opacity-50">— add</span>}
+			<AttributeTrigger tooltip={tooltip}>
+				{!hideLabel && (
+					<span className={value ? "opacity-70 mr-1" : "opacity-90"}>
+						{label}
 					</span>
-					<ChevronDown className="w-3 h-3 shrink-0 text-foreground" />
-				</button>
-			</PopoverTrigger>
+				)}
+				{value ? value : <span className="opacity-50">— add</span>}
+			</AttributeTrigger>
 			<PopoverContent
 				align="start"
 				sideOffset={4}

--- a/lib/canvas/__tests__/preservedAttributes.test.ts
+++ b/lib/canvas/__tests__/preservedAttributes.test.ts
@@ -32,6 +32,21 @@ describe("preservedAttributes", () => {
 		});
 	});
 
+	it("carries a reference image override, including an empty one", () => {
+		const source = element("image", {
+			referenceImagesOverride: "https://img/a.png",
+		});
+		expect(preservedAttributes(source, "animated_image")).toEqual({
+			referenceImagesOverride: "https://img/a.png",
+		});
+		expect(
+			preservedAttributes(
+				element("image", { referenceImagesOverride: "" }),
+				"animated_image",
+			),
+		).toEqual({ referenceImagesOverride: "" });
+	});
+
 	it("returns an empty object when there are no custom attributes", () => {
 		expect(preservedAttributes(element("image"), "animated_image")).toEqual({});
 	});

--- a/lib/canvas/characterNames.ts
+++ b/lib/canvas/characterNames.ts
@@ -1,6 +1,8 @@
 import uniq from "lodash/uniq";
 import type { CanvasContentElement } from "./types";
 
+export const CHARACTERS_ATTR = "characters";
+
 /**
  * Parse the comma-separated `characters` element attribute into trimmed,
  * non-empty character names. Single source for the format so the delimiter and
@@ -15,7 +17,7 @@ export function parseCharacterNames(value: string | undefined): string[] {
 
 const CHARACTER_NAME_EXTRACTORS: Record<string, (value: string) => string[]> = {
 	name: (v) => [v.trim()],
-	characters: parseCharacterNames,
+	[CHARACTERS_ATTR]: parseCharacterNames,
 };
 
 export function getElementCharacterNames(

--- a/lib/canvas/preservedAttributes.ts
+++ b/lib/canvas/preservedAttributes.ts
@@ -1,3 +1,5 @@
+import { REFERENCE_IMAGES_ATTR } from "@/lib/connectors/attributes/referenceImages";
+import { CHARACTERS_ATTR } from "./characterNames";
 import type { CanvasContentElement, CanvasElementType } from "./types";
 
 type ElementTypeGroup = readonly CanvasElementType[];
@@ -6,7 +8,8 @@ type ElementTypeGroup = readonly CanvasElementType[];
  * A map of attribute name and the types within which it's preserved
  */
 const PRESERVED_ATTRIBUTE_TYPES: Record<string, ElementTypeGroup> = {
-	characters: ["image", "animated_image"],
+	[CHARACTERS_ATTR]: ["image", "animated_image"],
+	[REFERENCE_IMAGES_ATTR]: ["image", "animated_image"],
 };
 
 export function preservedAttributes(
@@ -16,8 +19,9 @@ export function preservedAttributes(
 	const attrs = source.customAttributes ?? {};
 	const preserved: Record<string, string> = {};
 	for (const [attribute, types] of Object.entries(PRESERVED_ATTRIBUTE_TYPES)) {
-		if (attrs[attribute] && types.includes(targetType)) {
-			preserved[attribute] = attrs[attribute];
+		const value = attrs[attribute];
+		if (value !== undefined && types.includes(targetType)) {
+			preserved[attribute] = value;
 		}
 	}
 	return preserved;

--- a/lib/connectors/__tests__/factory.test.ts
+++ b/lib/connectors/__tests__/factory.test.ts
@@ -51,9 +51,11 @@ describe("resolveAttributeSchema", () => {
 
 	it("resolves distinct schemas for image vs animated_image", () => {
 		expect(resolveAttributeSchema("image", "openslop").keys).toEqual([
+			"referenceImagesOverride",
 			"motion",
 		]);
 		expect(resolveAttributeSchema("animated_image", "openslop").keys).toEqual([
+			"referenceImagesOverride",
 			"videoPrompt",
 			"duration",
 			"motion",

--- a/lib/connectors/__tests__/reference-images.test.ts
+++ b/lib/connectors/__tests__/reference-images.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import type { CanvasContentElement } from "@/lib/canvas/types";
 import { createReferenceImagesPlugin } from "@/lib/connectors/image/plugins/reference-images";
 import { createProjectStore, type ProjectStore } from "@/lib/project/store";
 import { stateCtx } from "./_state-ctx";
@@ -17,7 +18,7 @@ describe("createReferenceImagesPlugin", () => {
 	it("returns params unchanged when store and params are empty", () => {
 		const { beforeGenerate } = createReferenceImagesPlugin();
 		const params = { prompt: "a cat" };
-		expect(beforeGenerate?.(params, stateCtx(store))).toBe(params);
+		expect(beforeGenerate?.(params, stateCtx(store))).toEqual(params);
 	});
 
 	it("uses store images when params has none", () => {
@@ -46,6 +47,50 @@ describe("createReferenceImagesPlugin", () => {
 			prompt: "a cat",
 			referenceImages: ["https://img/existing.png", "https://img/store.png"],
 		});
+	});
+
+	it("uses the element's override in place of the store's images", () => {
+		store.getState().setReferenceImages(["https://img/store.png"]);
+		const { beforeGenerate } = createReferenceImagesPlugin();
+		expect(
+			beforeGenerate?.(
+				{
+					prompt: "a cat",
+					referenceImagesOverride: "https://img/own.png, https://img/two.png",
+				},
+				stateCtx(store),
+			),
+		).toEqual({
+			prompt: "a cat",
+			referenceImages: ["https://img/own.png", "https://img/two.png"],
+		});
+	});
+
+	it("an empty override generates with no reference images", () => {
+		store.getState().setReferenceImages(["https://img/store.png"]);
+		const { beforeGenerate } = createReferenceImagesPlugin();
+		expect(
+			beforeGenerate?.(
+				{ prompt: "a cat", referenceImagesOverride: "" },
+				stateCtx(store),
+			),
+		).toEqual({ prompt: "a cat" });
+	});
+
+	it("depends on the project's references only while inheriting them", () => {
+		const { dependencies } = createReferenceImagesPlugin();
+		const element = {
+			id: "el",
+			type: "image",
+			children: [],
+		} as unknown as CanvasContentElement;
+		expect(dependencies?.(element)).toHaveLength(1);
+		expect(
+			dependencies?.({
+				...element,
+				customAttributes: { referenceImagesOverride: "https://img/own.png" },
+			}),
+		).toEqual([]);
 	});
 
 	it("preserves existing referenceImages when store is empty", () => {

--- a/lib/connectors/animated_image/attributes.ts
+++ b/lib/connectors/animated_image/attributes.ts
@@ -1,7 +1,9 @@
 import { AttributeSchema } from "../attributes/schema";
 import { durationDef, motionDef } from "../attributes/common";
+import { referenceImagesDef } from "../attributes/referenceImages";
 
 export const ANIMATED_IMAGE_ATTRIBUTES = AttributeSchema.from([
+	referenceImagesDef,
 	{
 		key: "videoPrompt",
 		label: "Video prompt",

--- a/lib/connectors/attributes/__tests__/referenceImages.test.ts
+++ b/lib/connectors/attributes/__tests__/referenceImages.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+	parseReferenceImages,
+	serializeReferenceImages,
+} from "../referenceImages";
+
+describe("parseReferenceImages", () => {
+	it("distinguishes an absent attribute from an empty one", () => {
+		expect(parseReferenceImages(undefined)).toBeUndefined();
+		expect(parseReferenceImages("")).toEqual([]);
+	});
+
+	it("trims entries and drops blanks", () => {
+		expect(parseReferenceImages(" a.png , ,b.png ")).toEqual([
+			"a.png",
+			"b.png",
+		]);
+	});
+
+	it("round-trips a serialized list", () => {
+		const urls = ["https://img/a.png", "https://img/b.png"];
+		expect(parseReferenceImages(serializeReferenceImages(urls))).toEqual(urls);
+	});
+});

--- a/lib/connectors/attributes/referenceImages.ts
+++ b/lib/connectors/attributes/referenceImages.ts
@@ -1,0 +1,27 @@
+import type { AttributeDef } from "./schema";
+
+export const REFERENCE_IMAGES_ATTR = "referenceImagesOverride";
+
+/**
+ * The element's own reference images, or `undefined` when it carries no override
+ * and inherits the project's. An empty array is an override that clears them.
+ */
+export function parseReferenceImages(
+	value: string | undefined,
+): string[] | undefined {
+	if (value === undefined) return undefined;
+	return value
+		.split(",")
+		.map((url) => url.trim())
+		.filter(Boolean);
+}
+
+export const serializeReferenceImages = (urls: string[]): string =>
+	urls.join(",");
+
+/** No default: an absent value is what makes an element inherit the project's references. */
+export const referenceImagesDef: AttributeDef = {
+	key: REFERENCE_IMAGES_ATTR,
+	label: "References",
+	edit: { kind: "images" },
+};

--- a/lib/connectors/attributes/schema.ts
+++ b/lib/connectors/attributes/schema.ts
@@ -2,7 +2,9 @@ import type { IconComponent } from "@/components/ui/icon";
 
 export type AttributeEdit =
 	| { kind: "enum"; options: readonly string[] }
-	| { kind: "text"; placeholder?: string; rows?: number };
+	| { kind: "text"; placeholder?: string; rows?: number }
+	/** A list of image URLs, edited as tiles. */
+	| { kind: "images" };
 
 export interface AttributeSpec {
 	label: string;

--- a/lib/connectors/image/attributes.ts
+++ b/lib/connectors/image/attributes.ts
@@ -1,4 +1,8 @@
 import { AttributeSchema } from "../attributes/schema";
 import { motionDef } from "../attributes/common";
+import { referenceImagesDef } from "../attributes/referenceImages";
 
-export const IMAGE_ATTRIBUTES = AttributeSchema.from([motionDef("none")]);
+export const IMAGE_ATTRIBUTES = AttributeSchema.from([
+	referenceImagesDef,
+	motionDef("none"),
+]);

--- a/lib/connectors/image/plugins/character-references.ts
+++ b/lib/connectors/image/plugins/character-references.ts
@@ -1,21 +1,27 @@
 import compact from "lodash/compact";
-import { parseCharacterNames } from "@/lib/canvas/characterNames";
+import {
+	CHARACTERS_ATTR,
+	parseCharacterNames,
+} from "@/lib/canvas/characterNames";
 import type { ConnectorPlugin, PluginContext } from "@/lib/connectors/types";
 import { characterAvatarElementId } from "@/lib/project/characterAvatar";
 import { forCharacterAvatar } from "./characterAvatarNode";
 
-export type ParamsWithCharacters = { prompt: string; characters?: string };
+export type ParamsWithCharacters = {
+	prompt: string;
+	[CHARACTERS_ATTR]?: string;
+};
 
 /** Avatars arrive as dependency results, so this never races the jobs making them. */
 export function createCharacterReferencesPlugin(): ConnectorPlugin<ParamsWithCharacters> {
 	return {
 		name: "character-references",
 		dependencies: (element) =>
-			parseCharacterNames(element.customAttributes?.characters).map(
+			parseCharacterNames(element.customAttributes?.[CHARACTERS_ATTR]).map(
 				forCharacterAvatar,
 			),
 		beforeGenerate(params, ctx?: PluginContext<ParamsWithCharacters>) {
-			const { characters, ...rest } = params;
+			const { [CHARACTERS_ATTR]: characters, ...rest } = params;
 			if (!characters) return params;
 
 			const referenceImages = compact(

--- a/lib/connectors/image/plugins/reference-images.ts
+++ b/lib/connectors/image/plugins/reference-images.ts
@@ -1,3 +1,7 @@
+import {
+	parseReferenceImages,
+	REFERENCE_IMAGES_ATTR,
+} from "@/lib/connectors/attributes/referenceImages";
 import { requireState } from "@/lib/connectors/plugins";
 import type { ConnectorPlugin } from "@/lib/connectors/types";
 import { forReferenceImages } from "@/lib/generation/sourceNodes";
@@ -5,17 +9,33 @@ import { forReferenceImages } from "@/lib/generation/sourceNodes";
 export type ParamsWithReferenceImages = {
 	prompt: string;
 	referenceImages?: string[];
+	[REFERENCE_IMAGES_ATTR]?: string;
 };
 
+/**
+ * Reference images for the generation: the element's own when it carries an
+ * override, the project's otherwise. An overriding element declares no project
+ * dependency, so project references neither reach it nor stale it.
+ */
 export function createReferenceImagesPlugin(): ConnectorPlugin<ParamsWithReferenceImages> {
 	return {
 		name: "reference-images",
-		dependencies: () => [forReferenceImages],
+		dependencies: (element) =>
+			element.customAttributes?.[REFERENCE_IMAGES_ATTR] === undefined
+				? [forReferenceImages]
+				: [],
 		beforeGenerate(params, ctx) {
-			const { referenceImages: existing = [], ...rest } = params;
-			const stateImages = requireState(ctx, "reference-images").referenceImages;
-			if (stateImages.length === 0 && existing.length === 0) return params;
-			return { ...rest, referenceImages: [...existing, ...stateImages] };
+			const {
+				referenceImages: existing = [],
+				[REFERENCE_IMAGES_ATTR]: override,
+				...rest
+			} = params;
+			const urls = [
+				...existing,
+				...(parseReferenceImages(override) ??
+					requireState(ctx, "reference-images").referenceImages),
+			];
+			return urls.length === 0 ? rest : { ...rest, referenceImages: urls };
 		},
 	};
 }


### PR DESCRIPTION
## Summary
- Image and animated-image elements get an optional `referenceImagesOverride` attribute (comma-separated URLs), edited from a **References** pill in the element's settings popover. Absent = inherit the project's references, which is what existing elements do.
- The popover shows the project's images and says "Using project references"; the first add or remove copies them onto the element, and **Reset** restores inheritance. Uploads are multi-file, reusing the project-level picker.
- An overriding element declares no dependency on `project:referenceImages`, so project changes neither reach it nor stale it. Animated images pass the attribute down to their derived still.
- Implemented as a third `AttributeEdit` kind (`images`) on the existing attribute schema rather than special-casing the element card; the project picker was split into a props-driven `ReferenceImagePicker`, and the duplicated trigger pill became a shared `AttributeTrigger`.

Not included: clips (the video connector doesn't consume reference images today), and the CSV format can't hold a URL with a literal comma, same as the existing `characters` attribute.

Refs #249

## Test plan
- [x] `npm run lint`, `format:check`, `typecheck`, `knip`, `build`
- [x] `npm run test:run` — 1135 passing, including new coverage for override vs inherit, empty override, and the conditional dependency
- [ ] Manual: open an image element's settings, confirm the pill reads `Project (N)`; add an image and confirm it flips to `N custom` and the project's own list is untouched
- [ ] Manual: remove all overridden images, confirm the pill reads `None` and generation runs with no references
- [ ] Manual: **Reset** returns the element to the project's list, and editing project references restages inheriting elements but not overriding ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)