### PR TITLE
fix: keep RTL scripts from mirroring the element card layout

### DIFF
--- a/app/components/canvas/__tests__/textDirection.test.ts
+++ b/app/components/canvas/__tests__/textDirection.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { RenderElementProps } from "slate-react";
+import { splitTextDirection } from "../utils/textDirection";
+
+const baseAttributes = {
+	"data-slate-node": "element",
+	ref: null,
+} satisfies RenderElementProps["attributes"];
+
+describe("splitTextDirection", () => {
+	it("lifts dir out of the node attributes", () => {
+		const { dir, nodeAttributes } = splitTextDirection({
+			...baseAttributes,
+			dir: "rtl",
+		});
+
+		expect(dir).toBe("rtl");
+		expect(nodeAttributes).not.toHaveProperty("dir");
+		expect(nodeAttributes).toEqual(baseAttributes);
+	});
+
+	it("leaves left-to-right blocks undirected", () => {
+		const { dir, nodeAttributes } = splitTextDirection(baseAttributes);
+
+		expect(dir).toBeUndefined();
+		expect(nodeAttributes).toEqual(baseAttributes);
+	});
+
+	it("preserves the attributes Slate uses to anchor the node", () => {
+		const ref = () => {};
+		const { nodeAttributes } = splitTextDirection({
+			"data-slate-node": "element",
+			"data-slate-inline": true,
+			ref,
+			dir: "rtl",
+		});
+
+		expect(nodeAttributes).toEqual({
+			"data-slate-node": "element",
+			"data-slate-inline": true,
+			ref,
+		});
+	});
+});

--- a/app/components/canvas/dnd/SortableItem.tsx
+++ b/app/components/canvas/dnd/SortableItem.tsx
@@ -3,6 +3,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { RenderElementProps } from "slate-react";
 import type { CanvasElement } from "@/lib/canvas/types";
 import styles from "../styles/sortable.module.css";
+import { splitTextDirection } from "../utils/textDirection";
 import { DragHandle } from "./SortableActions";
 
 // Drag start re-renders every sortable, so `children` and `insertMenu` are
@@ -50,8 +51,10 @@ export function SortableItem({
 		disabled,
 	});
 
+	const { nodeAttributes } = splitTextDirection(attributes);
+
 	return (
-		<div {...attributes} className={wrapperClassName} style={wrapperStyle}>
+		<div {...nodeAttributes} className={wrapperClassName} style={wrapperStyle}>
 			<div
 				className={
 					contentClassName

--- a/app/components/canvas/elements/CompactElement.tsx
+++ b/app/components/canvas/elements/CompactElement.tsx
@@ -2,6 +2,7 @@ import { RenderElementProps } from "slate-react";
 import { Node } from "slate";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { ELEMENT_CONFIGS } from "@/lib/canvas/elementConfigs";
+import { splitTextDirection } from "../utils/textDirection";
 
 export function CompactElement({
 	attributes,
@@ -14,12 +15,13 @@ export function CompactElement({
 }) {
 	const config = ELEMENT_CONFIGS[element.type];
 	const text = Node.string(element).trim();
+	const { dir, nodeAttributes } = splitTextDirection(attributes);
 
 	return (
 		<div
 			className="inline-flex items-center gap-1 rounded-md py-0.5 animate-fadeInUp"
 			contentEditable={false}
-			{...attributes}
+			{...nodeAttributes}
 		>
 			<span
 				className={`flex items-center gap-1 rounded-md bg-muted px-1 py-0.5 ${config.colorClass}`}
@@ -29,6 +31,7 @@ export function CompactElement({
 			</span>
 			{text && (
 				<span
+					dir={dir}
 					className="max-w-[800px] truncate text-label text-muted-foreground"
 					contentEditable={false}
 				>

--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -5,6 +5,7 @@ import { ZERO_WIDTH_SPACE } from "@/lib/canvas/constants";
 import { ELEMENT_CONFIGS } from "@/lib/canvas/elementConfigs";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { resolveElementSchema } from "@/lib/canvas/elementConnector";
+import { splitTextDirection } from "../utils/textDirection";
 import { OutputPreview } from "./OutputPreview";
 import { DeleteButton } from "./DeleteButton";
 import { DuplicateButton } from "./DuplicateButton";
@@ -75,12 +76,13 @@ export function ElementContainer({
 }: ElementContainerProps) {
 	const config = ELEMENT_CONFIGS[element.type];
 	const isEmpty = Node.string(element) === ZERO_WIDTH_SPACE;
+	const { dir, nodeAttributes } = splitTextDirection(attributes);
 
 	return (
 		<ElementGenerationProvider element={element}>
 			<div
 				className="flex items-stretch mb-1.5 animate-fadeInUp"
-				{...attributes}
+				{...nodeAttributes}
 			>
 				{/* Left: element card */}
 				<div className="group/card @container relative min-w-0 flex-1 overflow-hidden rounded-2xl border border-border bg-element-card p-3">
@@ -107,16 +109,19 @@ export function ElementContainer({
 								<DeleteButton element={element} />
 							</div>
 						</div>
-						<div className="relative min-w-0 rounded-xl border border-transparent bg-element-input px-3 py-2.5 transition-colors hover:border-element-input-border-hover focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/30">
+						<div
+							dir={dir}
+							className="relative min-w-0 rounded-xl border border-transparent bg-element-input px-3 py-2.5 transition-colors hover:border-element-input-border-hover focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/30"
+						>
 							{isEmpty && (
 								<div
 									style={{ userSelect: "none" }}
-									className="pointer-events-none absolute top-2.5 left-3 text-left text-label text-muted-foreground"
+									className="pointer-events-none absolute top-2.5 start-3 text-start text-label text-muted-foreground"
 								>
 									{config.placeholder}
 								</div>
 							)}
-							<div className="overflow-hidden text-left text-label leading-relaxed text-foreground transition-[max-height,opacity] duration-200">
+							<div className="overflow-hidden text-start text-label leading-relaxed text-foreground transition-[max-height,opacity] duration-200">
 								{children}
 							</div>
 						</div>

--- a/app/components/canvas/utils/textDirection.ts
+++ b/app/components/canvas/utils/textDirection.ts
@@ -1,0 +1,14 @@
+import type { RenderElementProps } from "slate-react";
+
+/**
+ * Slate marks blocks whose text reads right-to-left with `dir` on the node
+ * attributes. Spread onto a card's outer element it mirrors the entire layout,
+ * so the two are kept apart: chrome stays left-to-right, and `dir` is applied
+ * to whichever element wraps the text itself.
+ */
+export function splitTextDirection({
+	dir,
+	...nodeAttributes
+}: RenderElementProps["attributes"]) {
+	return { dir, nodeAttributes };
+}

--- a/app/components/video/timeline/TimelineClip.tsx
+++ b/app/components/video/timeline/TimelineClip.tsx
@@ -42,12 +42,12 @@ function ClipHeader({
 			<Icon size={HEADER_ICON_SIZE} className="shrink-0" />
 			<SimpleTooltip
 				label={
-					<span className="block max-w-xs text-pretty">
+					<span dir="auto" className="block max-w-xs text-pretty">
 						{truncateMiddle(label, TOOLTIP_MAX_CHARS)}
 					</span>
 				}
 			>
-				<span className="truncate text-badge-xs text-foreground">
+				<span dir="auto" className="truncate text-badge-xs text-foreground">
 					{fit(label, width)}
 				</span>
 			</SimpleTooltip>


### PR DESCRIPTION
## Summary

- Slate sets `dir="rtl"` on blocks whose text reads right-to-left. That attribute was being spread onto the outermost layout div of every canvas element, so a single Arabic narration or dialogue line mirrored the whole card: prompt card swapped to the right, preview to the left, badges and button icons reversed, avatar on the wrong side.
- The `dir` now applies to the element wrapping the text instead of the card chrome. The prompt box uses logical properties (`text-start`, `start-3`) so its placeholder follows the script.
- Extracted `splitTextDirection` — three components spread the attribute bag, since a node is anchored both by `SortableItem` and by the container inside it.
- Timeline clip labels get `dir="auto"`; same bug class, user script text truncated inside LTR chrome left trailing periods stranded on the wrong side.

This is per-block detection, not an app-wide RTL mode. Surrounding UI stays LTR, so an Arabic character name still renders avatar-left.

## Test plan

- [x] Unit: `app/components/canvas/__tests__/textDirection.test.ts` covers the split, including that Slate's node-anchoring attributes (`data-slate-node`, `ref`) survive intact
- [x] Full CI locally: lint, format, typecheck, knip, build, 1215 unit tests, 3 Playwright smoke tests
- [x] Verified in the running app on a project with Arabic narration and dialogue — every card shell computes `ltr`, and the only `dir="rtl"` node left inside the editor is the text input box
- [ ] Sanity check that an all-English project is visually unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)