### PR TITLE
perf: nightly performance optimizations 2026-08-16

### DIFF
--- a/app/components/video/BottomDock.tsx
+++ b/app/components/video/BottomDock.tsx
@@ -18,7 +18,7 @@ const FILLS_DOCK: Record<BottomView, boolean> = {
 /** The transport bar and its panel, resized by a handle on the dock's top edge. */
 export function BottomDock({ children }: { children: ReactNode }) {
 	const { view } = useBottomView();
-	const { size, handleMouseDown, resizing } = useResize({
+	const { panelRef, style, handleMouseDown, resizing } = useResize({
 		axis: "vertical",
 		invert: true,
 		defaultSize: DEFAULT_HEIGHT,
@@ -30,8 +30,9 @@ export function BottomDock({ children }: { children: ReactNode }) {
 
 	return (
 		<div
+			ref={panelRef}
 			className="flex shrink-0 flex-col"
-			style={fills ? { height: size } : undefined}
+			style={fills ? style : undefined}
 		>
 			{fills ? (
 				<ResizeHandle

--- a/app/components/video/PlayerPanel.tsx
+++ b/app/components/video/PlayerPanel.tsx
@@ -37,7 +37,7 @@ function FitToAspectRatio({
 function TopPlayerPanelComponent() {
 	const aspectRatio = useVideoSetting("aspectRatio");
 
-	const { size, handleMouseDown, resizing } = useResize({
+	const { panelRef, style, handleMouseDown, resizing } = useResize({
 		axis: "vertical",
 		defaultSize: TOP_DEFAULT,
 		minSize: 150,
@@ -45,7 +45,7 @@ function TopPlayerPanelComponent() {
 	});
 
 	return (
-		<div className="shrink-0" style={{ height: size }}>
+		<div ref={panelRef} className="shrink-0" style={style}>
 			<div className="relative mx-auto h-[calc(100%-0.5rem)] max-w-6xl p-2">
 				<FitToAspectRatio ratio={getAspectRatioValue(aspectRatio)}>
 					<VideoPanel />
@@ -63,7 +63,7 @@ function TopPlayerPanelComponent() {
 function SidePlayerPanelComponent() {
 	const aspectRatio = useVideoSetting("aspectRatio");
 
-	const { size, handleMouseDown, resizing } = useResize({
+	const { panelRef, style, handleMouseDown, resizing } = useResize({
 		axis: "horizontal",
 		defaultSize: SIDE_DEFAULT,
 		minSize: 250,
@@ -71,7 +71,7 @@ function SidePlayerPanelComponent() {
 	});
 
 	return (
-		<div className="flex shrink-0" style={{ width: size }}>
+		<div ref={panelRef} className="flex shrink-0" style={style}>
 			<ResizeHandle
 				axis="horizontal"
 				resizing={resizing}

--- a/app/components/video/__tests__/useResize.test.ts
+++ b/app/components/video/__tests__/useResize.test.ts
@@ -1,5 +1,23 @@
 import { describe, expect, it, vi } from "vitest";
-import { attachResizeListeners, clampResize } from "../useResize";
+import {
+	attachResizeListeners,
+	clampResize,
+	panelSizeStyle,
+} from "../useResize";
+
+describe("panelSizeStyle", () => {
+	it("sizes a vertical panel by height, defaulting until a drag writes one", () => {
+		expect(panelSizeStyle("vertical", 260)).toEqual({
+			height: "var(--panel-size, 260px)",
+		});
+	});
+
+	it("sizes a horizontal panel by width", () => {
+		expect(panelSizeStyle("horizontal", 560)).toEqual({
+			width: "var(--panel-size, 560px)",
+		});
+	});
+});
 
 describe("clampResize", () => {
 	it("expands vertically when cursor moves down", () => {

--- a/app/components/video/useResize.ts
+++ b/app/components/video/useResize.ts
@@ -1,9 +1,30 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+	type CSSProperties,
+} from "react";
 import { clamp } from "@/lib/utils";
 
 export type ResizeAxis = "vertical" | "horizontal";
+
+/**
+ * The dragged size reaches the DOM as a custom property on the panel, so a drag
+ * writes one property instead of re-rendering the panel's subtree per mousemove.
+ * Nothing renders the variable, so an unrelated render can't clobber the drag.
+ */
+const SIZE_VAR = "--panel-size";
+
+export function panelSizeStyle(
+	axis: ResizeAxis,
+	defaultSize: number,
+): CSSProperties {
+	const size = `var(${SIZE_VAR}, ${defaultSize}px)`;
+	return axis === "vertical" ? { height: size } : { width: size };
+}
 
 /**
  * `invert` is for a handle on the panel's leading edge — a bottom dock grabbed
@@ -92,13 +113,8 @@ export function useResize({
 	maxViewportFraction: number;
 	invert?: boolean;
 }) {
-	const [size, setSize] = useState(defaultSize);
 	const [resizing, setResizing] = useState(false);
-	const sizeRef = useRef(size);
-	useEffect(() => {
-		sizeRef.current = size;
-	}, [size]);
-
+	const panelRef = useRef<HTMLDivElement>(null);
 	const cleanupRef = useRef<(() => void) | null>(null);
 
 	useEffect(
@@ -111,24 +127,34 @@ export function useResize({
 
 	const handleMouseDown = useCallback(
 		(e: React.MouseEvent) => {
+			const panel = panelRef.current;
+			if (!panel)
+				throw new Error("Resize handle fired before its panel mounted");
 			e.preventDefault();
 			cleanupRef.current?.();
 			setResizing(true);
-			const viewport =
-				axis === "vertical" ? window.innerHeight : window.innerWidth;
+			const vertical = axis === "vertical";
+			const rect = panel.getBoundingClientRect();
 			cleanupRef.current = attachResizeListeners(document, {
 				axis,
-				startPos: axis === "vertical" ? e.clientY : e.clientX,
-				startSize: sizeRef.current,
+				startPos: vertical ? e.clientY : e.clientX,
+				startSize: vertical ? rect.height : rect.width,
 				minSize,
-				maxSize: viewport * maxViewportFraction,
+				maxSize:
+					(vertical ? window.innerHeight : window.innerWidth) *
+					maxViewportFraction,
 				invert,
-				onResize: setSize,
+				onResize: (size) => panel.style.setProperty(SIZE_VAR, `${size}px`),
 				onEnd: () => setResizing(false),
 			});
 		},
 		[axis, minSize, maxViewportFraction, invert],
 	);
 
-	return { size, handleMouseDown, resizing };
+	return {
+		panelRef,
+		style: panelSizeStyle(axis, defaultSize),
+		handleMouseDown,
+		resizing,
+	};
 }


### PR DESCRIPTION
## What

Resizing a panel re-rendered everything inside it, once per mousemove.

`useResize` held the dragged size in React state (`useResize.ts:95`) and `attachResizeListeners` called `setSize` on every `mousemove`. At a normal pointer sample rate that is ~60 renders a second of the panel's entire subtree, for a change that is one CSS length:

- **Top / side player panel** (`PlayerPanel.tsx`) — `FitToAspectRatio` → `VideoPanel` → `VideoPanelBody` → `VideoPreview` → the Remotion `<Player>` and the composition under it, per sample, for the whole drag.
- **Bottom dock** (`BottomDock.tsx`) — `BottomTransportBar` plus whichever panel is open. With the timeline open that is every `Track`, every `TimelineClip`, every `ClipWaveform` and every ruler tick.

None of that subtree reads the size; it just sits inside the element that has it.

## Change

The dragged size reaches the DOM as a custom property written straight onto the panel element, which is the pattern `ScrubBar` already uses for `--scrub-pos` / `--scrub-preview`:

- `panelSizeStyle(axis, defaultSize)` gives the panel `height: var(--panel-size, 300px)` (or `width`, on the horizontal axis).
- `onResize` does `panel.style.setProperty("--panel-size", …)`. No render, no reconciliation — the browser recomputes the one length.
- Nothing ever renders the variable, so a re-render from an unrelated source (the dock's `view` flipping, an `aspectRatio` change) cannot clobber a size the user dragged.

Drag start reads its starting size off the element (`getBoundingClientRect`) instead of a mirrored copy, so `size` state, its `sizeRef` mirror and the effect that kept the two in sync all go away. `resizing` stays in state: it flips twice per drag and drives the handle's `select-none`.

Net: a drag re-renders nothing. Behaviour is unchanged — same clamping, same invert semantics for the dock's leading-edge handle, same default sizes.

## Not done

- No browser render-count trace for this PR. The repo has no component-render test setup, and the accounting here is structural rather than measured: the render was one `setState` per `mousemove` on the component that owns the player / timeline subtree, and there is now none.
- `ScrubBar`'s `setHoverRatio` per `pointermove` was looked at and left alone: its track is memoized and the fills are already variable-driven, so that render is one shallow component, not a subtree.
- `NumberScrubber` writing to the project store per `pointermove` is a real fanout, but it lands in `lib/generation` / `useGenerate` — the exact ground #577 covered.

## Open PR overlap check

Considered **#584** (`ActiveSceneSync`, `BottomTransportBar`, `PlayerControls`, `SeekTooltip`, `SegmentedSeekBar`, `VideoLayoutContext`, `storyboardScenes`, `useActiveSegmentIndex`, `lib/video/sceneSegments`), **#583** (`useTimelineZoom`, `lib/api/asset-bundle`), **#582** (auth / landing components), **#581** (`lib/generation`), **#580** (the agent branch — `lib/agent`, `lib/api`, `app/components/sloppy`, canvas panel), **#579** (RTL element direction), **#573** (`BottomTransportBar`).

This PR touches `useResize.ts`, `PlayerPanel.tsx`, `BottomDock.tsx` and `__tests__/useResize.test.ts`. None of the four appear in any open PR's diff. #573 and #584 both edit `BottomTransportBar.tsx`, which `BottomDock` renders but this PR does not modify. Non-overlapping.

## Checks

`lint`, `format:check`, `typecheck`, `knip`, `build`, `test` (1214 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)