### PR TITLE
refactor: nightly maintainability 2026-08-24

### DIFF
--- a/app/components/canvas/CanvasProviders.tsx
+++ b/app/components/canvas/CanvasProviders.tsx
@@ -11,6 +11,7 @@ import { ActiveSceneProvider } from "../scene-selection/ActiveSceneContext";
 import { AutoScrollProvider } from "../scene-selection/AutoScrollContext";
 import { ViewModeProvider } from "./ViewModeContext";
 import { ActiveCaptionFont } from "./CaptionFonts";
+import { SloppyModelProvider } from "../sloppy/SloppyModelProvider";
 import { SloppyProvider } from "../sloppy/SloppyProvider";
 import { EditorPanelProvider } from "./panel/EditorPanelContext";
 
@@ -45,9 +46,11 @@ export function CanvasProviders({
 						<ActiveSceneProvider>
 							<AutoScrollProvider>
 								<ViewModeProvider editor={editor}>
-									<SloppyProvider editor={editor}>
-										<EditorPanelProvider>{children}</EditorPanelProvider>
-									</SloppyProvider>
+									<SloppyModelProvider>
+										<SloppyProvider editor={editor}>
+											<EditorPanelProvider>{children}</EditorPanelProvider>
+										</SloppyProvider>
+									</SloppyModelProvider>
 								</ViewModeProvider>
 							</AutoScrollProvider>
 						</ActiveSceneProvider>

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -47,7 +47,7 @@ import {
 } from "@/lib/video/videoLength";
 import { useImageUpload } from "@/lib/upload/useImageUpload";
 import { cn } from "@/lib/utils";
-import { useSloppy } from "@/app/components/sloppy/SloppyProvider";
+import { useSloppyModel } from "@/app/components/sloppy/SloppyModelProvider";
 import { ActionButton } from "./ActionButton";
 import { ComposerAssets } from "./ComposerAssets";
 import { SettingPill, type SettingPillOption } from "./SettingPill";
@@ -194,7 +194,7 @@ function Composer({ value, onValueChange, onSubmit }: ComposerCopilotProps) {
 	const updateVideoSettings = useUpdateVideoSettings();
 	const addReferenceImages = useProject((s) => s.addReferenceImages);
 	const [language, setLanguage] = useScriptLanguage();
-	const { model, setModel, models } = useSloppy();
+	const { model, setModel, models } = useSloppyModel();
 
 	const {
 		openPicker,

--- a/app/components/sloppy/SloppyComposer.tsx
+++ b/app/components/sloppy/SloppyComposer.tsx
@@ -10,6 +10,7 @@ import {
 import { SelectMenu } from "@/components/ui/select-menu";
 import { PanelCard } from "../canvas/panel/PanelCard";
 import { ActionButton } from "../copilot/ActionButton";
+import { useSloppyModel } from "./SloppyModelProvider";
 import { useSloppy } from "./SloppyProvider";
 
 function ModelPicker({
@@ -49,7 +50,8 @@ function ModelPicker({
 }
 
 export function SloppyComposer() {
-	const { send, stop, loading, model, setModel, models } = useSloppy();
+	const { send, stop, loading } = useSloppy();
+	const { model, setModel, models } = useSloppyModel();
 	const [value, setValue] = useState("");
 	const hasText = value.trim().length > 0;
 

--- a/app/components/sloppy/SloppyModelProvider.tsx
+++ b/app/components/sloppy/SloppyModelProvider.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useMemo, useState, type ReactNode } from "react";
+import { createRequiredContext } from "@/lib/components/createRequiredContext";
+import { useConfig } from "@/lib/config/ConfigProvider";
+import { getDefaultConnector } from "@/lib/connectors/registry";
+
+type SloppyModelChoice = {
+	model: string;
+	setModel: (model: string) => void;
+	models: string[];
+};
+
+const [SloppyModelContext, useSloppyModel] =
+	createRequiredContext<SloppyModelChoice>("SloppyModelProvider");
+
+export { useSloppyModel };
+
+/**
+ * Which LLM the next turn runs on. Its own boundary because the choice comes
+ * from the connector config and outlives any turn, so a model picker does not
+ * have to subscribe to the agent's streaming status to render.
+ */
+export function SloppyModelProvider({ children }: { children: ReactNode }) {
+	const { connectorConfig } = useConfig();
+	const { config } = getDefaultConnector(connectorConfig, "llm");
+	const [model, setModel] = useState(config.defaultModel);
+
+	const choice = useMemo(
+		() => ({ model, setModel, models: config.models }),
+		[model, config.models],
+	);
+
+	return <SloppyModelContext value={choice}>{children}</SloppyModelContext>;
+}

--- a/app/components/sloppy/SloppyProvider.tsx
+++ b/app/components/sloppy/SloppyProvider.tsx
@@ -16,15 +16,12 @@ import { useAgentTools } from "@/lib/agent/tools/useAgentTools";
 import { useAgentContext } from "@/lib/agent/projectContext";
 import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { useConfig } from "@/lib/config/ConfigProvider";
-import { getDefaultConnector } from "@/lib/connectors/registry";
 import { toastError } from "@/lib/toastError";
+import { useSloppyModel } from "./SloppyModelProvider";
 
 type SloppyControl = {
 	send: (message: string) => void;
 	stop: () => void;
-	model: string;
-	setModel: (model: string) => void;
-	models: string[];
 	loading: boolean;
 	writingScript: boolean;
 };
@@ -75,12 +72,11 @@ export function SloppyProvider({
 	editor: Editor;
 	children: ReactNode;
 }) {
-	const { projectId, connectorConfig } = useConfig();
+	const { projectId } = useConfig();
 	const runTool = useAgentTools(editor);
 	const readContext = useAgentContext(editor);
 	const restored = useTranscript(projectId);
-	const { config } = getDefaultConnector(connectorConfig, "llm");
-	const [model, setModel] = useState(config.defaultModel);
+	const { model } = useSloppyModel();
 	const turnModel = useRef<string>(undefined);
 	// Stopping should also cancel the tool call in flight
 	const turn = useRef<AbortController>(undefined);
@@ -138,11 +134,8 @@ export function SloppyProvider({
 			},
 			loading: working,
 			writingScript,
-			model,
-			setModel,
-			models: config.models,
 		}),
-		[sendMessage, stop, working, writingScript, model, config.models],
+		[sendMessage, stop, working, writingScript, model],
 	);
 
 	// History sits in front of the chat's own turns rather than being written

--- a/lib/agent/__tests__/registry.test.ts
+++ b/lib/agent/__tests__/registry.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AgentToolContext } from "../tools/context";
-import { SLOPPY_TOOLS, executeToolCall } from "../tools/registry";
+import {
+	SCRIPT_TOOLS,
+	SLOPPY_TOOLS,
+	SNAPSHOT_TOOLS,
+	executeToolCall,
+} from "../tools/registry";
 import { MetadataSchema } from "@/lib/project/types";
 
 const metadata = MetadataSchema.parse({
@@ -383,5 +388,23 @@ describe("a call the editor cannot run", () => {
 			ok: false,
 			errorText: "render_video is not a tool.",
 		});
+	});
+});
+
+describe("tool flags", () => {
+	it("collects the tools whose output only lasts the turn", () => {
+		expect([...SNAPSHOT_TOOLS].sort()).toEqual([
+			"read_script",
+			"view_avatar",
+			"view_reference_images",
+		]);
+	});
+
+	it("collects the tools that rewrite the canvas", () => {
+		expect([...SCRIPT_TOOLS].sort()).toEqual([
+			"adapt_script",
+			"edit_script",
+			"write_script",
+		]);
 	});
 });

--- a/lib/agent/tools/adaptScript.ts
+++ b/lib/agent/tools/adaptScript.ts
@@ -46,4 +46,5 @@ export const adaptScript = defineTool({
 		await ctx.adaptScript(script, notes);
 		return "Put that script onto the canvas. Read it to see what landed.";
 	},
+	rewritesCanvas: true,
 });

--- a/lib/agent/tools/defineTool.ts
+++ b/lib/agent/tools/defineTool.ts
@@ -14,8 +14,12 @@ export function defineTool<Input, Output>(def: {
 	output: z.ZodType<Output>;
 	toModelOutput?: Tool<Input, Output>["toModelOutput"];
 	execute: (input: Input, ctx: AgentToolContext) => Promise<Output>;
+	/** Output that is only true until the next edit, so only its own turn keeps it. */
+	snapshot?: true;
+	/** The call rewrites the canvas, so what is rendered from it is mid-change. */
+	rewritesCanvas?: true;
 }) {
-	const { input, output, execute, ...rest } = def;
+	const { input, output, execute, snapshot, rewritesCanvas, ...rest } = def;
 	// Tool's shape is conditional on OUTPUT, which never resolves against a
 	// generic; the def parameter above already checks every field against it.
 	const spec = {
@@ -23,7 +27,7 @@ export function defineTool<Input, Output>(def: {
 		inputSchema: input,
 		outputSchema: output,
 	} as unknown as Tool<Input, Output>;
-	return { input, execute, spec };
+	return { input, execute, spec, snapshot, rewritesCanvas };
 }
 
 /** A tool-result image, handed to the model by URL for the provider to fetch. */

--- a/lib/agent/tools/editScript.ts
+++ b/lib/agent/tools/editScript.ts
@@ -57,4 +57,5 @@ export const editScript = defineTool({
 			"Read the script again before retrying; the ids you used may be stale.",
 		].join(" ");
 	},
+	rewritesCanvas: true,
 });

--- a/lib/agent/tools/readScript.ts
+++ b/lib/agent/tools/readScript.ts
@@ -49,4 +49,5 @@ export const readScript = defineTool({
 			]),
 		].join("\n\n");
 	},
+	snapshot: true,
 });

--- a/lib/agent/tools/registry.ts
+++ b/lib/agent/tools/registry.ts
@@ -66,19 +66,20 @@ export type AgentToolOutput = {
 	[TName in AgentToolName]: ToolOutput<TName>;
 }[AgentToolName];
 
+type ToolFlag = "snapshot" | "rewritesCanvas";
+
+const namesFlagged = (flag: ToolFlag): ReadonlySet<string> =>
+	new Set(
+		Object.entries(TOOLS)
+			.filter(([, def]) => def[flag])
+			.map(([name]) => name),
+	);
+
 /** Output that is only true until the next edit, so only its own turn keeps it. */
-export const SNAPSHOT_TOOLS = new Set<string>([
-	"read_script" satisfies AgentToolName,
-	"view_reference_images" satisfies AgentToolName,
-	"view_avatar" satisfies AgentToolName,
-]);
+export const SNAPSHOT_TOOLS = namesFlagged("snapshot");
 
 /** Calls that rewrite the canvas, so what is rendered from it is mid-change. */
-export const SCRIPT_TOOLS = new Set<string>([
-	"write_script" satisfies AgentToolName,
-	"adapt_script" satisfies AgentToolName,
-	"edit_script" satisfies AgentToolName,
-]);
+export const SCRIPT_TOOLS = namesFlagged("rewritesCanvas");
 
 /** A failure is reported, not thrown: the model reads it as the next observation. */
 export type ToolOutcome =

--- a/lib/agent/tools/viewAvatar.ts
+++ b/lib/agent/tools/viewAvatar.ts
@@ -31,4 +31,5 @@ export const viewAvatar = defineTool({
 			);
 		return { name, url };
 	},
+	snapshot: true,
 });

--- a/lib/agent/tools/viewReferenceImages.ts
+++ b/lib/agent/tools/viewReferenceImages.ts
@@ -29,4 +29,5 @@ export const viewReferenceImages = defineTool({
 			);
 		return { urls };
 	},
+	snapshot: true,
 });

--- a/lib/agent/tools/writeScript.ts
+++ b/lib/agent/tools/writeScript.ts
@@ -27,4 +27,5 @@ export const writeScript = defineTool({
 		await ctx.writeScript(brief);
 		return "Wrote a new script onto the canvas. Read it to see what landed.";
 	},
+	rewritesCanvas: true,
 });


### PR DESCRIPTION
Two behaviour-preserving structural changes. No product behaviour changes.

## Sloppy's model choice gets its own boundary

`useSloppy()` bundled the agent's turn control (`send`, `stop`, `loading`, `writingScript`) with the LLM picker (`model`, `setModel`, `models`). Those are different concerns on different clocks: the control value changes on every streaming status transition, while the model is a setting read off the connector config that outlives any turn.

The practical cost was `ComposerCopilot` — the brief composer, which only ever wanted the model list — depending on the ReAct loop's provider and re-rendering with it.

New `SloppyModelProvider` owns the choice and sits just above `SloppyProvider`, which now consumes it like anyone else. `useSloppy()` is down to the four fields its name implies; `ComposerCopilot` reaches for `useSloppyModel()` and nothing else.

## Tool behaviour flags live with the tools

`registry.ts` kept two hand-written sets of tool names, `SNAPSHOT_TOOLS` and `SCRIPT_TOOLS`, alongside the comment that "registration is the contract: one entry is a tool's whole definition". They were the exception: adding a tool meant remembering to edit a set three files away from where the tool is defined.

`defineTool` now takes optional `snapshot` / `rewritesCanvas` flags, the six affected tools declare their own, and the registry derives both sets. Membership is pinned by a new test at that seam.

## Validation

`npm run lint`, `format:check`, `typecheck`, `knip`, `build`, and the full suite (1311 tests) all pass.

## Open PR overlap check

Considered #626 (`lib/api/jobs.ts`, migration), #625 (`ProjectsList`, `ClipWaveform`), #624 (`lib/project/autosave`), #622 (canvas elements, `lib/generation`, `lib/canvas`, `lib/connectors`, `lib/video`, `components/ui`, docs). This PR touches `app/components/sloppy`, `app/components/copilot/ComposerCopilot.tsx`, `app/components/canvas/CanvasProviders.tsx` and `lib/agent/tools`, none of which appear in any open PR. Non-overlapping.

## Skipped

- `app/components/video/ScrubBar.tsx` has no `role="slider"` and no keyboard handling, so the seek and volume tracks are unreachable without a pointer. A real accessibility gap, but fixing it adds behaviour rather than preserving it — flagging for a human call instead of folding it into a refactor PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)