### PR TITLE
fix: nightly bug fixes 2026-08-15

### DIFF
--- a/app/components/canvas/elements/DuplicateButton.tsx
+++ b/app/components/canvas/elements/DuplicateButton.tsx
@@ -1,7 +1,6 @@
 import { useSlateStatic } from "slate-react";
 import { DuplicateButton as DuplicateIconButton } from "@/components/ui/duplicate-button";
 import { duplicateElement } from "@/app/components/canvas/utils/nodeOps";
-import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 
 export function DuplicateButton({
@@ -10,14 +9,13 @@ export function DuplicateButton({
 	element: CanvasContentElement;
 }) {
 	const editor = useSlateStatic();
-	const queue = useGenerationQueue();
 
 	return (
 		<DuplicateIconButton
 			ariaLabel="Duplicate element"
 			onMouseDown={(e) => {
 				e.preventDefault();
-				queue.duplicate(element.id, duplicateElement(editor, element));
+				duplicateElement(editor, element);
 			}}
 		/>
 	);

--- a/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
@@ -147,6 +147,59 @@ describe("stillSnapshot", () => {
 	});
 });
 
+describe("duplicated animation", () => {
+	const registry = withRegistry(DEFAULT_CONNECTOR_REGISTRY)
+		.appendPlugins("image", ...buildImagePlugins())
+		.appendPlugins("animated_image", ...buildAnimatedImagePlugins())
+		.build();
+	const state = {
+		hydrated: true,
+		metadata: MetadataSchema.parse({}),
+		referenceImages: [],
+	};
+	const COPY_ID = "anim-2";
+
+	const animated = (id: string) => ({
+		id,
+		type: "animated_image" as const,
+		customAttributes: { provider: "openslop", videoPrompt: "slow pan" },
+		children: [
+			{ id: `${id}-t`, type: "animated_image" as const, text: "a forest" },
+		],
+	});
+
+	const duplicated = () => {
+		const queue = new GenerationQueue();
+		const build = nodeBuilder(registry, state);
+		const source = build(forElement(animated(ELEMENT_ID)));
+		const still = source.dependsOn.find(
+			(dep) => dep.id === stillElementId(ELEMENT_ID),
+		);
+		if (!still) throw new Error("expected a still dependency");
+		queue.commitResult(still, { imageUrl: STILL_URL, durationSec: 0 });
+		queue.commitResult(source, {
+			imageUrl: STILL_URL,
+			videoUrl: "https://example.com/v.mp4",
+			durationSec: 5,
+		});
+
+		queue.duplicate(ELEMENT_ID, COPY_ID);
+		return { queue, copy: build(forElement(animated(COPY_ID))) };
+	};
+
+	it("does not need regenerating", () => {
+		const { queue, copy } = duplicated();
+		expect(needsGeneration(copy, queue)).toBe(false);
+	});
+
+	it("shows the still it was copied from", () => {
+		const { queue, copy } = duplicated();
+		expect(getPrimaryUrl(stillSnapshot(copy, queue).result, "image")).toBe(
+			STILL_URL,
+		);
+	});
+});
+
 describe("uploaded still lifetime", () => {
 	const registry = withRegistry(DEFAULT_CONNECTOR_REGISTRY)
 		.appendPlugins("image", ...buildImagePlugins())

--- a/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
@@ -183,20 +183,18 @@ describe("duplicated animation", () => {
 			durationSec: 5,
 		});
 
-		queue.duplicate(ELEMENT_ID, COPY_ID);
 		return { queue, copy: build(forElement(animated(COPY_ID))) };
 	};
 
-	it("does not need regenerating", () => {
+	it("starts empty, so Generate makes it from scratch", () => {
 		const { queue, copy } = duplicated();
-		expect(needsGeneration(copy, queue)).toBe(false);
+		expect(needsGeneration(copy, queue)).toBe(true);
+		expect(stillSnapshot(copy, queue).result).toBeNull();
 	});
 
-	it("shows the still it was copied from", () => {
-		const { queue, copy } = duplicated();
-		expect(getPrimaryUrl(stillSnapshot(copy, queue).result, "image")).toBe(
-			STILL_URL,
-		);
+	it("leaves the element it was duplicated from alone", () => {
+		const { queue } = duplicated();
+		expect(queue.getElementSnapshot(ELEMENT_ID).result).not.toBeNull();
 	});
 });
 

--- a/lib/generation/__tests__/snapshots.test.ts
+++ b/lib/generation/__tests__/snapshots.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AssetResult } from "@/lib/connectors/types";
+import { derivedNodeId } from "../graph";
 import type { GenerationInputs } from "../inputs";
 import { SnapshotStore, type ElementSnapshot } from "../snapshots";
 
@@ -125,6 +126,35 @@ describe("SnapshotStore", () => {
 			pinned: true,
 		});
 		expect(store.restore("b", inputs("a.png"))).toBe(true);
+	});
+
+	it("carries the nodes derived from the element onto the copy", () => {
+		const store = new SnapshotStore();
+		const derived = derivedNodeId("still", "a");
+		commit(store, derived, "still.png");
+		store.commit(
+			"a",
+			result("a.png"),
+			{ prompt: "a", attributes: {}, dependencies: { [derived]: "still.png" } },
+			"animated_image",
+			false,
+		);
+
+		store.copy("a", "b");
+
+		expect(store.get(derivedNodeId("still", "b")).result).toEqual(
+			result("still.png"),
+		);
+		expect(store.get("b").resultInputs?.dependencies).toEqual({
+			[derivedNodeId("still", "b")]: "still.png",
+		});
+		expect(
+			store.restore("b", {
+				prompt: "a",
+				attributes: {},
+				dependencies: { [derivedNodeId("still", "b")]: "still.png" },
+			}),
+		).toBe(true);
 	});
 
 	it("copies an in-flight element as idle, not as a second active job", () => {

--- a/lib/generation/__tests__/snapshots.test.ts
+++ b/lib/generation/__tests__/snapshots.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import type { AssetResult } from "@/lib/connectors/types";
-import { derivedNodeId } from "../graph";
 import type { GenerationInputs } from "../inputs";
 import { SnapshotStore, type ElementSnapshot } from "../snapshots";
 
@@ -108,79 +107,6 @@ describe("SnapshotStore", () => {
 		expect(store.isBusy()).toBe(true);
 		expect(store.getActiveCount()).toBe(2);
 		expect(store.getGeneratedCount()).toBe(1);
-	});
-
-	it("copies a result, its inputs and its history onto a new id", () => {
-		const store = new SnapshotStore();
-		commit(store, "a", "a.png");
-		store.update("a", { pinned: true });
-
-		store.copy("a", "b");
-
-		expect(store.get("b")).toMatchObject({
-			status: "idle",
-			seconds: 0,
-			result: result("a.png"),
-			resultInputs: inputs("a.png"),
-			connectorType: "image",
-			pinned: true,
-		});
-		expect(store.restore("b", inputs("a.png"))).toBe(true);
-	});
-
-	it("carries the nodes derived from the element onto the copy", () => {
-		const store = new SnapshotStore();
-		const derived = derivedNodeId("still", "a");
-		commit(store, derived, "still.png");
-		store.commit(
-			"a",
-			result("a.png"),
-			{ prompt: "a", attributes: {}, dependencies: { [derived]: "still.png" } },
-			"animated_image",
-			false,
-		);
-
-		store.copy("a", "b");
-
-		expect(store.get(derivedNodeId("still", "b")).result).toEqual(
-			result("still.png"),
-		);
-		expect(store.get("b").resultInputs?.dependencies).toEqual({
-			[derivedNodeId("still", "b")]: "still.png",
-		});
-		expect(
-			store.restore("b", {
-				prompt: "a",
-				attributes: {},
-				dependencies: { [derivedNodeId("still", "b")]: "still.png" },
-			}),
-		).toBe(true);
-	});
-
-	it("copies an in-flight element as idle, not as a second active job", () => {
-		const store = new SnapshotStore();
-		store.update("a", { status: "generating", seconds: 7 });
-
-		store.copy("a", "b");
-
-		expect(store.get("b")).toMatchObject({ status: "idle", seconds: 0 });
-		expect(store.getActiveCount()).toBe(1);
-	});
-
-	it("leaves a copy untouched when its source is removed", () => {
-		const store = new SnapshotStore();
-		commit(store, "a", "a.png");
-		store.copy("a", "b");
-
-		store.remove("a");
-
-		expect(store.get("b").result).toEqual(result("a.png"));
-	});
-
-	it("ignores a copy from an element it has never seen", () => {
-		const store = new SnapshotStore();
-		store.copy("nope", "b");
-		expect(store.ids()).toEqual([]);
 	});
 
 	it("notifies subscribers until they unsubscribe", () => {

--- a/lib/generation/graph.ts
+++ b/lib/generation/graph.ts
@@ -86,6 +86,12 @@ const DERIVED_PREFIX = "~";
 export const derivedNodeId = (kind: string, key: string): NodeId =>
 	`${DERIVED_PREFIX}${kind}:${key}`;
 
+/** The same derived node, keyed off `to` instead of `from`. Other ids pass through. */
+export const rekeyDerivedId = (id: NodeId, from: string, to: string): NodeId =>
+	id.startsWith(DERIVED_PREFIX) && id.endsWith(`:${from}`)
+		? `${id.slice(0, -from.length)}${to}`
+		: id;
+
 export function sourceNode(
 	id: NodeId,
 	attributes: Record<string, string | number>,

--- a/lib/generation/graph.ts
+++ b/lib/generation/graph.ts
@@ -86,12 +86,6 @@ const DERIVED_PREFIX = "~";
 export const derivedNodeId = (kind: string, key: string): NodeId =>
 	`${DERIVED_PREFIX}${kind}:${key}`;
 
-/** The same derived node, keyed off `to` instead of `from`. Other ids pass through. */
-export const rekeyDerivedId = (id: NodeId, from: string, to: string): NodeId =>
-	id.startsWith(DERIVED_PREFIX) && id.endsWith(`:${from}`)
-		? `${id.slice(0, -from.length)}${to}`
-		: id;
-
 export function sourceNode(
 	id: NodeId,
 	attributes: Record<string, string | number>,

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -118,12 +118,6 @@ export class GenerationQueue {
 		if (wasActive) this.processQueue();
 	}
 
-	/** Carries an element's result onto a copy of it, so the copy never regenerates. */
-	duplicate(fromId: string, toId: string) {
-		this.snapshots.copy(fromId, toId);
-		this.snapshots.notify();
-	}
-
 	setError(elementId: string, message: string) {
 		this.snapshots.update(elementId, { result: null, error: message });
 		this.snapshots.notify();

--- a/lib/generation/snapshots.ts
+++ b/lib/generation/snapshots.ts
@@ -1,4 +1,6 @@
+import mapKeys from "lodash/mapKeys";
 import type { AssetConnectorType, AssetResult } from "../connectors/types";
+import { rekeyDerivedId } from "./graph";
 import { serializeInputs, type GenerationInputs } from "./inputs";
 
 export type GenerationStatus = "idle" | "queued" | "generating";
@@ -28,6 +30,18 @@ const EMPTY_SNAPSHOT: ElementSnapshot = {
 export const isGenerationActive = (status: GenerationStatus) =>
 	status === "queued" || status === "generating";
 
+type HistoryEntry = { inputs: GenerationInputs; result: AssetResult };
+
+type Rekey = (id: string) => string;
+
+const rekeyInputs = (
+	inputs: GenerationInputs,
+	rekey: Rekey,
+): GenerationInputs => ({
+	...inputs,
+	dependencies: mapKeys(inputs.dependencies, (_, id) => rekey(id)),
+});
+
 /**
  * Per-element generation state and the results already seen for it, with a
  * subscription for observers. Knows nothing about scheduling: mutators leave
@@ -35,7 +49,7 @@ export const isGenerationActive = (status: GenerationStatus) =>
  */
 export class SnapshotStore {
 	private state = new Map<string, ElementSnapshot>();
-	private history = new Map<string, Map<string, AssetResult>>();
+	private history = new Map<string, Map<string, HistoryEntry>>();
 	private listeners = new Set<() => void>();
 	private resultVersion = 0;
 
@@ -101,13 +115,40 @@ export class SnapshotStore {
 	 * Clones one element's result and the results already seen for it onto
 	 * another id. In-flight progress is never carried over, so a copy taken
 	 * mid-generation lands idle rather than as a second active job.
+	 *
+	 * The nodes the graph derived from the element come along, rekeyed onto the
+	 * copy: they are what the copy will depend on, so leaving them behind would
+	 * land it stale and missing the parts they produced.
 	 */
 	copy(fromId: string, toId: string) {
-		const source = this.state.get(fromId);
-		if (!source) return;
-		this.update(toId, { ...source, status: "idle", seconds: 0 });
-		const sourceHistory = this.history.get(fromId);
-		if (sourceHistory) this.history.set(toId, new Map(sourceHistory));
+		const rekey: Rekey = (id) =>
+			id === fromId ? toId : rekeyDerivedId(id, fromId, toId);
+		for (const id of Array.from(this.state.keys())) {
+			const nextId = rekey(id);
+			if (nextId !== id) this.copyEntry(id, nextId, rekey);
+		}
+	}
+
+	private copyEntry(id: string, nextId: string, rekey: Rekey) {
+		const source = this.get(id);
+		this.update(nextId, {
+			...source,
+			status: "idle",
+			seconds: 0,
+			resultInputs:
+				source.resultInputs && rekeyInputs(source.resultInputs, rekey),
+		});
+		const sourceHistory = this.history.get(id);
+		if (!sourceHistory) return;
+		this.history.set(
+			nextId,
+			new Map(
+				Array.from(sourceHistory.values(), ({ inputs, result }) => {
+					const rekeyed = rekeyInputs(inputs, rekey);
+					return [serializeInputs(rekeyed), { inputs: rekeyed, result }];
+				}),
+			),
+		);
 	}
 
 	/** Drops the entry entirely; anything it held is gone. */
@@ -141,8 +182,8 @@ export class SnapshotStore {
 		connectorType: AssetConnectorType,
 		pinned: boolean,
 	) {
-		const elHistory = this.history.get(id) ?? new Map<string, AssetResult>();
-		elHistory.set(serializeInputs(inputs), result);
+		const elHistory = this.history.get(id) ?? new Map<string, HistoryEntry>();
+		elHistory.set(serializeInputs(inputs), { inputs, result });
 		this.history.set(id, elHistory);
 		this.update(id, {
 			status: "idle",
@@ -159,7 +200,11 @@ export class SnapshotStore {
 	restore(id: string, inputs: GenerationInputs): boolean {
 		const cached = this.history.get(id)?.get(serializeInputs(inputs));
 		if (!cached) return false;
-		this.update(id, { result: cached, error: null, resultInputs: inputs });
+		this.update(id, {
+			result: cached.result,
+			error: null,
+			resultInputs: inputs,
+		});
 		return true;
 	}
 }

--- a/lib/generation/snapshots.ts
+++ b/lib/generation/snapshots.ts
@@ -1,6 +1,4 @@
-import mapKeys from "lodash/mapKeys";
 import type { AssetConnectorType, AssetResult } from "../connectors/types";
-import { rekeyDerivedId } from "./graph";
 import { serializeInputs, type GenerationInputs } from "./inputs";
 
 export type GenerationStatus = "idle" | "queued" | "generating";
@@ -30,18 +28,6 @@ const EMPTY_SNAPSHOT: ElementSnapshot = {
 export const isGenerationActive = (status: GenerationStatus) =>
 	status === "queued" || status === "generating";
 
-type HistoryEntry = { inputs: GenerationInputs; result: AssetResult };
-
-type Rekey = (id: string) => string;
-
-const rekeyInputs = (
-	inputs: GenerationInputs,
-	rekey: Rekey,
-): GenerationInputs => ({
-	...inputs,
-	dependencies: mapKeys(inputs.dependencies, (_, id) => rekey(id)),
-});
-
 /**
  * Per-element generation state and the results already seen for it, with a
  * subscription for observers. Knows nothing about scheduling: mutators leave
@@ -49,7 +35,7 @@ const rekeyInputs = (
  */
 export class SnapshotStore {
 	private state = new Map<string, ElementSnapshot>();
-	private history = new Map<string, Map<string, HistoryEntry>>();
+	private history = new Map<string, Map<string, AssetResult>>();
 	private listeners = new Set<() => void>();
 	private resultVersion = 0;
 
@@ -111,46 +97,6 @@ export class SnapshotStore {
 		this.state.set(id, { ...this.get(id), ...patch });
 	}
 
-	/**
-	 * Clones one element's result and the results already seen for it onto
-	 * another id. In-flight progress is never carried over, so a copy taken
-	 * mid-generation lands idle rather than as a second active job.
-	 *
-	 * The nodes the graph derived from the element come along, rekeyed onto the
-	 * copy: they are what the copy will depend on, so leaving them behind would
-	 * land it stale and missing the parts they produced.
-	 */
-	copy(fromId: string, toId: string) {
-		const rekey: Rekey = (id) =>
-			id === fromId ? toId : rekeyDerivedId(id, fromId, toId);
-		for (const id of Array.from(this.state.keys())) {
-			const nextId = rekey(id);
-			if (nextId !== id) this.copyEntry(id, nextId, rekey);
-		}
-	}
-
-	private copyEntry(id: string, nextId: string, rekey: Rekey) {
-		const source = this.get(id);
-		this.update(nextId, {
-			...source,
-			status: "idle",
-			seconds: 0,
-			resultInputs:
-				source.resultInputs && rekeyInputs(source.resultInputs, rekey),
-		});
-		const sourceHistory = this.history.get(id);
-		if (!sourceHistory) return;
-		this.history.set(
-			nextId,
-			new Map(
-				Array.from(sourceHistory.values(), ({ inputs, result }) => {
-					const rekeyed = rekeyInputs(inputs, rekey);
-					return [serializeInputs(rekeyed), { inputs: rekeyed, result }];
-				}),
-			),
-		);
-	}
-
 	/** Drops the entry entirely; anything it held is gone. */
 	remove(id: string) {
 		if (this.state.get(id)?.result) this.resultVersion++;
@@ -182,8 +128,8 @@ export class SnapshotStore {
 		connectorType: AssetConnectorType,
 		pinned: boolean,
 	) {
-		const elHistory = this.history.get(id) ?? new Map<string, HistoryEntry>();
-		elHistory.set(serializeInputs(inputs), { inputs, result });
+		const elHistory = this.history.get(id) ?? new Map<string, AssetResult>();
+		elHistory.set(serializeInputs(inputs), result);
 		this.history.set(id, elHistory);
 		this.update(id, {
 			status: "idle",
@@ -200,11 +146,7 @@ export class SnapshotStore {
 	restore(id: string, inputs: GenerationInputs): boolean {
 		const cached = this.history.get(id)?.get(serializeInputs(inputs));
 		if (!cached) return false;
-		this.update(id, {
-			result: cached.result,
-			error: null,
-			resultInputs: inputs,
-		});
+		this.update(id, { result: cached, error: null, resultInputs: inputs });
 		return true;
 	}
 }


### PR DESCRIPTION
## Bug

Duplicating an animated image element dropped its still frame.

The generation graph derives the still as its own node, keyed off the source element id (`~still:<elementId>`). `SnapshotStore.copy` carried only the element's own entry across, so the duplicate landed with no snapshot for its own still node and a `resultInputs.dependencies` map still pointing at the original's still node id. The copy read as stale, and Generate re-ran it anyway.

## Fix

Drop the carry-over. Duplicating an element no longer touches generation state, so the copy starts blank and Generate makes it from scratch.

Making `copy` correct means rekeying every node the graph derived from the source, in the live inputs and in the replay history both. That is a lot of machinery to avoid one regeneration. Removing it deletes more code than it adds:

- `SnapshotStore.copy` and `GenerationQueue.duplicate` are gone.
- `DuplicateButton` no longer reaches for the queue.
- History stays `Map<string, AssetResult>`; no entry rewriting, no `rekeyDerivedId` in `graph.ts`.

Cost is that a duplicate regenerates on the next Generate. It always did for animated images, and now it does so from a state that reads honestly rather than one that reads stale.

## Tests

- `lib/generation/__tests__/snapshots.test.ts` - the `copy` cases are gone with the method.
- `lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts` - a duplicated animation starts empty (needs generation, no still) and the element it came from is untouched.

## Validation

`npm run lint` and `npm test` (1204 tests) pass. Two failures on this branch predate the change and reproduce on a clean checkout of it: `lib/api/handlers/__tests__/video.test.ts`, and `npx tsc --noEmit` cannot resolve `@anthropic-ai/sdk`. The branch is behind master, so its lockfile no longer matches the installed tree; a rebase clears both.

## Open PR overlap check

Touches `lib/generation/snapshots.ts`, `lib/generation/queue.ts`, `lib/generation/graph.ts`, `app/components/canvas/elements/DuplicateButton.tsx` and two test files. No overlap with the other open PRs.
