### PR TITLE
fix: nightly bug fixes 2026-08-14

### DIFF
--- a/lib/api/__tests__/sse.test.ts
+++ b/lib/api/__tests__/sse.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { formatSSE, createSSEResponse, readSSE } from "../sse";
+import { describe, expect, it, vi } from "vitest";
+import {
+	formatSSE,
+	createSSEResponse,
+	createSSEStreamResponse,
+	readSSE,
+} from "../sse";
+import { logger } from "../logger";
 
 function makeSSEStream(chunks: string[]): ReadableStream {
 	const encoder = new TextEncoder();
@@ -82,6 +88,57 @@ describe("createSSEResponse", () => {
 	});
 });
 
+describe("createSSEStreamResponse", () => {
+	it("returns a Response with SSE headers", () => {
+		const response = createSSEStreamResponse((async function* () {})(), "test");
+		expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+	});
+
+	it("streams every chunk, then closes", async () => {
+		async function* chunks() {
+			yield { a: 1 };
+			yield { b: 2 };
+		}
+		const text = await createSSEStreamResponse(chunks(), "test").text();
+		expect(text).toBe('data: {"a":1}\n\ndata: {"b":2}\n\n');
+	});
+
+	it("closes the source when the consumer cancels, without logging an error", async () => {
+		const error = vi.spyOn(logger, "error").mockImplementation(() => {});
+		let closed = false;
+		async function* endless() {
+			try {
+				for (let n = 0; ; n++) yield { n };
+			} finally {
+				closed = true;
+			}
+		}
+		const body = createSSEStreamResponse(endless(), "test").body;
+		if (!body) throw new Error("expected response body");
+		const reader = body.getReader();
+
+		await reader.read();
+		await reader.cancel();
+
+		expect(closed).toBe(true);
+		expect(error).not.toHaveBeenCalled();
+		error.mockRestore();
+	});
+
+	it("errors the stream and logs when the source throws", async () => {
+		const error = vi.spyOn(logger, "error").mockImplementation(() => {});
+		async function* failing() {
+			yield { a: 1 };
+			throw new Error("upstream died");
+		}
+		const response = createSSEStreamResponse(failing(), "test");
+
+		await expect(response.text()).rejects.toThrow("upstream died");
+		expect(error).toHaveBeenCalledWith(expect.any(Error), "test stream error");
+		error.mockRestore();
+	});
+});
+
 describe("readSSE", () => {
 	it("parses single SSE event", async () => {
 		const stream = makeSSEStream(['data: {"msg":"hello"}\n\n']);
@@ -151,13 +208,26 @@ describe("readSSE", () => {
 		expect(results).toEqual([{ a: 1 }]);
 	});
 
-	it("releases the underlying reader when the consumer breaks early", async () => {
-		const stream = makeSSEStream(['data: {"a":1}\n\n', 'data: {"b":2}\n\n']);
+	it("cancels the body when the consumer breaks early", async () => {
+		let cancelled = false;
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream({
+			start(controller) {
+				controller.enqueue(encoder.encode('data: {"a":1}\n\n'));
+				controller.enqueue(encoder.encode('data: {"b":2}\n\n'));
+			},
+			cancel() {
+				cancelled = true;
+			},
+		});
+
 		for await (const event of readSSE(stream)) {
 			expect(event).toEqual({ a: 1 });
 			break;
 		}
-		// If the lock had not been released, getReader() would throw.
+
+		expect(cancelled).toBe(true);
+		// Cancelling also releases the lock; otherwise getReader() would throw.
 		expect(() => stream.getReader()).not.toThrow();
 	});
 });

--- a/lib/api/sse.ts
+++ b/lib/api/sse.ts
@@ -42,22 +42,34 @@ export function createSSEResponse(
 	return new Response(stream.readable, { headers: SSE_HEADERS });
 }
 
+/**
+ * Pulls one chunk per read so a client that stops reading stops the source, and
+ * closes the source on cancel. Draining `iter` eagerly instead would keep the
+ * provider generating for a client that has already hung up, and would only
+ * notice on the enqueue that throws.
+ */
 export function createSSEStreamResponse<T>(
 	iter: AsyncIterable<T>,
 	label: string,
 ): Response {
 	const encoder = new TextEncoder();
+	const source = iter[Symbol.asyncIterator]();
 	const stream = new ReadableStream({
-		async start(controller) {
+		async pull(controller) {
 			try {
-				for await (const chunk of iter) {
-					controller.enqueue(encoder.encode(formatSSE(chunk)));
+				const { done, value } = await source.next();
+				if (done) {
+					controller.close();
+					return;
 				}
-				controller.close();
+				controller.enqueue(encoder.encode(formatSSE(value)));
 			} catch (error) {
 				logger.error(error, `${label} stream error`);
 				controller.error(error);
 			}
+		},
+		async cancel(reason) {
+			await source.return?.(reason);
 		},
 	});
 	return new Response(stream, { headers: SSE_HEADERS });
@@ -87,6 +99,10 @@ export async function* readSSE<T>(body: ReadableStream): AsyncGenerator<T> {
 			}
 		}
 	} finally {
+		// Cancel before releasing: a consumer that stops early leaves the response
+		// body unread, and only cancelling tears the connection down so the server
+		// learns to stop producing.
+		await reader.cancel();
 		reader.releaseLock();
 	}
 }

--- a/lib/gateway/__tests__/openslop-gateways.test.ts
+++ b/lib/gateway/__tests__/openslop-gateways.test.ts
@@ -215,6 +215,37 @@ describe("OpenSlop Gateway Clients", () => {
 			expect(body.stream).toBe(true);
 		});
 
+		it("cancels the response body when the caller stops consuming", async () => {
+			let cancelled = false;
+			const encoder = new TextEncoder();
+			const body = new ReadableStream({
+				start(controller) {
+					controller.enqueue(
+						encoder.encode('data: {"text":"Hel","done":false}\n\n'),
+					);
+					controller.enqueue(
+						encoder.encode('data: {"text":"lo!","done":false}\n\n'),
+					);
+				},
+				cancel() {
+					cancelled = true;
+				},
+			});
+			fetchMock.mockResolvedValue(
+				new Response(body, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				}),
+			);
+
+			const gw = new OpenSlopLLMGateway("https://api.test.com");
+			for await (const _ of gw.stream({ prompt: "hi" })) {
+				break;
+			}
+
+			expect(cancelled).toBe(true);
+		});
+
 		it("throws when stream response has no body", async () => {
 			fetchMock.mockResolvedValue(
 				new Response(null, { status: 200, headers: {} }),


### PR DESCRIPTION
## What

Stopping a script generation didn't actually stop it. Two defects in the SSE transport, one on each end of the stream.

### Server: `createSSEStreamResponse` never learned the client left

It drained the provider's async generator inside `start()` — no backpressure, no `cancel` handler. When a client hung up, the loop kept pulling tokens from the LLM. It only stopped by crashing on the next `controller.enqueue()`:

```
TypeError [ERR_INVALID_STATE]: Invalid state: Controller is already closed
  at Object.start (lib/api/sse.ts:54:17)
msg: "LLM stream error"
```

So every Stop logged a fabricated error at `error` level, burying real ones, and burned at least one extra chunk of generation.

Rewritten as `pull` + `cancel`: one chunk per read, and cancelling closes the source generator deterministically (which propagates through `AnthropicLLM.stream` to abort the upstream request).

### Client: `readSSE` released the reader instead of cancelling it

`releaseLock()` detaches the reader but leaves the stream un-cancelled, so a consumer that breaks early (`drainStream` on abort → `useStreamRun.stop`) left the response body unread and the connection open. The server had no way to find out. Now it cancels first, then releases.

The two are the same root cause — the stop path wasn't plumbed through the transport — and both halves are needed for Stop to reach the provider.

## Tests

3 regression tests, each verified to fail against the old code:

- `createSSEStreamResponse` closes the source on consumer cancel and logs nothing
- `readSSE` cancels the body when the consumer breaks early
- `OpenSlopLLMGateway.stream` cancels the response body when the caller stops consuming (covers the full generator-delegation chain)

Plus baseline coverage for `createSSEStreamResponse`, which had none: headers, happy-path framing, and the error path.

CI: lint, format:check, typecheck, knip, build, and 1187 tests all pass.

## Open PR overlap check

Considered #573, #569, #568, #567, #565. None touch `lib/api/sse.ts`, `lib/api/__tests__/`, or `lib/gateway/__tests__/` — those PRs are scoped to the transport bar, layout panel, canvas/video perf, copilot/captions panels, and the timeline view. No overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)