### PR TITLE
perf: nightly performance optimizations 2026-08-20

### DIFF
--- a/lib/canvas/__tests__/editorOps.test.ts
+++ b/lib/canvas/__tests__/editorOps.test.ts
@@ -33,9 +33,9 @@ function scene(children: CanvasContentElement[], id = "s1"): SceneElement {
 	return { id, type: "scene", children };
 }
 
-function makeEditor(scenes: SceneElement[]) {
+function makeEditor(nodes: (SceneElement | CanvasContentElement)[]) {
 	const editor = createEditor();
-	editor.children = scenes;
+	editor.children = nodes;
 	return editor;
 }
 
@@ -59,6 +59,15 @@ describe("findNodeById", () => {
 	it("does not match scene elements", () => {
 		const editor = makeEditor([scene([content("narration", "n1")], "s1")]);
 		expect(findNodeById(editor, "s1")).toBeNull();
+	});
+
+	// `withScenes` wraps these into a scene, so they exist only mid-normalization.
+	it("finds content sitting at the top level", () => {
+		const editor = makeEditor([
+			scene([content("narration", "n1")], "s1"),
+			content("image", "img1"),
+		]);
+		expect(findNodeById(editor, "img1")?.[1]).toEqual([1]);
 	});
 });
 

--- a/lib/canvas/editorOps.ts
+++ b/lib/canvas/editorOps.ts
@@ -2,29 +2,43 @@ import { Editor, Element, type NodeEntry, Path, Transforms } from "slate";
 import type { CanvasContentElement, CanvasElement } from "@/lib/canvas/types";
 import { withoutCaretMarker, ZERO_WIDTH_SPACE } from "./constants";
 import { isContentElement } from "./guards";
+import { isSceneElement } from "./scenes";
 import { makeNodeId } from "./nodeUtils";
 
-/** Any canvas element by id — scenes included. Use {@link findNodeById} when only content will do. */
+/**
+ * Any canvas element by id — scenes included. Use {@link findNodeById} when only
+ * content will do.
+ *
+ * Elements only ever sit at the top level or one scene down, so this walks those
+ * two levels instead of a generic Slate traversal, which descends into every
+ * text leaf in the document before it can rule one out.
+ */
 export function findElementById(
 	editor: Editor,
 	id: string,
 ): NodeEntry<CanvasElement> | null {
-	const [entry] = Editor.nodes<CanvasElement>(editor, {
-		at: [],
-		match: (n) => Element.isElement(n) && n.id === id,
-	});
-	return entry ?? null;
+	const nodes = editor.children;
+	for (let i = 0; i < nodes.length; i++) {
+		const node = nodes[i];
+		if (!Element.isElement(node)) continue;
+		if (node.id === id) return [node, [i]];
+		if (!isSceneElement(node)) continue;
+		for (let j = 0; j < node.children.length; j++) {
+			const child = node.children[j];
+			if (child.id === id) return [child, [i, j]];
+		}
+	}
+	return null;
 }
 
 export function findNodeById(
 	editor: Editor,
 	id: string,
 ): NodeEntry<CanvasContentElement> | null {
-	const [entry] = Editor.nodes<CanvasContentElement>(editor, {
-		at: [],
-		match: (n) => isContentElement(n) && n.id === id,
-	});
-	return entry ?? null;
+	const entry = findElementById(editor, id);
+	if (!entry) return null;
+	const [node, path] = entry;
+	return isContentElement(node) ? [node, path] : null;
 }
 
 /**


### PR DESCRIPTION
## What

Resolving a canvas element by its id walked the entire document.

`findElementById` / `findNodeById` ran `Editor.nodes(editor, { at: [] })`, which descends recursively into every node — including every text leaf of every element — running the match predicate and allocating a `NodeEntry` for each, until it hits the one it wants or runs out of document. The canvas document shape rules that work out by construction: `CanvasElement = SceneElement | CanvasContentElement`, a scene's children are content elements, and a content element's children are text. Elements only ever sit at the top level or one scene down.

Both functions now walk those two levels. `findNodeById` is `findElementById` narrowed to content, so the traversal has one home.

## Why it matters

The lookup sits on four repeating paths:

- **Script streaming** (`useScriptSync`) — up to three lookups per streamed chunk, and the targets are the nodes just appended at the *end* of the document, i.e. the worst case for a forward scan. Cost grows with the script as it streams in.
- **Drag-over** (`useDragAndDrop.handleDragOver`) — one lookup per pointer move for the whole drag.
- **Drag end** (`moveDraggedElement`) — two lookups.
- **Agent refine ops** (`lib/script/refine/applyOps`) — one to three per op, so a multi-op edit was quadratic in document size.

Measured on synthetic canvas documents (Node 22, warm, 500 iterations per measurement, µs per lookup):

| elements | target | `Editor.nodes` | two-level walk |
|---|---|---|---|
| 50 | tail | 173.9 | 5.9 |
| 50 | miss | 132.4 | 2.6 |
| 200 | tail | 441.5 | 10.0 |
| 200 | middle | 287.5 | 5.5 |
| 200 | miss | 430.3 | 8.9 |
| 500 | tail | 1072.0 | 23.8 |
| 500 | middle | 519.6 | 12.1 |
| 500 | miss | 1013.5 | 22.4 |

~45x, and it holds for the miss case, which is what `handleDragOver` hits whenever the pointer is over something that is not a canvas element.

In app terms, on a 200-element slop: streaming drops from ~1.3 ms of scanning per chunk to ~0.03 ms, and a drag stops spending ~0.3 ms per pointer move in a document walk. At 500 elements those are ~3.2 ms per chunk and ~0.5 ms per move.

No behavior change: ids are unique, so the first match is the same node either way. `findNodeById` still returns `null` for a scene or a text leaf.

## Tests

Existing `editorOps` coverage already pins the contract (content by id, scene by id, no text leaves, no scenes from `findNodeById`, misses). Added one case for content sitting at the top level, which is what the document looks like mid-normalization before `withScenes` wraps it.

## Skipped

- **Slate chunking (`getChunkSize` / `renderChunk`)**, the walkthrough's headline. Re-checked against `slate-react`'s implementation: `groupIntoChunks` picks depth from the child count, so at the recommended size of 1000 our ~40 top-level scenes get a flat chunk tree and no memoization win. Getting a win at our sizes needs a small chunk size, which nests chunk `<div>`s into the editor and breaks the `first:border-t-0` rule on `SortableScene`. The paint half is already covered — `.scene` carries `content-visibility: auto`.
- **`useNodeBuilder`'s whole-store subscription.** Real fanout — every element card rebuilds its generation node on any project-store write — but decoupling it means node staleness stops refreshing on project state changes unless a new subscription seam replaces it. That is the ground PR #577 covered.
- **`pointerWithin` collision detection** over every registered droppable. O(N) rect intersection per pointer move, but it is dnd-kit's own scheduling, not ours.
- **Remotion's per-frame path** (`MotionLayer`, `Captions`, `VideoComposition`) and the OSML stream parser were read and left alone; both are already tight.

## Open PR overlap check

Considered #604, #603, #602, #595, #593, #592, #590, #581 and diffed their file lists against this one. This PR touches `lib/canvas/editorOps.ts` and its test. #592 is the closest neighbour — it edits `lib/canvas/parseXmlTag.ts` and two test files in the same directory — but not `editorOps`. No file or theme here appears in any open PR.

## Checks

`lint`, `format:check`, `typecheck`, `knip`, `build`, `test:run` (141 files, 1269 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)