### PR TITLE
fix: shorten the measure-element-lengths tool label

### DIFF
--- a/app/components/sloppy/toolPresentation.tsx
+++ b/app/components/sloppy/toolPresentation.tsx
@@ -71,7 +71,7 @@ function offeredTool(part: ToolPart): ToolPresentation {
 		case "tool-measure_element_lengths":
 			return {
 				icon: Hourglass,
-				label: "Measuring how long each visual is shown",
+				label: "Measuring scene lengths",
 			};
 		case "tool-set_language":
 			return { icon: Translate, label: "Setting the language" };


### PR DESCRIPTION
## Summary
- Shortens the `measure_element_lengths` tool label from "Measuring how long each visual is shown" to "Measuring scene lengths" so it fits on one line in the tool strip.

## Test plan
- Trigger the measure element lengths tool in Sloppy and confirm the label renders without wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArqvtxiVArrPSyggQcQEaL