### PR TITLE
feat: pick the script's language in the composer

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -19,7 +19,7 @@ How we write code here, for humans and agents. The codebase is deliberately rigi
 - Don't reinvent. Reach for a popular, well-tested library before hand-rolling, and exhaust what our stack already does (Next.js, React, Remotion, Zustand, Supabase, Vercel, AWS) before adding a dependency. Hand-roll only when the logic is tiny and must be custom to this app.
 - Nothing leaks. No tight coupling, no hidden dependencies, no concerns bleeding across modules. Colocate logic, and give shared code one idiomatically named home. No barrel files.
 - Dependencies point one way. `lib/` is the domain layer and never imports from `app/` (the UI); shared logic lives in `lib/`. ESLint-enforced.
-- Comments are a last resort, not a habit. The code shows what it does. A comment earns its place only by capturing what the code can't: intent, invariants, tradeoffs, footguns. Don't narrate the code.
+- Comments are a last resort, not a habit. Write one only where a choice would look odd or arbitrary to a first-time reader with no context. Never comment history: what broke, what the code used to be, why an earlier attempt failed. That belongs in the commit message.
 - Test behavior, not internals. Cover the seams (pure helpers and module boundaries) so refactors stay safe.
 
 ## Frontend

--- a/app/api/v1/llm/route.ts
+++ b/app/api/v1/llm/route.ts
@@ -4,11 +4,12 @@ import { getLLMProvider } from "@/lib/api/providers";
 import { bodySchema, createApiRouteHandler } from "@/lib/api/route-handler";
 import { optionalReferenceImages } from "@/lib/api/request-schema-fields";
 import { createSSEStreamResponse } from "@/lib/api/sse";
+import { THINKING_LEVELS } from "@/lib/connectors/llm/enums";
 import { LLM_MODELS } from "@/lib/connectors/llm/openslop/models";
 
 const schema = bodySchema(LLM_MODELS, {
 	systemPrompt: z.string().optional(),
-	thinkingLevel: z.string().optional(),
+	thinkingLevel: z.enum(THINKING_LEVELS).optional(),
 	maxTokens: z.number().optional(),
 	temperature: z.number().optional(),
 	...optionalReferenceImages,

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -11,6 +11,7 @@ import {
 	Palette,
 	Plus,
 	Proportions,
+	Translate,
 	User,
 	X,
 } from "@/components/ui/icon";
@@ -25,6 +26,12 @@ import {
 } from "@/lib/templates/templates";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useProject } from "@/lib/project/useProject";
+import {
+	LANGUAGE_CHOICES,
+	languageLabel,
+	type LanguageChoice,
+} from "@/lib/project/language";
+import { useScriptLanguage } from "@/lib/project/useScriptLanguage";
 import type { Mode } from "@/lib/project/types";
 import type { AspectRatio } from "@/lib/video/aspectRatio";
 import { useAspectRatio } from "@/lib/video/useAspectRatio";
@@ -56,6 +63,9 @@ const ASPECT_RATIO_OPTIONS: SelectMenuOption<AspectRatio>[] = [
 const VIDEO_LENGTH_OPTIONS: SelectMenuOption<VideoLength>[] = VIDEO_LENGTHS.map(
 	(value) => ({ value, label: VIDEO_LENGTH_SPECS[value].label }),
 );
+
+const LANGUAGE_OPTIONS: SelectMenuOption<LanguageChoice>[] =
+	LANGUAGE_CHOICES.map((value) => ({ value, label: languageLabel(value) }));
 
 const TEMPLATE_OPTIONS: SelectMenuOption<string>[] = TEMPLATES.map((t) => ({
 	value: t.id,
@@ -197,6 +207,7 @@ export default function ComposerCopilot({
 	const videoLength = useVideoLength();
 	const updateMetadata = useProject((s) => s.updateMetadata);
 	const addReferenceImages = useProject((s) => s.addReferenceImages);
+	const [language, setLanguage] = useScriptLanguage();
 	const {
 		openCreateCharacter,
 		editCharacter,
@@ -209,6 +220,7 @@ export default function ComposerCopilot({
 		useImageUpload({ multiple: true, onUpload: addReferenceImages });
 	const isTemplateMode = mode === "template";
 	const isScriptMode = mode === "script";
+	const languageName = languageLabel(language);
 	const hasText = value.trim().length > 0;
 	const selectedTemplate = getTemplate(selectedTemplateId);
 
@@ -290,6 +302,18 @@ export default function ComposerCopilot({
 								aria-label={`Aspect ratio: ${aspectRatio}`}
 								icon={<Proportions className="mr-1 h-3 w-3" />}
 								label={aspectRatio}
+							/>
+						</SelectMenu>
+						<SelectMenu
+							value={language}
+							onChange={setLanguage}
+							options={LANGUAGE_OPTIONS}
+							itemClassName="rounded-lg text-label-xs"
+						>
+							<PillTrigger
+								aria-label={`Language: ${languageName}`}
+								icon={<Translate className="mr-1 h-3 w-3" />}
+								label={languageName}
 							/>
 						</SelectMenu>
 						{!isScriptMode && (

--- a/components/ui/icon.tsx
+++ b/components/ui/icon.tsx
@@ -96,6 +96,7 @@ export const Thickness = icon("thickness");
 export const TextSize = icon("text-size");
 export const TextBox = icon("text-box");
 export const TextBoxFill = icon("text-box-fill");
+export const Translate = icon("translate");
 export const Trash2 = icon("trash");
 export const Underline = icon("underline");
 export const User = icon("user");

--- a/lib/canvas/__tests__/osmlMetadata.test.ts
+++ b/lib/canvas/__tests__/osmlMetadata.test.ts
@@ -152,4 +152,25 @@ describe("collectWritableMetadata", () => {
 			style: "watercolor",
 		});
 	});
+
+	describe("narration language", () => {
+		const narrationScript = [
+			node("metadata_narration", { gender: "masculine", language: "es" }),
+		];
+
+		it("keeps a language the user picked for the narrator", () => {
+			const chosen = MetadataSchema.parse({
+				narration: { language: "en", voiceId: "pinned" },
+			});
+			expect(collectWritableMetadata(narrationScript, chosen)).toEqual({
+				narration: { gender: "masculine" },
+			});
+		});
+
+		it("takes the script's language when the narrator has none", () => {
+			expect(
+				collectWritableMetadata(narrationScript, MetadataSchema.parse({})),
+			).toEqual({ narration: { gender: "masculine", language: "es" } });
+		});
+	});
 });

--- a/lib/canvas/osmlMetadata.ts
+++ b/lib/canvas/osmlMetadata.ts
@@ -52,20 +52,14 @@ export function collectMetadata(nodes: ParsedElement[]): DeepPartial<Metadata> {
 	return metadata;
 }
 
-type TextMetadataKey = {
-	[K in keyof Metadata]-?: Metadata[K] extends string ? K : never;
-}[keyof Metadata];
-
-/** Fields the script may fill in but never rewrite: once set, they are the user's. */
-const WRITE_ONCE: readonly TextMetadataKey[] = ["style"];
-
 export function collectWritableMetadata(
 	nodes: ParsedElement[],
 	stored: Metadata,
 ): DeepPartial<Metadata> {
 	const patch = collectMetadata(nodes);
-	for (const field of WRITE_ONCE) {
-		if (stored[field].trim()) delete patch[field];
-	}
+
+	// Once the user sets these, the LLM-generated script shouldn't overwrite them
+	if (stored.style.trim()) delete patch.style;
+	if (stored.narration.language) delete patch.narration?.language;
 	return patch;
 }

--- a/lib/connectors/__tests__/metadata-voice.test.ts
+++ b/lib/connectors/__tests__/metadata-voice.test.ts
@@ -88,6 +88,42 @@ describe("createMetadataVoicePlugin", () => {
 		});
 	});
 
+	it("narrates the project's language, since the script no longer declares one", () => {
+		store.getState().updateMetadata({ language: "es" });
+		const { beforeGenerate } = createMetadataVoicePlugin();
+		expect(beforeGenerate?.({ prompt: "hola" }, stateCtx(store))).toEqual({
+			prompt: "hola",
+			language: "es",
+		});
+	});
+
+	it("leaves the language open on auto, so voice search falls back", () => {
+		const { beforeGenerate } = createMetadataVoicePlugin();
+		const result = beforeGenerate?.({ prompt: "hi" }, stateCtx(store));
+		expect(result).not.toHaveProperty("language", "auto");
+	});
+
+	it("prefers a pinned project language over a voice language left by an earlier script", () => {
+		store.getState().updateMetadata({
+			language: "es",
+			narration: { language: "en" },
+		});
+		const { beforeGenerate } = createMetadataVoicePlugin();
+		expect(beforeGenerate?.({ prompt: "hi" }, stateCtx(store))).toEqual({
+			prompt: "hi",
+			language: "es",
+		});
+	});
+
+	it("keeps the voice's own language on auto, where the project declares none", () => {
+		store.getState().updateMetadata({ narration: { language: "fr" } });
+		const { beforeGenerate } = createMetadataVoicePlugin();
+		expect(beforeGenerate?.({ prompt: "hi" }, stateCtx(store))).toEqual({
+			prompt: "hi",
+			language: "fr",
+		});
+	});
+
 	it("does not set fields that are absent in metadata", () => {
 		store.getState().updateMetadata({
 			narration: { gender: "feminine" },

--- a/lib/connectors/__tests__/osml.test.ts
+++ b/lib/connectors/__tests__/osml.test.ts
@@ -27,10 +27,34 @@ describe("osmlPlugin", () => {
 		const { systemPrompt } = beforeGenerate({ prompt: "hello" }) as {
 			systemPrompt: string;
 		};
-		expect(systemPrompt).toContain(
-			"the same language the user wrote their input in",
-		);
+		expect(systemPrompt).toContain("the language of the user's own topic");
 		expect(systemPrompt).toMatch(/descriptions in English/);
+	});
+
+	it("names English as the fallback rather than ruling any language out", () => {
+		const { systemPrompt } = beforeGenerate({ prompt: "hello" }) as {
+			systemPrompt: string;
+		};
+		expect(systemPrompt).toContain("or English when that is unclear");
+		expect(systemPrompt).not.toMatch(
+			/ignoring the language of|not the language of/,
+		);
+	});
+
+	it("pins the script to the project language", () => {
+		const state = { metadata: { language: "fr" } } as never;
+		const { systemPrompt } = beforeGenerate({ prompt: "hello" }, { state }) as {
+			systemPrompt: string;
+		};
+		expect(systemPrompt).toContain("dialogue in fr (ISO 639-1)");
+		expect(systemPrompt).not.toContain("the language of the user's own topic");
+	});
+
+	it("asks the script to report its language, the only voice signal auto mode has", () => {
+		const { systemPrompt } = beforeGenerate({ prompt: "hello" }) as {
+			systemPrompt: string;
+		};
+		expect(systemPrompt).toContain("- language: ISO 639-1 code");
 	});
 
 	it("derives the voice language attribute from the script rather than defaulting to English", () => {

--- a/lib/connectors/__tests__/story-kernel.test.ts
+++ b/lib/connectors/__tests__/story-kernel.test.ts
@@ -59,6 +59,18 @@ describe("storyModePlugin", () => {
 		expect(result).toContain("same language as the following outline");
 	});
 
+	it("pins both hops to the project's language, like the OSML prompt does", async () => {
+		const gateway = new RecordingLLMGateway();
+		const result = await transformPrompt("a knight and a dragon", {
+			gateway,
+			state: { metadata: { language: "fr" } },
+		} as never);
+
+		expect(gateway.prompts.at(0)).toContain("outline in fr (ISO 639-1)");
+		expect(result).toContain("in fr (ISO 639-1)");
+		expect(result).not.toContain("same language as the following outline");
+	});
+
 	it("throws when no context is provided", async () => {
 		await expect(transformPrompt("test")).rejects.toThrow(
 			"story-mode plugin requires gateway context",

--- a/lib/connectors/__tests__/template-mode.test.ts
+++ b/lib/connectors/__tests__/template-mode.test.ts
@@ -69,8 +69,18 @@ describe("createTemplateModePlugin", () => {
 		it("pastiches the example's form without inheriting its language", async () => {
 			const { transformPrompt } = createTemplateModePlugin(realTemplate.id);
 			const result = await transformPrompt?.("un PDG de la tech", fakeCtx);
-			expect(result).toContain("language of the user_input");
+			expect(result).toContain("same language that the user_input is in");
 			expect(result).not.toContain("tone, language, pacing");
+			expect(result).not.toContain("not the language of the example");
+		});
+
+		it("pins the story to the project's language, like the OSML prompt does", async () => {
+			const { transformPrompt } = createTemplateModePlugin(realTemplate.id);
+			const result = await transformPrompt?.("a tech CEO", {
+				state: { metadata: { language: "fr" } },
+			} as never);
+			expect(result).toContain("Write the story in fr (ISO 639-1)");
+			expect(result).not.toContain("same language that the user_input is in");
 		});
 
 		it("rejects when templateId is unknown", async () => {

--- a/lib/connectors/llm/enums.ts
+++ b/lib/connectors/llm/enums.ts
@@ -1,0 +1,5 @@
+export const THINKING_LEVELS = ["low", "medium", "high", "max"] as const;
+
+export type ThinkingLevel = (typeof THINKING_LEVELS)[number];
+
+export const DEFAULT_THINKING_LEVEL: ThinkingLevel = "high";

--- a/lib/connectors/llm/openslop/models.ts
+++ b/lib/connectors/llm/openslop/models.ts
@@ -1,3 +1,3 @@
 export const LLM_MODELS = {
-	"Slop LLM v1": "claude-opus-4-8",
+	"Slop LLM v1": "claude-opus-5",
 } as const;

--- a/lib/connectors/llm/plugins/character-avatar-style.ts
+++ b/lib/connectors/llm/plugins/character-avatar-style.ts
@@ -39,6 +39,7 @@ export function createCharacterAvatarStylePlugin(
 						prompt: dedent`Concisely describe the visual appearance of the character in the attached reference image in a short sentence. Focus on gender, ethnicity, face, hair, body type, art style, and any distinctive features. Do not describe the background.`,
 						referenceImages: [url],
 						maxTokens: 4096,
+						thinkingLevel: "low",
 					});
 					return `- ${name}: ${text.trim()}`;
 				}),

--- a/lib/connectors/llm/plugins/language-prompt.ts
+++ b/lib/connectors/llm/plugins/language-prompt.ts
@@ -1,0 +1,21 @@
+import dedent from "dedent";
+import { declaredLanguage } from "@/lib/project/language";
+import type { Metadata } from "@/lib/project/types";
+
+export const INPUT_LANGUAGE =
+	"the language of the user's own topic or script, or English when that is unclear";
+
+export function spokenLanguage(
+	metadata: Metadata | undefined,
+	fallback: string,
+): string {
+	const language = declaredLanguage(metadata?.language);
+	return language ? `${language} (ISO 639-1)` : fallback;
+}
+
+export function languagePrompt(language: string): string {
+	return dedent`
+		## **Language**
+		- Write all narration text and character dialogue in ${language}.
+		- Always write image, animated_image (including videoPrompt), sound, and music descriptions in English, whatever language the spoken text is in.`;
+}

--- a/lib/connectors/llm/plugins/osml.ts
+++ b/lib/connectors/llm/plugins/osml.ts
@@ -13,24 +13,21 @@ import {
 	TTS_SPEEDS,
 } from "@/lib/connectors/tts/enums";
 import type { LLMPlugin } from "@/lib/connectors/types";
+import {
+	INPUT_LANGUAGE,
+	languagePrompt,
+	spokenLanguage,
+} from "./language-prompt";
 
-export function osmlLanguagePrompt(spokenLanguage: string): string {
+function osmlSystemPrompt(language: string): string {
 	return dedent`
-		## **Language**
-		- Write all narration text and character dialogue in ${spokenLanguage}.
-		- Always write image, animated_image (including videoPrompt), sound, and music descriptions in English, whatever language the spoken text is in.`;
-}
-
-const OSML_SYSTEM_PROMPT = dedent`
 	The story script must be written in a special XML format that strictly follows these rules:
 
   ## **General Guidelines**
   - Never write words in ALL CAPS in narration or dialogue — the TTS engine mispronounces them. Acronyms (USA, FBI, NASA) stay capitalized; convey emphasis through word choice or punctuation.
   - Descriptions in image tags are opaque to the reader, so the narrative prose should include some details that are only in the image tags.
 
-${osmlLanguagePrompt(
-	"the same language the user wrote their input in, ignoring the language of any example, reference, or instruction text",
-)}
+${languagePrompt(language)}
 - Write the metadata_title in that same language, and the metadata_style description in English.
 
   ## **XML Tagging**
@@ -148,13 +145,17 @@ ${osmlLanguagePrompt(
   ### General XML Tag Rules
   - NEVER nest XML tags within other XML tags.
 `;
+}
 
 export const osmlPlugin: LLMPlugin = {
 	name: "osml",
-	beforeGenerate(params) {
-		if (!params.systemPrompt) {
-			return { ...params, systemPrompt: OSML_SYSTEM_PROMPT };
-		}
-		return params;
+	beforeGenerate(params, ctx) {
+		if (params.systemPrompt) return params;
+		return {
+			...params,
+			systemPrompt: osmlSystemPrompt(
+				spokenLanguage(ctx?.state?.metadata, INPUT_LANGUAGE),
+			),
+		};
 	},
 };

--- a/lib/connectors/llm/plugins/refine.ts
+++ b/lib/connectors/llm/plugins/refine.ts
@@ -3,7 +3,7 @@ import { CANVAS_ELEMENT_TYPES, DURATION_OPTIONS } from "@/lib/canvas/types";
 import { MOTION_EFFECTS } from "@/lib/video/motionEffects";
 import { MusicLength } from "@/lib/connectors/music/enums";
 import type { LLMPlugin } from "@/lib/connectors/types";
-import { osmlLanguagePrompt } from "./osml";
+import { languagePrompt } from "./language-prompt";
 
 const ELEMENT_TYPE_LIST = [...CANVAS_ELEMENT_TYPES].join(", ");
 const vals = (e: Record<string, string>) => Object.values(e).join(", ");
@@ -54,7 +54,7 @@ const REFINE_SYSTEM_PROMPT = dedent`
   - Minimize the number of operations. Only output what is necessary to fulfill the request.
   - Preserve existing element IDs — reference them, do not invent new ones.
 
-${osmlLanguagePrompt(
+${languagePrompt(
 	"the same language as the script you are editing, even when the refinement request is written in another language",
 )}
 `;

--- a/lib/connectors/llm/plugins/story-mode.ts
+++ b/lib/connectors/llm/plugins/story-mode.ts
@@ -6,6 +6,7 @@ import type {
 	PluginContext,
 } from "@/lib/connectors/types";
 import { requireGateway } from "@/lib/connectors/plugins";
+import { spokenLanguage } from "./language-prompt";
 import { prependSystemPrompt } from "./system-prompt";
 
 const STORY_MODE_SYSTEM_PROMPT = dedent`You are a highly engaging storyteller who expertly narrates video stories.
@@ -24,10 +25,11 @@ export const storyModePlugin: LLMPlugin = {
 		ctx?: PluginContext<LLMGenerateParams, LLMGenerateResult>,
 	) {
 		const gateway = requireGateway(ctx, "story-mode");
+		const { metadata } = ctx?.state ?? {};
 		const { text: outline } = await gateway.generate({
-			prompt: dedent`Outline an engaging story with a high-concept premise, characters, themes, conflict, twists, and a resolution. The story should be about the following: ${prompt}. Write the outline in the same language as that input. Do not write anything else, just the outline.`,
+			prompt: dedent`Outline an engaging story with a high-concept premise, characters, themes, conflict, twists, and a resolution. The story should be about the following: ${prompt}. Write the outline in ${spokenLanguage(metadata, "the same language as that input")}. Do not write anything else, just the outline.`,
 			maxTokens: 8192,
 		});
-		return dedent`Write a complete, engaging, and simple story for a 5th-grade reading level, in the same language as the following outline: ${outline}`;
+		return dedent`Write a complete, engaging, and simple story for a 5th-grade reading level, in ${spokenLanguage(metadata, "the same language as the following outline")}, based on the following outline: ${outline}`;
 	},
 };

--- a/lib/connectors/llm/plugins/template-mode.ts
+++ b/lib/connectors/llm/plugins/template-mode.ts
@@ -1,6 +1,7 @@
 import dedent from "dedent";
 import type { LLMPlugin } from "@/lib/connectors/types";
 import { getTemplate } from "@/lib/templates/templates";
+import { spokenLanguage } from "./language-prompt";
 import { prependSystemPrompt } from "./system-prompt";
 
 export function createTemplateModePlugin(templateId: string): LLMPlugin {
@@ -9,8 +10,12 @@ export function createTemplateModePlugin(templateId: string): LLMPlugin {
 		beforeGenerate(params) {
 			return prependSystemPrompt(params, getTemplate(templateId).systemPrompt);
 		},
-		async transformPrompt(prompt: string) {
-			return dedent`Pastiche this story format (with tone, pacing, imagery, plot techniques, story beats, structure, etc.) and reframe it to be about the following topic: <user_input>${prompt}</user_input>. Write the story in the language of the user_input, not the language of the example.
+		async transformPrompt(prompt: string, ctx) {
+			const language = spokenLanguage(
+				ctx?.state?.metadata,
+				"the same language that the user_input is in",
+			);
+			return dedent`Pastiche this story format (with tone, pacing, imagery, plot techniques, story beats, structure, etc.) and reframe it to be about the following topic: <user_input>${prompt}</user_input>. Write the story in ${language}.
 
 				Example story: ${getTemplate(templateId).exampleText}`;
 		},

--- a/lib/connectors/tts/plugins/metadata-voice.ts
+++ b/lib/connectors/tts/plugins/metadata-voice.ts
@@ -1,5 +1,6 @@
 import { requireState } from "@/lib/connectors/plugins";
 import { forVoice } from "@/lib/generation/sourceNodes";
+import { declaredLanguage } from "@/lib/project/language";
 import { MetadataVoiceSchema } from "@/lib/project/types";
 import type {
 	ConnectorPlugin,
@@ -11,7 +12,7 @@ export function createMetadataVoicePlugin(): ConnectorPlugin<TTSGenerateParams> 
 		name: "metadata-voice",
 		dependencies: (element) => [forVoice(element.customAttributes?.name)],
 		beforeGenerate(params, ctx) {
-			const { narration, characters } = requireState(
+			const { narration, characters, language } = requireState(
 				ctx,
 				"metadata-voice",
 			).metadata;
@@ -21,6 +22,7 @@ export function createMetadataVoicePlugin(): ConnectorPlugin<TTSGenerateParams> 
 			return {
 				...params,
 				...fields,
+				language: declaredLanguage(language) ?? fields.language,
 				voiceId: fields.voiceId ?? resolvedVoiceId,
 			};
 		},

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -4,6 +4,7 @@ import type { NodeSpec } from "@/lib/generation/graph";
 import type { ProjectData } from "@/lib/project/store";
 import type { WithMetadata } from "@/lib/providers/base";
 import type { AttributeSchema } from "./attributes/schema";
+import type { ThinkingLevel } from "./llm/enums";
 import type { TTSEmotion, TTSGender, TTSSpeed } from "./tts/enums";
 
 export type ConnectorType =
@@ -95,7 +96,7 @@ export interface Connector {
 
 export type LLMGenerateParams = ConnectorGenerateParams & {
 	systemPrompt?: string;
-	thinkingLevel?: string;
+	thinkingLevel?: ThinkingLevel;
 	maxTokens?: number;
 	temperature?: number;
 	referenceImages?: string[];

--- a/lib/project/__tests__/language.test.ts
+++ b/lib/project/__tests__/language.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+	AUTO_LANGUAGE,
+	LANGUAGE_CHOICES,
+	declaredLanguage,
+	languageLabel,
+} from "@/lib/project/language";
+
+describe("languageLabel", () => {
+	it("names Auto and spells out ISO codes", () => {
+		expect(languageLabel(AUTO_LANGUAGE)).toBe("Auto");
+		expect(languageLabel("es")).toBe("Spanish");
+	});
+});
+
+describe("LANGUAGE_CHOICES", () => {
+	it("offers Auto first so the default reads as the default", () => {
+		expect(LANGUAGE_CHOICES[0]).toBe(AUTO_LANGUAGE);
+		expect(LANGUAGE_CHOICES).toContain("es");
+	});
+});
+
+describe("declaredLanguage", () => {
+	it("reads Auto as no declared language, leaving the choice to the input", () => {
+		expect(declaredLanguage(AUTO_LANGUAGE)).toBeUndefined();
+		expect(declaredLanguage(undefined)).toBeUndefined();
+	});
+
+	it("passes a chosen language through", () => {
+		expect(declaredLanguage("es")).toBe("es");
+	});
+});

--- a/lib/project/__tests__/projectName.test.ts
+++ b/lib/project/__tests__/projectName.test.ts
@@ -5,6 +5,7 @@ import type { Metadata } from "../types";
 const base: Metadata = {
 	title: "",
 	style: "",
+	language: "auto",
 	narration: {},
 	characters: {},
 };

--- a/lib/project/__tests__/store.test.ts
+++ b/lib/project/__tests__/store.test.ts
@@ -9,6 +9,7 @@ describe("project store updateMetadata", () => {
 		expect(store.getState().metadata).toEqual({
 			title: "",
 			style: "cinematic",
+			language: "auto",
 			narration: {},
 			characters: {},
 		});
@@ -55,6 +56,7 @@ describe("project store updateMetadata", () => {
 		expect(store.getState().metadata).toEqual({
 			title: "",
 			style: "",
+			language: "auto",
 			narration: {},
 			characters: {},
 		});

--- a/lib/project/__tests__/storeSnapshot.test.ts
+++ b/lib/project/__tests__/storeSnapshot.test.ts
@@ -52,12 +52,19 @@ describe("storeSnapshot", () => {
 describe("parseStoreSnapshot", () => {
 	it("fills defaults for absent and partial rows", () => {
 		expect(parseStoreSnapshot(null)).toEqual({
-			metadata: { title: "", style: "", narration: {}, characters: {} },
+			metadata: {
+				title: "",
+				style: "",
+				language: "auto",
+				narration: {},
+				characters: {},
+			},
 			referenceImages: [],
 		});
 		expect(parseStoreSnapshot({ metadata: { title: "T" } }).metadata).toEqual({
 			title: "T",
 			style: "",
+			language: "auto",
 			narration: {},
 			characters: {},
 		});
@@ -68,6 +75,7 @@ describe("parseStoreSnapshot", () => {
 			metadata: {
 				title: "T",
 				style: "noir",
+				language: "es" as const,
 				narration: { age: "adult" as const },
 				characters: {
 					Ada: { appearance: "tall", gender: "feminine" as const },

--- a/lib/project/deriveArtStyle.ts
+++ b/lib/project/deriveArtStyle.ts
@@ -32,6 +32,7 @@ export async function deriveArtStyle(
 		prompt: DERIVE_PROMPT,
 		referenceImages,
 		maxTokens: 4096,
+		thinkingLevel: "low",
 	});
 	return text.trim();
 }

--- a/lib/project/language.ts
+++ b/lib/project/language.ts
@@ -1,0 +1,21 @@
+import { TTS_LANGUAGES, type TTSLanguage } from "@/lib/connectors/tts/enums";
+
+export const AUTO_LANGUAGE = "auto";
+
+export type LanguageChoice = typeof AUTO_LANGUAGE | TTSLanguage;
+
+export const LANGUAGE_CHOICES = [AUTO_LANGUAGE, ...TTS_LANGUAGES] as const;
+
+const displayNames = new Intl.DisplayNames(["en"], { type: "language" });
+
+export function languageLabel(choice: LanguageChoice): string {
+	return choice === AUTO_LANGUAGE
+		? "Auto"
+		: (displayNames.of(choice) ?? choice);
+}
+
+export function declaredLanguage(
+	choice: LanguageChoice | undefined,
+): TTSLanguage | undefined {
+	return choice === AUTO_LANGUAGE ? undefined : choice;
+}

--- a/lib/project/store.ts
+++ b/lib/project/store.ts
@@ -1,6 +1,7 @@
 import merge from "lodash/merge";
 import { immer } from "zustand/middleware/immer";
 import { createStore, type StoreApi } from "zustand/vanilla";
+import { AUTO_LANGUAGE } from "./language";
 import type {
 	DeepPartial,
 	Metadata,
@@ -32,7 +33,13 @@ export type ProjectStore = StoreApi<ProjectContext>;
 
 const initialState = {
 	hydrated: false,
-	metadata: { title: "", style: "", narration: {}, characters: {} } as Metadata,
+	metadata: {
+		title: "",
+		style: "",
+		language: AUTO_LANGUAGE,
+		narration: {},
+		characters: {},
+	} as Metadata,
 	referenceImages: [] as string[],
 };
 

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -6,6 +6,7 @@ import {
 	TTS_LANGUAGES,
 	TTS_PITCHES,
 } from "@/lib/connectors/tts/enums";
+import { AUTO_LANGUAGE, LANGUAGE_CHOICES } from "./language";
 import { ASPECT_RATIOS } from "@/lib/video/aspectRatio";
 import { CaptionStyleSchema } from "@/lib/video/captionStyle";
 import { VIDEO_LENGTHS } from "@/lib/video/videoLength";
@@ -64,6 +65,10 @@ export type Mode = (typeof MODES)[number];
 export const MetadataSchema = z.object({
 	title: z.string().default(""),
 	style: z.string().default(""),
+	language: z
+		.enum(LANGUAGE_CHOICES)
+		.default(AUTO_LANGUAGE)
+		.catch(AUTO_LANGUAGE),
 	narration: MetadataVoiceSchema.default({}),
 	characters: z.record(z.string(), MetadataCharacterSchema).default({}),
 	videoSettings: VideoSettingsSchema.optional(),

--- a/lib/project/useScriptLanguage.ts
+++ b/lib/project/useScriptLanguage.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useProject } from "./useProject";
+import type { LanguageChoice } from "./language";
+
+export function useScriptLanguage(): [
+	LanguageChoice,
+	(next: LanguageChoice) => void,
+] {
+	const language = useProject((s) => s.metadata.language);
+	const updateMetadata = useProject((s) => s.updateMetadata);
+	return [language, (next) => updateMetadata({ language: next })];
+}

--- a/lib/providers/__tests__/anthropic-llm.test.ts
+++ b/lib/providers/__tests__/anthropic-llm.test.ts
@@ -20,7 +20,7 @@ describe("AnthropicLLM", () => {
 		it("returns text and usage with defaults", async () => {
 			mockCreate.mockResolvedValue({
 				content: [{ type: "text", text: "Hello world" }],
-				model: "claude-opus-4-8",
+				model: "claude-opus-5",
 				usage: { input_tokens: 10, output_tokens: 5 },
 			});
 
@@ -29,13 +29,14 @@ describe("AnthropicLLM", () => {
 
 			expect(result).toEqual({
 				text: "Hello world",
-				model: "claude-opus-4-8",
+				model: "claude-opus-5",
 				usage: { inputTokens: 10, outputTokens: 5 },
 			});
 			expect(mockCreate).toHaveBeenCalledWith({
-				model: "claude-opus-4-8",
+				model: "claude-opus-5",
 				max_tokens: 65536,
-				temperature: undefined,
+				thinking: { type: "adaptive" },
+				output_config: { effort: "high" },
 				system: undefined,
 				messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
 			});
@@ -54,22 +55,36 @@ describe("AnthropicLLM", () => {
 				model: "custom",
 				systemPrompt: "You are helpful",
 				maxTokens: 100,
-				temperature: 0.5,
+				thinkingLevel: "low",
 			});
 
 			expect(mockCreate).toHaveBeenCalledWith({
 				model: "custom",
 				max_tokens: 100,
-				temperature: 0.5,
+				thinking: { type: "adaptive" },
+				output_config: { effort: "low" },
 				system: "You are helpful",
 				messages: [{ role: "user", content: [{ type: "text", text: "test" }] }],
 			});
 		});
 
+		it("drops temperature, which Claude rejects", async () => {
+			mockCreate.mockResolvedValue({
+				content: [{ type: "text", text: "ok" }],
+				model: "claude-opus-5",
+				usage: { input_tokens: 1, output_tokens: 1 },
+			});
+
+			const provider = new AnthropicLLM("test-key");
+			await provider.generate({ prompt: "hi", temperature: 0.5 });
+
+			expect(mockCreate.mock.calls[0][0]).not.toHaveProperty("temperature");
+		});
+
 		it("includes reference images as url blocks before the text", async () => {
 			mockCreate.mockResolvedValue({
 				content: [{ type: "text", text: "ok" }],
-				model: "claude-opus-4-8",
+				model: "claude-opus-5",
 				usage: { input_tokens: 1, output_tokens: 1 },
 			});
 

--- a/lib/providers/llm/anthropic.ts
+++ b/lib/providers/llm/anthropic.ts
@@ -4,6 +4,7 @@ import type {
 	LLMGenerateResult,
 } from "@/lib/connectors/types";
 import { parseImageSource } from "@/lib/api/imageSource";
+import { DEFAULT_THINKING_LEVEL } from "@/lib/connectors/llm/enums";
 import { BaseProvider } from "../base";
 
 const SUPPORTED_IMAGE_MEDIA_TYPES = [
@@ -72,9 +73,12 @@ export class AnthropicLLM extends BaseProvider<
 			{ type: "text" as const, text: params.prompt },
 		];
 		return {
-			model: params.model || "claude-opus-4-8",
+			model: params.model || "claude-opus-5",
 			max_tokens: params.maxTokens || 65536,
-			temperature: params.temperature,
+			thinking: { type: "adaptive" as const },
+			output_config: {
+				effort: params.thinkingLevel || DEFAULT_THINKING_LEVEL,
+			},
 			system: params.systemPrompt || undefined,
 			messages: [{ role: "user" as const, content }],
 		};

--- a/lib/templates/templates.ts
+++ b/lib/templates/templates.ts
@@ -283,7 +283,6 @@ export const TEMPLATES: Template[] = [
 			gender: "masculine",
 			accent: "british",
 			age: "child",
-			language: "en",
 			description: "Wistful, young male for emotional narrations",
 			voiceId: "4f7f1324-1853-48a6-b294-4e78e8036a83",
 		},
@@ -1274,7 +1273,6 @@ Wrap up with the aftermath — arrest, trial, sentence, ironic twist, or grim en
 			templateAsset("celebrity-death-4"),
 		],
 		narration: {
-			language: "en",
 			gender: "masculine",
 			age: "adult",
 			accent: "american",
@@ -1503,7 +1501,6 @@ Wrap up with the aftermath — arrest, trial, sentence, ironic twist, or grim en
 			templateAsset("stick-explainer-3"),
 		],
 		narration: {
-			language: "en",
 			gender: "masculine",
 			age: "adult",
 			accent: "american",


### PR DESCRIPTION
## Summary

- **Language dropdown in the composer**, beside the aspect ratio and length pills. Defaults to **Auto** (today's behaviour: the model follows the language you typed in); picking a language pins every prompt hop to it.
- Fix the vanilla sleep-story template generating Spanish scripts from English input. Both language rules were phrased as exclusions ("not the language of the example", "ignoring the language of any example, reference, or instruction text"), which in template mode disqualifies nearly every English signal in the prompt and pushes the model off English entirely. They now name the source positively, with English as the stated fallback, through one helper (`spokenLanguage`) that every prompt builder calls with the signal its own prompt can still see.
- The language is a **project-level field** (`metadata.language`), not `narration.language` — that one means the narrator *voice's* language and is carried per character too. Reading it as the script's language made three templates pin their scripts to English through voice-filter data.
- Voices still follow the words: in Auto the script reports the language it wrote in and that drives voice search; a pinned project language outranks that report, so switching the picker after an Auto run can't leave the old voice behind. A narrator language the user picked is write-once, so a later generation can't overwrite it.
- Wire up `thinkingLevel`, which existed on the params and the route schema but was never read by the provider. Typed as an enum, parsed at the route boundary, sent as `output_config.effort` with adaptive thinking. Defaults to `high`; the two short describe-a-reference-image calls drop to `low`.
- Bump the default model to `claude-opus-5`, which rejects `temperature` outright, so the Anthropic provider stops forwarding it. The parameter stays on the shared params and the route schema for providers that do support it.
- CONVENTIONS.md: tighten the comments rule — comments only where a choice would look odd to a first-time reader with no context, and never as changelog.

## Test plan

- [x] `npm run lint`, `format:check`, `typecheck`, `knip`, `build`
- [x] `npm run test` — 1178 passing
- [x] New coverage: OSML names English as the fallback and rules no language out; a pinned project language wins in all three prompt hops (OSML, template mode, both story-mode hops); the OSML spec still asks the script to report its language, which Auto relies on for voices; a pinned project language outranks a voice language left by an earlier script, and the voice's own language still wins on Auto; a user-picked narrator language survives a generation that reports a different one; the Anthropic request omits `temperature`

## Notes

- **Composer settings don't survive a reload — language included.** Autosave only mounts once a script exists (`useEditorSession` is rendered by `PostPromptView`), so the pre-prompt composer persists nothing. Pre-existing and unchanged here — the aspect ratio pill resets the same way. Worth a separate fix if we want composer state to stick.
- Uses the icon library's existing `translate` glyph (文/A) — the only new line in `icon.tsx` is the export; `icons.css` is untouched.
- Language names come from `Intl.DisplayNames` rather than a hand-maintained 42-entry label map.
- The installed `@anthropic-ai/sdk` (0.78.0) does not type the `xhigh` effort level, so the enum stops at `max`. Bumping the SDK would widen it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
