### PR TITLE
fix: wrap the composer options row on narrow screens

### DIFF
--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -262,7 +262,7 @@ function Composer({ value, onValueChange, onSubmit }: ComposerCopilotProps) {
 					</div>
 				</div>
 				<div className="flex items-center justify-between pt-2">
-					<div className="flex items-center gap-2">
+					<div className="flex min-w-0 flex-wrap items-center gap-2">
 						{inputElement}
 						<AttachMenu openPicker={openPicker} uploading={uploading} />
 						<SettingPill

--- a/app/components/copilot/SettingPill.tsx
+++ b/app/components/copilot/SettingPill.tsx
@@ -50,7 +50,7 @@ export function SettingPill<T extends string>({
 				aria-label={`${name}: ${selected.label}`}
 				disabled={disabled}
 				className={cn(
-					"focus-ring inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 font-body text-label text-foreground transition-colors hover:bg-button-hover disabled:pointer-events-none disabled:opacity-50",
+					"focus-ring inline-flex shrink-0 items-center gap-1 rounded-full bg-muted px-2 py-0.5 font-body text-label whitespace-nowrap text-foreground transition-colors hover:bg-button-hover disabled:pointer-events-none disabled:opacity-50",
 					className,
 				)}
 				style={style}


### PR DESCRIPTION
## Summary

The composer's options row was a single non-wrapping flex row, so on narrow viewports the pills compressed and clipped their labels instead of reflowing. Fixed at the row, not per pill, matching how #551 fixed the element-card actions row.

## Changes

- `ComposerCopilot.tsx` — pill group gets `min-w-0 flex-wrap`, so pills move to a second line instead of squashing. The submit `ActionButton` stays outside the wrapping group and stays anchored at the end of the row.
- `SettingPill.tsx` — pill button gets `shrink-0 whitespace-nowrap`, so labels stay intact rather than compressing.

No `sm:`/`md:` variants needed: the row is unchanged above the wrap point, so desktop layout is untouched. `SelectMenu` popovers already stay on-screen via Radix collision detection, so no change there.

Fixes #591
