### PR TITLE
fix(editor-sidebar): use pr-1 so the panel lines up with the nav rail

### DIFF
--- a/app/components/canvas/panel/EditorSidebar.tsx
+++ b/app/components/canvas/panel/EditorSidebar.tsx
@@ -118,7 +118,7 @@ function EditorSidebarComponent() {
 			</nav>
 
 			{current && HeaderIcon && Panel && (
-				<div className="flex w-60 shrink-0 flex-col gap-3 overflow-y-auto [scrollbar-gutter:stable] pr-2 pt-4 pb-3 text-panel-fg">
+				<div className="flex w-60 shrink-0 flex-col gap-3 overflow-y-auto [scrollbar-gutter:stable] pr-1 pt-4 pb-3 text-panel-fg">
 					<div className="flex items-center gap-2 px-1">
 						<HeaderIcon className="h-5 w-5 text-panel-label" />
 						<h2 className="text-body font-semibold text-panel-label">


### PR DESCRIPTION
Closes #560.

The scrolling panel container in `app/components/canvas/panel/EditorSidebar.tsx` used `pr-2` while the nav rail beside it pads by `1`, so the panel's right edge sat slightly further in and the two did not line up.

`pr-2` → `pr-1` on that div. One-line class change, exactly as the issue specifies.

Verified: `npx tsc --noEmit` clean; lint-staged eslint + prettier clean on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)