### PR TITLE
refactor: nightly maintainability 2026-08-15

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -47,4 +47,4 @@ One opt-in treatment: subtle film grain (`.grain`, theme-tuned `--grain-opacity`
 
 Idiomatic, shadcn-consistent primitives in `components/ui/` built with `class-variance-authority`, tokens only. Buttons: `default` (near-black inverse, for in-tool actions), `accent` (blurple, for hero/auth CTAs), plus `secondary`/`outline`/`ghost`/`icon`/`destructive`. Icons: masked SVG token set (`icons.css`), filled.
 
-Button **dimensions** come from the `size` prop (`sm`/`default`/`lg`/`icon`) defined in `buttonVariants` — never hand-size a button with `h-*`/`px-*`/`text-*` in `className`. Add a named `size` to the variant if you need a new one.
+Button **dimensions** come from the `size` prop (`sm`/`default`/`cta`/`lg`/`icon`) defined in `buttonVariants` — never hand-size a button with `h-*`/`px-*`/`text-*` in `className`. Add a named `size` to the variant if you need a new one.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Open-source, free forever.
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org) 18+
+- [Node.js](https://nodejs.org) 20.9+ (Next.js 16's minimum; CI runs 22)
 - A [Supabase](https://supabase.com) project (for auth and database)
 
 ### Setup
@@ -82,6 +82,7 @@ ELEVENLABS_API_KEY=       # Music + SFX
 CARTESIA_API_KEY=         # Text-to-speech
 BLOB_READ_WRITE_TOKEN=    # Vercel Blob (asset storage)
 NEXT_PUBLIC_BLOB_URL=     # Vercel Blob public URL
+PINECONE_API_KEY=         # Reuses similar past music/SFX generations; unset disables the cache
 ```
 
 4. Run the database migrations:
@@ -139,8 +140,11 @@ See [`ARCHITECTURE.md`](ARCHITECTURE.md) for how these layers interact.
 | `npm run dev`             | Start the dev server        |
 | `npm run build`           | Production build            |
 | `npm run lint`            | ESLint                      |
+| `npm run format:check`    | Prettier check              |
 | `npm run typecheck`       | TypeScript check            |
+| `npm run knip`            | Dead-code check             |
 | `npm run test:run`        | Run tests once (Vitest)     |
+| `npm run test:e2e`        | Smoke tests (Playwright)    |
 | `npm run db:push`         | Push migrations to Supabase |
 | `npm run remotion:studio` | Open Remotion Studio        |
 

--- a/app/components/AuthForm.tsx
+++ b/app/components/AuthForm.tsx
@@ -95,8 +95,9 @@ export default function AuthForm({
 				<Button
 					type="submit"
 					variant="accent"
+					size="cta"
 					disabled={loading}
-					className="mt-1 h-11 w-full"
+					className="mt-1 w-full"
 				>
 					{loading ? "Sending…" : submitLabel}
 				</Button>

--- a/app/components/EmailSentCard.tsx
+++ b/app/components/EmailSentCard.tsx
@@ -54,9 +54,10 @@ export default function EmailSentCard({
 			<Button
 				type="button"
 				variant="accent"
+				size="cta"
 				onClick={onResend}
 				disabled={loading}
-				className="h-11 w-full"
+				className="w-full"
 			>
 				{loading ? "Sending…" : resendLabel}
 			</Button>

--- a/app/components/GoogleOAuthButton.tsx
+++ b/app/components/GoogleOAuthButton.tsx
@@ -14,8 +14,9 @@ export default function GoogleOAuthButton({
 		<Button
 			type="button"
 			variant="outline"
+			size="cta"
 			onClick={onClick}
-			className="h-11 w-full gap-2.5"
+			className="w-full gap-2.5"
 		>
 			<GoogleIcon />
 			{children ?? "Continue with Google"}

--- a/app/components/canvas/elements/character/NewCharacterDialog.tsx
+++ b/app/components/canvas/elements/character/NewCharacterDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { Button } from "@/components/ui/button";
 import {
 	DialogContent,
 	DialogDescription,
@@ -76,13 +77,14 @@ function NewCharacterDialogBody({
 				)}
 
 				<DialogFooter>
-					<button
+					<Button
 						type="submit"
+						variant="secondary"
+						size="sm"
 						disabled={!canSubmit}
-						className="rounded-md border border-border bg-muted px-3 py-1 text-label font-medium text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-muted"
 					>
 						Create
-					</button>
+					</Button>
 				</DialogFooter>
 			</form>
 		</DialogContent>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -65,7 +65,7 @@ export default async function Home() {
 
 			<AccessCodeInput />
 
-			<Button type="button" variant="accent" className="mt-2 h-11 w-full">
+			<Button type="button" variant="accent" size="cta" className="mt-2 w-full">
 				Get Started
 			</Button>
 		</OnboardingCard>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -27,6 +27,8 @@ const buttonVariants = cva(
 			size: {
 				sm: "h-8 rounded-md px-3 text-label",
 				default: "h-9 px-4",
+				/** Auth and hero call to action; pair with `w-full`. */
+				cta: "h-11 px-4",
 				lg: "h-11 px-6 text-body-lg",
 				icon: "size-9",
 			},


### PR DESCRIPTION
## What

One named button size instead of four hand-sized copies, one dialog action put back on the design system, and three README claims that don't match the repo.

## `size="cta"` for the auth and hero call to action

DESIGN.md is explicit: *"Button dimensions come from the `size` prop … never hand-size a button with `h-*`/`px-*`/`text-*` in `className`. Add a named `size` to the variant if you need a new one."*

Four components hand-sized the same button anyway — `app/page.tsx`, `AuthForm`, `EmailSentCard`, `GoogleOAuthButton` each wrote `h-11 w-full`. They were all reaching for the same thing: the `default` size's padding and type at the taller auth/hero height. `lg` was not it (`px-6 text-body-lg`), so each one patched the height by hand and the shape had no name.

`cta: "h-11 px-4"` is that shape. The four call sites now pass `size="cta"` and keep only their layout classes (`w-full`, margins, `gap-2.5`).

## `NewCharacterDialog`'s Create button

Every other dialog footer in the character cluster renders a `<Button size="sm">`. This one hand-rolled the markup: `rounded-md border border-border bg-muted px-3 py-1 text-label font-medium text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-muted`.

Two of those classes are dead — `hover:bg-muted` and `disabled:hover:bg-muted` restate the base background, so the button had no hover state at all. It's now `<Button type="submit" variant="secondary" size="sm">`.

## README

- **Node 18 is wrong and it breaks a fresh clone.** `next@16.2.6` declares `engines.node >= 20.9.0` and CI runs 22, but the prerequisites said 18+. Now `20.9+`.
- **The checks list was incomplete.** Contributing says "run the checks, open a PR", but the scripts table omitted `format:check`, `knip` and `test:e2e` — three of the six things CI actually gates on. All three added.
- **`PINECONE_API_KEY` was undocumented.** `lib/providers/cache.ts` reads it to serve music/SFX generations from a vector cache and silently no-ops without it, so the feature was invisible to anyone setting up from the README. Added to the optional provider block.

## Behavior

Unchanged. `cta` renders the exact box the four call sites already produced (`h-11` over the `default` size's `px-4` and base `text-body`) — same pixels, now named. `NewCharacterDialog`'s Create button is the one visible delta and it is small: `--secondary` and `--muted` are both `var(--grey-50)` and `--secondary-foreground` is `--foreground`, so background and text are identical in both themes; what changes is that it gains a real hover (`bg-button-hover`), a focus ring, and the design system's `disabled:opacity-50` in place of `40`.

## Complexity delta

+3/−9 across 6 source files. One hand-rolled button element deleted, one hardcoded size removed from four components, one variant entry added.

## Skipped, with reasons

- **`AttributeBadge`'s if-chain over `spec.edit.kind`** (standing flag #20) — a `Record<AttributeEdit["kind"], AttributeEditor>` cannot be dispatched without an internal cast to reconcile the per-kind prop types, which is worse than the type-safe chain that's there now. Wants a human call, not a nightly.
- **One home for composer-mode facts** (standing flag #18: `ConfigProvider`'s `MODE_PLUGIN_FACTORIES` and `ComposerCopilot`'s `!isScriptMode` both encode "script mode has no target length") — this was PR #547, closed as "useless". Not re-proposing it.
- **`EditorToolbar`'s `sm:px-4`** is the same hand-sizing class as the four fixed here, but the file is under open PR #580.
- **`ElevenLabsSFX`/`ElevenLabsMusic` `pineconeCache` wiring** is duplicated, but at 2 sites — rule of three says wait.

## Open PR overlap check

Considered #573 (`BottomTransportBar`), #579 (RTL element direction), #580 (sloppy agent — 60+ files across `app/components/{sloppy,canvas,copilot,video/timeline}`, `lib/{agent,api,providers,script,video}`, `components/ui/icon.tsx`, `ARCHITECTURE.md`), #581 (`lib/generation/{graph,snapshots}`). This PR touches `README.md`, `components/ui/button.tsx`, `app/page.tsx`, `AuthForm.tsx`, `EmailSentCard.tsx`, `GoogleOAuthButton.tsx` and `NewCharacterDialog.tsx` — none appears in any open PR's diff. #580 edits `components/ui/icon.tsx` and `app/globals.css` but not `button.tsx`, and none of these PRs touches the auth/landing cluster or the character dialogs.

## Checks

`npm run lint`, `format:check`, `typecheck`, `knip`, `npm run build`, and `npm run test:run` (141 files / 1212 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)