### PR TITLE
fix: nightly security audit 2026-08-20

### DIFF
--- a/app/api/queues/asset-generate/route.ts
+++ b/app/api/queues/asset-generate/route.ts
@@ -1,5 +1,7 @@
 import { handleCallback } from "@vercel/queue";
-import type { AssetQueueMessage } from "@/lib/api/jobs";
 import { processQueuedJob } from "@/lib/api/process-job";
+import { parseAssetQueueCallback } from "@/lib/api/queue-callback";
 
-export const POST = handleCallback<AssetQueueMessage>(processQueuedJob);
+export const POST = handleCallback((message: unknown) =>
+	processQueuedJob(parseAssetQueueCallback(message)),
+);

--- a/lib/api/__tests__/process-job.test.ts
+++ b/lib/api/__tests__/process-job.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AssetQueueMessage } from "@/lib/api/jobs";
 import { JOB_TIMEOUT_MS } from "@/lib/gateway/base";
 
 const mockLoadJobForProcessing = vi.fn();
@@ -23,7 +22,7 @@ vi.mock("@/lib/api/logger", () => ({
 
 const { processQueuedJob } = await import("@/lib/api/process-job");
 
-const message: AssetQueueMessage = { jobId: "job-1", connectorType: "image" };
+const JOB_ID = "job-1";
 
 function stubPendingHandler(metadata: Record<string, unknown> = {}) {
 	mockGetJobHandler.mockReturnValue({
@@ -35,6 +34,7 @@ function pendingJob(ageMs = 0) {
 	return {
 		status: "pending",
 		id: "job-1",
+		connector_type: "image",
 		created_at: new Date(Date.now() - ageMs).toISOString(),
 	};
 }
@@ -49,7 +49,7 @@ describe("processQueuedJob", () => {
 	it("skips jobs that already completed", async () => {
 		mockLoadJobForProcessing.mockResolvedValue({ status: "completed" });
 
-		await processQueuedJob(message);
+		await processQueuedJob(JOB_ID);
 
 		expect(mockGetJobHandler).not.toHaveBeenCalled();
 		expect(mockUpdateJob).not.toHaveBeenCalled();
@@ -58,7 +58,7 @@ describe("processQueuedJob", () => {
 	it("skips jobs that already failed", async () => {
 		mockLoadJobForProcessing.mockResolvedValue({ status: "failed" });
 
-		await processQueuedJob(message);
+		await processQueuedJob(JOB_ID);
 
 		expect(mockGetJobHandler).not.toHaveBeenCalled();
 		expect(mockUpdateJob).not.toHaveBeenCalled();
@@ -68,7 +68,7 @@ describe("processQueuedJob", () => {
 		mockLoadJobForProcessing.mockResolvedValue(pendingJob());
 		mockGetJobHandler.mockReturnValue(undefined);
 
-		await expect(processQueuedJob(message)).rejects.toThrow(
+		await expect(processQueuedJob(JOB_ID)).rejects.toThrow(
 			"No job handler registered for image",
 		);
 		expect(mockUpdateJob).not.toHaveBeenCalled();
@@ -84,7 +84,7 @@ describe("processQueuedJob", () => {
 		};
 		mockGetJobHandler.mockReturnValue(handler);
 
-		await processQueuedJob(message);
+		await processQueuedJob(JOB_ID);
 
 		expect(handler.process).toHaveBeenCalledWith(job);
 		expect(mockUpdateJob).toHaveBeenNthCalledWith(1, "job-1", {
@@ -100,7 +100,7 @@ describe("processQueuedJob", () => {
 		mockLoadJobForProcessing.mockResolvedValue(pendingJob());
 		stubPendingHandler({ poll: "token" });
 
-		await processQueuedJob(message);
+		await processQueuedJob(JOB_ID);
 
 		expect(mockUpdateJob).toHaveBeenNthCalledWith(2, "job-1", {
 			metadata: { poll: "token" },
@@ -115,7 +115,7 @@ describe("processQueuedJob", () => {
 		});
 		stubPendingHandler({ providerJobId: "upstream-1" });
 
-		await processQueuedJob(message);
+		await processQueuedJob(JOB_ID);
 
 		expect(mockUpdateJob).not.toHaveBeenCalled();
 		expect(mockEnqueueJob).toHaveBeenCalled();
@@ -125,7 +125,7 @@ describe("processQueuedJob", () => {
 		mockLoadJobForProcessing.mockResolvedValue(pendingJob());
 		stubPendingHandler();
 
-		await processQueuedJob(message);
+		await processQueuedJob(JOB_ID);
 
 		expect(mockEnqueueJob).toHaveBeenCalledWith("job-1", "image", {
 			delaySeconds: expect.any(Number),
@@ -138,7 +138,7 @@ describe("processQueuedJob", () => {
 			process: vi.fn().mockResolvedValue({ kind: "completed", result: {} }),
 		});
 
-		await processQueuedJob(message);
+		await processQueuedJob(JOB_ID);
 
 		expect(mockEnqueueJob).not.toHaveBeenCalled();
 	});
@@ -148,9 +148,7 @@ describe("processQueuedJob", () => {
 		stubPendingHandler();
 		mockEnqueueJob.mockRejectedValue(new Error("queue unavailable"));
 
-		await expect(processQueuedJob(message)).rejects.toThrow(
-			"queue unavailable",
-		);
+		await expect(processQueuedJob(JOB_ID)).rejects.toThrow("queue unavailable");
 		expect(mockUpdateJob).not.toHaveBeenCalledWith(
 			"job-1",
 			expect.objectContaining({ status: "failed" }),
@@ -163,7 +161,7 @@ describe("processQueuedJob", () => {
 		);
 		stubPendingHandler();
 
-		await processQueuedJob(message);
+		await processQueuedJob(JOB_ID);
 
 		expect(mockEnqueueJob).not.toHaveBeenCalled();
 		expect(mockUpdateJob).toHaveBeenCalledWith("job-1", {
@@ -183,7 +181,7 @@ describe("processQueuedJob", () => {
 		};
 		mockGetJobHandler.mockReturnValue(handler);
 
-		await processQueuedJob(message);
+		await processQueuedJob(JOB_ID);
 
 		expect(handler.process).toHaveBeenCalled();
 		expect(mockUpdateJob).toHaveBeenLastCalledWith("job-1", {
@@ -198,10 +196,25 @@ describe("processQueuedJob", () => {
 			process: vi.fn().mockRejectedValue(new Error("provider down")),
 		});
 
-		await expect(processQueuedJob(message)).rejects.toThrow("provider down");
+		await expect(processQueuedJob(JOB_ID)).rejects.toThrow("provider down");
 		expect(mockUpdateJob).toHaveBeenNthCalledWith(2, "job-1", {
 			status: "failed",
 			error: expect.stringContaining("provider down"),
+		});
+	});
+
+	it("picks the handler from the job row's connector type", async () => {
+		mockLoadJobForProcessing.mockResolvedValue({
+			...pendingJob(),
+			connector_type: "tts",
+		});
+		stubPendingHandler();
+
+		await processQueuedJob(JOB_ID);
+
+		expect(mockGetJobHandler).toHaveBeenCalledWith("tts");
+		expect(mockEnqueueJob).toHaveBeenCalledWith("job-1", "tts", {
+			delaySeconds: expect.any(Number),
 		});
 	});
 });

--- a/lib/api/__tests__/queue-callback.test.ts
+++ b/lib/api/__tests__/queue-callback.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { parseAssetQueueCallback } from "@/lib/api/queue-callback";
+
+const JOB_ID = "1f5b0d1e-6c4a-4f0e-9a2b-8e7c3d5a1b90";
+
+describe("parseAssetQueueCallback", () => {
+	it("returns the job id from a well-formed message", () => {
+		expect(parseAssetQueueCallback({ jobId: JOB_ID })).toBe(JOB_ID);
+	});
+
+	it("ignores extra fields a caller attaches to the message", () => {
+		expect(
+			parseAssetQueueCallback({ jobId: JOB_ID, connectorType: "video" }),
+		).toBe(JOB_ID);
+	});
+
+	it.each([
+		undefined,
+		null,
+		"",
+		{},
+		{ jobId: "" },
+		{ jobId: "not-a-uuid" },
+		{ jobId: { toString: (): string => JOB_ID } },
+		{ jobId: [JOB_ID] },
+	])("rejects %o", (message) => {
+		expect(() => parseAssetQueueCallback(message)).toThrow(
+			"Rejected asset queue callback: malformed message",
+		);
+	});
+});

--- a/lib/api/process-job.ts
+++ b/lib/api/process-job.ts
@@ -2,7 +2,6 @@ import isEqual from "lodash/isEqual";
 import { stringifyError } from "@/lib/errors";
 import { isTerminal, JOB_TIMEOUT_MS } from "@/lib/gateway/base";
 import { getJobHandler } from "./job-handlers";
-import type { AssetQueueMessage } from "./jobs";
 import { enqueueJob, loadJobForProcessing, updateJob } from "./jobs";
 import { logger } from "./logger";
 
@@ -13,13 +12,11 @@ const PENDING_RETRY_SECONDS = 5;
  * working return `pending`, and the job is redelivered to this same function
  * until it completes or outlives the deadline.
  */
-export async function processQueuedJob({
-	jobId,
-	connectorType,
-}: AssetQueueMessage): Promise<void> {
+export async function processQueuedJob(jobId: string): Promise<void> {
 	const job = await loadJobForProcessing(jobId);
 	if (isTerminal(job.status)) return;
 
+	const connectorType = job.connector_type;
 	const handler = getJobHandler(connectorType);
 	if (!handler) {
 		throw new Error(`No job handler registered for ${connectorType}`);

--- a/lib/api/queue-callback.ts
+++ b/lib/api/queue-callback.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+// `handleCallback` does not authenticate the delivery, so treat the message as
+// untrusted input: keep only the server-issued job id and read the rest of the
+// job from its row.
+const AssetQueueCallback = z.object({ jobId: z.uuid() });
+
+export function parseAssetQueueCallback(message: unknown): string {
+	const parsed = AssetQueueCallback.safeParse(message);
+	if (!parsed.success) {
+		throw new Error("Rejected asset queue callback: malformed message");
+	}
+	return parsed.data.jobId;
+}


### PR DESCRIPTION
Fixes one real, unauthenticated-reachable issue in the asset-generate queue callback route. Behavior is otherwise unchanged.

## The issue

`app/api/queues/asset-generate/route.ts` passed the raw callback body to `processQueuedJob`, and `@vercel/queue` does not authenticate the delivery. Reading the shipped `dist/index.js` (v0.1.7), `handleCallback` → `parseCallback` → `ConsumerGroup.processMessage` invokes the handler before any ack, with no signature, HMAC, JWT, or OIDC check on the inbound path. The v2beta binary path declared in `vercel.json` takes its queue/consumer-group/message-id/receipt-handle entirely from request headers.

So an unauthenticated `POST /api/queues/asset-generate` with the right `ce-*` headers drove `processQueuedJob` with an attacker-chosen `jobId` **and** `connectorType`, reaching `loadJobForProcessing` (service-role client, bypasses RLS) and then a paid provider. The `connectorType` half needs no knowledge of any job id, so a caller could run a job through the wrong handler.

## The fix

- New `lib/api/queue-callback.ts`: `parseAssetQueueCallback` zod-parses the untrusted message down to a single field, `jobId`, required to be a UUID, and throws loudly otherwise. Everything else the caller sends is discarded.
- `lib/api/process-job.ts`: `processQueuedJob(jobId)` reads `connector_type` from the job row instead of the message, removing the handler-confusion primitive.

Net effect: a forged callback can do nothing a legitimate redelivery wouldn't, and only for a job whose server-issued UUIDv4 the caller already knows.

## Deliberately not done

A true delivery authenticator. The only forgery-proof option is a shared secret attached at send time via `SendOptions.headers` and verified in the callback parser, but the send side is `enqueueJob` in `lib/api/jobs.ts`, which open PR #593 already touches. `QueueClient`'s public surface (`send`/`handleCallback`/`handleNodeCallback`) offers no way to validate a receipt handle against the Queue Service. Stripping the receipt handle to force a `receiveMessageById` refetch was rejected: Vercel has already leased the message when it pushes, so that would likely throw `MessageLockedError` and break real deliveries.

**Follow-up once #593 lands:** add a `x-openslop-queue-secret` header in `enqueueJob` and verify it in `lib/api/queue-callback.ts` (confirm VQS replays custom headers on delivery first), or restrict the route at the Vercel firewall.

## Rest of the audit, nothing else actionable

- Dependencies: skipped entirely, open PR #595 covers the same `npm audit` / Dependabot set on `package.json` + `package-lock.json`.
- No `dangerouslySetInnerHTML`, `eval`, `new Function`, or `innerHTML` anywhere.
- No open redirects: every `NextResponse.redirect` uses a constant path or the `request.url` origin; `/auth/callback` takes no `next` param.
- SSRF: `lib/providers/tts/voicePreview.ts` enforces an HTTPS origin allow-list with `redirect: "manual"`; `asset-bundle.ts` fetches provider-issued URLs only.
- Secrets: clean scan (no `sk-`, `sb_secret_`, JWT, or `AKIA` literals); only `.env.example` is tracked and it holds no values.
- `NEXT_PUBLIC_*`: Supabase URL/anon key and blob base URL only, all genuinely public. `SUPABASE_SECRET_KEY` is server-only and throws if missing.
- Route auth: every `/api/v1/*` route goes through `withApiAccess`; `[jobId]` routes delegate to `pollJob`, scoped by `user.id`. `/api/dev/impersonate` 404s in production. `/api/validate-code` is intentionally public and leaks nothing.
- Headers: `next.config.ts` already ships nosniff, SAMEORIGIN, HSTS preload, strict-origin-when-cross-origin. No CSP; adding one to an app with inline runtime scripts is the speculative hardening this pass excludes, so it is flagged rather than changed.
- RLS: all four tables enabled with owner-scoped policies; `validate_access_code` is `security definer` with `set search_path = ''`.

## Validation

`lint`, `format:check`, `typecheck`, `knip`, `build`, and `test` (142 files, 1279 tests) all pass. Playwright e2e not run locally (needs a live app and Supabase env); this change is server-side with no UI or route-shape impact, so CI covers it.

## Open PR overlap check

Considered open PRs #581, #590, #592, #593, #595, #602. This PR touches `app/api/queues/asset-generate/route.ts`, `lib/api/process-job.ts`, `lib/api/queue-callback.ts`, and two test files, none of which any open PR modifies. The two findings whose fixes would have landed in overlapping files (`lib/api/jobs.ts` per #593, and the dependency set per #595) were deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)