### PR TITLE
refactor: nightly conventions audit 2026-08-20

### DIFF
--- a/lib/agent/tools/outlineStory.ts
+++ b/lib/agent/tools/outlineStory.ts
@@ -1,10 +1,8 @@
 import dedent from "dedent";
 import { z } from "zod";
 import { spokenLanguage } from "@/lib/script/prompt/language";
+import { outlinePrompt } from "@/lib/script/prompt/outline";
 import { defineTool } from "./defineTool";
-
-const outlinePrompt = (brief: string, language: string) =>
-	dedent`Outline an engaging story with a high-concept premise, characters, themes, conflict, twists, and a resolution. The story should be about the following: ${brief}. Write the outline in ${language}. Do not write anything else, just the outline.`;
 
 export const outlineStory = defineTool({
 	description: dedent`

--- a/lib/providers/__tests__/mock-llm.test.ts
+++ b/lib/providers/__tests__/mock-llm.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { outlinePrompt } from "@/lib/script/prompt/outline";
+import { MockLLM } from "../llm/mock";
+
+describe("MockLLM", () => {
+	it("answers an outline prompt with an outline, not a script", async () => {
+		const { text } = await new MockLLM().generate({
+			prompt: outlinePrompt("two friends in a forest", "English"),
+		});
+
+		expect(text).toContain("Premise:");
+		expect(text).not.toContain("<metadata_title>");
+	});
+
+	it("falls back to a script for anything else", async () => {
+		const { text } = await new MockLLM().generate({
+			prompt: "write me a video",
+		});
+
+		expect(text).toContain("<metadata_title>");
+	});
+});

--- a/lib/providers/llm/mock.ts
+++ b/lib/providers/llm/mock.ts
@@ -7,6 +7,7 @@ import type {
 	LLMGenerateParams,
 	LLMGenerateResult,
 } from "@/lib/connectors/types";
+import { OUTLINE_INSTRUCTION } from "@/lib/script/prompt/outline";
 import { matchAnimateImagePrompt } from "@/lib/script/refine/animatePrompt";
 import type { AgentModel } from "./agentModel";
 
@@ -104,9 +105,6 @@ const MOCK_SCRIPT = `<metadata_title>Little Red</metadata_title>
 const MOCK_STYLE =
 	"Warm, painterly storybook illustration with soft watercolor washes, gentle outlines, and golden hour lighting; whimsical and nostalgic.";
 
-const MOCK_CHARACTER_APPEARANCE =
-	"A cheerful young person with warm brown skin, dark curly hair, bright expressive eyes, wearing a simple colorful outfit; soft painterly storybook style.";
-
 const MOCK_OUTLINE = `Premise: In a village at the edge of an enchanted forest, a cheerful girl named Red sets out to deliver vegetables to her ailing grandmother and unexpectedly befriends a gentle, vegetarian wolf gathering berries for his own sick mother.
 
 Characters: Red (curious, kind); Wolf (gentle, misunderstood); Mother and Granny (warm anchors of home); Hunter (a watchful protector); Owl (the forest's quiet conscience).
@@ -128,11 +126,7 @@ const MOCK_RESPONSES: {
 		respond: () => MOCK_STYLE,
 	},
 	{
-		matches: (p) => /describe the visual appearance of the character/i.test(p),
-		respond: () => MOCK_CHARACTER_APPEARANCE,
-	},
-	{
-		matches: (p) => p.startsWith("Briefly outline an engaging story"),
+		matches: (p) => p.startsWith(OUTLINE_INSTRUCTION),
 		respond: () => MOCK_OUTLINE,
 	},
 ];

--- a/lib/script/prompt/outline.ts
+++ b/lib/script/prompt/outline.ts
@@ -1,0 +1,5 @@
+/** The instruction the outline opens with, so the mock can recognise its own prompt. */
+export const OUTLINE_INSTRUCTION = "Outline an engaging story";
+
+export const outlinePrompt = (brief: string, language: string): string =>
+	`${OUTLINE_INSTRUCTION} with a high-concept premise, characters, themes, conflict, twists, and a resolution. The story should be about the following: ${brief}. Write the outline in ${language}. Do not write anything else, just the outline.`;


### PR DESCRIPTION
Nightly CONVENTIONS.md compliance sweep. Master finally moved past the #580 mega-PR, so this is the first run in six with a real audit surface: 129 non-test source files changed since the last covered tip, 122 of them outside the open-PR footprint (#602–#605, #590, #592, #593, #595).

## Fixed

`outline_story` built its prompt inline and `MockLLM` matched a prefix of that same string — one piece of knowledge in two homes, and they had already drifted. The matcher looks for `"Briefly outline an engaging story"`; the prompt reads `"Outline an engaging story with a high-concept premise…"`. So `outline_story` running without an API key fell through to the default branch and answered with the entire mock OSML script instead of an outline.

The prompt now lives in `lib/script/prompt/outline.ts` next to the other prompt builders, exporting the instruction the mock matches on. Same shape as `lib/script/refine/animatePrompt.ts`, which already shares its matcher with the mock.

Also removed the mock's `describe the visual appearance of the character` branch — nothing in the repo produces a prompt carrying that phrase, so it was unreachable.

A test covers the seam: an outline prompt gets an outline back, anything else gets a script.

## Flagged, not fixed

- `lib/api/agentTurn.ts:104` — the turn's `onError` returns `stringifyError(error)` to the browser, full serialized error and all. Fourth site for the standing API-boundary flag (`with-auth.ts:18`, `sse.ts:29`, `process-job.ts:37`). Fixing it is an API-contract change and wants a human call.
- `app/components/sloppy/toolPresentation.tsx:22` — a 13-case switch where the rest of the repo uses a registry. It is exhaustive over a discriminated union and TS errors when a tool is added without a case, so it fails loudly at compile time; a `Record` keyed on tool name would need a cast to correlate each key with its own `part.input`. Left alone, same reasoning as the `AttributeBadge` if-chain.
- `lib/api/sse.ts:14` — `createSSEResponse` still has zero production callers, only its own test.

Everything else in the delta audited clean. `lib/agent/*`, `lib/api/{agentTurn,conversations}`, `app/api/v1/agent`, the whole `app/components/sloppy` cluster, `lib/script/prompt/*`, the video timeline/seek cluster and `EditorSidebar`'s panel registry all hold the line.

Checks: lint, typecheck, format:check, 1270 tests, `npm run build`.