### PR TITLE
feat: let Sloppy measure how long each visual is on screen

### DIFF
--- a/app/components/sloppy/__tests__/toolPresentation.test.ts
+++ b/app/components/sloppy/__tests__/toolPresentation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import type { ToolUIPart } from "ai";
+import type { SloppyTools } from "@/lib/agent/types";
+import { toolPresentation } from "../toolPresentation";
+
+const part = (type: string) =>
+	({
+		type,
+		toolCallId: "c1",
+		state: "input-available",
+		input: {},
+	}) as ToolUIPart<SloppyTools>;
+
+describe("toolPresentation", () => {
+	it("names the tool a live call runs", () => {
+		expect(toolPresentation(part("tool-read_script")).label).toBe(
+			"Reading the script",
+		);
+	});
+
+	it("still renders a tool a past build wrote into the transcript", () => {
+		const presentation = toolPresentation(part("tool-count_words"));
+
+		expect(presentation.label).toBe("count words");
+		expect(presentation.icon).toBeDefined();
+	});
+});

--- a/app/components/sloppy/toolPresentation.tsx
+++ b/app/components/sloppy/toolPresentation.tsx
@@ -7,18 +7,35 @@ import {
 	Hourglass,
 	Mic,
 	Pencil,
+	Robot,
 	SlidersHorizontal,
 	Translate,
 	User,
 	type IconComponent,
 } from "@/components/ui/icon";
+import { SLOPPY_TOOLS } from "@/lib/agent/tools/registry";
 import type { SloppyTools } from "@/lib/agent/types";
 
 type ToolPresentation = { icon: IconComponent; label: string };
 
-export function toolPresentation(
-	part: ToolUIPart<SloppyTools>,
-): ToolPresentation {
+type ToolPart = ToolUIPart<SloppyTools>;
+
+const OFFERED: ReadonlySet<string> = new Set(
+	Object.keys(SLOPPY_TOOLS).map((name) => `tool-${name}`),
+);
+
+/** A stored transcript can hold a tool this build has renamed away, and it still has to render. */
+const pastTool = (type: string): ToolPresentation => ({
+	icon: Robot,
+	label: type.replace(/^tool-/, "").replaceAll("_", " "),
+});
+
+export function toolPresentation(part: ToolPart): ToolPresentation {
+	return OFFERED.has(part.type) ? offeredTool(part) : pastTool(part.type);
+}
+
+/** Exhaustive over the tools this build offers: a new one without a case is a type error. */
+function offeredTool(part: ToolPart): ToolPresentation {
 	switch (part.type) {
 		case "tool-read_script":
 			return { icon: Eye, label: "Reading the script" };
@@ -49,8 +66,13 @@ export function toolPresentation(
 		}
 		case "tool-outline_story":
 			return { icon: Pencil, label: "Outlining the story" };
-		case "tool-count_words":
-			return { icon: Hourglass, label: "Counting the spoken words" };
+		case "tool-measure_total_length":
+			return { icon: Hourglass, label: "Measuring the video's length" };
+		case "tool-measure_element_lengths":
+			return {
+				icon: Hourglass,
+				label: "Measuring how long each visual is shown",
+			};
 		case "tool-set_language":
 			return { icon: Translate, label: "Setting the language" };
 		case "tool-set_metadata":

--- a/app/components/video/timeline/__tests__/timelineRows.test.ts
+++ b/app/components/video/timeline/__tests__/timelineRows.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { ELEMENT_TYPES, type CanvasElementType } from "@/lib/canvas/types";
 import { isBlankScene } from "@/lib/video/blankScene";
-import { buildVideoLayout } from "@/lib/video/scene-builder";
+import {
+	buildVideoLayout,
+	type BuildLayoutOptions,
+} from "@/lib/video/scene-builder";
 import type { ResolvedElement } from "@/lib/video/types";
 import { buildTimelineRows, packLanes } from "../timelineRows";
 
@@ -27,6 +30,10 @@ function el(
 		...overrides,
 	};
 }
+
+/** These rows are laid out from a visual's own length, which trimming makes moot. */
+const untrimmed = (elements: ResolvedElement[], options?: BuildLayoutOptions) =>
+	buildVideoLayout(elements, { trimVisualsToDialogue: false, ...options });
 
 describe("packLanes", () => {
 	const clip = (start: number, duration: number) => ({
@@ -60,16 +67,16 @@ describe("packLanes", () => {
 
 describe("buildTimelineRows", () => {
 	it("has no rows for an empty layout", () => {
-		expect(buildTimelineRows(buildVideoLayout([]))).toEqual([]);
+		expect(buildTimelineRows(untrimmed([]))).toEqual([]);
 	});
 
 	it("drops lanes that hold nothing", () => {
-		const rows = buildTimelineRows(buildVideoLayout([el("a", "image")]));
+		const rows = buildTimelineRows(untrimmed([el("a", "image")]));
 		expect(rows.map((row) => row.id)).toEqual(["foreground"]);
 	});
 
 	it("puts each role in its own lane, in stacking order", () => {
-		const layout = buildVideoLayout([
+		const layout = untrimmed([
 			el("bgm", "music"),
 			el("img", "image"),
 			el("sfx", "sound"),
@@ -91,7 +98,7 @@ describe("buildTimelineRows", () => {
 	});
 
 	it("merges narration and character into the voice lane, ordered by start", () => {
-		const layout = buildVideoLayout([
+		const layout = untrimmed([
 			el("n1", "narration", { durationSec: 2 }),
 			el("c1", "character", { durationSec: 3 }),
 			el("n2", "narration", { durationSec: 1 }),
@@ -106,7 +113,7 @@ describe("buildTimelineRows", () => {
 	});
 
 	it("expands a looped element into one clip per loop", () => {
-		const layout = buildVideoLayout([
+		const layout = untrimmed([
 			el("bgm", "music", { durationSec: 3, loops: 3 }),
 			el("img", "image", { durationSec: 9 }),
 		]);
@@ -122,7 +129,7 @@ describe("buildTimelineRows", () => {
 	});
 
 	it("trims the transition overlap so scenes abut instead of running over", () => {
-		const layout = buildVideoLayout([
+		const layout = untrimmed([
 			el("a", "image", { durationSec: 5 }),
 			el("b", "image", { durationSec: 5 }),
 			el("c", "image", { durationSec: 5 }),
@@ -137,7 +144,7 @@ describe("buildTimelineRows", () => {
 	});
 
 	it("keeps voices on one lane across a scene transition", () => {
-		const layout = buildVideoLayout([
+		const layout = untrimmed([
 			el("n1", "narration", { durationSec: 3 }),
 			el("a", "image", { durationSec: 3 }),
 			el("n2", "narration", { durationSec: 3 }),
@@ -151,7 +158,7 @@ describe("buildTimelineRows", () => {
 	});
 
 	it("drops a clip that starts after the video ends", () => {
-		const layout = buildVideoLayout([
+		const layout = untrimmed([
 			el("img", "image", { durationSec: 5 }),
 			el("sfx", "sound", { durationSec: 4, loops: 3 }),
 		]);
@@ -165,7 +172,7 @@ describe("buildTimelineRows", () => {
 	});
 
 	it("draws a clip that overruns the end only as far as the video goes", () => {
-		const layout = buildVideoLayout([
+		const layout = untrimmed([
 			el("img", "image", { durationSec: 5 }),
 			el("sfx", "sound", { durationSec: 4, loops: 2 }),
 		]);
@@ -176,7 +183,7 @@ describe("buildTimelineRows", () => {
 	});
 
 	it("splits overlapping sounds into a lane each", () => {
-		const layout = buildVideoLayout([
+		const layout = untrimmed([
 			el("img", "image", { durationSec: 10 }),
 			el("s1", "sound", { durationSec: 6 }),
 			el("s2", "sound", { durationSec: 6 }),
@@ -189,9 +196,7 @@ describe("buildTimelineRows", () => {
 	});
 
 	it("opens a blank scene when an overlay leads the video", () => {
-		const rows = buildTimelineRows(
-			buildVideoLayout([el("voice", "narration")]),
-		);
+		const rows = buildTimelineRows(untrimmed([el("voice", "narration")]));
 		const visual = rows.find((row) => row.id === "foreground");
 		expect(visual?.clips).toHaveLength(1);
 		expect(isBlankScene(visual?.clips[0].element as ResolvedElement)).toBe(

--- a/lib/agent/__tests__/registry.test.ts
+++ b/lib/agent/__tests__/registry.test.ts
@@ -17,6 +17,7 @@ const metadata = MetadataSchema.parse({
 const context = (over: Partial<AgentToolContext> = {}): AgentToolContext => ({
 	readScript: () => "<narration>hi</narration>",
 	countSpokenWords: () => 1,
+	measureElementLengths: () => [],
 	generateText: async () => "an outline",
 	referenceImages: () => [],
 	avatarUrl: () => undefined,
@@ -197,7 +198,7 @@ describe("executeToolCall", () => {
 
 	it("reports the count against the project's word budget", async () => {
 		const outcome = await executeToolCall(
-			{ toolName: "count_words", input: {} },
+			{ toolName: "measure_total_length", input: {} },
 			context({ countSpokenWords: () => 700 }),
 		);
 
@@ -208,13 +209,13 @@ describe("executeToolCall", () => {
 
 	it("says how far off the count is, so the model knows how much to cut or add", async () => {
 		const over = await executeToolCall(
-			{ toolName: "count_words", input: {} },
+			{ toolName: "measure_total_length", input: {} },
 			context({ countSpokenWords: () => 1000 }),
 		);
 		expect(over.ok && over.output).toContain("over by 100 words");
 
 		const under = await executeToolCall(
-			{ toolName: "count_words", input: {} },
+			{ toolName: "measure_total_length", input: {} },
 			context({ countSpokenWords: () => 500 }),
 		);
 		expect(under.ok && under.output).toContain("under by 40 words");
@@ -222,7 +223,7 @@ describe("executeToolCall", () => {
 
 	it("counts without a verdict when the length is auto", async () => {
 		const outcome = await executeToolCall(
-			{ toolName: "count_words", input: {} },
+			{ toolName: "measure_total_length", input: {} },
 			context({
 				countSpokenWords: () => 1000,
 				readMetadata: () =>
@@ -232,6 +233,50 @@ describe("executeToolCall", () => {
 
 		expect(outcome.ok && outcome.output).toContain("1000 spoken words");
 		expect(outcome.ok && outcome.output).not.toContain("over by");
+	});
+
+	it("reports what each visual is on screen for, and the dialogue holding it", async () => {
+		const outcome = await executeToolCall(
+			{ toolName: "measure_element_lengths", input: {} },
+			context({
+				measureElementLengths: () => [
+					{
+						id: "img1",
+						type: "image",
+						sceneNumber: 1,
+						seconds: 30,
+						words: 90,
+						dialogueIds: ["nar1"],
+					},
+					{
+						id: "ai1",
+						type: "animated_image",
+						sceneNumber: 2,
+						seconds: 1,
+						words: 0,
+						dialogueIds: [],
+					},
+				],
+			}),
+		);
+
+		expect(outcome.ok && outcome.output).toContain(
+			"Scene 1 image img1: 30.0s, from 90 words of dialogue after it (nar1)",
+		);
+		expect(outcome.ok && outcome.output).toContain(
+			"Scene 2 animated_image ai1: 1.0s, nothing after it, so it holds the minimum",
+		);
+	});
+
+	it("says the canvas has no visuals rather than reporting an empty table", async () => {
+		const outcome = await executeToolCall(
+			{ toolName: "measure_element_lengths", input: {} },
+			context(),
+		);
+
+		expect(outcome.ok && outcome.output).toBe(
+			"No visual elements on the canvas yet.",
+		);
 	});
 
 	it("hands over the reference images for the model to look at", async () => {
@@ -307,7 +352,8 @@ describe("SLOPPY_TOOLS", () => {
 			"view_reference_images",
 			"view_avatar",
 			"outline_story",
-			"count_words",
+			"measure_total_length",
+			"measure_element_lengths",
 			"set_metadata",
 			"set_narrator",
 			"set_character",

--- a/lib/agent/prompt.ts
+++ b/lib/agent/prompt.ts
@@ -25,6 +25,12 @@ const ROLE = dedent`
   - Finish by replying to the user. Keep replies brief. The user is watching the canvas, not your text.
   - Ask only when the answer would change the work. Otherwise decide and say what you chose.
 
+  # How long a visual is on screen
+  - A visual (image, animated_image, clip) is on screen for the dialogue after it, up to the
+    next visual. \`duration\` sets the generated video's length, not its time on screen.
+  - Never guess a length. measure_element_lengths reads them off the canvas and says how to
+    change one.
+
   # Personality when responding directly to the user
   - When responding to the user, you have the personality of an anxious overachiever intern
   - Respond to the user in a casual, informal, concise, friendly, and engaging way with imperfect grammar, formatting, punctuation, and capitalization. Do this ONLY for responses to the user, NEVER for tool calls or other internal communications.

--- a/lib/agent/tools/context.ts
+++ b/lib/agent/tools/context.ts
@@ -1,3 +1,4 @@
+import type { ElementLength } from "@/lib/video/elementLengths";
 import type { RefineOp } from "@/lib/script/refine/types";
 import type {
 	DeepPartial,
@@ -9,6 +10,7 @@ import type {
 export type AgentToolContext = {
 	readScript: () => string;
 	countSpokenWords: () => number;
+	measureElementLengths: () => ElementLength[];
 	referenceImages: () => string[];
 	avatarUrl: (name: string) => string | undefined;
 	/** One focused LLM call, for tools whose whole job is a generation. */

--- a/lib/agent/tools/measureElementLengths.ts
+++ b/lib/agent/tools/measureElementLengths.ts
@@ -1,0 +1,42 @@
+import dedent from "dedent";
+import { z } from "zod";
+import type { ElementLength } from "@/lib/video/elementLengths";
+import { NARRATION_WORDS_PER_MINUTE } from "@/lib/video/videoLength";
+import { defineTool } from "./defineTool";
+
+const WORDS_PER_SECOND = Math.round(NARRATION_WORDS_PER_MINUTE / 60);
+
+const from = ({ words, dialogueIds }: ElementLength) =>
+	words === 0
+		? "nothing after it, so it holds the minimum"
+		: `from ${words} words of dialogue after it (${dialogueIds.join(", ")})`;
+
+const line = (length: ElementLength) =>
+	`Scene ${length.sceneNumber} ${length.type} ${length.id}: ${length.seconds.toFixed(1)}s, ${from(length)}.`;
+
+export const measureElementLengths = defineTool({
+	description: dedent`
+	  Measure each visual: how long every image, animated_image and clip on the canvas is on
+	  screen, and which dialogue decides it. For the whole video's runtime, use
+	  measure_total_length instead.
+
+	  A visual is on screen for as long as the dialogue that follows it, up to the next
+	  visual, about ${WORDS_PER_SECOND} spoken words a second. The \`duration\` on an
+	  animated_image or clip is the generated video's length, not its time on screen.
+
+	  Run this whenever the user asks how long something is shown, or asks to change it. To
+	  shorten a visual, split the dialogue after it and insert a visual at the split; to
+	  lengthen one, merge or add dialogue.
+	`,
+	input: z.object({}),
+	output: z.string(),
+	execute: async (_input, ctx) => {
+		const lengths = ctx.measureElementLengths();
+		if (lengths.length === 0) return "No visual elements on the canvas yet.";
+
+		return [
+			`Estimated from the script at ${NARRATION_WORDS_PER_MINUTE} words a minute. Real lengths land once the audio is generated.`,
+			...lengths.map(line),
+		].join("\n");
+	},
+});

--- a/lib/agent/tools/measureTotalLength.ts
+++ b/lib/agent/tools/measureTotalLength.ts
@@ -9,11 +9,12 @@ import { defineTool } from "./defineTool";
 const minutes = (words: number) =>
 	(words / NARRATION_WORDS_PER_MINUTE).toFixed(1);
 
-export const countWords = defineTool({
+export const measureTotalLength = defineTool({
 	description: dedent`
-	  Count the spoken words on the canvas (narration and dialogue only; descriptions and
-	  attributes are silent) and estimate the video's runtime against the project's target
-	  length.
+	  Measure the whole video: the spoken words on the canvas (narration and dialogue only;
+	  descriptions and attributes are silent) and the runtime they add up to, against the
+	  project's target length. For how long each visual is on screen, use
+	  measure_element_lengths instead.
 
 	  You cannot judge length by looking at a script, so run this after writing or editing
 	  whenever length matters, and edit until the count lands in the target range.

--- a/lib/agent/tools/registry.ts
+++ b/lib/agent/tools/registry.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 import { errorMessage } from "@/lib/errors";
 import type { AgentToolContext } from "./context";
 import { adaptScript } from "./adaptScript";
-import { countWords } from "./countWords";
+import { measureElementLengths } from "./measureElementLengths";
+import { measureTotalLength } from "./measureTotalLength";
 import { editScript } from "./editScript";
 import { outlineStory } from "./outlineStory";
 import { readScript } from "./readScript";
@@ -26,7 +27,8 @@ const TOOLS = {
 	view_reference_images: viewReferenceImages,
 	view_avatar: viewAvatar,
 	outline_story: outlineStory,
-	count_words: countWords,
+	measure_total_length: measureTotalLength,
+	measure_element_lengths: measureElementLengths,
 	set_metadata: setMetadata,
 	set_narrator: setNarrator,
 	set_character: setCharacter,
@@ -94,7 +96,8 @@ export const agentToolCallSchema = z.discriminatedUnion("toolName", [
 	call("view_reference_images"),
 	call("view_avatar"),
 	call("outline_story"),
-	call("count_words"),
+	call("measure_total_length"),
+	call("measure_element_lengths"),
 	call("set_metadata"),
 	call("set_narrator"),
 	call("set_character"),

--- a/lib/agent/tools/useAgentTools.ts
+++ b/lib/agent/tools/useAgentTools.ts
@@ -5,6 +5,8 @@ import type { Editor } from "slate";
 import { clearEditor } from "@/lib/canvas/editorOps";
 import { serializeOSMLWithScenes } from "@/lib/canvas/osmlSerializer";
 import { countSpokenWords } from "@/lib/canvas/spokenWords";
+import { measureElementLengths } from "@/lib/video/elementLengths";
+import { DEFAULT_TRIM_VISUALS_TO_DIALOGUE } from "@/lib/video/scene-builder";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
 import { characterAvatarUrl } from "@/lib/project/characterAvatar";
@@ -27,6 +29,11 @@ export function useAgentTools(editor: Editor) {
 			const ctx: AgentToolContext = {
 				readScript: () => serializeOSMLWithScenes(editor.children),
 				countSpokenWords: () => countSpokenWords(editor.children),
+				measureElementLengths: () =>
+					measureElementLengths(
+						editor.children,
+						DEFAULT_TRIM_VISUALS_TO_DIALOGUE,
+					),
 				referenceImages: () => store.getState().referenceImages,
 				avatarUrl: (name) => characterAvatarUrl(queue, name),
 				generateText: async (prompt, options) => {

--- a/lib/api/handlers/__tests__/video.test.ts
+++ b/lib/api/handlers/__tests__/video.test.ts
@@ -59,7 +59,7 @@ describe("videoHandler.process", () => {
 			metadata: { providerJobId: "upstream-1" },
 		});
 		expect(generate).not.toHaveBeenCalled();
-		expect(poll).toHaveBeenCalledWith("upstream-1");
+		expect(poll).toHaveBeenCalledWith("upstream-1", { prompt: "a cat" });
 	});
 
 	it("throws when the provider returns no job id", async () => {

--- a/lib/api/handlers/video.ts
+++ b/lib/api/handlers/video.ts
@@ -21,7 +21,7 @@ export const videoHandler: JobHandler<VideoGenerateParams, VideoMetadata> = {
 			};
 		}
 
-		const upstream = await provider.poll(providerJobId);
+		const upstream = await provider.poll(providerJobId, job.request);
 		if (upstream.kind === "ready") {
 			return { kind: "completed", result: upstream.asset };
 		}

--- a/lib/canvas/spokenWords.ts
+++ b/lib/canvas/spokenWords.ts
@@ -3,7 +3,8 @@ import { getContentElements } from "./scenes";
 import { getElementBodyText } from "./osmlSerializer";
 import { ELEMENT_TYPES } from "./types";
 
-const countWords = (text: string) => text.split(/\s+/).filter(Boolean).length;
+export const countWords = (text: string) =>
+	text.split(/\s+/).filter(Boolean).length;
 
 /** Words the TTS engine will speak: narration and dialogue, nothing else. */
 export function countSpokenWords(descendants: Descendant[]): number {

--- a/lib/canvas/types.ts
+++ b/lib/canvas/types.ts
@@ -78,6 +78,8 @@ export const DURATION_OPTIONS = Array.from({ length: 12 }, (_, i) =>
 	String(i + 4),
 );
 
+export const DEFAULT_DURATION = "10";
+
 export const SCENE_TYPE = "scene" as const;
 
 export type CanvasEditor = BaseEditor & ReactEditor & { id?: string };

--- a/lib/connectors/animated_image/attributes.ts
+++ b/lib/connectors/animated_image/attributes.ts
@@ -1,4 +1,5 @@
 import { AttributeSchema } from "../attributes/schema";
+import { DEFAULT_DURATION } from "@/lib/canvas/types";
 import { durationDef, motionDef } from "../attributes/common";
 import { referenceImagesDef } from "../attributes/referenceImages";
 
@@ -14,6 +15,6 @@ export const ANIMATED_IMAGE_ATTRIBUTES = AttributeSchema.from([
 		},
 		default: "slow cinematic pan",
 	},
-	durationDef("10"),
+	durationDef(DEFAULT_DURATION),
 	motionDef("none"),
 ]);

--- a/lib/connectors/video/attributes.ts
+++ b/lib/connectors/video/attributes.ts
@@ -1,8 +1,9 @@
 import { AttributeSchema } from "../attributes/schema";
+import { DEFAULT_DURATION } from "@/lib/canvas/types";
 import { durationDef, motionDef, volumeDef } from "../attributes/common";
 
 export const VIDEO_ATTRIBUTES = AttributeSchema.from([
-	durationDef("10"),
+	durationDef(DEFAULT_DURATION),
 	volumeDef("5"),
 	motionDef("none"),
 ]);

--- a/lib/providers/__tests__/runware-video.test.ts
+++ b/lib/providers/__tests__/runware-video.test.ts
@@ -142,6 +142,21 @@ describe("RunwareVideo", () => {
 	});
 
 	describe("poll", () => {
+		it("stamps the completed asset with the duration that was requested", async () => {
+			mockGetResponse.mockResolvedValue([
+				{ taskUUID: "job-1", status: "completed", videoURL: "https://r.mp4" },
+			]);
+
+			const provider = new RunwareVideo("test-key");
+			const poll = await provider.poll("job-1", {
+				prompt: "test",
+				duration: 8,
+			});
+
+			expect(poll.kind).toBe("ready");
+			expect(poll.kind === "ready" && poll.asset.metadata?.durationSec).toBe(8);
+		});
+
 		it("returns the stored asset when the job is completed", async () => {
 			mockGetResponse.mockResolvedValue([
 				{
@@ -152,7 +167,7 @@ describe("RunwareVideo", () => {
 			]);
 
 			const provider = new RunwareVideo("test-key");
-			const result = await provider.poll("job-1");
+			const result = await provider.poll("job-1", { prompt: "test" });
 
 			expect(result).toMatchObject({
 				kind: "ready",
@@ -170,7 +185,7 @@ describe("RunwareVideo", () => {
 			]);
 
 			const provider = new RunwareVideo("test-key");
-			const result = await provider.poll("job-1");
+			const result = await provider.poll("job-1", { prompt: "test" });
 
 			expect(result).toEqual({
 				kind: "pending",
@@ -182,7 +197,9 @@ describe("RunwareVideo", () => {
 			mockGetResponse.mockResolvedValue([]);
 
 			const provider = new RunwareVideo("test-key");
-			await expect(provider.poll("missing")).rejects.toThrow("Job not found");
+			await expect(
+				provider.poll("missing", { prompt: "test" }),
+			).rejects.toThrow("Job not found");
 			expect(mockDisconnect).toHaveBeenCalled();
 		});
 	});

--- a/lib/providers/video/base.ts
+++ b/lib/providers/video/base.ts
@@ -5,6 +5,9 @@ import { BaseProvider } from "../base";
 
 export type VideoJobStatus = "queued" | "processing" | "completed" | "failed";
 
+/** What a video runs for when the request names no duration, for asking and for reporting. */
+export const DEFAULT_VIDEO_DURATION_SEC = 5;
+
 export type VideoJobMetadata = {
 	jobId: string;
 	durationSec?: number;
@@ -46,11 +49,19 @@ export abstract class BaseVideoProvider extends BaseProvider<
 
 	protected abstract _poll(jobId: string): Promise<VideoJob>;
 
-	async poll(jobId: string): Promise<VideoPoll> {
+	async poll(jobId: string, request: VideoGenerateParams): Promise<VideoPoll> {
 		const result = await this._poll(jobId);
 		if (this.toFiles(result).length === 0) {
 			return { kind: "pending", metadata: result.metadata };
 		}
-		return { kind: "ready", asset: await this.store(result) };
+		const metadata = {
+			jobId,
+			...result.metadata,
+			durationSec:
+				result.metadata?.durationSec ??
+				request.duration ??
+				DEFAULT_VIDEO_DURATION_SEC,
+		};
+		return { kind: "ready", asset: await this.store({ ...result, metadata }) };
 	}
 }

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -1,6 +1,6 @@
 import type { VideoGenerateParams } from "@/lib/connectors/types";
 import type { VideoJob, VideoJobStatus } from "./base";
-import { BaseVideoProvider } from "./base";
+import { BaseVideoProvider, DEFAULT_VIDEO_DURATION_SEC } from "./base";
 import { withRunware } from "../runware";
 
 function toVideoJob(video: {
@@ -33,7 +33,7 @@ export class RunwareVideo extends BaseVideoProvider {
 				model: params.model || "bytedance:seedance@2.0-fast",
 				width: params.width || 1280,
 				height: params.height || 720,
-				duration: params.duration || 5,
+				duration: params.duration ?? DEFAULT_VIDEO_DURATION_SEC,
 				outputType: "URL",
 				deliveryMethod: "async",
 				inputs: {
@@ -58,7 +58,7 @@ export class RunwareVideo extends BaseVideoProvider {
 			metadata: {
 				...job.metadata,
 				jobId: job.metadata?.jobId ?? "",
-				durationSec: params.duration ?? 5,
+				durationSec: params.duration ?? DEFAULT_VIDEO_DURATION_SEC,
 			},
 		};
 	}

--- a/lib/video/__tests__/elementLengths.test.ts
+++ b/lib/video/__tests__/elementLengths.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type { Descendant } from "slate";
+import type { CanvasElementType } from "@/lib/canvas/types";
+import { measureElementLengths } from "../elementLengths";
+import { DEFAULT_TRIM_VISUALS_TO_DIALOGUE } from "../scene-builder";
+
+let nextId = 0;
+const element = (
+	type: CanvasElementType,
+	text: string,
+	customAttributes?: Record<string, string>,
+) => {
+	const id = `e${nextId++}`;
+	return {
+		id,
+		type,
+		customAttributes,
+		children: [{ id: `${id}-t`, type, text }],
+	};
+};
+
+const scene = (...children: ReturnType<typeof element>[]): Descendant =>
+	({ id: `s${nextId++}`, type: "scene", children }) as unknown as Descendant;
+
+const words = (count: number) => Array(count).fill("word").join(" ");
+
+const trimmed = (nodes: Descendant[]) =>
+	measureElementLengths(nodes, DEFAULT_TRIM_VISUALS_TO_DIALOGUE);
+
+describe("measureElementLengths", () => {
+	it("holds a still for the dialogue that follows it, up to the next visual", () => {
+		const image = element("image", "A forest.");
+		const narration = element("narration", words(90));
+		const next = element("image", "A clearing.");
+
+		const [first, second] = trimmed([
+			scene(image, narration, next, element("narration", words(180))),
+		]);
+
+		expect(first).toMatchObject({
+			id: image.id,
+			seconds: 30,
+			words: 90,
+			dialogueIds: [narration.id],
+		});
+		expect(second.seconds).toBe(60);
+	});
+
+	it("counts dialogue across scene boundaries, since only a visual ends a span", () => {
+		const image = element("image", "A forest.");
+
+		const [only] = trimmed([
+			scene(image, element("narration", words(90))),
+			scene(element("character", words(90))),
+		]);
+
+		expect(only).toMatchObject({ seconds: 60, words: 180, sceneNumber: 1 });
+	});
+
+	it("cuts a clip to the dialogue after it, whatever it was generated at", () => {
+		const [cut, extended] = trimmed([
+			scene(
+				element("animated_image", "A pan.", { duration: "8" }),
+				element("narration", words(9)),
+				element("animated_image", "A zoom.", { duration: "4" }),
+				element("narration", words(90)),
+			),
+		]);
+
+		expect(cut.seconds).toBe(3);
+		expect(extended.seconds).toBe(30);
+	});
+
+	it("holds a clip for its generated length when trimming is off", () => {
+		const [held] = measureElementLengths(
+			[
+				scene(
+					element("animated_image", "A pan.", { duration: "8" }),
+					element("narration", words(9)),
+				),
+			],
+			false,
+		);
+
+		expect(held.seconds).toBe(8);
+	});
+
+	it("ignores silent elements and dialogue before the first visual", () => {
+		const image = element("image", "A forest.");
+
+		const lengths = trimmed([
+			scene(
+				element("narration", words(180)),
+				image,
+				element("music", "Soft piano."),
+				element("sound", "Wind"),
+			),
+		]);
+
+		expect(lengths).toHaveLength(1);
+		expect(lengths[0]).toMatchObject({ id: image.id, words: 0, seconds: 1 });
+	});
+
+	it("measures an empty canvas as nothing", () => {
+		expect(trimmed([])).toEqual([]);
+	});
+});

--- a/lib/video/__tests__/scene-builder.test.ts
+++ b/lib/video/__tests__/scene-builder.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { toFrames } from "../frames";
 import { isBlankScene } from "../blankScene";
-import { buildVideoLayout } from "../scene-builder";
+import { buildVideoLayout, type BuildLayoutOptions } from "../scene-builder";
 import type { ResolvedElement, Sequence, VideoLayout } from "../types";
 import type { CanvasElementType } from "@/lib/canvas/types";
 
@@ -52,10 +52,17 @@ function el(
 	};
 }
 
+/** Trimming makes a visual's own length moot, which most of these cases are built on. */
+const untrimmed = (
+	elements: ResolvedElement[],
+	options?: BuildLayoutOptions,
+): VideoLayout =>
+	buildVideoLayout(elements, { trimVisualsToDialogue: false, ...options });
+
 describe("buildVideoLayout", () => {
 	describe("empty input", () => {
 		it("returns an empty layout with the minimum frame count", () => {
-			const layout = buildVideoLayout([]);
+			const layout = untrimmed([]);
 			expect(layout.series).toHaveLength(0);
 			expect(layout.totalDurationSec).toBe(0);
 			expect(layout.totalFrames).toBe(2);
@@ -64,7 +71,7 @@ describe("buildVideoLayout", () => {
 
 	describe("foreground elements (image, clip)", () => {
 		it("creates a series entry for a single foreground element", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "img1", type: "image", durationSec: 5 }),
 			]);
 			expect(layout.series).toHaveLength(1);
@@ -75,7 +82,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("plays consecutive foreground elements end-to-end", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "img1", type: "image", durationSec: 5 }),
 				el({ id: "clip1", type: "clip", durationSec: 3 }),
 			]);
@@ -88,7 +95,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("places overlays on the rendered timeline so they align with transitioned visuals", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "img1", type: "image", durationSec: 5 }),
 				el({ id: "img2", type: "image", durationSec: 3 }),
 				el({ id: "n1", type: "narration", durationSec: 2 }),
@@ -99,7 +106,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("clamps a foreground shorter than the minimum duration", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "img1", type: "image", durationSec: 0 }),
 			]);
 			expect(layout.series).toHaveLength(1);
@@ -111,7 +118,7 @@ describe("buildVideoLayout", () => {
 
 	describe("overlay elements (narration, character)", () => {
 		it("opens a blank scene when no foreground precedes", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "n1", type: "narration", durationSec: 4 }),
 			]);
 			expect(layout.series).toHaveLength(1);
@@ -120,7 +127,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("collapses consecutive leading overlays into one blank scene", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "n1", type: "narration", durationSec: 3 }),
 				el({ id: "n2", type: "narration", durationSec: 4 }),
 			]);
@@ -133,7 +140,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("extends the current series entry to fit a longer overlay", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "clip1", type: "clip", durationSec: 5 }),
 				el({ id: "n1", type: "narration", durationSec: 8 }),
 			]);
@@ -145,7 +152,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("stacks consecutive overlays within the current series entry", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "img1", type: "image", durationSec: 0 }),
 				el({ id: "n1", type: "narration", durationSec: 5 }),
 				el({ id: "c1", type: "character", durationSec: 3 }),
@@ -156,7 +163,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("plays a foreground after the overlay that leads it", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "n1", type: "narration", durationSec: 9 }),
 				el({ id: "img1", type: "image", durationSec: 5 }),
 			]);
@@ -170,7 +177,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("delays the next foreground when an overlay extends past it", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "img1", type: "image", durationSec: 5 }),
 				el({ id: "n1", type: "narration", durationSec: 9 }),
 				el({ id: "clip1", type: "clip", durationSec: 6 }),
@@ -182,7 +189,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("starts the next foreground immediately when the overlay is shorter", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "img1", type: "image", durationSec: 30 }),
 				el({ id: "n1", type: "narration", durationSec: 9 }),
 				el({ id: "clip1", type: "clip", durationSec: 6 }),
@@ -194,7 +201,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("stretches the blank scene over the overlays that lead the video", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "n1", type: "narration", durationSec: 9 }),
 				el({ id: "c1", type: "character", durationSec: 3 }),
 				el({ id: "img1", type: "image", durationSec: 4 }),
@@ -214,7 +221,7 @@ describe("buildVideoLayout", () => {
 
 	describe("background elements (music)", () => {
 		it("trims a background to the foreground duration", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "m1", type: "music", durationSec: 30 }),
 				el({ id: "img1", type: "image", durationSec: 10 }),
 			]);
@@ -224,7 +231,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("clamps a background placed after a foreground to the minimum duration", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "img1", type: "image", durationSec: 10 }),
 				el({ id: "m1", type: "music", durationSec: 30 }),
 			]);
@@ -234,7 +241,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("caps the previous background when a new background of the same type starts", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "m1", type: "music", durationSec: 30 }),
 				el({ id: "img1", type: "image", durationSec: 10 }),
 				el({ id: "m2", type: "music", durationSec: 20 }),
@@ -246,7 +253,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("leaves an earlier background untouched when it ends before its replacement", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "m1", type: "music", durationSec: 10 }),
 				el({ id: "clip1", type: "clip", durationSec: 10 }),
 				el({ id: "c1", type: "character", durationSec: 5 }),
@@ -264,7 +271,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("collapses consecutive backgrounds at the same offset to the latest", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "m1", type: "music", durationSec: 10 }),
 				el({ id: "m2", type: "music", durationSec: 20 }),
 				el({ id: "m3", type: "music", durationSec: 30 }),
@@ -283,7 +290,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("emits N consecutive copies for a looped background, trimmed to the foreground span", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "m1", type: "music", durationSec: 10, loops: 4 }),
 				el({ id: "img1", type: "image", durationSec: 25 }),
 			]);
@@ -298,7 +305,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("drops looped background copies that fall after a replacement background", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "m1", type: "music", durationSec: 10, loops: 4 }),
 				el({ id: "img1", type: "image", durationSec: 15 }),
 				el({ id: "m2", type: "music", durationSec: 20 }),
@@ -315,7 +322,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("emits a clamped background sequence when no series elements exist", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "m1", type: "music", durationSec: 30 }),
 			]);
 			expect(layout.series).toHaveLength(0);
@@ -328,7 +335,7 @@ describe("buildVideoLayout", () => {
 
 	describe("effect elements (sound)", () => {
 		it("stacks multiple effects at the current cursor", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "s1", type: "sound", durationSec: 1 }),
 				el({ id: "s2", type: "sound", durationSec: 5 }),
 				el({ id: "clip1", type: "clip", durationSec: 6 }),
@@ -349,7 +356,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("trims effects that extend beyond the total duration", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "clip1", type: "clip", durationSec: 20 }),
 				el({ id: "s1", type: "sound", durationSec: 50 }),
 				el({ id: "s2", type: "sound", durationSec: 20 }),
@@ -363,7 +370,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("emits N consecutive copies of a looped effect at the native clip duration", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "clip1", type: "clip", durationSec: 12 }),
 				el({ id: "s1", type: "sound", durationSec: 4, loops: 3 }),
 			]);
@@ -379,7 +386,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("trims looped effect copies that extend past the total duration", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "clip1", type: "clip", durationSec: 5 }),
 				el({ id: "s1", type: "sound", durationSec: 4, loops: 3 }),
 			]);
@@ -394,7 +401,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("emits a clamped effect sequence when no series elements exist", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "s1", type: "sound", durationSec: 5 }),
 			]);
 			expect(layout.series).toHaveLength(0);
@@ -407,7 +414,7 @@ describe("buildVideoLayout", () => {
 
 	describe("mixed scenes", () => {
 		it("coagulates leading non-foreground elements into the first scene", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "m1", type: "music", durationSec: 10 }),
 				el({ id: "s1", type: "sound", durationSec: 5 }),
 				el({ id: "n1", type: "narration", durationSec: 4 }),
@@ -433,7 +440,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("composes foreground, overlay, and background within a single layout", () => {
-			const layout = buildVideoLayout([
+			const layout = untrimmed([
 				el({ id: "m1", type: "music", durationSec: 60 }),
 				el({ id: "img1", type: "image", durationSec: 3 }),
 				el({ id: "n1", type: "narration", durationSec: 5 }),
@@ -455,7 +462,7 @@ describe("buildVideoLayout", () => {
 
 	describe("config", () => {
 		it("computes totalFrames from totalDurationSec and a custom fps", () => {
-			const layout = buildVideoLayout(
+			const layout = untrimmed(
 				[el({ id: "img1", type: "image", durationSec: 5 })],
 				{ fps: 30 },
 			);
@@ -463,7 +470,7 @@ describe("buildVideoLayout", () => {
 		});
 
 		it("propagates custom width and height to the layout", () => {
-			const layout = buildVideoLayout(
+			const layout = untrimmed(
 				[el({ id: "img1", type: "image", durationSec: 1 })],
 				{ width: 1280, height: 720 },
 			);
@@ -484,7 +491,7 @@ describe("buildVideoLayout", () => {
 					el({ id: `img${i}`, type: "image", durationSec: 5 }),
 					el({ id: `n${i}`, type: "narration", durationSec: 4 }),
 				]).flat();
-				const layout = buildVideoLayout(elements, { fps });
+				const layout = untrimmed(elements, { fps });
 				const overlap = toFrames(layout.transitionDurationSec, fps);
 
 				let renderedStart = 0;
@@ -504,7 +511,7 @@ describe("buildVideoLayout", () => {
 			const elements = Array.from({ length: 10 }, (_, i) =>
 				el({ id: `img${i}`, type: "image", durationSec: 5 }),
 			);
-			const layout = buildVideoLayout(elements, { fps });
+			const layout = untrimmed(elements, { fps });
 			const overlap = toFrames(layout.transitionDurationSec, fps);
 
 			const rendered = layout.series.reduce(
@@ -513,6 +520,45 @@ describe("buildVideoLayout", () => {
 				0,
 			);
 			expect(layout.totalFrames).toBe(rendered);
+		});
+	});
+
+	describe("trimming visuals to dialogue (the default)", () => {
+		it("cuts a foreground to the dialogue after it, ignoring its own length", () => {
+			const layout = buildVideoLayout([
+				el({ id: "clip1", type: "clip", durationSec: 10 }),
+				el({ id: "n1", type: "narration", durationSec: 3 }),
+			]);
+			expect(layout.series[0].duration).toBe(3);
+			expect(layout.totalDurationSec).toBe(3);
+		});
+
+		it("holds a foreground with no dialogue after it for the minimum duration", () => {
+			const layout = buildVideoLayout([
+				el({ id: "clip1", type: "clip", durationSec: 10 }),
+			]);
+			expect(layout.series[0].duration).toBe(1);
+		});
+
+		it("trims a background to the dialogue-driven span, not the clip's own length", () => {
+			const layout = buildVideoLayout([
+				el({ id: "m1", type: "music", durationSec: 30 }),
+				el({ id: "clip1", type: "clip", durationSec: 10 }),
+				el({ id: "n1", type: "narration", durationSec: 4 }),
+			]);
+			expect(seqs(layout, "music")[0].duration).toBe(4);
+		});
+
+		it("plays the clip out in full when trimming is off", () => {
+			const layout = buildVideoLayout(
+				[
+					el({ id: "clip1", type: "clip", durationSec: 10 }),
+					el({ id: "n1", type: "narration", durationSec: 3 }),
+				],
+				{ trimVisualsToDialogue: false },
+			);
+			expect(layout.series[0].duration).toBe(10);
+			expect(layout.totalDurationSec).toBe(10);
 		});
 	});
 });

--- a/lib/video/elementAttributes.ts
+++ b/lib/video/elementAttributes.ts
@@ -1,4 +1,8 @@
-import type { CanvasContentElement } from "@/lib/canvas/types";
+import {
+	DEFAULT_DURATION,
+	DURATION_OPTIONS,
+	type CanvasContentElement,
+} from "@/lib/canvas/types";
 import { clamp } from "@/lib/utils";
 import { DEFAULT_MOTION, isMotionEffect } from "./motionEffects";
 import type { MotionEffect } from "./motionEffectNames";
@@ -21,6 +25,17 @@ export function getVolume(element: CanvasContentElement): number {
 	return Number.isFinite(raw)
 		? clamp(raw, VOLUME_MIN, VOLUME_MAX)
 		: DEFAULT_VOLUME;
+}
+
+const DURATIONS = DURATION_OPTIONS.map(Number);
+const DURATION_MIN = Math.min(...DURATIONS);
+const DURATION_MAX = Math.max(...DURATIONS);
+
+/** Seconds a timed visual is generated to run for, clamped to the offered options. */
+export function getDuration(element: CanvasContentElement): number {
+	const raw = Number(element.customAttributes?.duration);
+	if (!Number.isFinite(raw)) return Number(DEFAULT_DURATION);
+	return clamp(raw, DURATION_MIN, DURATION_MAX);
 }
 
 const LOOPS_MAX = 1000;

--- a/lib/video/elementLengths.ts
+++ b/lib/video/elementLengths.ts
@@ -1,0 +1,82 @@
+import type { Descendant } from "slate";
+import { getElementBodyText } from "@/lib/canvas/osmlSerializer";
+import { isSceneElement } from "@/lib/canvas/scenes";
+import { countWords } from "@/lib/canvas/spokenWords";
+import {
+	ELEMENT_TYPES,
+	FOREGROUND_TYPES,
+	type CanvasContentElement,
+	type CanvasElementType,
+} from "@/lib/canvas/types";
+import { getDuration } from "./elementAttributes";
+import { MIN_DURATION_SEC } from "./scene-builder";
+import { secondsForWords } from "./videoLength";
+
+/** How long one visual holds the screen, and what decides it. */
+export type ElementLength = {
+	id: string;
+	type: CanvasElementType;
+	sceneNumber: number;
+	seconds: number;
+	/** The spoken words that follow it, up to the next visual. */
+	words: number;
+	dialogueIds: string[];
+};
+
+type Span = {
+	element: CanvasContentElement;
+	sceneNumber: number;
+	words: number;
+	dialogueIds: string[];
+};
+
+/** A generated clip runs for its own length; a still has none of its own. */
+const ownSeconds = (element: CanvasContentElement): number =>
+	ELEMENT_TYPES[element.type].outputKind === "video" ? getDuration(element) : 0;
+
+const toLength = (
+	{ element, sceneNumber, words, dialogueIds }: Span,
+	trimVisualsToDialogue: boolean,
+): ElementLength => ({
+	id: element.id,
+	type: element.type,
+	sceneNumber,
+	words,
+	dialogueIds,
+	seconds: Math.max(
+		secondsForWords(words),
+		trimVisualsToDialogue ? 0 : ownSeconds(element),
+		MIN_DURATION_SEC,
+	),
+});
+
+/**
+ * What every visual on the canvas is on screen for, estimated from the script
+ * alone: the same rule `buildVideoLayout` lays out with, read off the unrendered
+ * script. Dialogue before the first visual belongs to no visual and is left out.
+ */
+export function measureElementLengths(
+	descendants: Descendant[],
+	trimVisualsToDialogue: boolean,
+): ElementLength[] {
+	const spans: Span[] = [];
+	let sceneNumber = 0;
+
+	for (const node of descendants) {
+		if (!isSceneElement(node)) continue;
+		sceneNumber += 1;
+
+		for (const element of node.children) {
+			if (FOREGROUND_TYPES.has(element.type)) {
+				spans.push({ element, sceneNumber, words: 0, dialogueIds: [] });
+				continue;
+			}
+			const open = spans.at(-1);
+			if (!open || ELEMENT_TYPES[element.type].connector !== "tts") continue;
+			open.words += countWords(getElementBodyText(element));
+			open.dialogueIds.push(element.id);
+		}
+	}
+
+	return spans.map((span) => toLength(span, trimVisualsToDialogue));
+}

--- a/lib/video/scene-builder.ts
+++ b/lib/video/scene-builder.ts
@@ -20,9 +20,18 @@ export type BuildLayoutOptions = Partial<VideoConfig> & {
 	transitionType?: TransitionType;
 	aspectRatio?: AspectRatio;
 	captionStyle?: CaptionStyle;
+	trimVisualsToDialogue?: boolean;
 };
 
-const MIN_DURATION_SEC = 1;
+/**
+ * Trimmed, a visual is on screen for the dialogue that follows it and no longer,
+ * so a generated clip's own length only decides what plays before it is cut.
+ * Untrimmed, the clip plays out in full and the dialogue can only extend it.
+ */
+export const DEFAULT_TRIM_VISUALS_TO_DIALOGUE = true;
+
+/** No sequence is ever shorter than this, however little content it holds. */
+export const MIN_DURATION_SEC = 1;
 // Durations accumulated on the frame grid land a few ULPs above a whole frame.
 // Without this slack the total ceils into a trailing frame with no content.
 const FRAME_EPSILON = 1e-6;
@@ -90,6 +99,10 @@ export function buildVideoLayout(
 		: undefined;
 	const cfg = { ...DEFAULT_CONFIG, ...aspectDims, ...options };
 	const transitionType = options?.transitionType ?? DEFAULT_TRANSITION;
+	const trimVisualsToDialogue =
+		options?.trimVisualsToDialogue ?? DEFAULT_TRIM_VISUALS_TO_DIALOGUE;
+	const visualDuration = (element: ResolvedElement) =>
+		trimVisualsToDialogue ? 0 : element.durationSec;
 	// TransitionSeries lays transitions down in whole frames, so the overlap has
 	// to sit on the frame grid too. Subtracting the raw seconds would drift the
 	// absolutely-positioned layers a fraction of a frame per scene boundary.
@@ -123,7 +136,7 @@ export function buildVideoLayout(
 					// subsequent overlay/background/effect lands on the rendered timeline.
 					cursor -= transitionDurationSec;
 				}
-				series.push(createSequence(element, cursor, element.durationSec));
+				series.push(createSequence(element, cursor, visualDuration(element)));
 				break;
 			}
 			case "overlay": {

--- a/lib/video/videoLength.ts
+++ b/lib/video/videoLength.ts
@@ -20,6 +20,10 @@ export const NARRATION_WORDS_PER_MINUTE = 180;
 const wordsForSeconds = (sec: number): number =>
 	Math.round((sec * NARRATION_WORDS_PER_MINUTE) / 600) * 10;
 
+/** How long a spoken-word count takes to say, the one rate the app estimates with. */
+export const secondsForWords = (words: number): number =>
+	(words * 60) / NARRATION_WORDS_PER_MINUTE;
+
 export type VideoLengthSpec = {
 	label: string;
 	minWords: number;


### PR DESCRIPTION
## Summary
- Adds `measure_element_lengths`, an agent tool reporting each visual's seconds on screen and the dialogue ids that decide it, so Sloppy can answer "make each image last 4 seconds" by splitting or merging dialogue instead of guessing. Backed by a new pure module `lib/video/elementLengths.ts`.
- Renames `count_words` to `measure_total_length`, so the two tools read as one question at two anchors: the whole video, or each element.
- Fixes the Runware provider never stamping `durationSec` on a completed job (every generated video resolved to 0s), and makes the behavior that bug produced explicit as `buildVideoLayout`'s `trimVisualsToDialogue` option, default `true`. Ready to become a `VideoSettings` field; nothing turns it off yet outside tests.
- Teaches the system prompt the actual rule, and gives `toolPresentation` a fallback so transcripts written before the rename still render.

## Test plan
- [x] `npm run lint`, `format:check`, `typecheck`, `knip`, `build`
- [x] `npm test` — 1283 passing, including new coverage for `measureElementLengths` (dialogue spans across scenes, silent elements ignored, the 1s floor), both trim modes in `scene-builder`, the poll duration stamp, and `toolPresentation`'s renamed-tool fallback
- [ ] In the app: ask Sloppy "how long is each image shown?" and then "make each one about 4 seconds", confirm it calls the tool and edits dialogue rather than guessing
- [ ] Open a conversation saved before this branch and confirm the transcript renders instead of throwing in `<Tool>`

## Notes
- Rendered output is unchanged for Runware projects. Mock projects will differ: `MockVideo` reports real 15s-174s stock clips, which until now became scenes that long and are now trimmed to their dialogue.
- The existing `scene-builder` and `timelineRows` suites are built on fixtures where a visual's own length defines the span, which trimming makes moot; they now go through a local `untrimmed()` helper, with a new dedicated block covering the trimmed default.
- Reported seconds are per-sequence and do not subtract the 0.4s transition overlap that adjacent scenes share.