### PR TITLE
fix: nightly bug fixes 2026-08-17

### DIFF
--- a/lib/api/handlers/__tests__/video.test.ts
+++ b/lib/api/handlers/__tests__/video.test.ts
@@ -12,7 +12,10 @@ vi.mock("@/lib/api/providers", async (importOriginal) => ({
 	getVideoProvider: () => ({ generate, poll }),
 }));
 
-type VideoJobRow = TypedJobRow<VideoGenerateParams, { providerJobId?: string }>;
+type VideoJobRow = TypedJobRow<
+	VideoGenerateParams,
+	{ providerJobId?: string; durationSec?: number }
+>;
 
 const bundle = { id: "bundle-1" } as unknown as BundleResponse;
 
@@ -25,7 +28,7 @@ function job(overrides: Partial<VideoJobRow> = {}): VideoJobRow {
 		status: "processing",
 		request: { prompt: "a cat" } as VideoGenerateParams,
 		result: null,
-		metadata: { providerJobId: "upstream-1" },
+		metadata: { providerJobId: "upstream-1", durationSec: 8 },
 		error: null,
 		created_at: "2026-01-01T00:00:00Z",
 		updated_at: "2026-01-01T00:00:00Z",
@@ -43,11 +46,13 @@ describe("videoHandler.process", () => {
 	});
 
 	it("submits upstream without polling a job it just created", async () => {
-		generate.mockResolvedValue({ metadata: { jobId: "upstream-9" } });
+		generate.mockResolvedValue({
+			metadata: { jobId: "upstream-9", durationSec: 10 },
+		});
 
 		await expect(videoHandler.process(job({ metadata: {} }))).resolves.toEqual({
 			kind: "pending",
-			metadata: { providerJobId: "upstream-9" },
+			metadata: { providerJobId: "upstream-9", durationSec: 10 },
 		});
 		expect(generate).toHaveBeenCalledWith({ prompt: "a cat" });
 		expect(poll).not.toHaveBeenCalled();
@@ -56,17 +61,25 @@ describe("videoHandler.process", () => {
 	it("advances the recorded upstream job without resubmitting", async () => {
 		await expect(videoHandler.process(job())).resolves.toEqual({
 			kind: "pending",
-			metadata: { providerJobId: "upstream-1" },
+			metadata: { providerJobId: "upstream-1", durationSec: 8 },
 		});
 		expect(generate).not.toHaveBeenCalled();
 		expect(poll).toHaveBeenCalledWith("upstream-1");
 	});
 
 	it("throws when the provider returns no job id", async () => {
-		generate.mockResolvedValue({ metadata: {} });
+		generate.mockResolvedValue({ metadata: { durationSec: 10 } });
 
 		await expect(videoHandler.process(job({ metadata: {} }))).rejects.toThrow(
-			"Video provider returned no jobId",
+			"unusable submission",
+		);
+	});
+
+	it("throws when the provider returns no duration", async () => {
+		generate.mockResolvedValue({ metadata: { jobId: "upstream-9" } });
+
+		await expect(videoHandler.process(job({ metadata: {} }))).rejects.toThrow(
+			"unusable submission",
 		);
 	});
 
@@ -76,7 +89,29 @@ describe("videoHandler.process", () => {
 
 		await expect(videoHandler.process(job())).resolves.toEqual({
 			kind: "completed",
-			result: asset,
+			result: { ...asset, metadata: { durationSec: 8 } },
+		});
+	});
+
+	// The upstream poll is keyed by job id alone and reports no duration, so
+	// without the submission's duration the finished video lays out as one second.
+	it("stamps the submitted duration onto the finished asset", async () => {
+		poll.mockResolvedValue({
+			kind: "ready",
+			asset: {
+				...bundle,
+				result: { video: "output.mp4" },
+				metadata: { jobId: "upstream-1", status: "completed" },
+			},
+		});
+
+		const outcome = await videoHandler.process(job());
+
+		expect(outcome).toMatchObject({
+			kind: "completed",
+			result: {
+				metadata: { jobId: "upstream-1", status: "completed", durationSec: 8 },
+			},
 		});
 	});
 

--- a/lib/api/handlers/video.ts
+++ b/lib/api/handlers/video.ts
@@ -2,32 +2,47 @@ import type { VideoGenerateParams } from "@/lib/connectors/types";
 import type { JobHandler } from "../job-handlers";
 import { getVideoProvider } from "../providers";
 
-type VideoMetadata = { providerJobId?: string };
+/**
+ * `durationSec` is carried across deliveries because only the submission knows
+ * how long the video is: an upstream poll is keyed by job id alone, so a result
+ * assembled from the poll would land with no duration and lay out as a
+ * one-second clip.
+ */
+type VideoMetadata = { providerJobId?: string; durationSec?: number };
 
 export const videoHandler: JobHandler<VideoGenerateParams, VideoMetadata> = {
 	process: async (job) => {
 		const provider = getVideoProvider();
-		const providerJobId = job.metadata.providerJobId;
+		const { providerJobId, durationSec } = job.metadata;
 		if (!providerJobId) {
-			const submitted = await provider.generate(job.request);
-			if (!submitted.metadata?.jobId) {
+			const submission = (await provider.generate(job.request)).metadata;
+			if (!submission?.jobId || submission.durationSec === undefined) {
 				throw new Error(
-					"Video provider returned no jobId for async generation",
+					`Video provider returned an unusable submission: jobId=${submission?.jobId}, durationSec=${submission?.durationSec}`,
 				);
 			}
 			return {
 				kind: "pending",
-				metadata: { providerJobId: submitted.metadata.jobId },
+				metadata: {
+					providerJobId: submission.jobId,
+					durationSec: submission.durationSec,
+				},
 			};
 		}
 
 		const upstream = await provider.poll(providerJobId);
 		if (upstream.kind === "ready") {
-			return { kind: "completed", result: upstream.asset };
+			return {
+				kind: "completed",
+				result: {
+					...upstream.asset,
+					metadata: { ...upstream.asset.metadata, durationSec },
+				},
+			};
 		}
 		if (upstream.metadata?.status === "failed") {
 			throw new Error(upstream.metadata.error ?? "Video generation failed");
 		}
-		return { kind: "pending", metadata: { providerJobId } };
+		return { kind: "pending", metadata: { providerJobId, durationSec } };
 	},
 };

--- a/lib/providers/__tests__/runware-video.test.ts
+++ b/lib/providers/__tests__/runware-video.test.ts
@@ -139,6 +139,23 @@ describe("RunwareVideo", () => {
 
 			expect(result.metadata?.durationSec).toBe(10);
 		});
+
+		// The recorded duration is what the finished video is laid out with, so it
+		// has to be the duration that was actually submitted, defaults included.
+		it("records the defaulted duration when the request carries none", async () => {
+			mockVideoInference.mockResolvedValue({
+				taskUUID: "job-3",
+				status: "processing",
+			});
+
+			const provider = new RunwareVideo("test-key");
+			const result = await provider.generate({ prompt: "test", duration: 0 });
+
+			expect(mockVideoInference).toHaveBeenCalledWith(
+				expect.objectContaining({ duration: 5 }),
+			);
+			expect(result.metadata?.durationSec).toBe(5);
+		});
 	});
 
 	describe("poll", () => {

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -3,6 +3,8 @@ import type { VideoJob, VideoJobStatus } from "./base";
 import { BaseVideoProvider } from "./base";
 import { withRunware } from "../runware";
 
+const DEFAULT_DURATION_SEC = 5;
+
 function toVideoJob(video: {
 	taskUUID: string;
 	status: string;
@@ -33,7 +35,7 @@ export class RunwareVideo extends BaseVideoProvider {
 				model: params.model || "bytedance:seedance@2.0-fast",
 				width: params.width || 1280,
 				height: params.height || 720,
-				duration: params.duration || 5,
+				duration: params.duration || DEFAULT_DURATION_SEC,
 				outputType: "URL",
 				deliveryMethod: "async",
 				inputs: {
@@ -58,7 +60,7 @@ export class RunwareVideo extends BaseVideoProvider {
 			metadata: {
 				...job.metadata,
 				jobId: job.metadata?.jobId ?? "",
-				durationSec: params.duration ?? 5,
+				durationSec: params.duration || DEFAULT_DURATION_SEC,
 			},
 		};
 	}


### PR DESCRIPTION
## What

A generated video's duration never reached the finished asset, so every clip and animated image rendered as a one-second scene.

### `durationSec` was lost between submitting and completing a video job

Video generation is async: the handler submits, gets a provider job id back, and polls until the provider hands over a URL. The duration is only known at submission — `RunwareVideo.submit` sends `duration` and `_generate` records `durationSec` in the submission's metadata, but `videoHandler` keeps only `jobId` from that response. The completed job's `result` is the bundle built from the **poll**, and `_poll` reports `{ jobId, status }` alone.

So `AssetBundle.manifest.metadata.durationSec` was absent on every completed video, `BaseAssetConnector.resolveBundle` read it as `Number(undefined ?? 0)` → `0`, and `resolveElements` handed a `durationSec: 0` element to `buildVideoLayout`, which clamps to `MIN_DURATION_SEC`. A 10-second clip became a 1-second scene, in the render and in the editor timeline alike.

`MockVideo._poll` returns a `durationSec`, which is why this never showed up in dev or in the existing tests.

The handler is the only layer that sees both ends of the job, and `process-job` already round-trips its `metadata` between deliveries, so the duration now rides along with `providerJobId` and is stamped onto the asset at completion. A submission missing either half of that contract now fails the job loudly instead of silently producing a one-second video.

### `RunwareVideo` recorded a duration it hadn't submitted

`submit` sent `params.duration || 5` while `_generate` recorded `params.duration ?? 5`, so `duration: 0` submitted 5 seconds and recorded 0 — a one-second clip again, now via the other path. Both resolve through one `DEFAULT_DURATION_SEC`.

## Tests

- `videoHandler` carries the submitted duration through the pending deliveries and stamps it onto the finished asset, alongside the upstream metadata.
- A submission missing `jobId` or `durationSec` rejects.
- `RunwareVideo` records the defaulted duration when the request carries none, matching what it submitted.

All seven new/updated assertions were verified to fail against the old code.

CI: lint, format:check, typecheck, knip, build, and the full vitest suite (141 files, 1215 tests) pass locally.

## Open PR overlap check

Considered #585, #584, #583, #582, #581, #580, #579, #573. #580 touches `lib/api/{agentTurn,conversations,providers,sse}.ts` and `lib/providers/llm/*` but not `lib/api/handlers/` or `lib/providers/video/`; #583 touches `lib/api/asset-bundle.ts` (read here, not modified); the rest are scoped to canvas/video UI, generation snapshots, and auth components. No overlap in files or themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)