### PR TITLE
fix: nightly bug fixes 2026-08-24

### DIFF
--- a/app/components/projects/ProjectsList.tsx
+++ b/app/components/projects/ProjectsList.tsx
@@ -33,14 +33,16 @@ export default function ProjectsList({
 		});
 	};
 
-	const handleDelete = async (id: string) => {
-		const previous = projects;
-		setProjects((p) => p.filter((x) => x.id !== id));
+	// Rolling back the one card, not the whole list: a snapshot taken before the
+	// request would resurrect anything another delete removed while it was in flight.
+	const handleDelete = async (project: ProjectRow) => {
+		const index = projects.indexOf(project);
+		setProjects((p) => p.filter((x) => x.id !== project.id));
 		try {
-			await deleteProject(id);
+			await deleteProject(project.id);
 		} catch (err) {
 			toastError(err, "Could not delete project");
-			setProjects(previous);
+			setProjects((p) => p.toSpliced(index, 0, project));
 		}
 	};
 
@@ -90,7 +92,7 @@ export default function ProjectsList({
 				description="This permanently deletes the project and everything generated in it. It can't be undone."
 				actionLabel="Delete project"
 				onConfirm={() => {
-					if (deleting) handleDelete(deleting.id);
+					if (deleting) handleDelete(deleting);
 					setDeleting(undefined);
 				}}
 			/>

--- a/app/components/video/timeline/ClipWaveform.tsx
+++ b/app/components/video/timeline/ClipWaveform.tsx
@@ -21,25 +21,26 @@ type Decode =
 	| { status: "ready"; peaks: number[] }
 	| { status: "failed" };
 
+/** Keyed on the source it settled for, so a clip whose asset changed never keeps painting the old one. */
 function usePeaks(src: string): Decode {
-	const [decode, setDecode] = useState<Decode>({ status: "loading" });
+	const [settled, setSettled] = useState<{ src: string; decode: Decode }>();
 
 	useEffect(() => {
 		let cancelled = false;
 		loadPeaks(src)
 			.then((peaks) => {
-				if (!cancelled) setDecode({ status: "ready", peaks });
+				if (!cancelled) setSettled({ src, decode: { status: "ready", peaks } });
 			})
 			.catch((error) => {
 				console.error("Failed to decode audio:", error);
-				if (!cancelled) setDecode({ status: "failed" });
+				if (!cancelled) setSettled({ src, decode: { status: "failed" } });
 			});
 		return () => {
 			cancelled = true;
 		};
 	}, [src]);
 
-	return decode;
+	return settled?.src === src ? settled.decode : { status: "loading" };
 }
 
 /**


### PR DESCRIPTION
Two stale-state bugs in the client. Behaviour is otherwise unchanged.

## The timeline paints the wrong waveform after a regenerated take

`ClipWaveform`'s `usePeaks` kept its `Decode` state across a `src` change. `TimelineClip` keys a clip on `${element.id}-${start}`, so regenerating an audio element swaps `src` under a live component: the hook holds `{status: "ready", peaks}` from the previous asset and repaints it until the new fetch and decode land — seconds of showing an envelope that belongs to audio no longer on the clip.

The decode now carries the source it settled for, and anything else reads as loading. `lib/components/Waveform.tsx` already guards the same way (`peaksSettledFor`); this brings the timeline's copy in line.

## A failed delete can resurrect an already-deleted project

`ProjectsList.handleDelete` optimistically filtered the card out, then rolled back to `previous` — the whole list as it stood when the handler was created. Confirm delete on A, then confirm delete on B while A's request is still in flight: if A fails, `setProjects(previous)` restores a list that still contains B, which the server has already deleted. B's card comes back and stays until a reload.

The rollback now re-inserts the one project at its index instead of replacing the list, so a failure can only undo its own removal.

## Tests

None added. Both fixes are React component state, and this repo's vitest setup has no jsdom or Testing Library (`vitest.setup.ts` mocks the Supabase client only; every existing suite tests pure functions). Extracting either into a pure helper purely to have something to assert on would be a worse shape than the fix. Full suite still green: 147 test files passed.

## Checks

`lint`, `format:check`, `typecheck`, `knip`, `build`, `test:coverage` all pass.

## Open PR overlap check

Considered #622 (`feat: keep every take an element has produced`) and #624 (`fix(autosave): skip a save whose payload has not changed`). #622 touches `lib/canvas/*`, `lib/generation/*`, `lib/connectors/*`, `app/components/canvas/*`, `components/ui/*` and `app/components/video/BottomTransportBar.tsx`; #624 touches `lib/project/autosave.ts` and its test. Neither touches `app/components/projects/ProjectsList.tsx` or `app/components/video/timeline/ClipWaveform.tsx`. This PR is non-overlapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)