### PR TITLE
fix(autosave): skip a save whose payload has not changed

### DIFF
--- a/app/components/canvas/hooks/useAutosave.ts
+++ b/app/components/canvas/hooks/useAutosave.ts
@@ -6,7 +6,6 @@ import { serializeOSMLWithScenes } from "@/lib/canvas/osmlSerializer";
 import { createAutosaver } from "@/lib/project/autosave";
 import { useProjectStoreHandle } from "@/lib/project/ProjectStoreProvider";
 import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
-import { useScriptInitial } from "@/lib/script/ScriptProvider";
 
 const TOAST_OPTIONS = {
 	id: "autosave",
@@ -21,14 +20,12 @@ const TOAST_OPTIONS = {
 export function useAutosave(projectId: string, editor: Editor): () => void {
 	const queue = useGenerationQueue();
 	const store = useProjectStoreHandle();
-	const initialScript = useScriptInitial();
 
 	const autosaver = useMemo(
 		() =>
 			createAutosaver({
 				projectId,
 				store,
-				initialScript,
 				getScript: () => serializeOSMLWithScenes(editor.children),
 				getGeneration: () => queue.snapshot(),
 				onSaved: () => toast("Saved", TOAST_OPTIONS),
@@ -38,8 +35,12 @@ export function useAutosave(projectId: string, editor: Editor): () => void {
 						duration: 4000,
 					}),
 			}),
-		[projectId, store, initialScript, queue, editor],
+		[projectId, store, queue, editor],
 	);
+
+	// Runs after the rehydration effect above it in useEditorSession, so the
+	// loaded document is the baseline and reopening a project saves nothing.
+	useEffect(() => autosaver.markSaved(), [autosaver]);
 
 	useEffect(() => () => autosaver.flush(), [autosaver]);
 

--- a/app/components/canvas/hooks/useAutosave.ts
+++ b/app/components/canvas/hooks/useAutosave.ts
@@ -6,6 +6,7 @@ import { serializeOSMLWithScenes } from "@/lib/canvas/osmlSerializer";
 import { createAutosaver } from "@/lib/project/autosave";
 import { useProjectStoreHandle } from "@/lib/project/ProjectStoreProvider";
 import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
+import { useScriptInitial } from "@/lib/script/ScriptProvider";
 
 const TOAST_OPTIONS = {
 	id: "autosave",
@@ -20,12 +21,14 @@ const TOAST_OPTIONS = {
 export function useAutosave(projectId: string, editor: Editor): () => void {
 	const queue = useGenerationQueue();
 	const store = useProjectStoreHandle();
+	const initialScript = useScriptInitial();
 
 	const autosaver = useMemo(
 		() =>
 			createAutosaver({
 				projectId,
 				store,
+				initialScript,
 				getScript: () => serializeOSMLWithScenes(editor.children),
 				getGeneration: () => queue.snapshot(),
 				onSaved: () => toast("Saved", TOAST_OPTIONS),
@@ -35,7 +38,7 @@ export function useAutosave(projectId: string, editor: Editor): () => void {
 						duration: 4000,
 					}),
 			}),
-		[projectId, store, queue, editor],
+		[projectId, store, initialScript, queue, editor],
 	);
 
 	useEffect(() => () => autosaver.flush(), [autosaver]);

--- a/app/components/canvas/hooks/useEditorSession.ts
+++ b/app/components/canvas/hooks/useEditorSession.ts
@@ -24,7 +24,6 @@ export function useEditorSession(): EditorSession {
 	useProjectRehydrate(editor, useScriptInitial());
 	useScriptSync(editor);
 	useMetadataSync();
-	// Last: autosave takes the document these leave behind as its saved baseline.
 	const onDocumentChange = useAutosave(projectId, editor);
 
 	return { editor, onDocumentChange };

--- a/app/components/canvas/hooks/useEditorSession.ts
+++ b/app/components/canvas/hooks/useEditorSession.ts
@@ -24,6 +24,7 @@ export function useEditorSession(): EditorSession {
 	useProjectRehydrate(editor, useScriptInitial());
 	useScriptSync(editor);
 	useMetadataSync();
+	// Last: autosave takes the document these leave behind as its saved baseline.
 	const onDocumentChange = useAutosave(projectId, editor);
 
 	return { editor, onDocumentChange };

--- a/lib/project/__tests__/autosave.test.ts
+++ b/lib/project/__tests__/autosave.test.ts
@@ -70,7 +70,6 @@ describe("createAutosaver", () => {
 		createAutosaver({
 			projectId,
 			store,
-			initialScript: "<osml/>",
 			getScript: () => "<osml/>",
 			getGeneration: () => ({}),
 			onSaved,
@@ -153,6 +152,7 @@ describe("createAutosaver", () => {
 	it("does not save when the hydrated state is unchanged", async () => {
 		hydrate();
 		const autosaver = build();
+		autosaver.markSaved();
 		// The echo a real open produces: metadata written back with identical content.
 		store.getState().updateMetadata({ title: "Moon Rabbit" });
 		autosaver.schedule();
@@ -162,30 +162,43 @@ describe("createAutosaver", () => {
 		expect(onSaved).not.toHaveBeenCalled();
 	});
 
-	it("does not save the loaded script back when the editor rehydrates", async () => {
+	it("does not save the document it was handed as already saved", async () => {
 		hydrate();
-		// Slate is filled in an effect, so the editor is empty at this point.
+		// Slate is filled in an effect, so the editor is empty until markSaved.
 		let script = "";
 		const autosaver = createAutosaver({
 			projectId,
 			store,
-			initialScript: "<osml/>",
 			getScript: () => script,
 			getGeneration: () => ({}),
 			onSaved,
 			onError,
 		});
 
-		script = "<osml/>";
 		autosaver.schedule();
+		script = "<osml/>";
+		autosaver.markSaved();
 		await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
 
 		expect(saveProject).not.toHaveBeenCalled();
 	});
 
+	it("saves an edit made after the baseline was taken", async () => {
+		hydrate();
+		const autosaver = build();
+		autosaver.markSaved();
+
+		edit();
+		autosaver.schedule();
+		await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+
+		expect(saveProject).toHaveBeenCalledTimes(1);
+	});
+
 	it("saves the first real edit after an unchanged open", async () => {
 		hydrate();
 		const autosaver = build();
+		autosaver.markSaved();
 		store.getState().updateMetadata({ title: "Moon Rabbit" });
 		autosaver.schedule();
 		await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
@@ -221,7 +234,6 @@ describe("createAutosaver", () => {
 		const autosaver = createAutosaver({
 			projectId,
 			store,
-			initialScript: "<osml/>",
 			getScript: () => "<osml/>",
 			getGeneration: () => generation,
 			onSaved,

--- a/lib/project/__tests__/autosave.test.ts
+++ b/lib/project/__tests__/autosave.test.ts
@@ -97,7 +97,6 @@ describe("createAutosaver", () => {
 		store.getState().markHydrated();
 	};
 
-	/** A real user change, so the autosaver has something to save. */
 	let refCount = 0;
 	const edit = () => {
 		refCount += 1;
@@ -240,7 +239,6 @@ describe("createAutosaver", () => {
 			onError,
 		});
 
-		// A finished generation result, with the store untouched.
 		generation = { a: imageSnapshot("https://cdn/a.png") };
 		autosaver.schedule();
 		await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);

--- a/lib/project/__tests__/autosave.test.ts
+++ b/lib/project/__tests__/autosave.test.ts
@@ -12,6 +12,7 @@ import {
 	AUTOSAVE_DEBOUNCE_MS,
 	buildProjectSave,
 	createAutosaver,
+	type GenerationSnapshot,
 } from "../autosave";
 import { createProjectStore, type ProjectStore } from "../store";
 import type { ProjectStoreSnapshot } from "../storeSnapshot";
@@ -83,6 +84,7 @@ describe("createAutosaver", () => {
 		onError = vi.fn<(error: unknown) => void>();
 		projectId = `p-${saveProject.mock.calls.length}-${Math.random()}`;
 		store = createProjectStore();
+		refCount = 0;
 	});
 
 	afterEach(() => {
@@ -95,11 +97,25 @@ describe("createAutosaver", () => {
 		store.getState().markHydrated();
 	};
 
+	/** A real user change, so the autosaver has something to save. */
+	let refCount = 0;
+	const edit = () => {
+		refCount += 1;
+		store
+			.getState()
+			.setReferenceImages(
+				Array.from({ length: refCount }, (_, i) => `https://cdn/ref-${i}.png`),
+			);
+	};
+
 	it("coalesces a burst of changes into one save", async () => {
 		hydrate();
 		const autosaver = build();
+		edit();
 		autosaver.schedule();
+		edit();
 		autosaver.schedule();
+		edit();
 		autosaver.schedule();
 
 		expect(saveProject).not.toHaveBeenCalled();
@@ -116,6 +132,7 @@ describe("createAutosaver", () => {
 	it("flush runs a pending save immediately", async () => {
 		hydrate();
 		const autosaver = build();
+		edit();
 		autosaver.schedule();
 		autosaver.flush();
 		await vi.advanceTimersByTimeAsync(0);
@@ -132,11 +149,80 @@ describe("createAutosaver", () => {
 		expect(onSaved).not.toHaveBeenCalled();
 	});
 
+	it("does not save when the hydrated state is unchanged", async () => {
+		hydrate();
+		const autosaver = build();
+		// The echo a real open produces: metadata written back with identical content.
+		store.getState().updateMetadata({ title: "Moon Rabbit" });
+		autosaver.schedule();
+		await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+
+		expect(saveProject).not.toHaveBeenCalled();
+		expect(onSaved).not.toHaveBeenCalled();
+	});
+
+	it("saves the first real edit after an unchanged open", async () => {
+		hydrate();
+		const autosaver = build();
+		store.getState().updateMetadata({ title: "Moon Rabbit" });
+		autosaver.schedule();
+		await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+		expect(saveProject).not.toHaveBeenCalled();
+
+		edit();
+		autosaver.schedule();
+		await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+
+		expect(saveProject).toHaveBeenCalledTimes(1);
+		expect(onSaved).toHaveBeenCalledTimes(1);
+	});
+
+	it("skips a repeat of a payload it just saved", async () => {
+		hydrate();
+		const autosaver = build();
+		edit();
+		autosaver.schedule();
+		await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+		expect(saveProject).toHaveBeenCalledTimes(1);
+
+		// Same content again: an idempotent write, not a change.
+		store.getState().setReferenceImages([...store.getState().referenceImages]);
+		autosaver.schedule();
+		await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+
+		expect(saveProject).toHaveBeenCalledTimes(1);
+	});
+
+	it("still saves when only the generation snapshot changed", async () => {
+		hydrate();
+		let generation: GenerationSnapshot = {};
+		const autosaver = createAutosaver({
+			projectId,
+			store,
+			getScript: () => "<osml/>",
+			getGeneration: () => generation,
+			onSaved,
+			onError,
+		});
+
+		// A finished generation result, with the store untouched.
+		generation = { a: imageSnapshot("https://cdn/a.png") };
+		autosaver.schedule();
+		await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+
+		expect(saveProject).toHaveBeenCalledTimes(1);
+		expect(saveProject).toHaveBeenCalledWith(
+			projectId,
+			expect.objectContaining({ thumbnail_url: "https://cdn/a.png" }),
+		);
+	});
+
 	it("reports a failed save instead of throwing", async () => {
 		hydrate();
 		const boom = new Error("offline");
 		saveProject.mockRejectedValue(boom);
 		const autosaver = build();
+		edit();
 		autosaver.schedule();
 		await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
 

--- a/lib/project/__tests__/autosave.test.ts
+++ b/lib/project/__tests__/autosave.test.ts
@@ -70,6 +70,7 @@ describe("createAutosaver", () => {
 		createAutosaver({
 			projectId,
 			store,
+			initialScript: "<osml/>",
 			getScript: () => "<osml/>",
 			getGeneration: () => ({}),
 			onSaved,
@@ -161,6 +162,27 @@ describe("createAutosaver", () => {
 		expect(onSaved).not.toHaveBeenCalled();
 	});
 
+	it("does not save the loaded script back when the editor rehydrates", async () => {
+		hydrate();
+		// Slate is filled in an effect, so the editor is empty at this point.
+		let script = "";
+		const autosaver = createAutosaver({
+			projectId,
+			store,
+			initialScript: "<osml/>",
+			getScript: () => script,
+			getGeneration: () => ({}),
+			onSaved,
+			onError,
+		});
+
+		script = "<osml/>";
+		autosaver.schedule();
+		await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
+
+		expect(saveProject).not.toHaveBeenCalled();
+	});
+
 	it("saves the first real edit after an unchanged open", async () => {
 		hydrate();
 		const autosaver = build();
@@ -199,6 +221,7 @@ describe("createAutosaver", () => {
 		const autosaver = createAutosaver({
 			projectId,
 			store,
+			initialScript: "<osml/>",
 			getScript: () => "<osml/>",
 			getGeneration: () => generation,
 			onSaved,

--- a/lib/project/autosave.ts
+++ b/lib/project/autosave.ts
@@ -32,8 +32,6 @@ export function buildProjectSave(
 export interface AutosaverOptions {
 	projectId: string;
 	store: ProjectStore;
-	/** The script as loaded, ie the one the server already holds. */
-	initialScript: string;
 	/**
 	 * Produces the script for the next save. Called only when a save runs, so
 	 * serializing stays off the per-keystroke path.
@@ -49,20 +47,21 @@ export interface Autosaver {
 	schedule: () => void;
 	/** Run any pending save immediately. */
 	flush: () => void;
+	/** Treat the current state as the one the server already holds. */
+	markSaved: () => void;
 }
 
 /**
  * Debounces edits into one save at a time. The queue keeps a slow save from
  * overlapping the next one, so the last scheduled state always lands last.
  *
- * A save whose payload the server already holds is dropped. Restoring the
- * loaded document into the empty editor is a Slate change like any other, so
- * without this an untouched project saves itself on open and reports "Saved".
+ * A save whose payload matches the last one is dropped. Restoring the loaded
+ * document into the empty editor is a Slate change like any other, so without
+ * this an untouched project saves itself on open and reports "Saved".
  */
 export function createAutosaver({
 	projectId,
 	store,
-	initialScript,
 	getScript,
 	getGeneration,
 	onSaved,
@@ -70,13 +69,11 @@ export function createAutosaver({
 }: AutosaverOptions): Autosaver {
 	const queue = new PQueue({ concurrency: 1 });
 
-	// The script is taken as loaded rather than from `getScript()`: Slate is
-	// rehydrated in an effect, so the editor is still empty while this runs.
-	let lastSaved = buildProjectSave(
-		extractStoreSnapshot(store),
-		initialScript,
-		getGeneration(),
-	);
+	const buildInput = (): SaveProjectInput =>
+		buildProjectSave(extractStoreSnapshot(store), getScript(), getGeneration());
+
+	/** Null until the loaded state is known: an unknown baseline has to save. */
+	let lastSaved: SaveProjectInput | null = null;
 
 	const save = async () => {
 		if (!store.getState().hydrated) {
@@ -84,11 +81,7 @@ export function createAutosaver({
 			return;
 		}
 		try {
-			const input = buildProjectSave(
-				extractStoreSnapshot(store),
-				getScript(),
-				getGeneration(),
-			);
+			const input = buildInput();
 			if (isEqual(input, lastSaved)) return;
 			await saveProject(projectId, input);
 			lastSaved = input;
@@ -108,6 +101,9 @@ export function createAutosaver({
 		schedule,
 		flush: () => {
 			schedule.flush();
+		},
+		markSaved: () => {
+			lastSaved = buildInput();
 		},
 	};
 }

--- a/lib/project/autosave.ts
+++ b/lib/project/autosave.ts
@@ -32,6 +32,8 @@ export function buildProjectSave(
 export interface AutosaverOptions {
 	projectId: string;
 	store: ProjectStore;
+	/** The script as loaded, ie the one the server already holds. */
+	initialScript: string;
 	/**
 	 * Produces the script for the next save. Called only when a save runs, so
 	 * serializing stays off the per-keystroke path.
@@ -53,14 +55,14 @@ export interface Autosaver {
  * Debounces edits into one save at a time. The queue keeps a slow save from
  * overlapping the next one, so the last scheduled state always lands last.
  *
- * A save whose payload matches the last one is dropped. Hydration emits three
- * store updates before the user touches anything, and the metadata sync writes
- * identical content back on mount, so without this an untouched project saves
- * itself on open and tells the user it was "Saved".
+ * A save whose payload the server already holds is dropped. Restoring the
+ * loaded document into the empty editor is a Slate change like any other, so
+ * without this an untouched project saves itself on open and reports "Saved".
  */
 export function createAutosaver({
 	projectId,
 	store,
+	initialScript,
 	getScript,
 	getGeneration,
 	onSaved,
@@ -68,20 +70,13 @@ export function createAutosaver({
 }: AutosaverOptions): Autosaver {
 	const queue = new PQueue({ concurrency: 1 });
 
-	const buildInput = (): SaveProjectInput =>
-		buildProjectSave(extractStoreSnapshot(store), getScript(), getGeneration());
-
-	/**
-	 * Payload of the last save known to be on the server. Seeded from the loaded
-	 * state so the hydration echo has something to match; ProjectEditor hydrates
-	 * the store before the editor renders, so that state is available here.
-	 *
-	 * Left null while the store is unhydrated: an unknown baseline must save
-	 * rather than skip, so the worst case is a redundant write, never a lost edit.
-	 */
-	let lastSaved: SaveProjectInput | null = store.getState().hydrated
-		? buildInput()
-		: null;
+	// The script is taken as loaded rather than from `getScript()`: Slate is
+	// rehydrated in an effect, so the editor is still empty while this runs.
+	let lastSaved = buildProjectSave(
+		extractStoreSnapshot(store),
+		initialScript,
+		getGeneration(),
+	);
 
 	const save = async () => {
 		if (!store.getState().hydrated) {
@@ -89,9 +84,12 @@ export function createAutosaver({
 			return;
 		}
 		try {
-			const input = buildInput();
-			// Nothing changed since the last save: skip the write and the toast.
-			if (lastSaved !== null && isEqual(input, lastSaved)) return;
+			const input = buildProjectSave(
+				extractStoreSnapshot(store),
+				getScript(),
+				getGeneration(),
+			);
+			if (isEqual(input, lastSaved)) return;
 			await saveProject(projectId, input);
 			lastSaved = input;
 			onSaved();

--- a/lib/project/autosave.ts
+++ b/lib/project/autosave.ts
@@ -1,4 +1,5 @@
 import debounce from "lodash/debounce";
+import isEqual from "lodash/isEqual";
 import PQueue from "p-queue";
 import type { ElementSnapshot } from "@/lib/generation/snapshots";
 import { saveProject, type SaveProjectInput } from "./api";
@@ -51,6 +52,11 @@ export interface Autosaver {
 /**
  * Debounces edits into one save at a time. The queue keeps a slow save from
  * overlapping the next one, so the last scheduled state always lands last.
+ *
+ * A save whose payload matches the last one is dropped. Hydration emits three
+ * store updates before the user touches anything, and the metadata sync writes
+ * identical content back on mount, so without this an untouched project saves
+ * itself on open and tells the user it was "Saved".
  */
 export function createAutosaver({
 	projectId,
@@ -62,18 +68,32 @@ export function createAutosaver({
 }: AutosaverOptions): Autosaver {
 	const queue = new PQueue({ concurrency: 1 });
 
+	const buildInput = (): SaveProjectInput =>
+		buildProjectSave(extractStoreSnapshot(store), getScript(), getGeneration());
+
+	/**
+	 * Payload of the last save known to be on the server. Seeded from the loaded
+	 * state so the hydration echo has something to match; ProjectEditor hydrates
+	 * the store before the editor renders, so that state is available here.
+	 *
+	 * Left null while the store is unhydrated: an unknown baseline must save
+	 * rather than skip, so the worst case is a redundant write, never a lost edit.
+	 */
+	let lastSaved: SaveProjectInput | null = store.getState().hydrated
+		? buildInput()
+		: null;
+
 	const save = async () => {
 		if (!store.getState().hydrated) {
 			console.error("Autosave aborted: store not hydrated", { projectId });
 			return;
 		}
 		try {
-			const input = buildProjectSave(
-				extractStoreSnapshot(store),
-				getScript(),
-				getGeneration(),
-			);
+			const input = buildInput();
+			// Nothing changed since the last save: skip the write and the toast.
+			if (lastSaved !== null && isEqual(input, lastSaved)) return;
 			await saveProject(projectId, input);
+			lastSaved = input;
 			onSaved();
 		} catch (err) {
 			console.error("Autosave failed", err);


### PR DESCRIPTION
Closes #623

Opening a project fired a full autosave ~2s later with no user input, writing a new row and popping the "Saved" toast on an untouched project.

Took the suggested direction — dedupe in `createAutosaver` rather than special-casing hydration at each call site, so hydration echoes, the idempotent metadata sync, and any future emit-without-change path are all covered at once. `createAutosaver` keeps the last saved `SaveProjectInput` and returns early when the newly built one is deeply equal (`lodash/isEqual`, alongside the `lodash/debounce` already imported).

### Seeding the baseline

The one design question was where the initial baseline comes from — it has to be the as-loaded state, or the first save after open isn't recognised as a no-op.

It can be captured eagerly at `createAutosaver` time, because `ProjectEditor` hydrates the store inside a `useState` initializer *before* children render (`app/projects/[id]/ProjectEditor.tsx:33-37`). By the time `useAutosave`'s `useMemo` runs, the store is already hydrated and the editor exists. So no subscription and no new lifecycle hook are needed.

When the store *isn't* hydrated at construction, `lastSaved` stays `null` and the first save runs unconditionally. That direction is deliberate: an unknown baseline should cost a redundant write, never a dropped edit.

### Three existing tests needed real edits

`coalesces a burst of changes into one save`, `flush runs a pending save immediately`, and `reports a failed save instead of throwing` all called `schedule()` without changing anything, so after this fix they were correctly skipped. They now make an actual store change first, via a small `edit()` helper that appends a reference image — which also matches what "a burst of changes" claims to be testing. `edit()` touches `referenceImages` rather than the title so the coalescing test's `name: "Moon Rabbit"` assertion still means something.

### New coverage

- **hydrate → schedule with unchanged state → no save** (the issue's requested case, using the real echo: metadata written back with identical content)
- **the first real edit after an unchanged open still saves**
- **a repeat of a payload just saved is skipped** (idempotent write after a genuine one)
- **a generation-result change still saves**, with the store untouched — this is the acceptance criterion most at risk from a store-only dirty check, and it passes because `generation` is part of the compared payload

Verified the new tests actually catch the bug — removing just the `isEqual` early-return line:

```
× does not save when the hydrated state is unchanged
× saves the first real edit after an unchanged open
× skips a repeat of a payload it just saved
3 failed | 8 passed
```

Note the generation test stays green there, as it should — it is guarding against over-correction, not the bug.

Full checks: `vitest run` **1313 passed (147 files)**, `tsc --noEmit` clean, `eslint` clean, `prettier` applied.
