### PR TITLE
feat(upload): drag and drop or paste images onto the composer

### DIFF
--- a/app/api/upload/image/route.ts
+++ b/app/api/upload/image/route.ts
@@ -3,11 +3,10 @@ import { z } from "zod";
 import { AssetBundle } from "@/lib/api/asset-bundle";
 import { imageFile } from "@/lib/api/request-schema-fields";
 import { createSessionFormRouteHandler } from "@/lib/api/route-handler";
-
-const MAX_SIZE = 10 * 1024 * 1024;
+import { MAX_IMAGE_UPLOAD_BYTES } from "@/lib/upload/imageFiles";
 
 const UploadImageForm = z.object(
-	{ file: imageFile(MAX_SIZE) },
+	{ file: imageFile(MAX_IMAGE_UPLOAD_BYTES) },
 	{ error: "No file provided" },
 );
 

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -43,6 +43,7 @@ import {
 	type VideoLength,
 } from "@/lib/video/videoLength";
 import { useImageUpload } from "@/lib/upload/useImageUpload";
+import { cn } from "@/lib/utils";
 import { useSloppy } from "@/app/components/sloppy/SloppyProvider";
 import { ActionButton } from "./ActionButton";
 import { ComposerAssets } from "./ComposerAssets";
@@ -199,8 +200,14 @@ export default function ComposerCopilot({
 		dialogs,
 	} = useAssetEditDialogs();
 
-	const { openPicker, uploading, uploadingCount, inputElement } =
-		useImageUpload({ multiple: true, onUpload: addReferenceImages });
+	const {
+		openPicker,
+		uploading,
+		uploadingCount,
+		inputElement,
+		dropZoneProps,
+		isDraggingOver,
+	} = useImageUpload({ multiple: true, onUpload: addReferenceImages });
 	const hasText = value.trim().length > 0;
 	const pasting = intent === "script";
 	const activeTemplate = pasting ? undefined : template;
@@ -216,7 +223,13 @@ export default function ComposerCopilot({
 	};
 
 	return (
-		<div className="w-full rounded-xl border border-accent/30 bg-card transition-shadow focus-within:shadow-elevation-5">
+		<div
+			{...dropZoneProps}
+			className={cn(
+				"relative w-full rounded-xl border bg-card transition-shadow focus-within:shadow-elevation-5",
+				isDraggingOver ? "border-accent" : "border-accent/30",
+			)}
+		>
 			<div className="px-4 py-3">
 				<div className="mb-3 flex justify-center">
 					<SegmentedControl
@@ -319,6 +332,11 @@ export default function ComposerCopilot({
 					/>
 				</div>
 			</div>
+			{isDraggingOver && (
+				<div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-xl bg-card/90 font-body text-body text-accent">
+					Drop images to add them as references
+				</div>
+			)}
 			{dialogs}
 		</div>
 	);

--- a/lib/upload/__tests__/imageFiles.test.ts
+++ b/lib/upload/__tests__/imageFiles.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { MAX_IMAGE_UPLOAD_BYTES, partitionImageFiles } from "../imageFiles";
+
+const makeFile = (name: string, type: string, size = 1) =>
+	new File([new Uint8Array(size)], name, { type });
+
+describe("partitionImageFiles", () => {
+	it("accepts image files under the size cap", () => {
+		const png = makeFile("a.png", "image/png");
+		const webp = makeFile("b.webp", "image/webp");
+
+		expect(partitionImageFiles([png, webp])).toEqual({
+			accepted: [png, webp],
+			rejected: [],
+		});
+	});
+
+	it("rejects non-image files", () => {
+		const pdf = makeFile("script.pdf", "application/pdf");
+
+		expect(partitionImageFiles([pdf])).toEqual({
+			accepted: [],
+			rejected: [{ name: "script.pdf", reason: "is not an image" }],
+		});
+	});
+
+	it("rejects images over the size cap", () => {
+		const huge = makeFile("huge.png", "image/png", MAX_IMAGE_UPLOAD_BYTES + 1);
+
+		expect(partitionImageFiles([huge])).toEqual({
+			accepted: [],
+			rejected: [{ name: "huge.png", reason: "is over 10 MB" }],
+		});
+	});
+
+	it("keeps the accepted files when only some are rejected", () => {
+		const ok = makeFile("ok.png", "image/png");
+		const bad = makeFile("bad.txt", "text/plain");
+
+		const { accepted, rejected } = partitionImageFiles([ok, bad, ok]);
+
+		expect(accepted).toEqual([ok, ok]);
+		expect(rejected).toHaveLength(1);
+	});
+
+	it("treats a file exactly at the cap as acceptable", () => {
+		const exact = makeFile("exact.png", "image/png", MAX_IMAGE_UPLOAD_BYTES);
+
+		expect(partitionImageFiles([exact]).accepted).toEqual([exact]);
+	});
+});

--- a/lib/upload/imageFiles.ts
+++ b/lib/upload/imageFiles.ts
@@ -1,0 +1,33 @@
+export const MAX_IMAGE_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+export interface RejectedImageFile {
+	name: string;
+	reason: string;
+}
+
+/**
+ * Mirrors the `imageFile` schema the upload route enforces, so a file the user
+ * drops is rejected with a message here rather than by a round trip.
+ */
+export function partitionImageFiles(files: File[]): {
+	accepted: File[];
+	rejected: RejectedImageFile[];
+} {
+	const accepted: File[] = [];
+	const rejected: RejectedImageFile[] = [];
+
+	for (const file of files) {
+		if (!file.type.startsWith("image/")) {
+			rejected.push({ name: file.name, reason: "is not an image" });
+		} else if (file.size > MAX_IMAGE_UPLOAD_BYTES) {
+			rejected.push({
+				name: file.name,
+				reason: `is over ${MAX_IMAGE_UPLOAD_BYTES / 1024 / 1024} MB`,
+			});
+		} else {
+			accepted.push(file);
+		}
+	}
+
+	return { accepted, rejected };
+}

--- a/lib/upload/useImageUpload.tsx
+++ b/lib/upload/useImageUpload.tsx
@@ -1,8 +1,29 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toastError } from "@/lib/toastError";
+import { partitionImageFiles } from "@/lib/upload/imageFiles";
 import { uploadImage } from "@/lib/upload/uploadImage";
+
+const carriesFiles = (data: DataTransfer) => data.types.includes("Files");
+
+/**
+ * Without this, a file dropped anywhere but a drop zone makes the browser
+ * navigate away from the app to open it.
+ */
+function useBlockStrayFileDrops() {
+	useEffect(() => {
+		const block = (e: DragEvent) => {
+			if (e.dataTransfer && carriesFiles(e.dataTransfer)) e.preventDefault();
+		};
+		window.addEventListener("dragover", block);
+		window.addEventListener("drop", block);
+		return () => {
+			window.removeEventListener("dragover", block);
+			window.removeEventListener("drop", block);
+		};
+	}, []);
+}
 
 export function useImageUpload({
 	onUpload,
@@ -13,10 +34,18 @@ export function useImageUpload({
 }) {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [uploadingCount, setUploadingCount] = useState(0);
+	const [isDraggingOver, setIsDraggingOver] = useState(false);
 
-	const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-		const files = Array.from(e.target.files ?? []);
+	useBlockStrayFileDrops();
+
+	const upload = async (candidates: File[]) => {
+		const { accepted, rejected } = partitionImageFiles(candidates);
+		for (const { name, reason } of rejected)
+			toastError(`${name} ${reason}`, "Not uploaded");
+
+		const files = multiple ? accepted : accepted.slice(0, 1);
 		if (files.length === 0) return;
+
 		setUploadingCount(files.length);
 		try {
 			const results = await Promise.allSettled(files.map(uploadImage));
@@ -28,6 +57,14 @@ export function useImageUpload({
 			if (urls.length > 0) onUpload(urls);
 		} finally {
 			setUploadingCount(0);
+		}
+	};
+
+	const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+		const files = Array.from(e.target.files ?? []);
+		try {
+			await upload(files);
+		} finally {
 			if (inputRef.current) inputRef.current.value = "";
 		}
 	};
@@ -43,10 +80,37 @@ export function useImageUpload({
 		/>
 	);
 
+	const dropZoneProps = {
+		onDragOver: (e: React.DragEvent) => {
+			if (!carriesFiles(e.dataTransfer)) return;
+			e.preventDefault();
+			e.dataTransfer.dropEffect = "copy";
+			setIsDraggingOver(true);
+		},
+		onDragLeave: (e: React.DragEvent) => {
+			if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+			setIsDraggingOver(false);
+		},
+		onDrop: (e: React.DragEvent) => {
+			if (!carriesFiles(e.dataTransfer)) return;
+			e.preventDefault();
+			setIsDraggingOver(false);
+			void upload(Array.from(e.dataTransfer.files));
+		},
+		onPaste: (e: React.ClipboardEvent) => {
+			const files = Array.from(e.clipboardData.files);
+			if (files.length === 0) return;
+			e.preventDefault();
+			void upload(files);
+		},
+	};
+
 	return {
 		openPicker: () => inputRef.current?.click(),
 		uploading: uploadingCount > 0,
 		uploadingCount,
 		inputElement,
+		dropZoneProps,
+		isDraggingOver,
 	};
 }

--- a/lib/upload/useImageUpload.tsx
+++ b/lib/upload/useImageUpload.tsx
@@ -46,7 +46,7 @@ export function useImageUpload({
 		const files = multiple ? accepted : accepted.slice(0, 1);
 		if (files.length === 0) return;
 
-		setUploadingCount(files.length);
+		setUploadingCount((n) => n + files.length);
 		try {
 			const results = await Promise.allSettled(files.map(uploadImage));
 			const urls: string[] = [];
@@ -56,7 +56,7 @@ export function useImageUpload({
 			}
 			if (urls.length > 0) onUpload(urls);
 		} finally {
-			setUploadingCount(0);
+			setUploadingCount((n) => n - files.length);
 		}
 	};
 


### PR DESCRIPTION
## Summary

Dragging an image file onto the composer did nothing (the browser navigated away to the file), and pasting an image did nothing either. Uploads were click-to-pick only.

This solves it once in `lib/upload` rather than as a one-off on the composer:

- `useImageUpload` now owns the `File[]` upload path, which both the hidden `<input>` change event and the new drop/paste handlers feed. It returns `dropZoneProps` and `isDraggingOver`, so the other consumers (`UploadImageButton`, `ReferenceImages`) can adopt drag-and-drop by spreading the same props, with no bespoke handlers.
- New `lib/upload/imageFiles.ts` holds the client-side gate: image MIME plus the 10MB cap. The upload route now imports `MAX_IMAGE_UPLOAD_BYTES` from there, so the limit has one home instead of two. Rejected files raise a toast naming the file and the reason, rather than being dropped silently.
- A window-level listener prevents the default only for drags carrying files, so a drop just outside the zone no longer navigates the app away, while dragging text into the textarea still works.
- `ComposerCopilot` spreads `dropZoneProps` on its root and shows a drop-target state while dragging: the existing accent border goes solid and a "Drop images to add them as references" overlay appears. Accent on focus/selection only, per `DESIGN.md`; no new tokens or one-off colors.

Uploading tiles keep using the existing `uploadingCount` shimmer in `ComposerAssets`, so dropped and pasted images surface there unchanged. The attach-menu click-to-pick flow is untouched.

## Selected issue and why it was safe

Picked #587 (`size: S`) because the acceptance criteria are explicit, the code area is small and self-contained, and no product or design decision is required. The only visual addition is a drop-target state built from existing tokens.

No XS issues qualified: the sole open one (#558) is already covered by open PR #573.

## Validation

- `npm run lint` — pass
- `npm run format:check` — pass
- `npm run typecheck` — pass
- `npm run knip` — pass
- `npm run build` — pass
- `npm run test:coverage` — 1217 tests, 142 files, all pass (5 new tests for `partitionImageFiles`)
- `npm run test:e2e` — 3 Playwright smoke tests pass

Drag/drop and paste behavior itself is not covered by an automated test; the new coverage is on the pure file-partition helper that decides what gets uploaded.

## Open PR overlap check

Checked all 10 open PRs with `gh pr diff --name-only`. Nothing touches `lib/upload/*`, `app/api/upload/*`, or `ComposerCopilot.tsx`. The nearest neighbor is #580, which touches `ComposerHero.tsx`, `copilot/InlineCopilot.tsx`, and `sloppy/SloppyComposer.tsx` — no shared files.

## Skipped as too large or decision-heavy

#254 (audio mix defaults: "narration up, character down" is unspecified, and `PlayerControls.tsx` overlaps PRs #584/#585), #461 (caption highlight styling is a design decision), and all remaining open issues, which are M/L/XL.

Closes #587