### PR TITLE
fix: nightly bug fixes 2026-08-10

### DIFF
--- a/app/components/canvas/elements/attributes/TextAttributePopover.tsx
+++ b/app/components/canvas/elements/attributes/TextAttributePopover.tsx
@@ -36,7 +36,9 @@ export function TextAttributePopover({
 	const commit = useCallback(
 		(next: string) => {
 			if (next === value) return;
-			updateElementAttrs(editor, element, { [attrKey]: next });
+			// Clearing the field means the element has no such attribute. Writing ""
+			// instead would persist as `attr=""` and read back as a changed input.
+			updateElementAttrs(editor, element, { [attrKey]: next || null });
 		},
 		[editor, element, attrKey, value],
 	);

--- a/lib/canvas/__tests__/osmlSerializer.test.ts
+++ b/lib/canvas/__tests__/osmlSerializer.test.ts
@@ -192,6 +192,12 @@ describe("serialize round trip", () => {
 		expect(serializeOSML([scene])).toBe(first);
 	});
 
+	it("keeps the whitespace a user typed into an attribute", () => {
+		const appearance = "a tall  woman\nin a red coat";
+		const scene = reload(wrap(el("image", "she waits", { appearance })));
+		expect(scene.children[0].customAttributes?.appearance).toBe(appearance);
+	});
+
 	it("keeps a reloaded empty element recognisably empty", () => {
 		const scene = reload(
 			wrap(

--- a/lib/canvas/__tests__/parseXmlTag.test.ts
+++ b/lib/canvas/__tests__/parseXmlTag.test.ts
@@ -26,6 +26,22 @@ describe("parseXmlTag", () => {
 		});
 	});
 
+	it("preserves whitespace inside an attribute value", () => {
+		expect(
+			parseXmlTag('image appearance="a tall  woman\nin a red coat"'),
+		).toEqual({
+			tag: "image",
+			attributes: { appearance: "a tall  woman\nin a red coat" },
+		});
+	});
+
+	it("parses attributes separated by a newline", () => {
+		expect(parseXmlTag('character\nname="Lyra"\ngender="feminine"')).toEqual({
+			tag: "character",
+			attributes: { name: "Lyra", gender: "feminine" },
+		});
+	});
+
 	it("keeps a `tag` attribute separate from the tag name", () => {
 		expect(parseXmlTag('image tag="hero"')).toEqual({
 			tag: "image",

--- a/lib/canvas/parseXmlTag.ts
+++ b/lib/canvas/parseXmlTag.ts
@@ -7,8 +7,12 @@ export type XmlTag = {
 };
 
 export function parseXmlTag(tagString: string): XmlTag {
-	const [rawTag, ...rest] = tagString.trim().split(/\s+/);
-	const attributesString = rest.join(" ");
+	// Slice rather than split/rejoin: whitespace inside an attribute value is
+	// part of what the user typed, and collapsing it loses their line breaks.
+	const trimmed = tagString.trim();
+	const nameEnd = trimmed.search(/\s/);
+	const rawTag = nameEnd === -1 ? trimmed : trimmed.slice(0, nameEnd);
+	const attributesString = nameEnd === -1 ? "" : trimmed.slice(nameEnd);
 	const attributes: Record<string, string> = {};
 	const regex = /(\w+)="([^"]*)"/g;
 	let match: RegExpExecArray | null;

--- a/lib/connectors/__tests__/character-references.test.ts
+++ b/lib/connectors/__tests__/character-references.test.ts
@@ -80,6 +80,15 @@ describe("character-references plugin", () => {
 		expect(result).toEqual(params);
 	});
 
+	it("strips an empty characters attribute", () => {
+		const result = runBeforeGenerate(plugin, {
+			prompt: "A sunset",
+			characters: "",
+		});
+		expect(result).toEqual({ prompt: "A sunset" });
+		expect(result).not.toHaveProperty("characters");
+	});
+
 	it("handles whitespace in character CSV", () => {
 		setupCharacters({
 			Alice: "https://img/alice.png",

--- a/lib/connectors/image/plugins/character-references.ts
+++ b/lib/connectors/image/plugins/character-references.ts
@@ -22,7 +22,7 @@ export function createCharacterReferencesPlugin(): ConnectorPlugin<ParamsWithCha
 			),
 		beforeGenerate(params, ctx?: PluginContext<ParamsWithCharacters>) {
 			const { [CHARACTERS_ATTR]: characters, ...rest } = params;
-			if (!characters) return params;
+			if (!characters) return rest;
 
 			const referenceImages = compact(
 				parseCharacterNames(characters).map(


### PR DESCRIPTION
Three correctness fixes around empty and whitespace-bearing custom attributes, found by nightly bug hunt.

## Bugs fixed

**`parseXmlTag` collapsed whitespace inside attribute values.** It split the tag on `/\s+/` and rejoined the attribute string with single spaces, so every run of whitespace in an attribute value was flattened. Text attributes (`appearance`, `videoPrompt`, …) are edited in a `<textarea>`, and `escapeXml` does not escape newlines, so a user's line breaks and indentation were silently destroyed on the next save/reload — violating the round-trip invariant `lib/canvas/xmlEscape.ts` documents. Now the tag name is sliced off and the attribute regex runs over the remainder verbatim, which also drops the join.

**`TextAttributePopover` wrote `""` when a field was cleared.** That persists as `attr=""` in the OSML and reads back as a changed generation input (`toNode` puts `customAttributes` straight into `inputs.attributes`), so an element the user cleared back to its original state is marked stale and regenerates. It now deletes the key, matching how `writeCharacters` already handles the `characters` attribute.

**`character-references` leaked an empty `characters` attribute.** `beforeGenerate` returned `params` untouched when the attribute was present but empty, so the raw attribute rode downstream into the provider params; every other path in that plugin strips it. Reachable from LLM-authored OSML.

## Tests

- `parseXmlTag`: whitespace and newlines preserved inside an attribute value; attributes separated by a newline still parse.
- `osmlSerializer`: serialize → `parseOSML` round trip keeps the whitespace a user typed into an attribute.
- `character-references`: an empty `characters` attribute is stripped.

All three new behavioural tests fail against the pre-fix code and pass after.

## Validation

`lint`, `format:check`, `typecheck`, `knip`, `build`, `test:coverage` all pass. 133 files / 1144 tests.

## Open PR overlap check

Only one PR open: **#545** (`feat: caption styling controls in the editor sidebar`), covering `app/components/canvas/panel/*`, `components/ui/*`, `components/captions/*`, `remotion/*`, `lib/video/caption*`, `lib/video/{scene-builder,types}.ts`, `app/components/video/useVideoLayout.ts`, `app/globals.css`, and `package*.json`. This PR touches `lib/canvas/parseXmlTag.ts`, `lib/connectors/image/plugins/character-references.ts`, `app/components/canvas/elements/attributes/TextAttributePopover.tsx` and their tests — no file or theme overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)