### PR TITLE
fix: nightly bug fixes 2026-08-21

### DIFF
--- a/lib/canvas/osmlSerializer.ts
+++ b/lib/canvas/osmlSerializer.ts
@@ -4,7 +4,8 @@ import { getContentElements, isSceneElement } from "@/lib/canvas/scenes";
 import { withoutCaretMarker } from "./constants";
 import { escapeXml } from "./xmlEscape";
 
-export const SCENE_MARKER_PATTERN = /^---\s*Scene\s+\d+\s*---\s*$/m;
+/** Matched a line at a time, so a marker inside element text can be told apart. */
+export const SCENE_MARKER_PATTERN = /^---\s*Scene\s+\d+\s*---\s*$/;
 const sceneMarker = (n: number) => `\n--- Scene ${n} ---\n`;
 
 export function getElementText(element: ParsedElement): string {

--- a/lib/project/__tests__/serialize.test.ts
+++ b/lib/project/__tests__/serialize.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	getElementBodyText,
 	getElementText,
 	serializeOSMLWithScenes,
 } from "@/lib/canvas/osmlSerializer";
@@ -54,6 +55,35 @@ describe("splitScenes", () => {
 		expect(parts[0]).toContain('<image id="a"></image>');
 		expect(parts[1]).toContain("<narration");
 	});
+
+	it("keeps a marker line that sits inside element text with its element", () => {
+		const osml = [
+			"--- Scene 1 ---",
+			'<narration id="a">before',
+			"--- Scene 2 ---",
+			"after</narration>",
+			'<image id="b"></image>',
+		].join("\n");
+
+		expect(splitScenes(osml)).toEqual([
+			'<narration id="a">before\n--- Scene 2 ---\nafter</narration>\n<image id="b"></image>',
+		]);
+	});
+
+	it("still splits on the marker that follows a multi-line element", () => {
+		const osml = [
+			"--- Scene 1 ---",
+			'<narration id="a">one',
+			"two</narration>",
+			"--- Scene 2 ---",
+			'<image id="b"></image>',
+		].join("\n");
+
+		const parts = splitScenes(osml);
+		expect(parts).toHaveLength(2);
+		expect(parts[0]).toBe('<narration id="a">one\ntwo</narration>');
+		expect(parts[1]).toBe('<image id="b"></image>');
+	});
 });
 
 describe("deserializeWithScenes", () => {
@@ -88,6 +118,24 @@ describe("deserializeWithScenes", () => {
 		expect(image.id).toBe("image-id");
 		expect(image.customAttributes?.prompt).toBe('a 24" monitor & a <box>');
 		expect(getElementText(image)).toContain("5 < 10 & 20 > 15");
+	});
+
+	it("round-trips text holding a line that reads as a scene marker", () => {
+		const original = [
+			makeScene([makeEl("narration", "before\n--- Scene 2 ---\nafter")]),
+			makeScene([makeEl("image", "a castle")]),
+		];
+
+		const scenes = deserializeWithScenes(
+			serializeOSMLWithScenes(original),
+			connectors,
+		);
+
+		expect(scenes).toHaveLength(2);
+		expect(getElementBodyText(scenes[0].children[0])).toBe(
+			"before\n--- Scene 2 ---\nafter",
+		);
+		expect(scenes[1].children[0].type).toBe("image");
 	});
 
 	it("round-trips with serializeWithScenes preserving customAttributes.url", () => {

--- a/lib/project/serialize.ts
+++ b/lib/project/serialize.ts
@@ -8,12 +8,33 @@ import type { ConnectorRegistry } from "@/lib/connectors/registry";
 /** The document a project starts from when there is no generated script. */
 export const BLANK_SCRIPT = "<narration></narration>";
 
+const ELEMENT_TAG = /<(\/?)[A-Za-z_][^<>]*>/g;
+
+/** Element tags never nest, so the last one on a line decides what follows it. */
+function isInsideElement(line: string, open: boolean): boolean {
+	const last = [...line.matchAll(ELEMENT_TAG)].at(-1);
+	return last ? last[1] !== "/" : open;
+}
+
+/**
+ * Scene markers only separate scenes between elements. Element text can hold a
+ * line that reads as one, and splitting there would cut the element in half and
+ * lose the rest of the scene on the next load.
+ */
 export function splitScenes(osml: string): string[] {
-	if (!osml.trim()) return [];
-	return osml
-		.split(SCENE_MARKER_PATTERN)
-		.map((chunk) => chunk.trim())
-		.filter((chunk) => chunk.length > 0);
+	const scenes: string[][] = [[]];
+	let insideElement = false;
+
+	for (const line of osml.split("\n")) {
+		if (!insideElement && SCENE_MARKER_PATTERN.test(line)) {
+			scenes.push([]);
+			continue;
+		}
+		scenes[scenes.length - 1].push(line);
+		insideElement = isInsideElement(line, insideElement);
+	}
+
+	return scenes.map((lines) => lines.join("\n").trim()).filter(Boolean);
 }
 
 export function deserializeWithScenes(


### PR DESCRIPTION
## Bug

A saved script stores scenes as `--- Scene N ---` marker lines between serialized elements. `splitScenes` split the whole document on that marker with a `/m` regex, so a marker-looking line **inside an element's text** was treated as a scene boundary.

Element text can legitimately span lines (the LLM streams multi-line narration, and pasted scripts keep their line breaks). When such a line reads as a marker, reloading the project cut the element in half: its text was truncated at the marker and the rest of the scene came back as a separate scene with a dangling `</narration>`. Silent document corruption on the persistence path.

## Fix

Split a line at a time, tracking whether the previous line left an element tag open. Only markers that sit between elements separate scenes. `SCENE_MARKER_PATTERN` loses its `/m` flag since it is now matched against one line.

No format change: what gets written is byte-for-byte what it was, and existing scripts split exactly as before unless they were already being corrupted.

## Tests

- `splitScenes` keeps a marker line inside element text with its element
- `splitScenes` still splits on the marker that follows a multi-line element
- `deserializeWithScenes` round-trips text holding a line that reads as a scene marker

## Checks

`lint`, `format:check`, `typecheck`, `knip`, `build`, `test:coverage` all pass.

## Open PR overlap check

Considered #602, #603, #604, #605, #606, #607, #608. None touches `lib/project/serialize.ts` or `lib/canvas/osmlSerializer.ts`; #602 touches `lib/video/*` and `app/components/sloppy/*`, #605 `lib/canvas/editorOps.ts`, #608 `app/components/canvas/utils/*` and `lib/components/scrollIntoContainer.ts`. This PR is non-overlapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)