### PR TITLE
perf: nightly performance optimizations 2026-08-14

### DIFF
--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Trash2 } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { CloseButton } from "@/components/ui/close-button";
@@ -20,6 +20,7 @@ import {
 import { isNodeStale } from "@/lib/generation/graph";
 import { isGenerationActive } from "@/lib/generation/snapshots";
 import { forCharacterAvatar } from "@/lib/connectors/image/plugins/characterAvatarNode";
+import { useGenerationValue } from "@/lib/generation/useGenerationValue";
 import { useNodeBuilder } from "@/lib/generation/useNodeBuilder";
 import { characterAvatarElementId } from "@/lib/project/characterAvatar";
 import { deleteCharacter } from "@/lib/project/deleteCharacter";
@@ -75,9 +76,8 @@ function CharacterEditDialogBody({
 		q.getElementSnapshot(avatarElementId),
 	);
 	const avatarUrl = avatarSnapshot.result?.imageUrl;
-	const avatarNode = useMemo(
-		() => buildNode(forCharacterAvatar(name)),
-		[buildNode, name],
+	const isStale = useGenerationValue((q) =>
+		isNodeStale(buildNode(forCharacterAvatar(name)), q),
 	);
 
 	if (!character) return null;
@@ -87,10 +87,8 @@ function CharacterEditDialogBody({
 
 	const regenerateAvatar = () => {
 		if (character.avatarUploaded) update({ avatarUploaded: false });
-		queue.enqueueGraph([avatarNode]);
+		queue.enqueueGraph([buildNode(forCharacterAvatar(name))]);
 	};
-
-	const isStale = isNodeStale(avatarNode, queue);
 
 	const generating = isGenerationActive(avatarSnapshot.status);
 	const hasAppearance = Boolean(character.appearance?.trim());
@@ -188,7 +186,7 @@ function CharacterEditDialogBody({
 							className="absolute left-2 top-2 z-10 bg-card shadow-sm ring-1 ring-border"
 							onUpload={(url) => {
 								queue.commitResult(
-									avatarNode,
+									buildNode(forCharacterAvatar(name)),
 									{ imageUrl: url, durationSec: 0 },
 									{ pinned: true },
 								);

--- a/app/components/canvas/hooks/useGenerate.ts
+++ b/app/components/canvas/hooks/useGenerate.ts
@@ -1,9 +1,11 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 import {
 	useGenerationQueue,
 	useQueueSelector,
 } from "@/lib/generation/GenerationQueueProvider";
 import { forElement, isNodeStale, nodeInputs } from "@/lib/generation/graph";
+import { serializeInputs } from "@/lib/generation/inputs";
+import { useGenerationValue } from "@/lib/generation/useGenerationValue";
 import { useNodeBuilder } from "@/lib/generation/useNodeBuilder";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 
@@ -11,24 +13,32 @@ export function useGenerate(element: CanvasContentElement) {
 	const queue = useGenerationQueue();
 	const buildNode = useNodeBuilder();
 	const snapshot = useQueueSelector((q) => q.getElementSnapshot(element.id));
-	const node = useMemo(
-		() => buildNode(forElement(element)),
-		[buildNode, element],
-	);
-	const stale = useQueueSelector((q) => isNodeStale(node, q));
+	const node = buildNode(forElement(element));
+
+	// The inputs this element would regenerate from, or null while its result is
+	// current. Watching the inputs rather than the node keeps project edits that
+	// nothing here reads off every card's render path.
+	const staleInputs = useGenerationValue((q) => {
+		const current = buildNode(forElement(element));
+		return isNodeStale(current, q)
+			? serializeInputs(nodeInputs(current, q))
+			: null;
+	});
 
 	useEffect(() => {
-		if (!stale) return;
-		queue.restoreResult(element.id, nodeInputs(node, queue));
-	}, [queue, element.id, node, stale]);
+		if (!staleInputs) return;
+		const current = buildNode(forElement(element));
+		queue.restoreResult(element.id, nodeInputs(current, queue));
+	}, [queue, element, buildNode, staleInputs]);
 
 	const generate = useCallback(() => {
-		if (!node.inputs.prompt) {
+		const current = buildNode(forElement(element));
+		if (!current.inputs.prompt) {
 			queue.setError(element.id, "Enter a prompt first");
 			return;
 		}
-		queue.enqueueGraph([node]);
-	}, [queue, element.id, node]);
+		queue.enqueueGraph([current]);
+	}, [queue, element, buildNode]);
 
 	const discard = useCallback(() => {
 		queue.discard(element.id);
@@ -40,7 +50,7 @@ export function useGenerate(element: CanvasContentElement) {
 		seconds: snapshot.seconds,
 		result: snapshot.result,
 		error: snapshot.error,
-		stale,
+		stale: staleInputs !== null,
 		hasPrompt: Boolean(node.inputs.prompt),
 		hasResult: Boolean(snapshot.result),
 		generate,

--- a/lib/generation/useGenerationValue.ts
+++ b/lib/generation/useGenerationValue.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+import { useProjectStoreHandle } from "@/lib/project/ProjectStoreProvider";
+import { useGenerationQueue } from "./GenerationQueueProvider";
+import type { GenerationQueue } from "./queue";
+
+/**
+ * A value derived from generation state as a whole: what the queue has settled
+ * plus the project state nodes are built from. Derive a primitive, and the
+ * subscriber re-renders when that value changes rather than on every write to
+ * either store.
+ */
+export function useGenerationValue<T extends string | number | boolean | null>(
+	derive: (queue: GenerationQueue) => T,
+): T {
+	const queue = useGenerationQueue();
+	const store = useProjectStoreHandle();
+	const subscribe = useCallback(
+		(onChange: () => void) => {
+			const stop = [queue.subscribe(onChange), store.subscribe(onChange)];
+			return () => {
+				for (const off of stop) off();
+			};
+		},
+		[queue, store],
+	);
+	const read = () => derive(queue);
+	return useSyncExternalStore(subscribe, read, read);
+}

--- a/lib/generation/useNodeBuilder.ts
+++ b/lib/generation/useNodeBuilder.ts
@@ -2,15 +2,19 @@
 
 import { useMemo } from "react";
 import { useConfig } from "@/lib/config/ConfigProvider";
-import { useProject } from "@/lib/project/useProject";
+import { useProjectStoreHandle } from "@/lib/project/ProjectStoreProvider";
 import { nodeBuilder, type NodeBuilder } from "./resolveGraph";
 
-/** Rebuilt on any store write, so reading something new costs only a source node. */
+/**
+ * Builds against the project state as it is when called, so holding a builder
+ * costs nothing: a store write re-derives what reads a node, not everyone who
+ * can build one.
+ */
 export function useNodeBuilder(): NodeBuilder {
 	const { connectorConfig } = useConfig();
-	const state = useProject((store) => store);
-	return useMemo(
-		() => nodeBuilder(connectorConfig, state),
-		[connectorConfig, state],
+	const store = useProjectStoreHandle();
+	return useMemo<NodeBuilder>(
+		() => (spec) => nodeBuilder(connectorConfig, store.getState())(spec),
+		[connectorConfig, store],
 	);
 }


### PR DESCRIPTION
## What

Every element card builds its generation node through `useNodeBuilder`, which was memoized on the whole project store. Zustand + immer hands out a new root object on every write, so *any* project edit gave every card a new builder, a new node, a new `useGenerate` result and a new `ElementGenerationContext` value — re-rendering each card's whole subtree.

The writes that do this are the high-frequency ones:

- `NumberScrubber` / `ColorField` in the captions panel write per `pointermove` (`useCaptionStyle` → `updateMetadata`)
- `ProjectTitle` and the art style field write per keystroke
- `useMetadataSync` writes as `metadata_*` tags arrive during script streaming

None of that is something a card reads, yet all of it re-rendered every card at pointer/keystroke rate.

## Change

- `useNodeBuilder` reads project state **when it is called** instead of closing over a snapshot, so it no longer subscribes to the store and its identity is stable. Callers that build inside a handler (`useGenerateAll`, regenerate/upload in `CharacterEditModal`) get a strictly fresher node for free.
- `useGenerate` subscribes to the value it actually cares about: the serialized inputs a stale element would regenerate from, or `null` while its result is current. A project write that changes nothing this card reads no longer renders it. The restore-from-history effect keys off those inputs, so it still fires exactly when they drift.
- `useGenerationValue` is the new seam: one subscription across both halves of generation state (the queue's snapshots and the project state nodes are built from), deriving a primitive so subscribers wake only when the derived value changes. `CharacterEditModal` uses it for the avatar's staleness, which previously only refreshed because an unrelated store write happened to re-render the dialog.

No behavior change: staleness, restore-from-history and enqueue all resolve against the same state they did before.

## Not done

- No test added for the hook wiring — the repo has no React renderer in its test setup, and pulling one in for this is out of scope. The logic itself (`isNodeStale`, `nodeInputs`, `serializeInputs`) is already covered in `lib/generation/__tests__`.
- Remotion's per-frame path (`MotionLayer`, `Captions`, `motionEffects`) and the OSML stream parser / `useScriptSync` were profiled and left alone: both are already tight, and anything left there is marginal.

## Open PR overlap check

Considered #576, #575, #573, #569, #568, #567, #565. None touch `lib/generation/*`, `useGenerate.ts` or `CharacterEditModal.tsx`. Closest neighbours: #568 touches other canvas hooks (`useAutosave`, `useEditorSession`, `useEditorSetup`) but not `useGenerate`; #576 touches `character/fields.tsx` and `CharactersPicker.tsx` but not `CharacterEditModal.tsx`. Non-overlapping.

## Checks

`lint`, `format:check`, `typecheck`, `knip`, `build`, `test` (1182 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)