### PR TITLE
refactor: nightly maintainability 2026-08-17

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4,36 +4,36 @@ OpenSlop is an AI creative media studio: a focused editor plus auth, onboarding,
 
 ## Aesthetic
 
-Clean, warm, and quiet. The tool is a bright focused workspace; the gallery is a dark immersive showcase. Surfaces carry the weight; color marks what is live or actionable.
+Clean, warm, and quiet. A focused workspace. Surfaces carry the weight; color marks what is live or actionable.
 
 Tokens live in `app/globals.css` (raw palette ramps + semantic tokens, light and dark), exposed to Tailwind via `@theme inline`.
 
 ## Theme
 
-Global light + dark via `next-themes` (`attribute="class"`, default light, no system). Editor surfaces read light; the projects gallery reads dark. Both are themeable; a `ThemeToggle` lives in shared chrome. The palette ramps flip in `.dark`, so semantic tokens that reference them adapt automatically.
+Global light + dark via `next-themes` (`attribute="class"`, default light, system enabled). One theme covers every surface — editor, gallery, auth — and nothing is forced light or dark. Light / Dark / System live in the Appearance submenu of the account dropdown (`UserProfile`). The palette ramps flip in `.dark`, so semantic tokens adapt automatically.
 
 ## Color
 
 - **Neutrals:** warm, red-tinted greys (`--grey-900` foreground through `--grey-0`).
-- **Surfaces:** `--background`, `--surface-recessed` (panels), `--card` / `--surface-elevated` (raised; popovers and select menus sit here, with `--surface-hover` for hovered controls on them). Borders are hairline (`--border`).
+- **Surfaces:** `--background`, `--surface-recessed` (panels), `--card` / `--surface-elevated` (raised: popovers, select menus, with `--surface-hover` for hovered controls on them), `--element-card` (element cards and side-panel sections, text from `--panel-fg` / `--panel-label`). Borders are hairline (`--border`).
 - **Accent — blurple** (`--accent`, `--ring`): focus rings, selection, links, send, and `accent` CTAs only. Disciplined, never an ambient wash.
 - **State:** `--destructive` (red), `--success` (green), `--caution` (amber).
-- **Media-type tints** (`--media-character/image/clip/animated/music/sound/narration`): used as the element-card icon color so each storyboard type reads at a glance. Brighter in dark, deeper in light.
-- **Scrims** (`--overlay`, `--on-media`, `--on-media-foreground`): theme-independent dark washes. `bg-overlay` for modal/dialog scrims; `bg-on-media/55…80` for chrome floating over media or video (`--on-media` is solid black, so the opacity modifier sets the strength), paired with `text-on-media-foreground`.
+- **Media-type tints** (`--media-character/image/clip/animated/music/sound/narration`): the element-card icon color, so each storyboard type reads at a glance. Brighter in dark, deeper in light.
+- **Scrims** (`--overlay`, `--on-media`, `--on-media-foreground`): theme-independent dark washes. `bg-overlay` for modal scrims; `bg-on-media/55…80` for chrome floating over media (`--on-media` is solid black, so the opacity modifier sets the strength), paired with `text-on-media-foreground`.
 
-Use semantic tokens (`bg-background`, `text-foreground`, `border-border`, `bg-card`, `text-muted-foreground`, `bg-accent`, `ring-ring`), never raw hexes, `bg-black/N`, or `*-white/N` literals — reach for the scrim tokens above for dark washes over media.
+Use semantic tokens (`bg-background`, `text-foreground`, `border-border`, `bg-card`, `text-muted-foreground`, `bg-accent`, `ring-ring`), never raw hexes, `bg-black/N`, or `*-white/N` literals — reach for the scrim tokens for dark washes over media.
 
 ## Typography
 
-UI and titles use **Sloptastic** (`--font-sans`, `.font-title`), a clean grotesque; body text and form controls — inputs, textareas, selects, and dropdown menus — use **Inter** (`--font-body`). **IBM Plex Mono** (`--font-mono`) for timecodes and durations. Two display faces for marketing surfaces only: **Instrument Serif** (`--font-serif`, hero headlines) and **Sentient** (`--font-sentient`, the onboarding wordmark). `.font-title` is Sloptastic with tight tracking; `.font-body` is Inter.
+UI and titles use **Sloptastic** (`--font-sans`, `.font-title`), a clean grotesque; body text and form controls — inputs, textareas, selects, dropdown menus — use **Inter** (`--font-body`). **IBM Plex Mono** (`--font-mono`) for timecodes and durations. Marketing surfaces only: **Instrument Serif** (`--font-serif`, hero headlines) and **Sentient** (`.font-sentient`, the onboarding wordmark).
 
-The scale lives as `@theme` tokens in `app/globals.css`: use the `text-badge-xs` / `text-badge` / `text-label-xs` / `text-label` / `text-body` / `text-body-lg` / `text-heading-sm` / `text-heading` / `text-heading-lg` / `text-display` utilities — named font-sizes that each bake in a matching line-height, so a bare token (e.g. `text-body`) needs no `leading-*`. Add `leading-*` only to deliberately override the baked leading, and `font-medium` for a heavier weight. Don't hand-pick raw `text-xs` / `text-sm` or `text-[Npx]` arbitraries. Caveat: `.font-body` / `.font-title` are declared unlayered, so their `line-height: 1.5` / `1.2` beats the token's baked leading on any surface that pairs them (form controls, buttons, titles) — those surfaces take their leading from the font class, not the size token, and need an explicit `leading-*` to change it.
+The scale lives as `@theme` tokens in `app/globals.css`: `text-badge-xs` / `text-badge` / `text-label-xs` / `text-label` / `text-body` / `text-body-lg` / `text-heading-sm` / `text-heading` / `text-heading-lg` / `text-display`. Each bakes in its own line-height, so a bare token needs no `leading-*`; add one only to override, and `font-medium` for weight. Never hand-pick `text-xs` / `text-sm` or `text-[Npx]` arbitraries. Caveat: `.font-body` / `.font-title` are declared unlayered, so their `line-height` (1.5 / 1.2) beats the token's baked leading wherever they pair (form controls, buttons, titles) — those surfaces need an explicit `leading-*` to change it.
 
 In a dense row, a primary label and its secondary description share one size and weight (e.g. both `text-label`), differentiated by color alone — `text-foreground` for the label, `text-muted-foreground` for the description. Don't shrink or bold the label to set it apart.
 
 ## Spacing, radius, elevation
 
-4px base spacing. Radius via `--radius`; cards `rounded-xl`, overlays (modals, popovers, dropdowns, selects) and form controls (inputs, textareas, select triggers) `rounded-md`, pills `rounded-full`. Depth comes from token elevations `shadow-elevation-1/3/5/10`, not glow — popovers and menus sit at `shadow-elevation-3`.
+4px base spacing. Radius via `--radius`; cards `rounded-xl`, overlays (modals, popovers, dropdowns, selects) and form controls `rounded-md`, pills `rounded-full`. Depth comes from token elevations `shadow-elevation-1/3/5/10`, not glow — popovers and menus sit at `shadow-elevation-3`.
 
 ## Motion
 
@@ -41,10 +41,15 @@ Eases `--ease-casual` / `--ease-productive` / `--ease-expressive`; durations `--
 
 ## Texture
 
-One opt-in treatment: subtle film grain (`.grain`, theme-tuned `--grain-opacity`) plus an optional soft blurple radial (`<Glow/>`). Tasteful and quiet. Allowed on landing/auth, the gallery, empty states, and editor chrome. No grain on dense element cards. No glass. No rainbow backdrops.
+Two opt-in treatments, both quiet:
+
+- `.grain` — subtle film grain (theme-tuned `--grain-opacity`) on raised surfaces: dialogs, panel cards, the canvas card, onboarding, the inline copilot. Needs a positioned element; it paints through `::after`. No grain on dense element cards.
+- `.dot-grid-bg` — a repeating "+" dot grid, the page backdrop behind the editor and the gallery. Render it as an `aria-hidden`, `pointer-events-none` layer behind content.
+
+No glass. No rainbow backdrops.
 
 ## Components
 
-Idiomatic, shadcn-consistent primitives in `components/ui/` built with `class-variance-authority`, tokens only. Buttons: `default` (near-black inverse, for in-tool actions), `accent` (blurple, for hero/auth CTAs), plus `secondary`/`outline`/`ghost`/`icon`/`destructive`. Icons: masked SVG token set (`icons.css`), filled.
+Idiomatic, shadcn-consistent primitives in `components/ui/` built with `class-variance-authority`, tokens only. Icons: masked SVG token set (`components/ui/icons.css`), filled.
 
-Button **dimensions** come from the `size` prop (`sm`/`default`/`cta`/`lg`/`icon`) defined in `buttonVariants` — never hand-size a button with `h-*`/`px-*`/`text-*` in `className`. Add a named `size` to the variant if you need a new one.
+Button `variant` covers color only: `default` (near-black inverse, in-tool actions), `accent` (blurple, hero/auth CTAs), `generate` (the generate action's own `--generate` token family, including its disabled state), plus `secondary`/`outline`/`ghost`/`destructive`/`link`. **Dimensions** come from the `size` prop (`sm`/`default`/`cta`/`lg`/`icon`) in `buttonVariants` — never hand-size a button with `h-*`/`px-*`/`text-*` in `className`. Add a named `size` to the variant if you need a new one.


### PR DESCRIPTION
## What

`DESIGN.md` is the mandated source of truth for every visual decision — `CLAUDE.md` says to read it before any UI work. It had drifted from the code, and three of its statements sent a reader to things that do not exist. Verified every claim in the file against master; corrected the ones that were wrong, left the rest alone.

## Changes

**Theme** — three errors in one paragraph:
- "no system" — `app/layout.tsx:64` sets `enableSystem`, and `UserProfile`'s `THEME_MODES` offers Light / Dark / **System**.
- "Editor surfaces read light; the projects gallery reads dark" — nothing is forced. There is no `forcedTheme` and no `.dark` wrapper anywhere in `app/`; the gallery (`ProjectsList`) paints `bg-background text-foreground` off the same global theme as the editor.
- "a `ThemeToggle` lives in shared chrome" — no such component exists. The switcher is the Appearance submenu of the account dropdown in `UserProfile.tsx`.

**Texture** — `<Glow/>` does not exist either, and the real second treatment was undocumented: `.dot-grid-bg` (`globals.css:494`) is the page backdrop on `PrePromptView`, `PostPromptView`, `ProjectsList`, and `projects/[id]/loading.tsx`. The section now lists the two treatments actually in use, with where each one belongs and the positioning each needs.

**Components** — `icon` was listed as a button *variant*; it is a `size` (the line below already says so, so the file contradicted itself). The `generate` variant (its own `--generate` token family incl. the disabled state) and `link` were missing.

**Surfaces** — added `--element-card` and the `--panel-fg` / `--panel-label` pair. Element cards and side-panel sections are a distinct surface in the code (`PanelCard`, the canvas card, `InlineCopilot`) and the enumeration skipped them.

Net +10/−5, one file. No code touched, so no behavior change.

## Checks

`npm run lint`, `format:check`, `typecheck`, `build`, `npx knip`, and `npm test` (141 files / 1212 tests) all pass.

## Open PR overlap check

Considered #588 (`lib/api/handlers/video`, `lib/providers/video/runware`), #585 (`BottomDock`/`PlayerPanel`/`useResize`), #584 (transport + storyboard + `lib/video/sceneSegments`), #583 (timeline zoom, `lib/api/asset-bundle`), #582 (auth cluster, `components/ui/button`, `README.md`, `app/page.tsx`), #581 (`lib/generation/{graph,snapshots}`), #580 (sloppy agent — 90 files incl. `ARCHITECTURE.md`, `app/globals.css`, `components/ui/{button,icon,disclosure}`), #579 (RTL element direction), #573 (`BottomTransportBar`).

`DESIGN.md` is touched by none of them, and this PR changes no other file. Note that #582 and #580 own the two docs a design change would otherwise reach for (`README.md`, `ARCHITECTURE.md`) and both own `components/ui/button.tsx` — so this PR deliberately only *describes* the button variants on master and adds no `buttonVariants` entry of its own.

## Skipped, with reasons

- **Prop drilling in the bottom transport row** (`player`/`layout`/`segments`/`fps` into `SegmentedSeekBar`, `TimeDisplay`, `ScenePill` from a parent that reads them out of `PlayerControlContext` + `VideoLayoutContext`) — still the one substantial architecture item outstanding, still blocked: the fix is a rewrite of `BottomTransportBar`'s body, which is #573's diff.
- **The peaks-decode effect in `Waveform.tsx` vs `usePeaks` in `ClipWaveform.tsx`** — two sites, and `Waveform`'s variant additionally threads `peaksCache` and `loadedSrc`. Rule of three unmet; extracting now would add more than it removes.
- **`ScrubBar` has no `role="slider"` / `aria-value*` / keyboard handling**, so neither the seek bar nor the volume bar is keyboard-operable. Real, and both consumers would inherit one fix — but it is an added behavior, which this runbook excludes. Belongs to the bugs/a11y nightly.
- Swept and confirmed clean this pass, no change warranted: `lib/components/{peaks,soundwave,useElementWidth}` (new in #565, never audited — `useElementWidth`'s cleanup-returning callback ref is exactly right), `lib/providers/tts/cartesia.ts`, `lib/connectors/{factory,plugins,attributes/*}`, `lib/video/scene-builder.ts`, `lib/project/{store,storeSnapshot,ProjectStoreProvider}`, `lib/api/route-handler.ts`, the canvas hooks cluster, the captions panel cluster, `LayoutPanel`/`PropertiesPanel`/`PanelCard`, `ComposerCopilot`, `ProjectsList`, `AccessCodeInput`, `app/projects/[id]/loading.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)