### PR TITLE
fix(captions): center the Classic caption preset

### DIFF
--- a/lib/video/captionPresets.ts
+++ b/lib/video/captionPresets.ts
@@ -22,7 +22,7 @@ const text = (style: Partial<CaptionTextStyle>): CaptionTextStyle => ({
 });
 
 export const CAPTION_PRESETS: readonly CaptionPreset[] = [
-	preset("classic", "Classic", {}),
+	preset("classic", "Classic", { alignX: "center" }),
 	preset("karaoke", "Karaoke", {
 		font: "bangers",
 		fontSize: 62,


### PR DESCRIPTION
Closes #562.

Every caption preset except `classic` sets `alignX: "center"`. `classic` was declared with an empty override:

```ts
preset("classic", "Classic", {}),
```

so it inherited `alignX: "left"` from `DEFAULT_CAPTION_STYLE` (confirmed at `lib/video/captionStyle.ts:80`) and rendered left-hugging captions — the odd one out among the presets.

```ts
preset("classic", "Classic", { alignX: "center" }),
```

`DEFAULT_CAPTION_STYLE` itself is untouched, so the default for non-preset styles is unchanged, as the issue asked.

Verified: `npx tsc --noEmit` clean, `vitest run` 211 passed across 14 files (`lib/video`), lint-staged eslint + prettier clean on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)