### PR TITLE
fix(canvas): scope scroll-to-scene to the canvas scroll container

### DIFF
--- a/app/components/canvas/utils/scrollToScene.ts
+++ b/app/components/canvas/utils/scrollToScene.ts
@@ -1,6 +1,8 @@
+import { scrollIntoContainer } from "@/lib/components/scrollIntoContainer";
+
 export function scrollToScene(sceneId: string) {
 	const node = document.querySelector(
 		`[data-scene-id="${CSS.escape(sceneId)}"]`,
 	);
-	node?.scrollIntoView({ behavior: "smooth", block: "center" });
+	if (node) scrollIntoContainer(node, "center");
 }

--- a/app/components/sloppy/SloppyPanel.tsx
+++ b/app/components/sloppy/SloppyPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { memo, useEffect, useRef, useState } from "react";
+import { scrollIntoContainer } from "@/lib/components/scrollIntoContainer";
 import { cn } from "@/lib/utils";
 import { trailingAssistant } from "@/lib/agent/messages";
 import type { SloppyMessage } from "@/lib/agent/types";
@@ -78,7 +79,7 @@ export function SloppyPanel() {
 	const endRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
-		endRef.current?.scrollIntoView({ block: "end" });
+		if (endRef.current) scrollIntoContainer(endRef.current, "end", "auto");
 	}, [messages]);
 
 	return (

--- a/lib/components/__tests__/scrollIntoContainer.test.ts
+++ b/lib/components/__tests__/scrollIntoContainer.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { scrollTopFor } from "../scrollIntoContainer";
+
+const extent = (top: number, height: number) => ({ top, height });
+
+describe("scrollTopFor", () => {
+	it("centers a node that sits below the container", () => {
+		expect(scrollTopFor(extent(100, 500), extent(400, 100), 0, "center")).toBe(
+			100,
+		);
+	});
+
+	it("keeps the container's existing scroll offset in the result", () => {
+		expect(
+			scrollTopFor(extent(100, 500), extent(400, 100), 250, "center"),
+		).toBe(350);
+	});
+
+	it("centers a node that sits above the current viewport", () => {
+		expect(
+			scrollTopFor(extent(100, 500), extent(-300, 100), 800, "center"),
+		).toBe(200);
+	});
+
+	it("aligns the node's bottom edge with the container's for block end", () => {
+		expect(scrollTopFor(extent(0, 400), extent(600, 100), 0, "end")).toBe(300);
+	});
+
+	it("never scrolls past the top of the container", () => {
+		expect(scrollTopFor(extent(100, 500), extent(120, 40), 0, "center")).toBe(
+			0,
+		);
+	});
+});

--- a/lib/components/scrollIntoContainer.ts
+++ b/lib/components/scrollIntoContainer.ts
@@ -1,0 +1,47 @@
+export type ScrollBlock = "center" | "end";
+
+type Extent = { top: number; height: number };
+
+export function scrollTopFor(
+	container: Extent,
+	node: Extent,
+	scrollTop: number,
+	block: ScrollBlock,
+): number {
+	const slack =
+		(container.height - node.height) * (block === "center" ? 0.5 : 1);
+	return Math.max(0, node.top - container.top + scrollTop - slack);
+}
+
+function scrollableAncestor(node: Element): Element | null {
+	for (let el = node.parentElement; el; el = el.parentElement) {
+		const { overflowY } = getComputedStyle(el);
+		if (overflowY === "auto" || overflowY === "scroll") return el;
+	}
+	return null;
+}
+
+/**
+ * `scrollIntoView` aligns every scroll-container ancestor, including
+ * `overflow: hidden` ones the user has no way to scroll back.
+ */
+export function scrollIntoContainer(
+	node: Element,
+	block: ScrollBlock,
+	behavior: ScrollBehavior = "smooth",
+) {
+	const container = scrollableAncestor(node);
+	const target = container ?? document.scrollingElement;
+	if (!target) return;
+
+	const extent = container
+		? container.getBoundingClientRect()
+		: { top: 0, height: window.innerHeight };
+	const top = scrollTopFor(
+		extent,
+		node.getBoundingClientRect(),
+		target.scrollTop,
+		block,
+	);
+	target.scrollTo({ top, behavior });
+}


### PR DESCRIPTION
## Summary

`scrollToScene` called `scrollIntoView`, which aligns **every** scroll-container ancestor up to the viewport. `overflow: hidden` boxes are scroll containers too: they can't be scrolled by the user, but they scroll fine programmatically. `PostPromptView` nests five of them between a scene node and the document, so at ~980px with Sloppy open and a dock showing, clicking a scene shifted the whole app shell above the fold with no scrollbar to bring it back.

The fix scopes the scroll to a single container:

- New `lib/components/scrollIntoContainer.ts` resolves the nearest ancestor whose computed `overflow-y` is `auto` or `scroll` (so `overflow: hidden` ancestors are never candidates) and calls `scrollTo` on that one element. Falls back to the document scrolling element when nothing above the node is user-scrollable.
- `scrollTopFor(container, node, scrollTop, block)` is a pure function holding the scroll math, clamped at 0.
- `scrollToScene` delegates to it, so all four call sites inherit the fix without changing: `Storyboard`, `Timeline`, `PlayerControls`, and `ActiveSceneSync` (auto-scroll during playback).
- `SloppyPanel`'s transcript auto-scroll had the same unscoped call on every message change; it now scrolls its own transcript container.

No layout changes. Smooth behavior and centering are unchanged on wide screens.

## Why this issue was safe and small

#601 is a `size: S` bug with an obvious single fix site and a suggested direction the issue itself calls out as fitting the repo (scope the container, don't add `scroll-into-view-if-needed`). The change is 4 files, +86/-2, with no visual or product decisions involved.

## Validation

Every step from `.github/workflows/ci.yml`, run locally:

| step | result |
| --- | --- |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm run knip` | pass |
| `npm run build` | pass |
| `npm run test:coverage` | pass (142 files) |
| `npm run test:e2e` | pass (3 tests) |

The scroll math is covered by 5 unit tests on `scrollTopFor` with no jsdom layout dependence (the repo has no DOM test environment configured, so container-selection behavior is not asserted in a test; the acceptance criteria only ask for the math).

## Open-PR overlap check

Checked all 11 open PRs with `gh pr diff <n> --name-only`. None touches `scrollToScene.ts`, `SloppyPanel.tsx`, or `lib/components/scrollIntoContainer.ts`. PR #607 imports `scrollToScene` in `Timeline.tsx` and `ActiveSceneSync.tsx` but does not modify it, so both branches merge cleanly and #607's call sites pick up this fix for free.

## Skipped candidates

No `size: xs` issues are open. Every other open issue is `size: M`+ or product-heavy (BYOK, local mode, community feed, i18n, publishing kit) or design-direction work (a11y audit #385, variant picker #451). #591 (composer options row overflow) is the closest sibling but is a visual/responsive-layout decision better made with `DESIGN.md` in hand and a human eye on the result. #587 already has open PR #590.

Closes #601