### PR TITLE
fix: nightly bug fixes 2026-08-16

### DIFF
--- a/app/components/video/timeline/__tests__/useTimelineZoom.test.ts
+++ b/app/components/video/timeline/__tests__/useTimelineZoom.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { fitPxPerSec } from "../useTimelineZoom";
+
+describe("fitPxPerSec", () => {
+	it("fits the whole video across the viewport", () => {
+		expect(fitPxPerSec(30, 600)).toBe(20);
+	});
+
+	it("has no scale before the viewport is measured", () => {
+		expect(fitPxPerSec(30, 0)).toBe(0);
+	});
+
+	// Timeline subtracts its gutter and ruler tail from the measured width, so an
+	// unmeasured (or very narrow) viewport arrives here negative.
+	it("has no scale for a viewport narrower than its own chrome", () => {
+		expect(fitPxPerSec(30, -72)).toBe(0);
+	});
+
+	it("has no scale for a video with no length", () => {
+		expect(fitPxPerSec(0, 600)).toBe(0);
+	});
+});

--- a/app/components/video/timeline/useTimelineZoom.ts
+++ b/app/components/video/timeline/useTimelineZoom.ts
@@ -5,18 +5,29 @@ import { useState } from "react";
 /** Multiples of fit-to-width; the timeline never zooms below the whole video. */
 const ZOOM_LEVELS = [1, 1.5, 2, 3, 4, 6, 8];
 
+/**
+ * Pixels per second at 1x: the whole video across the viewport. A viewport not
+ * yet measured (or narrower than the chrome subtracted from it) has no scale —
+ * a negative one would lay every clip, tick and playhead out backwards.
+ */
+export function fitPxPerSec(
+	totalDurationSec: number,
+	viewportWidth: number,
+): number {
+	if (totalDurationSec <= 0 || viewportWidth <= 0) return 0;
+	return viewportWidth / totalDurationSec;
+}
+
 export function useTimelineZoom(
 	totalDurationSec: number,
 	viewportWidth: number,
 ) {
 	const [level, setLevel] = useState(0);
 	const zoom = ZOOM_LEVELS[level];
-	const fitPxPerSec =
-		totalDurationSec > 0 ? viewportWidth / totalDurationSec : 0;
 
 	return {
 		zoom,
-		pxPerSec: fitPxPerSec * zoom,
+		pxPerSec: fitPxPerSec(totalDurationSec, viewportWidth) * zoom,
 		canZoomIn: level < ZOOM_LEVELS.length - 1,
 		canZoomOut: level > 0,
 		zoomIn: () => setLevel((l) => Math.min(l + 1, ZOOM_LEVELS.length - 1)),

--- a/lib/api/__tests__/asset-bundle.test.ts
+++ b/lib/api/__tests__/asset-bundle.test.ts
@@ -204,6 +204,40 @@ describe("AssetBundle", () => {
 			vi.unstubAllGlobals();
 		});
 
+		it("rejects two files sharing a filename rather than storing one of them", async () => {
+			await expect(
+				AssetBundle.upload("tts", "cartesia", [
+					{
+						key: "audio",
+						filename: "output.wav",
+						data: Buffer.from("a"),
+						contentType: "audio/wav",
+					},
+					{
+						key: "preview",
+						filename: "output.wav",
+						data: Buffer.from("b"),
+						contentType: "audio/wav",
+					},
+				]),
+			).rejects.toThrow(/share the filename "output\.wav"/);
+			expect(putMock).not.toHaveBeenCalled();
+		});
+
+		it("rejects a file named like the manifest the bundle writes itself", async () => {
+			await expect(
+				AssetBundle.upload("upload", "user", [
+					{
+						key: "image",
+						filename: "manifest.json",
+						data: Buffer.from("fake-image"),
+						contentType: "image/png",
+					},
+				]),
+			).rejects.toThrow(/cannot be named "manifest\.json"/);
+			expect(putMock).not.toHaveBeenCalled();
+		});
+
 		it("throws when a remote file's source url is already dead", async () => {
 			vi.stubGlobal(
 				"fetch",

--- a/lib/api/asset-bundle.ts
+++ b/lib/api/asset-bundle.ts
@@ -38,6 +38,31 @@ export type BundleFileRemote = BundleFileBase & {
 
 export type BundleFile = BundleFileData | BundleFileRemote;
 
+const MANIFEST_FILENAME = "manifest.json";
+
+/**
+ * Blob storage overwrites by path, so two files sharing a name in one bundle
+ * silently become one, and the manifest points both keys at whichever upload
+ * landed last. The manifest is written to the same prefix, so its name is
+ * reserved too.
+ */
+function assertDistinctFilenames(files: BundleFile[]): void {
+	const seen = new Set<string>();
+	for (const { key, filename } of files) {
+		if (filename === MANIFEST_FILENAME) {
+			throw new Error(
+				`Bundle file "${key}" cannot be named "${MANIFEST_FILENAME}"`,
+			);
+		}
+		if (seen.has(filename)) {
+			throw new Error(
+				`Bundle files "${key}" and an earlier file share the filename "${filename}"`,
+			);
+		}
+		seen.add(filename);
+	}
+}
+
 type PutBody = Parameters<typeof import("@vercel/blob").put>[1];
 
 /** Remote sources stream in at an unknown size, so they upload in chunks. */
@@ -102,6 +127,7 @@ export class AssetBundle {
 		files: BundleFile[],
 		metadata?: Record<string, unknown>,
 	): Promise<BundleResponse> {
+		assertDistinctFilenames(files);
 		const { put } = await import("@vercel/blob");
 		const id = nanoid();
 		const basePath = `assets/${type}/${provider}/${id}`;
@@ -131,7 +157,7 @@ export class AssetBundle {
 			metadata,
 		};
 
-		await put(`${basePath}/manifest.json`, JSON.stringify(manifest), {
+		await put(`${basePath}/${MANIFEST_FILENAME}`, JSON.stringify(manifest), {
 			access: "public",
 			contentType: "application/json",
 			addRandomSuffix: false,


### PR DESCRIPTION
## What

Two correctness bugs, each in a place where the wrong value was accepted silently rather than rejected.

### `AssetBundle.upload` let one bundle file overwrite another

Blob storage overwrites by path, and the manifest is written to the same prefix as the files it describes. So two files in one bundle sharing a `filename` silently became one object, with the manifest pointing both keys at whichever `put` landed last — and a file named `manifest.json` was clobbered by the manifest write itself. That last case is reachable from `/api/upload/image`: `sanitizeFilename` passes `manifest.json` straight through, so uploading an image with that name returned a URL that serves the bundle manifest as the image, with the manifest gone too.

Both are the same defect — the bundle never checked that its filenames were distinct — so `upload` now validates up front and throws with the offending key/filename before writing anything.

### The timeline laid itself out backwards until its viewport was measured

`Timeline` passes `viewportWidth - GUTTER_PX - RULER_TAIL_PX` into `useTimelineZoom`, and `useElementWidth` reports `0` until the scroller is measured. That made `pxPerSec` **-72 / totalDurationSec** on the first paint: clips positioned at negative offsets, a negative `gridTemplateColumns` track, negative tick spacing in the ruler, and a playhead left of the origin. The same thing sticks for as long as the dock is narrower than its own chrome.

The scale now comes from `fitPxPerSec`, which returns `0` for an unmeasured or too-narrow viewport instead of a negative scale.

## Tests

- `AssetBundle.upload` rejects two files sharing a filename, and rejects a file named `manifest.json` — both assert nothing was written.
- `fitPxPerSec` covers the fit case, the unmeasured viewport, the negative width `Timeline` actually passes, and a zero-length video.

Both suites were verified to fail against the old code.

CI: lint, format:check, typecheck, knip, build, and the full vitest suite pass locally.

## Open PR overlap check

Considered #582, #581, #580, #579, #573. #580 touches `lib/api/{agentTurn,conversations,providers,sse}.ts` but not `asset-bundle.ts`; #580/#579 touch `timeline/TimelineClip.tsx` but not `useTimelineZoom.ts`; #581 is scoped to `lib/generation/{graph,snapshots}.ts`; #582 to auth/dialog components; #573 to the transport bar. No overlap in files or themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)