### PR TITLE
perf: nightly performance optimizations 2026-08-12

### DIFF
--- a/app/components/canvas/ViewModeContext.tsx
+++ b/app/components/canvas/ViewModeContext.tsx
@@ -1,22 +1,91 @@
 "use client";
 
-import { useCallback, useMemo, useState, type ReactNode } from "react";
+import {
+	useCallback,
+	useState,
+	useSyncExternalStore,
+	type ReactNode,
+} from "react";
 import type { Editor } from "slate";
 import type { CanvasElement } from "@/lib/canvas/types";
 import { isSceneElement } from "@/lib/canvas/scenes";
 import { createRequiredContext } from "@/lib/components/createRequiredContext";
 
-type ViewModeValue = {
+export type ViewModeStore = {
 	isCollapsed: (sceneId: string) => boolean;
-	hasCollapsed: boolean;
+	hasCollapsed: () => boolean;
+	subscribe: (onChange: () => void) => () => void;
 	toggle: (sceneId: string) => void;
 	expandAll: () => void;
 	collapseAll: () => void;
 };
 
+/**
+ * Every element card asks whether its scene is collapsed, but a toggle changes
+ * the answer for one scene. Holding the collapsed set in the context would
+ * re-render all of them; holding a store lets each card subscribe and re-render
+ * only when its own scene flips.
+ */
+export function createViewModeStore(editor: Editor): ViewModeStore {
+	let collapsed: ReadonlySet<string> = new Set();
+	const listeners = new Set<() => void>();
+
+	const replace = (next: ReadonlySet<string>) => {
+		collapsed = next;
+		for (const listener of listeners) listener();
+	};
+
+	return {
+		isCollapsed: (sceneId) => collapsed.has(sceneId),
+		hasCollapsed: () => collapsed.size > 0,
+		subscribe: (onChange) => {
+			listeners.add(onChange);
+			return () => {
+				listeners.delete(onChange);
+			};
+		},
+		toggle: (sceneId) => {
+			const next = new Set(collapsed);
+			if (!next.delete(sceneId)) next.add(sceneId);
+			replace(next);
+		},
+		expandAll: () => replace(new Set()),
+		collapseAll: () =>
+			replace(
+				new Set(
+					(editor.children as CanvasElement[])
+						.filter(isSceneElement)
+						.map((scene) => scene.id),
+				),
+			),
+	};
+}
+
 const [ViewModeContext, useViewMode] =
-	createRequiredContext<ViewModeValue>("ViewModeContext");
+	createRequiredContext<ViewModeStore>("ViewModeContext");
 export { useViewMode };
+
+const notCollapsed = () => false;
+
+/** Whether `sceneId` is collapsed, re-rendering only when that answer flips. */
+export function useIsCollapsed(sceneId: string): boolean {
+	const store = useViewMode();
+	const getSnapshot = useCallback(
+		() => store.isCollapsed(sceneId),
+		[store, sceneId],
+	);
+	return useSyncExternalStore(store.subscribe, getSnapshot, notCollapsed);
+}
+
+/** Whether any scene is collapsed, for the expand/collapse-all control. */
+export function useHasCollapsed(): boolean {
+	const store = useViewMode();
+	return useSyncExternalStore(
+		store.subscribe,
+		store.hasCollapsed,
+		notCollapsed,
+	);
+}
 
 export function ViewModeProvider({
 	editor,
@@ -25,39 +94,6 @@ export function ViewModeProvider({
 	editor: Editor;
 	children: ReactNode;
 }) {
-	const [collapsedScenes, setCollapsedScenes] = useState<Set<string>>(
-		() => new Set(),
-	);
-
-	const isCollapsed = useCallback(
-		(sceneId: string) => collapsedScenes.has(sceneId),
-		[collapsedScenes],
-	);
-
-	const toggle = useCallback((sceneId: string) => {
-		setCollapsedScenes((prev) => {
-			const next = new Set(prev);
-			if (next.has(sceneId)) next.delete(sceneId);
-			else next.add(sceneId);
-			return next;
-		});
-	}, []);
-
-	const expandAll = useCallback(() => {
-		setCollapsedScenes(new Set());
-	}, []);
-
-	const collapseAll = useCallback(() => {
-		const scenes = (editor.children as CanvasElement[]).filter(isSceneElement);
-		setCollapsedScenes(new Set(scenes.map((scene) => scene.id)));
-	}, [editor]);
-
-	const hasCollapsed = collapsedScenes.size > 0;
-
-	const value = useMemo(
-		() => ({ isCollapsed, hasCollapsed, toggle, expandAll, collapseAll }),
-		[isCollapsed, hasCollapsed, toggle, expandAll, collapseAll],
-	);
-
-	return <ViewModeContext value={value}>{children}</ViewModeContext>;
+	const [store] = useState(() => createViewModeStore(editor));
+	return <ViewModeContext value={store}>{children}</ViewModeContext>;
 }

--- a/app/components/canvas/__tests__/viewMode.test.ts
+++ b/app/components/canvas/__tests__/viewMode.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Editor } from "slate";
+import { SCENE_TYPE } from "@/lib/canvas/types";
+import { createViewModeStore } from "../ViewModeContext";
+
+const editorWith = (...sceneIds: string[]) =>
+	({
+		children: sceneIds.map((id) => ({
+			type: SCENE_TYPE,
+			id,
+			children: [],
+		})),
+	}) as unknown as Editor;
+
+describe("createViewModeStore", () => {
+	it("starts fully expanded", () => {
+		const store = createViewModeStore(editorWith("scene-1"));
+		expect(store.isCollapsed("scene-1")).toBe(false);
+		expect(store.hasCollapsed()).toBe(false);
+	});
+
+	it("toggles one scene without touching the others", () => {
+		const store = createViewModeStore(editorWith("scene-1", "scene-2"));
+
+		store.toggle("scene-1");
+		expect(store.isCollapsed("scene-1")).toBe(true);
+		expect(store.isCollapsed("scene-2")).toBe(false);
+		expect(store.hasCollapsed()).toBe(true);
+
+		store.toggle("scene-1");
+		expect(store.isCollapsed("scene-1")).toBe(false);
+		expect(store.hasCollapsed()).toBe(false);
+	});
+
+	it("collapses every scene in the document and expands them again", () => {
+		const store = createViewModeStore(editorWith("scene-1", "scene-2"));
+
+		store.collapseAll();
+		expect(store.isCollapsed("scene-1")).toBe(true);
+		expect(store.isCollapsed("scene-2")).toBe(true);
+
+		store.expandAll();
+		expect(store.hasCollapsed()).toBe(false);
+	});
+
+	it("notifies subscribers on every write", () => {
+		const store = createViewModeStore(editorWith("scene-1"));
+		const listener = vi.fn();
+		store.subscribe(listener);
+
+		store.toggle("scene-1");
+		store.collapseAll();
+		store.expandAll();
+		expect(listener).toHaveBeenCalledTimes(3);
+	});
+
+	it("stops notifying once unsubscribed", () => {
+		const store = createViewModeStore(editorWith("scene-1"));
+		const listener = vi.fn();
+		store.subscribe(listener)();
+
+		store.toggle("scene-1");
+		expect(listener).not.toHaveBeenCalled();
+	});
+});

--- a/app/components/canvas/dnd/DragOverlay.tsx
+++ b/app/components/canvas/dnd/DragOverlay.tsx
@@ -8,7 +8,7 @@ import { CompactElement } from "../elements/CompactElement";
 import { ElementContainer } from "../elements/ElementContainer";
 import { SceneContainer } from "../elements/SceneContainer";
 import { useSceneIndex } from "../hooks/useSceneIndex";
-import { useViewMode } from "../ViewModeContext";
+import { useIsCollapsed } from "../ViewModeContext";
 import styles from "../styles/sortable.module.css";
 
 /**
@@ -24,8 +24,8 @@ export function DragOverlayContent({ element }: { element: CanvasElement }) {
 	);
 
 	const sceneIndex = useSceneIndex(element.id);
-	const { isCollapsed } = useViewMode();
-	const collapsed = isSceneElement(element) && isCollapsed(element.id);
+	const sceneCollapsed = useIsCollapsed(element.id);
+	const collapsed = isSceneElement(element) && sceneCollapsed;
 
 	const renderElement = useCallback(
 		({ attributes, children, element: node }: RenderElementProps) => {

--- a/app/components/canvas/dnd/SortableContent.tsx
+++ b/app/components/canvas/dnd/SortableContent.tsx
@@ -9,7 +9,7 @@ import type {
 import { parentSceneId } from "@/lib/canvas/scenes";
 import { ELEMENT_LIST } from "@/lib/canvas/elementConfigs";
 import { insertElement } from "@/lib/canvas/insertElement";
-import { useViewMode } from "../ViewModeContext";
+import { useIsCollapsed } from "../ViewModeContext";
 import { CompactElement } from "../elements/CompactElement";
 import { ElementContainer } from "../elements/ElementContainer";
 import { SortableItem } from "./SortableItem";
@@ -38,11 +38,10 @@ export function SortableContent({
 	const [isMenuOpen, setIsMenuOpen] = useState(false);
 	const editor = useSlateStatic();
 	const { connectorConfig } = useConfig();
-	const { isCollapsed } = useViewMode();
 
 	const path = ReactEditor.findPath(editor, element);
 	const sceneId = parentSceneId(editor, path);
-	const collapsed = isCollapsed(sceneId);
+	const collapsed = useIsCollapsed(sceneId);
 	const Content = collapsed ? CompactElement : ElementContainer;
 
 	const insertGap = useDropIndex(sceneId) === path[path.length - 1];

--- a/app/components/canvas/dnd/SortableScene.tsx
+++ b/app/components/canvas/dnd/SortableScene.tsx
@@ -1,7 +1,7 @@
 import { RenderElementProps } from "slate-react";
 import type { SceneElement } from "@/lib/canvas/types";
 import { useActiveSceneId } from "@/app/components/scene-selection/ActiveSceneContext";
-import { useViewMode } from "../ViewModeContext";
+import { useIsCollapsed } from "../ViewModeContext";
 import styles from "../styles/sortable.module.css";
 import { SceneContainer } from "../elements/SceneContainer";
 import { useSceneIndex } from "../hooks/useSceneIndex";
@@ -19,13 +19,13 @@ export function SortableScene({
 	children: React.ReactNode;
 }) {
 	const isActive = useActiveSceneId() === element.id;
-	const { isCollapsed } = useViewMode();
+	const collapsed = useIsCollapsed(element.id);
 	const sceneIndex = useSceneIndex(element.id);
 	return (
 		<SortableItem
 			sceneId={element.id}
 			sortableType="scene"
-			disabled={!isCollapsed(element.id)}
+			disabled={!collapsed}
 			wrapperClassName={`${styles.scene} border-t pt-3 mt-3 first:border-t-0 first:pt-0 first:mt-0 ${isActive ? "border-transparent" : "border-border"}`}
 			contentClassName={isActive ? ACTIVE_SCENE_CLASS : undefined}
 			attributes={attributes}

--- a/app/components/canvas/elements/SceneContainer.tsx
+++ b/app/components/canvas/elements/SceneContainer.tsx
@@ -8,7 +8,7 @@ import type { SceneElement } from "@/lib/canvas/types";
 import { useSceneSequence } from "@/app/components/video/VideoLayoutContext";
 import { isForeground } from "@/lib/canvas/guards";
 import { useDropIndex } from "../dnd/DragTransferContext";
-import { useViewMode } from "../ViewModeContext";
+import { useIsCollapsed, useViewMode } from "../ViewModeContext";
 import { CollapsibleHeader } from "./CollapsibleHeader";
 import { DeleteButton } from "./DeleteButton";
 import { ForegroundPreview } from "./ForegroundPreview";
@@ -178,8 +178,8 @@ function ExpandedScene({
 }
 
 export function SceneContainer(props: SceneProps) {
-	const { isCollapsed } = useViewMode();
-	return isCollapsed(props.element.id) ? (
+	const collapsed = useIsCollapsed(props.element.id);
+	return collapsed ? (
 		<CollapsedScene {...props} />
 	) : (
 		<ExpandedScene {...props} />

--- a/app/components/canvas/panel/LayoutPanel.tsx
+++ b/app/components/canvas/panel/LayoutPanel.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/select-field";
 import { useAutoScroll } from "@/app/components/scene-selection/AutoScrollContext";
 import { usePlayerPosition } from "@/app/components/video/PlayerPositionContext";
-import { useViewMode } from "../ViewModeContext";
+import { useHasCollapsed, useViewMode } from "../ViewModeContext";
 import { PanelCard, PanelField } from "./PanelCard";
 
 type PlayerPositionValue = "top" | "right" | "hidden";
@@ -21,7 +21,8 @@ type PlayerPositionValue = "top" | "right" | "hidden";
 export function LayoutPanel() {
 	const { position, visible, setPosition, setVisible, narrowViewport } =
 		usePlayerPosition();
-	const { hasCollapsed, expandAll, collapseAll } = useViewMode();
+	const { expandAll, collapseAll } = useViewMode();
+	const hasCollapsed = useHasCollapsed();
 	const { enabled, setEnabled } = useAutoScroll();
 
 	const positionValue: PlayerPositionValue = visible ? position : "hidden";


### PR DESCRIPTION
## What

Collapsing a single scene re-rendered **every** element card on the canvas.

`ViewModeContext` held the collapsed set as its value, and `isCollapsed` was a `useCallback` keyed on that set (`ViewModeContext.tsx:32-35`). So every `toggle` produced a new context value, and **context updates bypass both `React.memo` and Slate's element memoization** — every `SortableContent` re-ran `ReactEditor.findPath` + `parentSceneId` and rebuilt its whole `ElementContainer` subtree (icon chip, character pills, model badge, settings `Popover`, delete/upload/animate/generate buttons, output preview), to change the rendering of the one scene that actually flipped.

This is item 5 of #510, and the same shape as the drag-transfer fanout fixed in #523.

- **`ViewModeContext`** now carries a store (`isCollapsed` / `hasCollapsed` / `subscribe` / `toggle` / `expandAll` / `collapseAll`) instead of the collapsed set. The context value is created once and never changes identity.
- **`useIsCollapsed(sceneId)`** is the consumer surface for the four components that render off collapse state (`SortableContent`, `SortableScene`, `SceneContainer`, `DragOverlayContent`). Each subscribes via `useSyncExternalStore` and re-renders only when its own scene's answer flips.
- **`useHasCollapsed()`** does the same for `LayoutPanel`'s expand/collapse-all toggle, which is the only reader of that flag.

Every call site keeps its exact previous condition, so collapsed cards, the collapsed scene frame, the disabled scene drag handle and the drag overlay all behave as before.

## Why it matters

A collapse toggle is a normal navigation action on a long slop, and today it costs a full-document rebuild. Consumer counts on a 40-scene / 200-element document:

| | before | after |
|---|---|---|
| context consumers re-rendered per toggle | 240 (200 cards + 40 scenes) | 0 |
| `useIsCollapsed` subscribers whose value changed | — | 1 scene + its ~5 cards |
| `ElementContainer` subtrees rebuilt per toggle | 200 | ~5 |

`expandAll` / `collapseAll` still change every scene's answer, and still re-render everything — that is the correct amount of work for those two buttons.

I did not re-measure the per-card rebuild cost in a browser for this PR. #523 measured exactly this fanout on the same fixture (200 cards, `ElementContainer` rebuilds, 435 ms longest task for a 200-card rebuild storm); this change removes the same 200-card rebuild from the collapse path.

## Open PR overlap check

Open PRs at the time of this run: **#553** (storyboard strip — `PostPromptView`, `BottomTransportBar`, `BottomViewContext/Toggle`, `VideoLayoutContext`, `storyboard/*`, `ActiveSceneContext`, `SortableScene`, `LayoutPanel`, `insertScene`), **#554** (`lib/video/captionPresets.ts`), **#555** (nightly maintainability — `useEditorSession`, caption panels, `PlayerPanel`, `useVideoLayout`, `lib/project/*`, `lib/video/*`).

No theme overlap. Two file overlaps with #553, both unavoidable because those files read the collapse state: `SortableScene.tsx` (#553 edits the import block and hoists `ACTIVE_SCENE_CLASS`; this edits the `useViewMode` line and the `disabled` prop) and `LayoutPanel.tsx` (#553 adds a `BottomViewToggle` field; this edits the `useViewMode` destructure). Both should merge cleanly or conflict trivially.

## Considered and skipped

- **Item 4 of #510** (lower the document subscription so keystrokes stop re-rendering the whole shell) is the larger remaining win, but it lands in `PostPromptView.tsx`, `useEditorSession.ts` and `VideoLayoutContext.tsx` — all held by #553/#555. Deferred on the overlap guard, not on merit.
- **Item 1 of #510** (Slate chunking via `getChunkSize`). At this app's scale the editor's top-level children are ~40 scenes, so the `if (!chunking)` branch's per-keystroke work is ~80 WeakMap writes and 40 memo comparators — microseconds. The paint half of the walkthrough's chunking advice is already covered: `.scene` carries `content-visibility: auto` with `contain-intrinsic-size`. Enabling chunking here would be the trivial-gain PR the issue warns about.
- **Waveform / video preview viewport gating** — already proposed and closed as #476.
- **`findElementById` in the drag-over path** — already proposed and closed as #548.

## Validation

`npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run knip`, `npm run build`, `npm test -- --run` (1184 passing, including a new pure test for the store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)