### PR TITLE
fix: nightly security audit 2026-08-22

### DIFF
--- a/app/api/render/progress/__tests__/progress.test.ts
+++ b/app/api/render/progress/__tests__/progress.test.ts
@@ -106,7 +106,7 @@ describe("POST /api/render/progress", () => {
 		const res = await POST(makeRequest(validBody));
 
 		expect(res.status).toBe(500);
-		expect((await res.json()).error).toContain("output file");
+		expect((await res.json()).error).toBe("render/progress failed");
 	});
 
 	it("reports in-flight progress otherwise", async () => {

--- a/lib/api/__tests__/route-handler.test.ts
+++ b/lib/api/__tests__/route-handler.test.ts
@@ -8,6 +8,7 @@ import {
 	createSessionFormRouteHandler,
 	createSessionRouteHandler,
 } from "../route-handler";
+import { logger } from "../logger";
 
 vi.mock("../logger", () => ({
 	logger: { warn: vi.fn(), error: vi.fn() },
@@ -134,26 +135,26 @@ describe("createApiRouteHandler", () => {
 		expect(await res.json()).toEqual({ ok: true, prompt: "hello" });
 	});
 
-	it("returns 500 with the error message when handle throws an Error", async () => {
+	it("returns 500 without the error detail when handle throws an Error", async () => {
+		const cause = new Error("boom at /srv/app/lib/secret.ts");
 		const handler = makeHandler(async () => {
-			throw new Error("boom");
+			throw cause;
 		});
 		const res = await handler(makeRequest({ prompt: "hello" }));
 		expect(res.status).toBe(500);
 		const json = await res.json();
-		expect(json.error).toContain("TestRoute failed: ");
-		expect(json.error).toContain("boom");
+		expect(json.error).toBe("TestRoute failed");
+		expect(logger.error).toHaveBeenCalledWith(cause, "TestRoute failed");
 	});
 
-	it("stringifies non-Error throws", async () => {
+	it("returns 500 without the error detail for non-Error throws", async () => {
 		const handler = makeHandler(async () => {
 			throw "raw string failure";
 		});
 		const res = await handler(makeRequest({ prompt: "hello" }));
 		expect(res.status).toBe(500);
 		const json = await res.json();
-		expect(json.error).toContain("TestRoute failed: ");
-		expect(json.error).toContain("raw string failure");
+		expect(json.error).toBe("TestRoute failed");
 	});
 });
 

--- a/lib/api/with-auth.ts
+++ b/lib/api/with-auth.ts
@@ -1,12 +1,13 @@
 import type { User } from "@supabase/supabase-js";
-import { stringifyError } from "../errors";
 import { getUser } from "./auth";
 import { logger } from "./logger";
 import { forbidden, serverError, unauthorized } from "./response";
 
 type RouteBody = (user: User) => Promise<Response>;
 
-// Uniform error envelope: thrown errors are logged and returned as 500.
+// Uniform error envelope: thrown errors are logged in full and returned as a
+// 500 that names the route only. The serialized cause carries stack frames and
+// upstream detail, which the caller has no business reading.
 async function runGuarded(
 	label: string,
 	run: () => Promise<Response>,
@@ -15,7 +16,7 @@ async function runGuarded(
 		return await run();
 	} catch (error) {
 		logger.error(error, `${label} failed`);
-		return serverError(`${label} failed: ${stringifyError(error)}`);
+		return serverError(`${label} failed`);
 	}
 }
 


### PR DESCRIPTION
## Fix: API error responses leaked serialized exceptions

`runGuarded` in `lib/api/with-auth.ts` is the single error envelope for every API route. On a thrown error it returned:

```ts
serverError(`${label} failed: ${stringifyError(error)}`)
```

`stringifyError` is `JSON.stringify(serializeError(error))`, so the 500 body carried the full error object: message, **stack frames with absolute server file paths**, `cause` chains, and whatever upstream detail Supabase or a provider SDK attached. That body is returned to the caller on every route, including the unauthenticated public ones (`/api/validate-code`). Any user who can make a route throw (an upstream provider failure, a DB error) reads back internal server structure — CWE-209.

The fix returns `${label} failed` and nothing else. The error is still logged in full via `logger.error(error, ...)`, so nothing is swallowed and the failure is still loud.

### Audited, no change needed
- **Dependencies** — `npm audit`: one moderate, `uuid@9` via `@runware/sdk-js` (GHSA-w5hq-g745-h8pq). Not exploitable here: the bug is a missing bounds check on the caller-supplied `buf` argument to `v3/v5/v6`, which nothing in this tree reaches. No fix published upstream; forcing `uuid@11` on a dep declaring `^9.0.1` is a larger break than the risk. No open Dependabot alerts.
- **Secrets** — no hardcoded keys; only `.env.example` is tracked.
- **SSRF** — `/api/v1/tts/voices/preview` is already origin-allowlisted (`fetchAllowedVoicePreview`, HTTPS + host + port, `redirect: "manual"`). `referenceImages` URLs go to the model provider, not to a server-side fetch.
- **Supabase/RLS** — every table has RLS with `auth.uid() = user_id` policies; access codes are only reachable through the security-definer RPC. Service-role client is confined to queue processing and the dev-only impersonate route (404s in production).
- **Auth** — `withApiAccess` gates on `app_metadata.api_access` (not user-writable); job polling and conversations are scoped by `user_id`.
- **Injection/XSS** — no `dangerouslySetInnerHTML`, `eval`, or `new Function` in app code. Uploads sanitize filenames and land on a separate blob origin.
- **Headers** — nosniff / SAMEORIGIN / HSTS / Referrer-Policy already set in `next.config.ts`.

### Noted, not fixed here
`jobs.error` stores `stringifyError(...)` and `pollJob` returns it to the job owner — the same disclosure class, one tier lower (authenticated owner only). `lib/api/process-job.ts` is owned by open PR #603, so it is left alone per the overlap guard.

### Open PR overlap check
Considered #602, #603, #604, #605, #606, #607, #608, #614, #615, #616, #617. This PR touches `lib/api/with-auth.ts`, `lib/api/__tests__/route-handler.test.ts`, and `app/api/render/progress/__tests__/progress.test.ts` — none appear in any open PR's file list. #603 is the nearest (also `lib/api/`) but is confined to the queue callback path. Non-overlapping.

### Validation
`lint`, `format:check`, `typecheck`, `knip`, `build`, `test` all pass (1286 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)