### PR TITLE
perf: nightly performance optimizations 2026-08-22

### DIFF
--- a/app/components/canvas/__tests__/withChunking.test.ts
+++ b/app/components/canvas/__tests__/withChunking.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createEditor } from "slate";
+import { withReact } from "slate-react";
+import { withChunking } from "../plugins/withChunking";
+import {
+	SCENE_TYPE,
+	type CanvasEditor,
+	type SceneElement,
+} from "@/lib/canvas/types";
+
+function makeEditor(): CanvasEditor {
+	return withChunking(withReact(createEditor()) as CanvasEditor);
+}
+
+const scene: SceneElement = {
+	id: "s",
+	type: SCENE_TYPE,
+	children: [
+		{
+			id: "n",
+			type: "narration",
+			children: [{ id: "t", type: "narration", text: "hi" }],
+		},
+	],
+};
+
+describe("withChunking", () => {
+	it("chunks the editor's scenes", () => {
+		const editor = makeEditor();
+		expect(editor.getChunkSize(editor)).toBeGreaterThan(0);
+	});
+
+	it("leaves a scene's elements unchunked", () => {
+		const editor = makeEditor();
+		expect(editor.getChunkSize(scene)).toBeNull();
+	});
+});

--- a/app/components/canvas/hooks/useEditorSetup.ts
+++ b/app/components/canvas/hooks/useEditorSetup.ts
@@ -5,6 +5,7 @@ import { withHistory } from "slate-history";
 import flow from "lodash/flow";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import type { CanvasEditor } from "@/lib/canvas/types";
+import { withChunking } from "../plugins/withChunking";
 import { withNodeId } from "../plugins/withNodeId";
 import { withLayout } from "../plugins/withLayout";
 import { withScenes } from "../plugins/withScenes";
@@ -17,6 +18,7 @@ export function useEditorSetup(): CanvasEditor {
 		flow(
 			withHistory,
 			withReact,
+			withChunking,
 			withLayout(connectorConfig),
 			withScenes,
 			withFlatPaste,

--- a/app/components/canvas/plugins/withChunking.ts
+++ b/app/components/canvas/plugins/withChunking.ts
@@ -1,0 +1,26 @@
+import { Editor, type Ancestor } from "slate";
+import type { CanvasEditor } from "@/lib/canvas/types";
+
+/**
+ * Scenes per chunk. Below this many scenes `slate-react` builds a flat chunk
+ * tree and the optimization costs nothing; above it the tree deepens, so a
+ * keystroke reconciles `SCENE_CHUNK_SIZE × depth` scenes instead of all of
+ * them. Scenes are heavy subtrees, so the size is far below the plain-text
+ * default the walkthrough suggests.
+ */
+const SCENE_CHUNK_SIZE = 8;
+
+/**
+ * Chunks the editor's top-level scenes, per the Slate performance walkthrough.
+ * Only the chunks containing changed scenes re-render; the rest are memoized,
+ * and their index/parent bookkeeping is skipped entirely.
+ *
+ * Scene children are left unchunked: a scene holds a handful of elements, which
+ * is under any useful chunk size.
+ */
+export const withChunking = (editor: CanvasEditor): CanvasEditor => {
+	editor.getChunkSize = (node: Ancestor) =>
+		Editor.isEditor(node) ? SCENE_CHUNK_SIZE : null;
+
+	return editor;
+};


### PR DESCRIPTION
## What

Typing in the canvas re-runs `slate-react`'s editor-level `useChildren` over **every** top-level scene, whichever scene was edited. Per `node_modules/slate-react/dist/index.js:2441-2483`, without chunking that is, per change, for N scenes:

- `2N` `NODE_TO_INDEX` / `NODE_TO_PARENT` WeakMap writes (the explicit `if (!chunking)` branch),
- `N` `ReactEditor.findKey` lookups,
- `2N` `createElement` calls (`ElementContext.Provider` + `MemoizedElement`),
- `N` memo comparators, and N children for React to reconcile.

`MemoizedElement` still stops unedited scenes re-rendering their subtree, so this is reconciliation overhead rather than card renders — but it is O(document) on the app's most-used interaction, and it is exactly what chunking removes.

This is item 1 of #510 and the headline technique in the [Slate performance walkthrough](https://docs.slatejs.org/walkthroughs/09-performance) ("10x in ideal circumstances"). It was deferred in #568 over the chunk-size / separator interaction; see "Why it's safe now" below.

## Change

`withChunking` sets `editor.getChunkSize`: a size for the editor root, `null` for everything else. That is the whole plugin — the rest is `slate-react`'s own machinery.

- **Chunk size 8.** The depth `slate-react` picks comes from the child count (`index.js:2056-2065`): at the walkthrough's plain-text default of 1000, a document of a few hundred scenes gets depth 0 — a flat tree and no win, which is what stalled #568. Scenes are heavy subtrees, not paragraphs, so the size belongs far lower. At 8, a document with 8 scenes or fewer still gets depth 0 and pays nothing; past that the tree deepens and only the chunks on the path to the edited scene re-render.
- **Scene children stay unchunked.** A scene holds a handful of elements, under any useful chunk size.

Per-change children work at the editor root, counted from the depth formula above:

| scenes | chunk depth | unchunked | chunked |
| --- | --- | --- | --- |
| 8 | 0 | 8 | 8 |
| 40 | 1 | 40 | 13 |
| 100 | 2 | 100 | 18 |
| 200 | 2 | 200 | 20 |
| 480 | 2 | 480 | 24 |

The WeakMap writes drop out entirely: with chunking they happen only for nodes the chunk-tree reconciler reports as inserted, updated or reindexed.

## Why it's safe now

`defaultRenderChunk` returns its children unwrapped (`index.js:2348-2351`), so no `renderChunk` is supplied and **no DOM changes**. Scenes stay siblings of one another, so the `first:border-t-0` separator rule on `SortableScene` and `content-visibility` on `.scene` behave exactly as before, and dnd-kit registration (keyed on element ids) is untouched.

`withChunking` is ordered after `withReact`, which overrides `getChunkSize` to `null` and reads it back at call time for its `move_node` chunk bookkeeping (`index.js:4516-4529`) — so scene reordering and `withScenes` normalization moves are handled by the library.

## Open PR overlap check

Considered open PRs #620, #619, #617, #616, #615, #614, #608, #607, #606, #605, #604, #603, #602 and diffed their file lists against this one. No overlap: they cover `lib/script/prompt` + templates, `lib/api`, `lib/canvas/osml*`, `lib/connectors`, `lib/video`, `app/components/video/**`, `app/components/sloppy/**`, the asset/copilot components and `lib/agent`. Nothing here touches those files or themes.

## Skipped

- **`content-visibility: auto` on element cards (item 2 of #510).** Already in place at the scene level (`sortable.module.css`); pushing it down to individual cards puts it inside the contenteditable subtree, which is not worth the selection risk for a second-order paint win.
- **`ViewModeContext` identity churn (item 5).** #556 shipped that shape and was closed.
- **`getLayoutKey` / `sceneItems` / autosave serialization.** #510 measured these at sub-millisecond even at 480 elements. Optimizing them is the trivial-gain PR.
- **Remotion per-frame path** (`MotionLayer`, `Captions`, `motionEffects`) and the OSML stream parser. Re-read both; still tight, nothing material left.

## Checks

`lint`, `format:check`, `typecheck`, `knip`, `build`, `test:coverage` (145 files) all pass.