### PR TITLE
perf: nightly performance optimizations 2026-08-18

### DIFF
--- a/app/api/v1/__tests__/routes.test.ts
+++ b/app/api/v1/__tests__/routes.test.ts
@@ -20,11 +20,11 @@ vi.mock("@/lib/api/providers", () => ({
 
 const mockCreateJob = vi.fn();
 const mockEnqueueJob = vi.fn();
-const mockGetJob = vi.fn();
+const mockGetJobPoll = vi.fn();
 vi.mock("@/lib/api/jobs", () => ({
 	createJob: (...args: unknown[]) => mockCreateJob(...args),
 	enqueueJob: (...args: unknown[]) => mockEnqueueJob(...args),
-	getJob: (...args: unknown[]) => mockGetJob(...args),
+	getJobPoll: (...args: unknown[]) => mockGetJobPoll(...args),
 }));
 
 vi.mock("@/lib/api/logger", () => ({
@@ -267,8 +267,8 @@ describe("API routes", () => {
 	describe("GET /api/v1/video/[jobId]", () => {
 		it("returns job status", async () => {
 			const { GET } = await import("@/app/api/v1/video/[jobId]/route");
-			mockGetJob.mockResolvedValue({
-				id: "j1",
+			mockGetJobPoll.mockResolvedValue({
+				jobId: "j1",
 				status: "completed",
 				result: { id: "x", provider: "p", result: { video: "v.mp4" } },
 				error: null,
@@ -285,7 +285,7 @@ describe("API routes", () => {
 
 		it("returns 404 when job is missing", async () => {
 			const { GET } = await import("@/app/api/v1/video/[jobId]/route");
-			mockGetJob.mockResolvedValue(null);
+			mockGetJobPoll.mockResolvedValue(null);
 
 			const req = makeRequest("/api/v1/video/j1", undefined, "GET");
 			const res = await GET(req, { params: Promise.resolve({ jobId: "j1" }) });
@@ -294,7 +294,7 @@ describe("API routes", () => {
 
 		it("returns 500 on lookup error", async () => {
 			const { GET } = await import("@/app/api/v1/video/[jobId]/route");
-			mockGetJob.mockRejectedValue(new Error("db error"));
+			mockGetJobPoll.mockRejectedValue(new Error("db error"));
 
 			const req = makeRequest("/api/v1/video/j1", undefined, "GET");
 			const res = await GET(req, { params: Promise.resolve({ jobId: "j1" }) });

--- a/app/components/canvas/elements/ForegroundPreview.tsx
+++ b/app/components/canvas/elements/ForegroundPreview.tsx
@@ -1,15 +1,20 @@
+import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
 import { ELEMENT_TYPES, type CanvasContentElement } from "@/lib/canvas/types";
-import { useGenerate } from "../hooks/useGenerate";
 import { PlaceholderBallsLoader } from "./preview/placeholderBalls";
 import { MediaWithSkeleton } from "./MediaWithSkeleton";
 import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 
+// Mounted once per scene by both the storyboard and the collapsed canvas, and
+// read-only: it takes the element's snapshot straight off the queue rather than
+// `useGenerate`, whose node graph and restore effect belong to the element card.
 export function ForegroundPreview({
 	element,
 }: {
 	element: CanvasContentElement;
 }) {
-	const { result, status } = useGenerate(element);
+	const { result, status } = useQueueSelector((queue) =>
+		queue.getElementSnapshot(element.id),
+	);
 	const { outputKind } = ELEMENT_TYPES[element.type];
 	const url = getPrimaryUrl(result, outputKind);
 

--- a/lib/api/__tests__/jobs.test.ts
+++ b/lib/api/__tests__/jobs.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getJobPoll } from "../jobs";
+
+const maybeSingle = vi.fn();
+const select = vi.fn();
+const from = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: async () => ({ from }),
+}));
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	const filtered = { eq: vi.fn(() => filtered), maybeSingle };
+	select.mockReturnValue(filtered);
+	from.mockReturnValue({ select });
+	maybeSingle.mockResolvedValue({ data: null, error: null });
+});
+
+describe("getJobPoll", () => {
+	it("reads only the columns the poll exposes", async () => {
+		await getJobPoll("job-1", "user-1");
+		expect(select).toHaveBeenCalledWith("id, status, result, error");
+	});
+
+	it("returns the poll view of the row", async () => {
+		maybeSingle.mockResolvedValue({
+			data: {
+				id: "job-1",
+				status: "completed",
+				result: { id: "asset-1" },
+				error: null,
+			},
+			error: null,
+		});
+		await expect(getJobPoll("job-1", "user-1")).resolves.toEqual({
+			jobId: "job-1",
+			status: "completed",
+			result: { id: "asset-1" },
+			error: null,
+		});
+	});
+
+	it("returns null when no job matches", async () => {
+		await expect(getJobPoll("job-1", "user-1")).resolves.toBeNull();
+	});
+
+	it("throws when the read fails", async () => {
+		maybeSingle.mockResolvedValue({ data: null, error: { message: "boom" } });
+		await expect(getJobPoll("job-1", "user-1")).rejects.toThrow("boom");
+	});
+});

--- a/lib/api/jobs.ts
+++ b/lib/api/jobs.ts
@@ -3,7 +3,7 @@ import isUndefined from "lodash/isUndefined";
 import omitBy from "lodash/omitBy";
 import type { BundleResponse } from "@/lib/api/asset-bundle";
 import type { ConnectorType } from "@/lib/connectors/types";
-import type { JobStatus } from "@/lib/gateway/base";
+import type { JobPoll, JobStatus } from "@/lib/gateway/base";
 import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/service";
 
@@ -50,19 +50,31 @@ export async function createJob(input: {
 	return { id: data.id };
 }
 
-export async function getJob(
+/**
+ * The polled view of a job, read as the columns it serves. A job is polled once
+ * a second until it settles, and `request` holds the whole generation payload,
+ * reference images inlined as data URIs included.
+ */
+export async function getJobPoll(
 	jobId: string,
 	userId: string,
-): Promise<JobRow | null> {
+): Promise<JobPoll | null> {
 	const supabase = await createClient();
 	const { data, error } = await supabase
 		.from("jobs")
-		.select("*")
+		.select("id, status, result, error")
 		.eq("id", jobId)
 		.eq("user_id", userId)
 		.maybeSingle();
 	if (error) throw new Error(`Failed to load job: ${error.message}`);
-	return (data as JobRow) ?? null;
+	if (!data) return null;
+	const row = data as Pick<JobRow, "id" | "status" | "result" | "error">;
+	return {
+		jobId: row.id,
+		status: row.status,
+		result: row.result,
+		error: row.error,
+	};
 }
 
 export async function loadJobForProcessing(jobId: string): Promise<JobRow> {

--- a/lib/api/route-handler.ts
+++ b/lib/api/route-handler.ts
@@ -3,8 +3,7 @@ import type { User } from "@supabase/supabase-js";
 import { z } from "zod";
 import type { ConnectorType } from "@/lib/connectors/types";
 import { withApiAccess, withPublic, withSession } from "./with-auth";
-import type { JobPoll } from "@/lib/gateway/base";
-import { createJob, enqueueJob, getJob } from "./jobs";
+import { createJob, enqueueJob, getJobPoll } from "./jobs";
 import {
 	parseBody,
 	parseFormData,
@@ -124,14 +123,9 @@ export async function pollJob(
 	return withApiAccess("Job poll", async (user) => {
 		const { jobId } = await context.params;
 		if (!jobId) return badRequest("jobId is required");
-		const job = await getJob(jobId, user.id);
-		if (!job) return NextResponse.json({ error: "Not found" }, { status: 404 });
-		const view: JobPoll = {
-			jobId: job.id,
-			status: job.status,
-			result: job.result,
-			error: job.error,
-		};
+		const view = await getJobPoll(jobId, user.id);
+		if (!view)
+			return NextResponse.json({ error: "Not found" }, { status: 404 });
 		return NextResponse.json(view);
 	});
 }


### PR DESCRIPTION
Two repeating read paths that pulled far more than they used. No behavior changes.

## Scene preview off the element card's generation hook

`ForegroundPreview` is mounted once per scene by the storyboard and again by every collapsed scene in the canvas, and each instance called `useGenerate`. That hook builds the element's generation node graph from project state on every render, runs a recursive `isNodeStale` walk on every queue notification (which the elapsed ticker fires once a second while anything is generating), and owns a `restoreResult` effect that the element's own card already runs.

The preview only reads `result` and `status`, so it now subscribes to the element's snapshot directly via `useQueueSelector`. On a 20-scene project with the storyboard open, that drops 20 node-graph builds per render and 20 staleness walks per tick, and removes the duplicated restore effects. This is the same consolidation PR #443 did for the element cards; the preview was the last direct `useGenerate` caller outside `ElementGenerationProvider`.

Matches the Slate performance walkthrough's guidance on not subscribing unmodified elements to state they don't read.

## Job poll reads the columns it serves

`getJob` ran `select("*")` and `pollJob` then projected four fields out of the row. Assets are polled once a second until they settle, up to the per-type concurrency limits at once, so every poll dragged the whole `request` payload (and `metadata`) back out of Postgres and threw it away. `referenceImages` and `frameImages` accept data URIs, so that column is unbounded.

`getJob` is now `getJobPoll`, returning the typed `JobPoll` view straight from a four-column read, so the query and the response shape have one home and cannot drift apart again. Covered by a new `lib/api/__tests__/jobs.test.ts`.

## Open PR overlap check

Considered open PRs #592, #590, #589, #588, #585, #584, #583, #582, #581, #580, #579, #573 and diffed their file lists against this one. No file, module, or theme here is touched by any of them: they cover the video/timeline/transport components, `lib/video`, `lib/generation/graph`, the upload flow, the agent, auth pages, and `DESIGN.md`.

## Skipped

- Splitting `captionStyle` out of the `useVideoLayout` memo. It is a pure passthrough into `VideoLayout`, but the layout object identity changes either way, so the downstream re-derivations still run and the saved work is not worth the split.
- Caching the timeline scroller's bounding rect across pointer moves. Real forced-layout read per move, but too small to justify on its own.
- Memoizing `needsGeneration` over shared graph nodes. It re-walks shared subgraphs, but the win is fractions of a millisecond and it would be a cache shim.

## Checks

`npm run lint`, `format:check`, `typecheck`, `knip`, `build`, `test:run` (1216 passing) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)