### PR TITLE
feat: seed blank projects with a welcome narration

### DIFF
--- a/lib/project/serialize.ts
+++ b/lib/project/serialize.ts
@@ -6,7 +6,8 @@ import { makeNodeId } from "@/lib/canvas/nodeUtils";
 import type { ConnectorRegistry } from "@/lib/connectors/registry";
 
 /** The document a project starts from when there is no generated script. */
-export const BLANK_SCRIPT = "<narration></narration>";
+export const BLANK_SCRIPT =
+	"<narration>Welcome to OpenSlop! Add an element, or ask Sloppy to plan or write a story for you</narration>";
 
 export function splitScenes(osml: string): string[] {
 	if (!osml.trim()) return [];

--- a/lib/script/ScriptProvider.tsx
+++ b/lib/script/ScriptProvider.tsx
@@ -59,7 +59,7 @@ export function ScriptProvider({
 	const { connectorConfig } = useConfig();
 	const store = useProjectStoreHandle();
 	const updateMetadata = useProject((s) => s.updateMetadata);
-	const [script, setScript] = useState(initialScript);
+	const [script] = useState(initialScript);
 	const [showWorkspace, setShowWorkspace] = useState(initialScript.length > 0);
 	const { nodes, appendChunk, reset } = useOSMLStreamParser();
 
@@ -89,9 +89,10 @@ export function ScriptProvider({
 	);
 
 	const startBlank = useCallback(() => {
-		setScript(BLANK_SCRIPT);
+		updateMetadata({ title: "Untitled" });
 		setShowWorkspace(true);
-	}, []);
+		appendChunk(BLANK_SCRIPT);
+	}, [appendChunk, updateMetadata]);
 
 	const control = useMemo<ScriptControl>(
 		() => ({ runScript, setShowWorkspace, startBlank }),


### PR DESCRIPTION
## What

Blank projects now open with a narration element that greets the user instead of an empty one:

> Welcome to OpenSlop! Add an element, or ask Sloppy to plan or write a story for you

`startBlank` also sets the project title to "Untitled" and feeds the blank script through `appendChunk`, so it reaches the canvas by the same OSML stream path a generated script does rather than a separate `setScript` seed.

## Testing

lint, format:check, typecheck, knip, build, and the full vitest suite (1286 tests) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArqvtxiVArrPSyggQcQEaL