### PR TITLE
refactor: nightly maintainability 2026-08-21

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -38,7 +38,7 @@ Turns are stored as the SDK's UI message type, so the stream, the rows and the p
 
 The generation pipeline is split so providers and asset types can be swapped independently:
 
-- **Connectors** (`lib/connectors/`): what the editor calls. Model-agnostic, plugin-pipelined, return an `AssetResult`.
+- **Connectors** (`lib/connectors/`): what the editor calls. Model-agnostic, plugin-pipelined, return an `AssetResult`. `DEFAULT_CONNECTOR_REGISTRY` declares each type's static plugin chain; `ConfigProvider` appends only the chains that need a live project store.
 - **Gateways** (`lib/gateway/`): thin HTTP clients between connectors and our `/api/v1/*` routes. This seam lets connectors run against the live API or a mock. Today there is one OpenSlop gateway. A BYOK gateway will be added so users can call providers with their own API keys.
 - **Providers** (`lib/providers/`): server-side adapters for vendors (Runware, ElevenLabs, Cartesia, Anthropic). Call the vendor SDK, upload assets, return a bundle response. LLM providers go through the Vercel AI SDK; `getLLMProvider` in `lib/api/providers.ts` is the one place a vendor is chosen, and the provider's `agentModel()` builds the `LanguageModel` and maps vendor-specific knobs like reasoning effort.
 

--- a/lib/config/ConfigProvider.tsx
+++ b/lib/config/ConfigProvider.tsx
@@ -7,13 +7,7 @@ import {
 	withRegistry,
 	type ConnectorRegistry,
 } from "@/lib/connectors/registry";
-import { buildImagePlugins } from "../connectors/image/plugins/imageChain";
-import { buildAnimatedImagePlugins } from "../connectors/animated_image/plugins/animated-image-chain";
-import { createMetadataVoicePlugin } from "../connectors/tts/plugins/metadata-voice";
-import { createReferenceImagesPlugin } from "../connectors/image/plugins/reference-images";
-import { createDimensionsPlugin } from "../connectors/plugins/dimensions";
 import { createVoiceHydratePlugin } from "../connectors/tts/plugins/voice-hydrate";
-import { createVoiceSearchPlugin } from "../connectors/tts/plugins/voice-search";
 import { useProjectStoreHandle } from "@/lib/project/ProjectStoreProvider";
 
 type ConfigContextValue = {
@@ -36,16 +30,7 @@ export function ConfigProvider({
 
 	const configWithPlugins = useMemo<ConnectorRegistry>(() => {
 		return withRegistry(DEFAULT_CONNECTOR_REGISTRY)
-			.appendPlugins("image", ...buildImagePlugins())
-			.appendPlugins(
-				"video",
-				createReferenceImagesPlugin(),
-				createDimensionsPlugin("video"),
-			)
-			.appendPlugins("tts", createMetadataVoicePlugin())
-			.appendPlugins("tts", createVoiceSearchPlugin())
 			.appendPlugins("tts", createVoiceHydratePlugin(store))
-			.appendPlugins("animated_image", ...buildAnimatedImagePlugins())
 			.build();
 	}, [store]);
 

--- a/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
@@ -4,11 +4,7 @@ import type {
 	AssetResult,
 	PluginContext,
 } from "@/lib/connectors/types";
-import { buildImagePlugins } from "@/lib/connectors/image/plugins/imageChain";
-import {
-	DEFAULT_CONNECTOR_REGISTRY,
-	withRegistry,
-} from "@/lib/connectors/registry";
+import { DEFAULT_CONNECTOR_REGISTRY } from "@/lib/connectors/registry";
 import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 import {
 	forElement,
@@ -18,7 +14,6 @@ import {
 import { GenerationQueue } from "@/lib/generation/queue";
 import { nodeBuilder } from "@/lib/generation/resolveGraph";
 import { MetadataSchema } from "@/lib/project/types";
-import { buildAnimatedImagePlugins } from "../animated-image-chain";
 import {
 	createStillFramePlugin,
 	stillElementId,
@@ -84,10 +79,7 @@ describe("still-frame plugin", () => {
 });
 
 describe("stillSnapshot", () => {
-	const registry = withRegistry(DEFAULT_CONNECTOR_REGISTRY)
-		.appendPlugins("image", ...buildImagePlugins())
-		.appendPlugins("animated_image", ...buildAnimatedImagePlugins())
-		.build();
+	const registry = DEFAULT_CONNECTOR_REGISTRY;
 	const state = {
 		hydrated: true,
 		metadata: MetadataSchema.parse({}),
@@ -148,10 +140,7 @@ describe("stillSnapshot", () => {
 });
 
 describe("duplicated animation", () => {
-	const registry = withRegistry(DEFAULT_CONNECTOR_REGISTRY)
-		.appendPlugins("image", ...buildImagePlugins())
-		.appendPlugins("animated_image", ...buildAnimatedImagePlugins())
-		.build();
+	const registry = DEFAULT_CONNECTOR_REGISTRY;
 	const state = {
 		hydrated: true,
 		metadata: MetadataSchema.parse({}),
@@ -199,10 +188,7 @@ describe("duplicated animation", () => {
 });
 
 describe("uploaded still lifetime", () => {
-	const registry = withRegistry(DEFAULT_CONNECTOR_REGISTRY)
-		.appendPlugins("image", ...buildImagePlugins())
-		.appendPlugins("animated_image", ...buildAnimatedImagePlugins())
-		.build();
+	const registry = DEFAULT_CONNECTOR_REGISTRY;
 	const state = {
 		hydrated: true,
 		metadata: MetadataSchema.parse({}),

--- a/lib/connectors/animated_image/plugins/still-frame.ts
+++ b/lib/connectors/animated_image/plugins/still-frame.ts
@@ -1,13 +1,13 @@
 import omit from "lodash/omit";
 import type { CanvasContentElement } from "@/lib/canvas/types";
-import type {
-	AnimatedImageGenerateParams,
-	AssetResult,
-	ConnectorPlugin,
-	PluginContext,
+import {
+	DEFAULT_PROVIDER,
+	type AnimatedImageGenerateParams,
+	type AssetResult,
+	type ConnectorPlugin,
+	type PluginContext,
 } from "@/lib/connectors/types";
 import { buildImagePlugins } from "@/lib/connectors/image/plugins/imageChain";
-import { DEFAULT_PROVIDER } from "@/lib/connectors/registry";
 import {
 	derivedNodeId,
 	type GenerationNode,

--- a/lib/connectors/registry.ts
+++ b/lib/connectors/registry.ts
@@ -1,5 +1,11 @@
 import set from "lodash/fp/set";
 import { createConnector } from "./factory";
+import { buildAnimatedImagePlugins } from "./animated_image/plugins/animated-image-chain";
+import { buildImagePlugins } from "./image/plugins/imageChain";
+import { createReferenceImagesPlugin } from "./image/plugins/reference-images";
+import { createDimensionsPlugin } from "./plugins/dimensions";
+import { createMetadataVoicePlugin } from "./tts/plugins/metadata-voice";
+import { createVoiceSearchPlugin } from "./tts/plugins/voice-search";
 import { IMAGE_MODELS } from "./image/openslop/models";
 import { LLM_MODELS } from "./llm/openslop/models";
 import { MUSIC_MODELS } from "./music/openslop/models";
@@ -33,16 +39,23 @@ const openslopConfig = (
 	},
 });
 
-/** Derived nodes have no settings UI to pin a provider, so they take this one. */
-export const DEFAULT_PROVIDER: ProviderKey = "openslop";
-
-/** Plugin-free baseline; project-scoped plugin chains are layered on by `ConfigProvider`. */
+/** Static plugin chains; `ConfigProvider` layers the project-scoped ones on top. */
 export const DEFAULT_CONNECTOR_REGISTRY: ConnectorRegistry = {
 	llm: openslopConfig("Slop LLM v1", LLM_MODELS),
-	tts: openslopConfig("Slop TTS v1", TTS_MODELS),
-	image: openslopConfig("Slop Image v1", IMAGE_MODELS),
-	animated_image: openslopConfig("Slop Video v1", VIDEO_MODELS),
-	video: openslopConfig("Slop Video v1", VIDEO_MODELS),
+	tts: openslopConfig("Slop TTS v1", TTS_MODELS, [
+		createMetadataVoicePlugin(),
+		createVoiceSearchPlugin(),
+	]),
+	image: openslopConfig("Slop Image v1", IMAGE_MODELS, buildImagePlugins()),
+	animated_image: openslopConfig(
+		"Slop Video v1",
+		VIDEO_MODELS,
+		buildAnimatedImagePlugins(),
+	),
+	video: openslopConfig("Slop Video v1", VIDEO_MODELS, [
+		createReferenceImagesPlugin(),
+		createDimensionsPlugin("video"),
+	]),
 	sfx: openslopConfig("Slop SFX v1", SFX_MODELS),
 	music: openslopConfig("Slop Music v1", MUSIC_MODELS),
 };

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -20,6 +20,9 @@ export type AssetConnectorType = Exclude<ConnectorType, "llm">;
 
 export type ProviderKey = "openslop";
 
+/** Derived nodes have no settings UI to pin a provider, so they take this one. */
+export const DEFAULT_PROVIDER: ProviderKey = "openslop";
+
 export type VoiceSearchFn = (params: VoiceSearchParams) => Promise<VoiceInfo[]>;
 
 export interface PluginContext<TParams = unknown, TResult = unknown> {

--- a/lib/project/characterAvatar.ts
+++ b/lib/project/characterAvatar.ts
@@ -1,6 +1,6 @@
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
-import { DEFAULT_PROVIDER } from "@/lib/connectors/registry";
+import { DEFAULT_PROVIDER } from "@/lib/connectors/types";
 import { derivedNodeId, type NodeResults } from "@/lib/generation/graph";
 import type { ProjectData } from "@/lib/project/store";
 


### PR DESCRIPTION
## What

Static connector plugin chains were declared imperatively in `ConfigProvider`, in four divergent styles, even though none of them has a runtime dependency. They now live in `DEFAULT_CONNECTOR_REGISTRY`, which already owns every other piece of a connector's static config.

- `image` → `buildImagePlugins()`, `animated_image` → `buildAnimatedImagePlugins()`, `video` → reference-images + dimensions, `tts` → metadata-voice + voice-search.
- `ConfigProvider` keeps only the one chain that needs a live project store (`createVoiceHydratePlugin(store)`).
- `DEFAULT_PROVIDER` moves from `registry.ts` to `types.ts` next to `ProviderKey`. It was a *value* import in `still-frame.ts`, which sits in the transitive closure of the chain builders, so leaving it in the registry would have made registry-imports-chains a real runtime cycle.
- `still-frame.test.ts` no longer hand-rolls the same `withRegistry(...).appendPlugins(...)` wiring in three places; it uses the registry directly.
- One line in ARCHITECTURE.md saying where chains are declared.

Append order per type is unchanged, so the resolved plugin list for every connector is byte-identical. No behavior change.

## Complexity delta

7 files, +36/−49. Three duplicated test fixtures collapsed; the plugin-composition surface in the React provider goes from 6 appends over 7 imports to 1 append over 1 import.

## Skipped

- `lib/supabase/env.ts`'s `""` env defaults (soft fail-loudly violation): making it throw is a behavior change, which this runbook forbids. Still open for a human call.
- `ScrubBar.tsx` has no `role="slider"`/keyboard support — belongs to the bugs/a11y nightly.
- Moving the `ConnectorRegistry` *type* into `types.ts` would clear the three new `import type`-only madge cycles (registry → chains → `characterAvatarNode` → registry, all runtime-erased, matching the four already on master), but it touches ~20 import sites including `lib/project/serialize.ts`, which PR #614 owns.

## Open PR overlap check

Considered #614, #608, #607, #606, #605, #604, #603, #602. Their footprint covers `lib/canvas/{osmlSerializer,editorOps}`, `lib/project/serialize`, `app/components/video/**`, `app/components/sloppy/**`, `lib/agent/tools/{registry,outlineStory}`, `lib/providers/llm/mock`, `lib/script/prompt/outline`, `lib/api/{process-job,queue-callback}`, `lib/video/elementAttributes`, `Editor.tsx`, `Waveform.tsx`, `CharacterEditModal`, `AudioPlayer`, `PreviewCacheContext`, `scrollToScene`/`scrollIntoContainer`. This PR touches none of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)