### PR TITLE
feat: tie image descriptions to the narration they play under

### DIFF
--- a/lib/connectors/__tests__/osml.test.ts
+++ b/lib/connectors/__tests__/osml.test.ts
@@ -64,6 +64,19 @@ describe("osmlPlugin", () => {
 		expect(systemPrompt).not.toContain('Default to "en"');
 	});
 
+	it("ties each image to the moment its narration describes without dropping the standalone-prompt rule", () => {
+		const { systemPrompt } = beforeGenerate({ prompt: "hello" }) as {
+			systemPrompt: string;
+		};
+		expect(systemPrompt).toContain(
+			"depict the specific moment described by the narration and dialogue that follow it",
+		);
+		expect(systemPrompt).toContain("must be written as a standalone prompt");
+		expect(systemPrompt).toContain(
+			"Reference characters by their names in the image description",
+		);
+	});
+
 	it("deters motion on animated_image, which competes with the videoPrompt animation", () => {
 		const { systemPrompt } = beforeGenerate({ prompt: "hello" }) as {
 			systemPrompt: string;

--- a/lib/connectors/llm/plugins/osml.ts
+++ b/lib/connectors/llm/plugins/osml.ts
@@ -72,6 +72,7 @@ ${languagePrompt(language)}
 		EffectType,
 	).join(", ")}
   - Image descriptions should describe the time of day, the background, the weather (if outdoors), and objects in detail.
+  - Each image must depict the specific moment described by the narration and dialogue that follow it, up to the next image tag: the concrete subject, action, and expression of those lines, not just the scene's general setting. If the line names an object, a gesture, or a reaction, it belongs in the description.
   - Each <image> description must be written as a standalone prompt, as if the generative image model has absolutely no knowledge of the story, prior images, or previous prompts.
 	- Reference characters by their names in the image description, NEVER describe their appearance in the image description
   - Each image description should include all relevant details about the scene (except for art style and character descriptions), even if this requires repeating details from previous descriptions or the story.
@@ -83,7 +84,7 @@ ${languagePrompt(language)}
   - duration: optional. The length of the animated clip in seconds (default 5). Allowed values: ${DURATION_OPTIONS.join(", ")}.
   - motion: normally set to "none". Only set a motion effect when the videoPrompt describes subject movement with no camera move of its own. Allowed motion values: ${MOTION_EFFECTS.join(", ")}.
   - characters: optional. Same as for <image> — a comma-separated list of exact story character names appearing in the frame. Example: <animated_image videoPrompt="..." characters="Red,Granny">Red hands the basket to Granny at the cottage door.</animated_image>
-  - All <image> description rules apply unchanged: write a prompt that describes the time of day, background, weather, and objects in detail. Repeat any details necessary even if they appeared in earlier prompts.
+  - All <image> description rules apply unchanged: depict the moment the following narration and dialogue describe, and write a prompt that describes the time of day, background, weather, and objects in detail. Repeat any details necessary even if they appeared in earlier prompts.
   - Use <animated_image> sparingly — mostly at intro shots and hero moments. Default to <image> for typical scenes; image-to-video generation is significantly slower and more expensive.
 
   ### Sound XML Tags


### PR DESCRIPTION
## Summary

Image prompts were authored with no rule tying them to the lines they illustrate, so the model described the scene's general setting while the narration named a concrete moment. This adds that rule to the OSML image section:

- `<image>`: each description must depict the specific moment described by the narration and dialogue that follow it, up to the next image tag — the concrete subject, action, and expression of those lines, not just the setting.
- `<animated_image>`: the "all image rules apply" bullet now names the moment requirement explicitly.

The standalone-prompt rule and the reference-characters-by-name rule are unchanged, and a test pins all three together so a future prompt edit can't silently drop one.

Per the issue's suggested direction, this is the authoring-side fix only. The structural change (a scene-context plugin making an image node depend on its scene's narration) is deliberately not taken up front; it should be judged on whether this prompt rule falls short in real script generations, and filed separately if so. That evaluation needs live generations and is not something this change can verify.

## Why this was safe and small

Prompt-text change in one file plus one test. No runtime behavior, no schema change, no UI.

## Validation

- `npm run lint` — pass
- `npm run format:check` — pass
- `npm run typecheck` — pass
- `npm run knip` — pass
- `npm run build` — pass
- `npm test` — 137 files, 1180 tests pass
- `npm run test:e2e` — 3 pass

## Open PR overlap check

Open PRs #553, #554, #555, #556 touch canvas/video/captions/project-store files. Neither `lib/connectors/llm/plugins/osml.ts` nor `lib/connectors/__tests__/osml.test.ts` appears in any of their diffs.

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)