### PR TITLE
fix: show the still node's progress under the Still toggle

### DIFF
--- a/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
+++ b/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
@@ -14,7 +14,6 @@ import type {
 	PlaceholderProps,
 } from "./status";
 
-/** One side of the toggle: the node it shows and that node's own progress. */
 type ModeState = GenerationState & {
 	error: string | null;
 	url: string | undefined;
@@ -25,8 +24,6 @@ type AnimatedImageMediaProps = Pick<PlaceholderProps, "onDiscard"> & {
 	still: ModeState;
 };
 
-// The toggle picks the node, so the card never blends the two: while the still
-// renders, Still shows it generating and Video honestly reads "Queued…".
 export function AnimatedImageMedia({
 	animated,
 	still,

--- a/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
+++ b/app/components/canvas/elements/preview/AnimatedImagePreview.tsx
@@ -3,24 +3,37 @@
 import { useState, type CSSProperties } from "react";
 import { Image as ImageIcon, Video } from "@/components/ui/icon";
 import { MediaToggle } from "@/components/ui/media-toggle";
-import { stillFrameUrl } from "@/lib/connectors/animated_image/plugins/still-frame";
+import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
+import { stillSnapshot } from "@/lib/connectors/animated_image/plugins/still-frame";
 import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
 import { useElementGeneration } from "../ElementGenerationContext";
 import { MediaResult } from "./results";
-import type { ElementPreviewProps, PlaceholderProps } from "./status";
+import type {
+	ElementPreviewProps,
+	GenerationState,
+	PlaceholderProps,
+} from "./status";
 
-type AnimatedImageMediaProps = PlaceholderProps & {
-	stillUrl?: string;
-	videoUrl?: string;
+/** One side of the toggle: the node it shows and that node's own progress. */
+type ModeState = GenerationState & {
+	error: string | null;
+	url: string | undefined;
 };
 
+type AnimatedImageMediaProps = Pick<PlaceholderProps, "onDiscard"> & {
+	animated: ModeState;
+	still: ModeState;
+};
+
+// The toggle picks the node, so the card never blends the two: while the still
+// renders, Still shows it generating and Video honestly reads "Queued…".
 export function AnimatedImageMedia({
-	stillUrl,
-	videoUrl,
-	...state
+	animated,
+	still,
+	onDiscard,
 }: AnimatedImageMediaProps) {
 	const [mode, setMode] = useState<"animated" | "still">("animated");
-	const animated = mode === "animated";
+	const { url, ...state } = mode === "animated" ? animated : still;
 
 	return (
 		<div
@@ -29,8 +42,9 @@ export function AnimatedImageMedia({
 		>
 			<MediaResult
 				{...state}
-				url={animated ? videoUrl : stillUrl}
-				outputKind={animated ? "video" : "image"}
+				onDiscard={onDiscard}
+				url={url}
+				outputKind={mode === "animated" ? "video" : "image"}
 			/>
 			<MediaToggle
 				className="absolute top-2 right-2 z-30 shadow-sm"
@@ -46,17 +60,25 @@ export function AnimatedImageMedia({
 }
 
 export function AnimatedImagePreview({
+	status,
+	seconds,
+	error,
 	result,
-	...state
+	onDiscard,
 }: ElementPreviewProps) {
 	const { node } = useElementGeneration();
-	const stillUrl = useQueueSelector((queue) => stillFrameUrl(node, queue));
+	const still = useQueueSelector((queue) => stillSnapshot(node, queue));
 
 	return (
 		<AnimatedImageMedia
-			{...state}
-			stillUrl={stillUrl}
-			videoUrl={result?.videoUrl}
+			onDiscard={onDiscard}
+			animated={{ status, seconds, error, url: result?.videoUrl }}
+			still={{
+				status: still.status,
+				seconds: still.seconds,
+				error: still.error,
+				url: getPrimaryUrl(still.result, "image"),
+			}}
 		/>
 	);
 }

--- a/app/components/canvas/elements/preview/__tests__/cancelOffset.test.tsx
+++ b/app/components/canvas/elements/preview/__tests__/cancelOffset.test.tsx
@@ -48,7 +48,13 @@ describe("cancel button offset", () => {
 	});
 
 	it("is pushed below the still/video toggle by AnimatedImageMedia", () => {
-		const html = withTooltip(<AnimatedImageMedia {...generating} />);
+		const html = withTooltip(
+			<AnimatedImageMedia
+				onDiscard={() => {}}
+				animated={{ ...generating, url: undefined }}
+				still={{ ...generating, url: undefined }}
+			/>,
+		);
 		expect(html).toContain("--cancel-offset:2.5rem");
 	});
 
@@ -65,13 +71,19 @@ const mediaToggleClass = (html: string) => {
 };
 
 describe("AnimatedImageMedia", () => {
+	const failed = {
+		status: "idle",
+		seconds: 0,
+		error: "generation failed",
+		url: undefined,
+	} as const;
+
 	it("stacks the still/video toggle above the error overlay so it stays clickable", () => {
 		const html = withTooltip(
 			<AnimatedImageMedia
-				status="idle"
-				seconds={0}
-				error="generation failed"
 				onDiscard={() => {}}
+				animated={failed}
+				still={failed}
 			/>,
 		);
 		// Error overlay renders at z-20; the toggle must sit above it.

--- a/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
@@ -135,7 +135,6 @@ describe("stillSnapshot", () => {
 		expect(frameUrl(node, queue)).toBeUndefined();
 	});
 
-	// The card shows the still's progress while the animation is still queued.
 	it("reports the still node's own state, not the animation's", () => {
 		const queue = new GenerationQueue();
 		const node = nodeBuilder(registry, state)(forElement(animated));

--- a/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
@@ -9,7 +9,12 @@ import {
 	DEFAULT_CONNECTOR_REGISTRY,
 	withRegistry,
 } from "@/lib/connectors/registry";
-import { forElement, needsGeneration } from "@/lib/generation/graph";
+import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
+import {
+	forElement,
+	needsGeneration,
+	type GenerationNode,
+} from "@/lib/generation/graph";
 import { GenerationQueue } from "@/lib/generation/queue";
 import { nodeBuilder } from "@/lib/generation/resolveGraph";
 import { MetadataSchema } from "@/lib/project/types";
@@ -17,7 +22,7 @@ import { buildAnimatedImagePlugins } from "../animated-image-chain";
 import {
 	createStillFramePlugin,
 	stillElementId,
-	stillFrameUrl,
+	stillSnapshot,
 } from "../still-frame";
 
 const ELEMENT_ID = "anim-1";
@@ -78,7 +83,7 @@ describe("still-frame plugin", () => {
 	});
 });
 
-describe("stillFrameUrl", () => {
+describe("stillSnapshot", () => {
 	const registry = withRegistry(DEFAULT_CONNECTOR_REGISTRY)
 		.appendPlugins("image", ...buildImagePlugins())
 		.appendPlugins("animated_image", ...buildAnimatedImagePlugins())
@@ -94,6 +99,9 @@ describe("stillFrameUrl", () => {
 		customAttributes: { provider: "openslop", videoPrompt: "slow pan" },
 		children: [{ id: "t", type: "animated_image" as const, text: "a forest" }],
 	};
+
+	const frameUrl = (node: GenerationNode, queue: GenerationQueue) =>
+		getPrimaryUrl(stillSnapshot(node, queue).result, "image");
 
 	// Regression: the preview used to read the animation's own result, so an
 	// uploaded still stayed invisible until the animation re-rendered.
@@ -111,20 +119,32 @@ describe("stillFrameUrl", () => {
 			videoUrl: "https://example.com/v.mp4",
 			durationSec: 5,
 		});
-		expect(stillFrameUrl(node, queue)).toBeUndefined();
+		expect(frameUrl(node, queue)).toBeUndefined();
 
 		queue.commitResult(
 			still,
 			{ imageUrl: "uploaded.png", durationSec: 0 },
 			{ pinned: true },
 		);
-		expect(stillFrameUrl(node, queue)).toBe("uploaded.png");
+		expect(frameUrl(node, queue)).toBe("uploaded.png");
 	});
 
 	it("has no still frame before one exists", () => {
 		const queue = new GenerationQueue();
 		const node = nodeBuilder(registry, state)(forElement(animated));
-		expect(stillFrameUrl(node, queue)).toBeUndefined();
+		expect(frameUrl(node, queue)).toBeUndefined();
+	});
+
+	// The card shows the still's progress while the animation is still queued.
+	it("reports the still node's own state, not the animation's", () => {
+		const queue = new GenerationQueue();
+		const node = nodeBuilder(registry, state)(forElement(animated));
+		queue.setError(stillElementId(ELEMENT_ID), "still failed");
+
+		expect(stillSnapshot(node, queue)).toBe(
+			queue.getElementSnapshot(stillElementId(ELEMENT_ID)),
+		);
+		expect(queue.getElementSnapshot(ELEMENT_ID).error).toBeNull();
 	});
 });
 

--- a/lib/connectors/animated_image/plugins/still-frame.ts
+++ b/lib/connectors/animated_image/plugins/still-frame.ts
@@ -13,6 +13,7 @@ import {
 	type GenerationNode,
 	type NodeSpec,
 } from "@/lib/generation/graph";
+import type { GenerationQueue } from "@/lib/generation/queue";
 import type { ElementSnapshot } from "@/lib/generation/snapshots";
 
 /**
@@ -51,20 +52,13 @@ export const forStillOf =
 export const stillDependency = (node: GenerationNode) =>
 	node.dependsOn.find((dep) => dep.id === stillElementId(node.id));
 
-/** The read half of the queue, for callers that need the still's own progress. */
-type SnapshotResults = { getElementSnapshot(id?: string): ElementSnapshot };
-
 /**
- * The still node's own state: the frame the element currently has, which an
- * upload replaces immediately, plus the status and elapsed time of the run that
- * produces it. The animation's own result carries the frame it was rendered
- * from, so reading that instead would show the previous still until it
- * re-renders, and would report the animation's progress rather than the still's.
+ * The snapshot of the still a node depends on
  */
 export const stillSnapshot = (
 	node: GenerationNode,
-	results: SnapshotResults,
-): ElementSnapshot => results.getElementSnapshot(stillDependency(node)?.id);
+	queue: GenerationQueue,
+): ElementSnapshot => queue.getElementSnapshot(stillDependency(node)?.id);
 
 const stillFrame = (
 	ctx?: PluginContext<AnimatedImageGenerateParams, AssetResult>,

--- a/lib/connectors/animated_image/plugins/still-frame.ts
+++ b/lib/connectors/animated_image/plugins/still-frame.ts
@@ -8,13 +8,12 @@ import type {
 } from "@/lib/connectors/types";
 import { buildImagePlugins } from "@/lib/connectors/image/plugins/imageChain";
 import { DEFAULT_PROVIDER } from "@/lib/connectors/registry";
-import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 import {
 	derivedNodeId,
 	type GenerationNode,
-	type NodeResults,
 	type NodeSpec,
 } from "@/lib/generation/graph";
+import type { ElementSnapshot } from "@/lib/generation/snapshots";
 
 /**
  * Attributes that drive only the animation. `model` is among them: it names a
@@ -52,17 +51,20 @@ export const forStillOf =
 export const stillDependency = (node: GenerationNode) =>
 	node.dependsOn.find((dep) => dep.id === stillElementId(node.id));
 
+/** The read half of the queue, for callers that need the still's own progress. */
+type SnapshotResults = { getElementSnapshot(id?: string): ElementSnapshot };
+
 /**
- * The frame the element currently has, which an upload replaces immediately. The
- * animation's own result carries the frame it was rendered from, so reading that
- * instead would show the previous still until it re-renders.
+ * The still node's own state: the frame the element currently has, which an
+ * upload replaces immediately, plus the status and elapsed time of the run that
+ * produces it. The animation's own result carries the frame it was rendered
+ * from, so reading that instead would show the previous still until it
+ * re-renders, and would report the animation's progress rather than the still's.
  */
-export const stillFrameUrl = (node: GenerationNode, results: NodeResults) => {
-	const still = stillDependency(node);
-	return still
-		? getPrimaryUrl(results.getElementSnapshot(still.id).result, "image")
-		: undefined;
-};
+export const stillSnapshot = (
+	node: GenerationNode,
+	results: SnapshotResults,
+): ElementSnapshot => results.getElementSnapshot(stillDependency(node)?.id);
 
 const stillFrame = (
 	ctx?: PluginContext<AnimatedImageGenerateParams, AssetResult>,


### PR DESCRIPTION
## Summary

An animated image read "Queued…" for most of the time it was actually working. It is two nodes — a still-image node feeding the animation node — and the card read every status off the animation, which genuinely stays queued until the still settles. So the element type doing the most work was the one that looked idle while doing it.

The toggle now picks the node, per the direction on the issue (and explicitly not the aggregate approach closed in #540):

- Still → the still node's `status`, `seconds`, `error`, and frame
- Video → the animation node's, as before

`stillFrameUrl` becomes `stillSnapshot`, which returns the still node's whole snapshot instead of just its url, keeping the still-node lookup in the `animated_image` connector. `AnimatedImageMedia` takes one `ModeState` per side and resolves which to render from its own `mode`, so no status is invented, nothing is blended, and no other element type changes.

## Why this issue was safe and small

Issue #506 is `size: S` with a maintainer comment prescribing the exact approach, so there was no design decision to make. The change is four files, confined to the animated-image preview and its still-node helper. Plain single-node elements are untouched — `OutputPreview` still hands every preview the element's own status.

## Validation

All CI-equivalent checks from `.github/workflows/ci.yml`, all passing:

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run knip`
- `npm run build`
- `npm run test:coverage` — 133 files, 1141 tests
- `npm run test:e2e` — 3 smoke tests

Coverage is at the seam the issue asked for (where the still node's snapshot is selected), not on rendered copy: `stillSnapshot` now has a case asserting it returns the still node's snapshot and leaves the animation's untouched, alongside the existing uploaded-frame regression tests.

## Open PR overlap

Checked #545, #546, #547, #548 with `gh pr diff --name-only`. None touches `AnimatedImagePreview.tsx`, `still-frame.ts`, or either test file.

## Skipped candidates

No `size:xs` issues are open. Skipped as too broad, product-heavy, or unvalidatable unattended: #543 (prompt-rule change with no local way to judge output quality, plus an explicit "decide with evidence" step), #536/#535/#492/#491/#462/#451/#385/#379 and the rest of the M/L/XL enhancement backlog. #270 (subtitle controls) overlaps open PR #545.

Closes #506