### PR TITLE
feat(canvas): duplicate an element, carrying its generation snapshot

### DIFF
--- a/app/components/canvas/elements/DuplicateButton.tsx
+++ b/app/components/canvas/elements/DuplicateButton.tsx
@@ -1,0 +1,24 @@
+import { useSlateStatic } from "slate-react";
+import { DuplicateButton as DuplicateIconButton } from "@/components/ui/duplicate-button";
+import { duplicateElement } from "@/app/components/canvas/utils/nodeOps";
+import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
+import type { CanvasContentElement } from "@/lib/canvas/types";
+
+export function DuplicateButton({
+	element,
+}: {
+	element: CanvasContentElement;
+}) {
+	const editor = useSlateStatic();
+	const queue = useGenerationQueue();
+
+	return (
+		<DuplicateIconButton
+			ariaLabel="Duplicate element"
+			onMouseDown={(e) => {
+				e.preventDefault();
+				queue.duplicate(element.id, duplicateElement(editor, element));
+			}}
+		/>
+	);
+}

--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -7,6 +7,7 @@ import { useConfig } from "@/lib/config/ConfigProvider";
 import { resolveElementSchema } from "@/lib/canvas/elementConnector";
 import { OutputPreview } from "./OutputPreview";
 import { DeleteButton } from "./DeleteButton";
+import { DuplicateButton } from "./DuplicateButton";
 import { ElementCharacters } from "./ElementCharacters";
 import { AttributeBadge } from "./AttributeBadge";
 import { ElementGenerateButton, ElementStaleIndicator } from "./GenerateButton";
@@ -101,7 +102,8 @@ export function ElementContainer({
 								<ModelBadge element={element} />
 								<ElementSettings element={element} />
 							</div>
-							<div className="shrink-0 opacity-0 pointer-events-none transition-opacity duration-200 group-hover/card:opacity-100 group-hover/card:pointer-events-auto">
+							<div className="flex shrink-0 items-center gap-1 opacity-0 pointer-events-none transition-opacity duration-200 group-hover/card:opacity-100 group-hover/card:pointer-events-auto">
+								<DuplicateButton element={element} />
 								<DeleteButton element={element} />
 							</div>
 						</div>

--- a/app/components/canvas/utils/nodeOps.ts
+++ b/app/components/canvas/utils/nodeOps.ts
@@ -1,6 +1,6 @@
 import { type Editor, Transforms } from "slate";
 import { ReactEditor } from "slate-react";
-import { setNodeAttrs } from "@/lib/canvas/editorOps";
+import { duplicateNode, setNodeAttrs } from "@/lib/canvas/editorOps";
 import type { CanvasContentElement, CanvasElement } from "@/lib/canvas/types";
 
 /** Merge attrs into a live element's customAttributes (a null value deletes the key). */
@@ -10,6 +10,14 @@ export function updateElementAttrs(
 	attrs: Record<string, string | null>,
 ): void {
 	setNodeAttrs(editor, ReactEditor.findPath(editor, element), element, attrs);
+}
+
+/** Inserts a copy of a live element directly after it. Returns the copy's id. */
+export function duplicateElement(
+	editor: Editor,
+	element: CanvasContentElement,
+): string {
+	return duplicateNode(editor, element, ReactEditor.findPath(editor, element));
 }
 
 export function removeElement(editor: Editor, element: CanvasElement): void {

--- a/components/ui/duplicate-button.tsx
+++ b/components/ui/duplicate-button.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { Copy } from "@/components/ui/icon";
+import { cn } from "@/lib/utils";
+import { IconButton, TooltipIconButton } from "@/components/ui/icon-button";
+
+export function DuplicateButton({
+	className,
+	...props
+}: React.ComponentProps<typeof IconButton>) {
+	return (
+		<TooltipIconButton
+			label="Duplicate"
+			className={cn("bg-muted text-muted-foreground", className)}
+			{...props}
+		>
+			<Copy className="h-4 w-4" />
+		</TooltipIconButton>
+	);
+}

--- a/lib/canvas/__tests__/editorOps.test.ts
+++ b/lib/canvas/__tests__/editorOps.test.ts
@@ -3,6 +3,7 @@ import { createEditor, Editor } from "slate";
 import type { CanvasContentElement, SceneElement } from "@/lib/canvas/types";
 import { ZERO_WIDTH_SPACE } from "../constants";
 import {
+	duplicateNode,
 	findElementById,
 	findNodeById,
 	updateNodeText,
@@ -135,6 +136,40 @@ describe("updateNodeText", () => {
 		expect(Editor.string(editor, [0, 0])).toBe(
 			`${ZERO_WIDTH_SPACE}hello there`,
 		);
+	});
+});
+
+describe("duplicateNode", () => {
+	it("inserts the copy directly after the original", () => {
+		const editor = makeEditor([
+			scene([
+				content("narration", "n1", "hello"),
+				content("image", "img1", "a cat"),
+			]),
+		]);
+
+		const copyId = duplicateNode(
+			editor,
+			content("narration", "n1", "hello"),
+			[0, 0],
+		);
+
+		const children = (editor.children[0] as SceneElement).children;
+		expect(children.map((c) => c.id)).toEqual(["n1", copyId, "img1"]);
+		expect(Editor.string(editor, [0, 1])).toBe(Editor.string(editor, [0, 0]));
+	});
+
+	it("gives the copy and its leaves fresh ids, keeping the attributes", () => {
+		const el = content("character", "c1", "line", { name: "Lyra" });
+		const editor = makeEditor([scene([el])]);
+
+		const copyId = duplicateNode(editor, el, [0, 0]);
+
+		const copy = (editor.children[0] as SceneElement).children[1];
+		expect(copyId).not.toBe("c1");
+		expect(copy.customAttributes).toEqual({ name: "Lyra" });
+		expect(copy.children.map((leaf) => leaf.id)).not.toContain("c1-t");
+		expect(new Set(copy.children.map((leaf) => leaf.id)).size).toBe(2);
 	});
 });
 

--- a/lib/canvas/editorOps.ts
+++ b/lib/canvas/editorOps.ts
@@ -1,7 +1,8 @@
-import { Editor, Element, type NodeEntry, type Path, Transforms } from "slate";
+import { Editor, Element, type NodeEntry, Path, Transforms } from "slate";
 import type { CanvasContentElement, CanvasElement } from "@/lib/canvas/types";
 import { withoutCaretMarker, ZERO_WIDTH_SPACE } from "./constants";
 import { isContentElement } from "./guards";
+import { makeNodeId } from "./nodeUtils";
 
 /** Any canvas element by id — scenes included. Use {@link findNodeById} when only content will do. */
 export function findElementById(
@@ -24,6 +25,24 @@ export function findNodeById(
 		match: (n) => isContentElement(n) && n.id === id,
 	});
 	return entry ?? null;
+}
+
+/** Inserts a copy of the node at `at`, with fresh ids, right after it. Returns the copy's id. */
+export function duplicateNode(
+	editor: Editor,
+	element: CanvasContentElement,
+	at: Path,
+): string {
+	const copy: CanvasContentElement = {
+		...element,
+		id: makeNodeId(),
+		children: element.children.map((child) => ({
+			...child,
+			id: makeNodeId(),
+		})),
+	};
+	Transforms.insertNodes(editor, copy, { at: Path.next(at) });
+	return copy.id;
 }
 
 /**

--- a/lib/generation/__tests__/snapshots.test.ts
+++ b/lib/generation/__tests__/snapshots.test.ts
@@ -109,6 +109,50 @@ describe("SnapshotStore", () => {
 		expect(store.getGeneratedCount()).toBe(1);
 	});
 
+	it("copies a result, its inputs and its history onto a new id", () => {
+		const store = new SnapshotStore();
+		commit(store, "a", "a.png");
+		store.update("a", { pinned: true });
+
+		store.copy("a", "b");
+
+		expect(store.get("b")).toMatchObject({
+			status: "idle",
+			seconds: 0,
+			result: result("a.png"),
+			resultInputs: inputs("a.png"),
+			connectorType: "image",
+			pinned: true,
+		});
+		expect(store.restore("b", inputs("a.png"))).toBe(true);
+	});
+
+	it("copies an in-flight element as idle, not as a second active job", () => {
+		const store = new SnapshotStore();
+		store.update("a", { status: "generating", seconds: 7 });
+
+		store.copy("a", "b");
+
+		expect(store.get("b")).toMatchObject({ status: "idle", seconds: 0 });
+		expect(store.getActiveCount()).toBe(1);
+	});
+
+	it("leaves a copy untouched when its source is removed", () => {
+		const store = new SnapshotStore();
+		commit(store, "a", "a.png");
+		store.copy("a", "b");
+
+		store.remove("a");
+
+		expect(store.get("b").result).toEqual(result("a.png"));
+	});
+
+	it("ignores a copy from an element it has never seen", () => {
+		const store = new SnapshotStore();
+		store.copy("nope", "b");
+		expect(store.ids()).toEqual([]);
+	});
+
 	it("notifies subscribers until they unsubscribe", () => {
 		const store = new SnapshotStore();
 		let calls = 0;

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -118,6 +118,12 @@ export class GenerationQueue {
 		if (wasActive) this.processQueue();
 	}
 
+	/** Carries an element's result onto a copy of it, so the copy never regenerates. */
+	duplicate(fromId: string, toId: string) {
+		this.snapshots.copy(fromId, toId);
+		this.snapshots.notify();
+	}
+
 	setError(elementId: string, message: string) {
 		this.snapshots.update(elementId, { result: null, error: message });
 		this.snapshots.notify();

--- a/lib/generation/snapshots.ts
+++ b/lib/generation/snapshots.ts
@@ -97,6 +97,19 @@ export class SnapshotStore {
 		this.state.set(id, { ...this.get(id), ...patch });
 	}
 
+	/**
+	 * Clones one element's result and the results already seen for it onto
+	 * another id. In-flight progress is never carried over, so a copy taken
+	 * mid-generation lands idle rather than as a second active job.
+	 */
+	copy(fromId: string, toId: string) {
+		const source = this.state.get(fromId);
+		if (!source) return;
+		this.update(toId, { ...source, status: "idle", seconds: 0 });
+		const sourceHistory = this.history.get(fromId);
+		if (sourceHistory) this.history.set(toId, new Map(sourceHistory));
+	}
+
 	/** Drops the entry entirely; anything it held is gone. */
 	remove(id: string) {
 		if (this.state.get(id)?.result) this.resultVersion++;


### PR DESCRIPTION
## Summary

Adds a duplicate action to each element card, next to delete. The copy lands directly after the original with fresh node ids, and the source element's generation snapshot is cloned onto the new id, so a generated element renders immediately rather than regenerating.

- `SnapshotStore.copy(fromId, toId)` clones `result`, `resultInputs`, `connectorType` and `pinned`, plus the per-id result history, forcing `status: "idle"` / `seconds: 0`. A duplicate taken mid-generation lands idle, never as a second active job. Copying from an id the store has never seen is a no-op, so the caller has no edge case to handle.
- `GenerationQueue.duplicate(fromId, toId)` exposes it to the app and notifies observers.
- `duplicateNode(editor, element, at)` in `lib/canvas/editorOps.ts` does the path-based clone-and-insert; `duplicateElement` in `nodeOps.ts` is the thin `ReactEditor.findPath` wrapper, mirroring `removeElement`.
- `components/ui/duplicate-button.tsx` mirrors the existing `delete-button.tsx` primitive; the hover action row now holds both buttons.

Because the copy carries `resultInputs`, `connectorType` and `pinned`, staleness checks and the pinned-never-regenerate rule behave identically on the copy. History is cloned rather than shared, so deleting either side leaves the other's result intact.

## Why this was safe and small

Issue #563 is labelled size S with explicit acceptance criteria and named code paths. The change is additive: no existing call site changed behaviour, and the only edit to shared UI is one added button plus the flex wrapper needed to sit two buttons side by side.

## Validation

All CI-equivalent checks from `.github/workflows/ci.yml`, all passing:

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run knip`
- `npm run build`
- `npm run test:coverage` — 139 files, 1188 tests passed
- `npm run test:e2e` — 3 passed

New tests cover the two seams: `SnapshotStore.copy` (result/inputs/history carry-over, idle copy of an in-flight element, independence after the source is removed, unknown-source no-op) and `duplicateNode` (insert position, fresh element and leaf ids, attributes preserved).

## Open-PR overlap check

Checked all 8 open PRs by file. The only shared file is `ElementContainer.tsx`, also touched by #565 — a one-line `config.icon` → `<config.Icon />` change roughly ten lines above the action row edited here. Different theme, non-adjacent hunks, no conflict. No other touched file appears in any open PR.

## Skipped candidates

- #559, #558 — the only `size:xs` issues, both already covered by open PRs (#569, #573).
- #332 (read-only timeline) — covered by open PR #565.
- #461 (karaoke word highlight) — the highlight treatment is an open design decision, and the issue leaves the on/off toggle unresolved.
- #254 (audio mixing defaults) — "narration up, character down" has no target values; a product judgment call.
- Everything else open is size M or larger.

Closes #563