### PR TITLE
fix(canvas): wrap narrow element actions

### DIFF
--- a/app/components/canvas/elements/AnimateButton.tsx
+++ b/app/components/canvas/elements/AnimateButton.tsx
@@ -23,7 +23,7 @@ export function AnimateButton({ element }: { element: CanvasContentElement }) {
 			onClick={() => refineScript(animateImagePrompt(element.id))}
 		>
 			<MagicVideo aria-hidden="true" />
-			<span className="hidden sm:inline">Animate</span>
+			<span className="hidden @sm:inline">Animate</span>
 		</Button>
 	);
 }

--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -119,7 +119,7 @@ export function ElementContainer({
 							</div>
 						</div>
 						<div
-							className="mt-2 flex items-center justify-end gap-2 select-none"
+							className="mt-2 flex min-w-0 flex-wrap items-center justify-end gap-2 select-none"
 							contentEditable={false}
 						>
 							<ElementStaleIndicator />


### PR DESCRIPTION
## Summary

- let element-card actions wrap when their card is too narrow, while keeping each line right-aligned with the existing spacing
- key the Animate label to the element card's existing container breakpoint instead of the viewport breakpoint
- leave `SceneContainer` unchanged because it has no analogous action row

Fixes #550

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run knip`
- `npm run test:coverage` (133 files, 1,140 tests)
- `npm run build`
- `npm run test:e2e` (3 Chromium smoke tests)
- local browser check at a 220 px card width: actions wrap to two right-aligned rows, row/column gaps are both 8 px, and `scrollWidth` equals `clientWidth`
- local browser check confirmed the Animate label is hidden in the narrow card and visible in a wide card under the same viewport

## AI assistance

OpenAI Codex assisted with implementation and validation. I reviewed the final two-line source diff and all reported test results.
