### PR TITLE
perf: nightly performance optimizations 2026-08-24

### DIFF
--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -4,10 +4,7 @@ import { useCallback, useMemo, KeyboardEvent } from "react";
 import { Editor } from "slate";
 import { Editable, RenderElementProps } from "slate-react";
 import { DndContext, DragOverlay, pointerWithin } from "@dnd-kit/core";
-import {
-	SortableContext,
-	verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
+import { SortableContext } from "@dnd-kit/sortable";
 import { useDragAndDrop } from "./dnd/useDragAndDrop";
 import { DragTransferContext } from "./dnd/DragTransferContext";
 import { findElementById } from "@/lib/canvas/editorOps";
@@ -16,6 +13,8 @@ import { SortableScene } from "./dnd/SortableScene";
 import { SortableContent } from "./dnd/SortableContent";
 import { DragOverlayContent } from "./dnd/DragOverlay";
 import { AssetsSection } from "./elements/AssetsSection";
+import { displaceListedItems } from "./dnd/sortingStrategy";
+import styles from "./styles/sortable.module.css";
 
 export default function Canvas({ editor }: { editor: Editor }) {
 	const {
@@ -66,15 +65,12 @@ export default function Canvas({ editor }: { editor: Editor }) {
 				onDragCancel={handleDragCancel}
 			>
 				<AssetsSection />
-				<SortableContext
-					items={sceneItems}
-					strategy={verticalListSortingStrategy}
-				>
+				<SortableContext items={sceneItems} strategy={displaceListedItems}>
 					<Editable
 						placeholder="Start typing your story…"
 						renderElement={renderElement}
 						onKeyDown={handleKeyDown}
-						className="font-body text-body leading-relaxed focus-ring"
+						className={`font-body text-body leading-relaxed focus-ring${activeId ? ` ${styles.sorting}` : ""}`}
 					/>
 				</SortableContext>
 				<DragOverlay>

--- a/app/components/canvas/__tests__/sortingStrategy.test.ts
+++ b/app/components/canvas/__tests__/sortingStrategy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import type { ClientRect } from "@dnd-kit/core";
+import { displaceListedItems } from "../dnd/sortingStrategy";
+
+const rectAt = (top: number): ClientRect => ({
+	top,
+	bottom: top + 100,
+	left: 0,
+	right: 200,
+	width: 200,
+	height: 100,
+});
+
+const rects = [rectAt(0), rectAt(100), rectAt(200)];
+
+const displace = (index: number) =>
+	displaceListedItems({
+		rects,
+		activeIndex: 0,
+		overIndex: 2,
+		index,
+		activeNodeRect: rects[0],
+	});
+
+describe("displaceListedItems", () => {
+	it("displaces a listed item", () => {
+		expect(displace(1)).toEqual({ x: 0, y: -100, scaleX: 1, scaleY: 1 });
+	});
+
+	it("leaves an item that is not in the sortable list alone", () => {
+		expect(displace(-1)).toBeNull();
+	});
+});

--- a/app/components/canvas/dnd/SortableItem.tsx
+++ b/app/components/canvas/dnd/SortableItem.tsx
@@ -43,7 +43,6 @@ export function SortableItem({
 		transform,
 		transition,
 		isDragging,
-		isSorting,
 		attributes: sortableAttributes,
 	} = useSortable({
 		id: element.id,
@@ -52,6 +51,7 @@ export function SortableItem({
 	});
 
 	const { nodeAttributes } = splitTextDirection(attributes);
+	const displacement = CSS.Transform.toString(transform);
 
 	return (
 		<div {...nodeAttributes} className={wrapperClassName} style={wrapperStyle}>
@@ -64,9 +64,8 @@ export function SortableItem({
 				{...sortableAttributes}
 				ref={setNodeRef}
 				style={{
-					transition,
-					transform: CSS.Transform.toString(transform),
-					pointerEvents: isSorting ? "none" : undefined,
+					transform: displacement,
+					transition: displacement ? transition : undefined,
 					opacity: isDragging ? 0 : 1,
 				}}
 			>

--- a/app/components/canvas/dnd/sortingStrategy.ts
+++ b/app/components/canvas/dnd/sortingStrategy.ts
@@ -1,0 +1,14 @@
+import {
+	verticalListSortingStrategy,
+	type SortingStrategy,
+} from "@dnd-kit/sortable";
+
+/**
+ * Only scenes are listed in the canvas `SortableContext`. dnd-kit still asks the
+ * strategy about every other card, and the vertical strategy answers with an
+ * identity transform, so an inline `transform` lands on every element in the
+ * document each time the pointer crosses onto a scene and is stripped again when
+ * it leaves. Returning null for unlisted cards leaves them untouched.
+ */
+export const displaceListedItems: SortingStrategy = (args) =>
+	args.index === -1 ? null : verticalListSortingStrategy(args);

--- a/app/components/canvas/styles/sortable.module.css
+++ b/app/components/canvas/styles/sortable.module.css
@@ -3,6 +3,12 @@
 	z-index: 0;
 }
 
+/* Held on the canvas for the duration of a drag: the alternative is writing
+   `pointer-events` inline onto every card when one starts and again when it ends. */
+.sorting .sortable {
+	pointer-events: none;
+}
+
 /* Skips style recalc and paint for offscreen scenes during a drag. `auto`
    caches each scene's real height, so the scrollbar settles after first paint. */
 .scene {


### PR DESCRIPTION
Follow-up to the note on #621: dragging a scene in a large script runs at ~10 fps with 200 ms frame gaps. This goes after one concrete reason for that.

## What was wrong

`SortableContext` on the canvas lists scene ids only. Every content card still calls `useSortable`, so dnd-kit asks the strategy about it too, passing `index: -1`. `verticalListSortingStrategy` falls through its three displacement branches and returns `{x: 0, y: 0, scaleX: 1, scaleY: 1}` — an identity transform — rather than nothing.

`useSortable` applies a strategy result whenever `activeIndex` and `overIndex` are both valid. During a scene drag that is true the whole time the pointer sits over a scene, so every content card in the document gets

```
transform: translate3d(0px, 0px, 0) scaleX(1) scaleY(1);
transition: transform 200ms ease;
```

written inline. The moment the pointer crosses onto a content card, `overIndex` goes to -1, displacement switches off, and all of them are stripped again. Scenes are interleaved with their content, so that flips repeatedly over a single drag: each flip is an inline style write to every card in the script plus the style recalc behind it, and each transform is a stacking context and containing block the compositor did not have a frame earlier. In a 71-scene script roughly 300 of the ~370 sortables are paying this and none of them can move.

The `pointer-events` write had the same shape: `isSorting` is `Boolean(active)`, identical on every sortable, so drag start wrote `pointer-events: none` inline onto all of them and drag end wrote it back off.

## What changed

- `displaceListedItems` returns null for an item that is not in the sortable list and defers to `verticalListSortingStrategy` otherwise. Scenes displace exactly as before; nothing else is touched.
- `transition` is now paired with the transform that gives it something to animate, so a card with no displacement gets no transition write either.
- Drag-time `pointer-events: none` rides one class on the canvas for the length of the drag instead of an inline write per card at each end of it.

No behavior change: the same items are draggable, the same items are drop targets, displacement animates the same way, and cards are inert during a drag exactly as before.

## Verification

`npm run lint`, `format:check`, `typecheck`, `knip`, `build`, and `npm run test:run` (1311 tests) all pass. `displaceListedItems` is covered by a unit test.

Not browser-profiled: reproducing #621's setup needs an authenticated session against real projects, which this run does not have. The mechanism above is read off the installed `@dnd-kit/sortable@10.0.0` source rather than measured, and the honest framing is that it removes work that provably has no effect on what the user sees, not that a frame-rate delta has been demonstrated.

## Open PR overlap check

Considered #622, #624, #625, #626, #627. They cover `app/components/canvas/elements/**`, `lib/canvas/**`, `lib/generation/**`, `lib/agent/**`, `lib/api/jobs.ts`, `lib/project/autosave.ts`, `app/components/projects/ProjectsList.tsx`, and `app/components/video/timeline/ClipWaveform.tsx`. This PR touches only `app/components/canvas/Canvas.tsx`, `app/components/canvas/dnd/**`, and `app/components/canvas/styles/sortable.module.css`, none of which appear in any open PR.

## Skipped

- Cutting the ~370 `ResizeObserver` instances dnd-kit creates and connects at drag start. Real work, and it likely defeats the `content-visibility: auto` on scenes, but `resizeObserverConfig: {disabled: true}` is a bare knob and justifying it needs the measurement this run cannot take.
- Dropping `useSortable` entirely for disabled sortables. A boolean `disabled` in dnd-kit means `{draggable: true, droppable: false}`, so those cards are still load-bearing drop targets. Not safe.
- `findElementById`'s full-document walk in the drag-over path. Already guarded to cross-scene moves only, and the rewrite has been declined five times.