### PR TITLE
fix: animate the still an image already generated

### DIFF
--- a/app/components/canvas/elements/AnimateButton.tsx
+++ b/app/components/canvas/elements/AnimateButton.tsx
@@ -3,6 +3,9 @@
 import { MagicVideo } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { animateImagePrompt } from "@/lib/script/refine/animatePrompt";
+import { carryOverStill } from "@/lib/connectors/animated_image/plugins/still-frame";
+import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
+import { useNodeBuilder } from "@/lib/generation/useNodeBuilder";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { useSloppy } from "@/app/components/sloppy/SloppyProvider";
 import { useEditorPanel } from "../panel/EditorPanelContext";
@@ -10,6 +13,8 @@ import { useEditorPanel } from "../panel/EditorPanelContext";
 export function AnimateButton({ element }: { element: CanvasContentElement }) {
 	const { send, loading } = useSloppy();
 	const { setActive } = useEditorPanel();
+	const queue = useGenerationQueue();
+	const buildNode = useNodeBuilder();
 
 	if (element.type !== "image") return null;
 
@@ -23,6 +28,7 @@ export function AnimateButton({ element }: { element: CanvasContentElement }) {
 			disabled={loading}
 			onMouseDown={(e) => e.preventDefault()}
 			onClick={() => {
+				carryOverStill(element, queue, buildNode);
 				setActive("sloppy");
 				void send(animateImagePrompt(element.id));
 			}}

--- a/app/components/canvas/elements/AnimateButton.tsx
+++ b/app/components/canvas/elements/AnimateButton.tsx
@@ -2,10 +2,9 @@
 
 import { MagicVideo } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
+import { ReactEditor, useSlateStatic } from "slate-react";
 import { animateImagePrompt } from "@/lib/script/refine/animatePrompt";
-import { carryOverStill } from "@/lib/connectors/animated_image/plugins/still-frame";
-import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
-import { useNodeBuilder } from "@/lib/generation/useNodeBuilder";
+import { parentSceneId, sceneIndexOf } from "@/lib/canvas/scenes";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { useSloppy } from "@/app/components/sloppy/SloppyProvider";
 import { useEditorPanel } from "../panel/EditorPanelContext";
@@ -13,8 +12,7 @@ import { useEditorPanel } from "../panel/EditorPanelContext";
 export function AnimateButton({ element }: { element: CanvasContentElement }) {
 	const { send, loading } = useSloppy();
 	const { setActive } = useEditorPanel();
-	const queue = useGenerationQueue();
-	const buildNode = useNodeBuilder();
+	const editor = useSlateStatic();
 
 	if (element.type !== "image") return null;
 
@@ -28,9 +26,13 @@ export function AnimateButton({ element }: { element: CanvasContentElement }) {
 			disabled={loading}
 			onMouseDown={(e) => e.preventDefault()}
 			onClick={() => {
-				carryOverStill(element, queue, buildNode);
+				const path = ReactEditor.findPath(editor, element);
 				setActive("sloppy");
-				void send(animateImagePrompt(element.id));
+				void send(
+					animateImagePrompt(
+						sceneIndexOf(editor.children, parentSceneId(editor, path)),
+					),
+				);
 			}}
 		>
 			<MagicVideo aria-hidden="true" />

--- a/app/components/canvas/elements/ElementHistoryButton.tsx
+++ b/app/components/canvas/elements/ElementHistoryButton.tsx
@@ -4,7 +4,7 @@ import { useCallback } from "react";
 import { useSlateStatic } from "slate-react";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import type { ElementVersion } from "@/lib/generation/versions";
-import { applyNodeInputs } from "../utils/nodeOps";
+import { applyElementVersion } from "../utils/nodeOps";
 import { VersionHistoryPopover } from "./VersionHistoryPopover";
 
 export function ElementHistoryButton({
@@ -13,13 +13,10 @@ export function ElementHistoryButton({
 	element: CanvasContentElement;
 }) {
 	const editor = useSlateStatic();
-	const restoreInputs = useCallback(
-		(version: ElementVersion) =>
-			applyNodeInputs(editor, element, version.inputs),
+	const restore = useCallback(
+		(version: ElementVersion) => applyElementVersion(editor, element, version),
 		[editor, element],
 	);
 
-	return (
-		<VersionHistoryPopover elementId={element.id} onRestore={restoreInputs} />
-	);
+	return <VersionHistoryPopover elementId={element.id} onRestore={restore} />;
 }

--- a/app/components/canvas/elements/VersionHistoryPopover.tsx
+++ b/app/components/canvas/elements/VersionHistoryPopover.tsx
@@ -19,7 +19,6 @@ import { restoreVersion } from "@/lib/generation/restore";
 import { versionKey, type ElementVersion } from "@/lib/generation/versions";
 import { relativeTime } from "@/lib/project/relativeTime";
 import { toastError } from "@/lib/toastError";
-import { formatTime } from "@/lib/video/timestamps";
 import { cn } from "@/lib/utils";
 import {
 	useElementHistory,
@@ -66,7 +65,7 @@ function VersionRow({
 	active: boolean;
 	onRestore: () => void;
 }) {
-	const { audioUrl, durationSec } = version.result;
+	const { audioUrl } = version.result;
 	return (
 		<li
 			aria-current={active}
@@ -85,14 +84,6 @@ function VersionRow({
 						<Dot />
 						{version.pinned && <Pin className="h-3 w-3" />}
 						{relativeTime(version.createdAt)}
-						{durationSec > 0 && (
-							<>
-								<Dot />
-								<span className="font-mono tabular-nums">
-									{formatTime(durationSec)}
-								</span>
-							</>
-						)}
 					</span>
 					<span className="w-full truncate text-label-xs text-muted-foreground">
 						{version.inputs.prompt

--- a/app/components/canvas/utils/nodeOps.ts
+++ b/app/components/canvas/utils/nodeOps.ts
@@ -1,13 +1,12 @@
 import { type Editor, Transforms } from "slate";
 import { ReactEditor } from "slate-react";
 import {
+	applyNodeVersion,
 	duplicateNode,
-	replaceGenerationAttrs,
 	mergeAttrs,
-	updateNodeText,
 } from "@/lib/canvas/editorOps";
 import type { CanvasContentElement, CanvasElement } from "@/lib/canvas/types";
-import type { NodeInputs } from "@/lib/generation/inputs";
+import type { ElementVersion } from "@/lib/generation/versions";
 
 /** Merge attrs into a live element's attributes (a null value deletes the key). */
 export function updateElementAttrs(
@@ -18,14 +17,13 @@ export function updateElementAttrs(
 	mergeAttrs(editor, ReactEditor.findPath(editor, element), element, attrs);
 }
 
-export function applyNodeInputs(
+/** Restore a live element to the state a version was generated from. */
+export function applyElementVersion(
 	editor: Editor,
 	element: CanvasContentElement,
-	inputs: NodeInputs,
+	version: Pick<ElementVersion, "elementType" | "inputs">,
 ): void {
-	const path = ReactEditor.findPath(editor, element);
-	replaceGenerationAttrs(editor, path, inputs.attributes);
-	updateNodeText(editor, path, inputs.prompt);
+	applyNodeVersion(editor, ReactEditor.findPath(editor, element), version);
 }
 
 /** Inserts a copy of a live element directly after it. Returns the copy's id. */

--- a/lib/agent/tools/editScript.ts
+++ b/lib/agent/tools/editScript.ts
@@ -22,6 +22,13 @@ export const editScript = defineTool({
 	  - set: change an element. Send only what changes, and the full replacement \`text\` when
 	    text changes. Set an attribute to null to drop it.
 
+	  \`deps\` goes on a \`set\` and reuses a result the element already has, instead of
+	  throwing it away. Send it whenever you retype an element into one built on what it
+	  already made: an image becoming an animated_image sends
+	  \`deps: {"still": "<the image's id>"}\`, so the animation opens on the picture that
+	  image already made instead of generating a new one. Retyping keeps the id, so that is
+	  the id you already read. \`still\` is the only name \`deps\` takes today.
+
 	  To move an element, remove it and insert it again.
 
 	  Element types: ${ELEMENT_TYPES}

--- a/lib/agent/tools/useAgentTools.ts
+++ b/lib/agent/tools/useAgentTools.ts
@@ -11,7 +11,7 @@ import { useConfig } from "@/lib/config/ConfigProvider";
 import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
 import { characterAvatarUrl } from "@/lib/project/characterAvatar";
 import { createDefaultConnector } from "@/lib/connectors/registry";
-import { applyRefineOps } from "@/lib/script/refine/applyOps";
+import { applyScriptEdit } from "@/lib/generation/scriptEdit";
 import { normalizeCharacterName } from "@/lib/project/characterName";
 import { useProjectStoreHandle } from "@/lib/project/ProjectStoreProvider";
 import { useScriptControl } from "@/lib/script/ScriptProvider";
@@ -42,7 +42,16 @@ export function useAgentTools(editor: Editor) {
 					return text;
 				},
 				readMetadata: () => store.getState().metadata,
-				editScript: (ops) => applyRefineOps(editor, ops, connectorConfig),
+				editScript: (ops) =>
+					applyScriptEdit(
+						{
+							editor,
+							queue,
+							connectors: connectorConfig,
+							state: store.getState(),
+						},
+						ops,
+					),
 				// The stream appends what it cannot find by id, so the canvas is cleared
 				// first or the new script stacks under the old one.
 				writeScript: (brief) => {

--- a/lib/canvas/__tests__/editorOps.test.ts
+++ b/lib/canvas/__tests__/editorOps.test.ts
@@ -3,6 +3,7 @@ import { createEditor, Editor } from "slate";
 import type { CanvasContentElement, SceneElement } from "@/lib/canvas/types";
 import { ZERO_WIDTH_SPACE } from "../constants";
 import {
+	applyNodeVersion,
 	clearEditor,
 	duplicateNode,
 	findElementById,
@@ -257,5 +258,57 @@ describe("clearEditor", () => {
 		clearEditor(editor);
 
 		expect(editor.children).toEqual([]);
+	});
+});
+
+describe("applyNodeVersion", () => {
+	const version = (
+		elementType: CanvasContentElement["type"] | undefined,
+		attributes: Record<string, string>,
+		prompt: string,
+	) => ({ elementType, inputs: { prompt, attributes, dependencies: {} } });
+
+	// An animated image restored to the image version it was animated from keeps
+	// the videoPrompt of the animation without it.
+	it("restores the type the version was generated as", () => {
+		const el = content("animated_image", "n1", "a fox", {
+			style: "ink",
+			videoPrompt: "slow pan",
+		});
+		const editor = makeEditor([scene([el])]);
+
+		applyNodeVersion(
+			editor,
+			[0, 0],
+			version("image", { style: "ink" }, "a fox"),
+		);
+
+		const node = (editor.children[0] as SceneElement).children[0];
+		expect(node.type).toBe("image");
+		expect(node.generationAttributes).toEqual({ style: "ink" });
+	});
+
+	it("restores the prompt the version was generated from", () => {
+		const el = content("image", "n1", "a fox");
+		const editor = makeEditor([scene([el])]);
+
+		applyNodeVersion(editor, [0, 0], version("image", {}, "a wolf"));
+
+		expect(Editor.string(editor, [0, 0])).toBe(`${ZERO_WIDTH_SPACE}a wolf`);
+	});
+
+	it("leaves the type alone for a version stored without one", () => {
+		const el = content("animated_image", "n1", "a fox", { style: "ink" });
+		const editor = makeEditor([scene([el])]);
+
+		applyNodeVersion(
+			editor,
+			[0, 0],
+			version(undefined, { style: "oil" }, "a fox"),
+		);
+
+		const node = (editor.children[0] as SceneElement).children[0];
+		expect(node.type).toBe("animated_image");
+		expect(node.generationAttributes).toEqual({ style: "oil" });
 	});
 });

--- a/lib/canvas/constants.ts
+++ b/lib/canvas/constants.ts
@@ -10,3 +10,6 @@ export const ZERO_WIDTH_SPACE = "\u200B";
  */
 export const withoutCaretMarker = (text: string): string =>
 	text.replaceAll(ZERO_WIDTH_SPACE, "");
+
+/** The line a serialized script puts between one scene and the next. */
+export const SCENE_MARKER_PATTERN = /^---\s*Scene\s+\d+\s*---\s*$/m;

--- a/lib/canvas/editorOps.ts
+++ b/lib/canvas/editorOps.ts
@@ -1,6 +1,7 @@
 import mapValues from "lodash/mapValues";
 import { Editor, Element, type NodeEntry, Path, Transforms } from "slate";
 import type { CanvasContentElement, CanvasElement } from "@/lib/canvas/types";
+import type { ElementVersion } from "@/lib/generation/versions";
 import { flatAttributes, splitAttributes } from "@/lib/video/elementAttributes";
 import { withoutCaretMarker, ZERO_WIDTH_SPACE } from "./constants";
 import { isContentElement } from "./guards";
@@ -92,6 +93,23 @@ export function replaceGenerationAttrs(
 		{ generationAttributes: mapValues(attributes, String) },
 		{ at: path },
 	);
+}
+
+/**
+ * Puts an element back into the state that produced a version: the type it was
+ * generated as, and the prompt and attributes it was generated from. Restoring
+ * the inputs alone would leave, say, an animated image holding the attributes of
+ * the image it was animated from, with no videoPrompt left to animate on.
+ */
+export function applyNodeVersion(
+	editor: Editor,
+	path: Path,
+	{ elementType, inputs }: Pick<ElementVersion, "elementType" | "inputs">,
+): void {
+	if (elementType)
+		Transforms.setNodes(editor, { type: elementType }, { at: path });
+	replaceGenerationAttrs(editor, path, inputs.attributes);
+	updateNodeText(editor, path, inputs.prompt);
 }
 
 export function mergeAttrs(

--- a/lib/canvas/osmlSerializer.ts
+++ b/lib/canvas/osmlSerializer.ts
@@ -5,7 +5,6 @@ import { withoutCaretMarker } from "./constants";
 import { flatAttributes } from "@/lib/video/elementAttributes";
 import { escapeXml } from "./xmlEscape";
 
-export const SCENE_MARKER_PATTERN = /^---\s*Scene\s+\d+\s*---\s*$/m;
 const sceneMarker = (n: number) => `\n--- Scene ${n} ---\n`;
 
 export function getElementText(element: ParsedElement): string {

--- a/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
@@ -15,6 +15,7 @@ import { GenerationQueue } from "@/lib/generation/queue";
 import { nodeBuilder } from "@/lib/generation/resolveGraph";
 import { MetadataSchema } from "@/lib/project/types";
 import {
+	carryOverStill,
 	createStillFramePlugin,
 	stillElementId,
 	stillSnapshot,
@@ -245,5 +246,73 @@ describe("uploaded still lifetime", () => {
 		const { animation, still } = afterUpload("a forest", "slow pan");
 		expect(still).toBe(false);
 		expect(animation).toBe(false);
+	});
+});
+
+describe("carryOverStill", () => {
+	const registry = DEFAULT_CONNECTOR_REGISTRY;
+	const state = {
+		hydrated: true,
+		metadata: MetadataSchema.parse({}),
+		referenceImages: [],
+	};
+	const image = {
+		id: ELEMENT_ID,
+		type: "image" as const,
+		generationAttributes: { provider: "openslop" },
+		children: [{ id: "t", type: "image" as const, text: "a forest" }],
+	};
+	const animated = (text = "a forest") => ({
+		...image,
+		type: "animated_image" as const,
+		generationAttributes: {
+			...image.generationAttributes,
+			videoPrompt: "slow pan",
+		},
+		children: [{ id: "t", type: "animated_image" as const, text }],
+	});
+
+	const stillOf = (node: GenerationNode) => {
+		const still = node.dependsOn.find(
+			(dep) => dep.id === stillElementId(ELEMENT_ID),
+		);
+		if (!still) throw new Error("expected a still dependency");
+		return still;
+	};
+
+	const animate = (generated: boolean) => {
+		const queue = new GenerationQueue();
+		const build = nodeBuilder(registry, state);
+		if (generated)
+			queue.commitResult(build(forElement(image)), {
+				imageUrl: STILL_URL,
+				durationSec: 0,
+			});
+		carryOverStill(image, queue, build);
+		return { queue, build };
+	};
+
+	it("animates the frame the image already had", () => {
+		const { queue, build } = animate(true);
+		const node = build(forElement(animated()));
+
+		expect(stillSnapshot(node, queue).result?.imageUrl).toBe(STILL_URL);
+		expect(needsGeneration(stillOf(node), queue)).toBe(false);
+		expect(needsGeneration(node, queue)).toBe(true);
+	});
+
+	it("leaves the carried-over still stale-able by its own prompt", () => {
+		const { queue, build } = animate(true);
+		const edited = build(forElement(animated("a meadow")));
+
+		expect(needsGeneration(stillOf(edited), queue)).toBe(true);
+	});
+
+	it("does nothing for an image that has not been generated", () => {
+		const { queue, build } = animate(false);
+		const node = build(forElement(animated()));
+
+		expect(stillSnapshot(node, queue).result).toBeNull();
+		expect(needsGeneration(stillOf(node), queue)).toBe(true);
 	});
 });

--- a/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
@@ -15,7 +15,6 @@ import { GenerationQueue } from "@/lib/generation/queue";
 import { nodeBuilder } from "@/lib/generation/resolveGraph";
 import { MetadataSchema } from "@/lib/project/types";
 import {
-	carryOverStill,
 	createStillFramePlugin,
 	stillElementId,
 	stillSnapshot,
@@ -246,73 +245,5 @@ describe("uploaded still lifetime", () => {
 		const { animation, still } = afterUpload("a forest", "slow pan");
 		expect(still).toBe(false);
 		expect(animation).toBe(false);
-	});
-});
-
-describe("carryOverStill", () => {
-	const registry = DEFAULT_CONNECTOR_REGISTRY;
-	const state = {
-		hydrated: true,
-		metadata: MetadataSchema.parse({}),
-		referenceImages: [],
-	};
-	const image = {
-		id: ELEMENT_ID,
-		type: "image" as const,
-		generationAttributes: { provider: "openslop" },
-		children: [{ id: "t", type: "image" as const, text: "a forest" }],
-	};
-	const animated = (text = "a forest") => ({
-		...image,
-		type: "animated_image" as const,
-		generationAttributes: {
-			...image.generationAttributes,
-			videoPrompt: "slow pan",
-		},
-		children: [{ id: "t", type: "animated_image" as const, text }],
-	});
-
-	const stillOf = (node: GenerationNode) => {
-		const still = node.dependsOn.find(
-			(dep) => dep.id === stillElementId(ELEMENT_ID),
-		);
-		if (!still) throw new Error("expected a still dependency");
-		return still;
-	};
-
-	const animate = (generated: boolean) => {
-		const queue = new GenerationQueue();
-		const build = nodeBuilder(registry, state);
-		if (generated)
-			queue.commitResult(build(forElement(image)), {
-				imageUrl: STILL_URL,
-				durationSec: 0,
-			});
-		carryOverStill(image, queue, build);
-		return { queue, build };
-	};
-
-	it("animates the frame the image already had", () => {
-		const { queue, build } = animate(true);
-		const node = build(forElement(animated()));
-
-		expect(stillSnapshot(node, queue).result?.imageUrl).toBe(STILL_URL);
-		expect(needsGeneration(stillOf(node), queue)).toBe(false);
-		expect(needsGeneration(node, queue)).toBe(true);
-	});
-
-	it("leaves the carried-over still stale-able by its own prompt", () => {
-		const { queue, build } = animate(true);
-		const edited = build(forElement(animated("a meadow")));
-
-		expect(needsGeneration(stillOf(edited), queue)).toBe(true);
-	});
-
-	it("does nothing for an image that has not been generated", () => {
-		const { queue, build } = animate(false);
-		const node = build(forElement(animated()));
-
-		expect(stillSnapshot(node, queue).result).toBeNull();
-		expect(needsGeneration(stillOf(node), queue)).toBe(true);
 	});
 });

--- a/lib/connectors/animated_image/plugins/still-frame.ts
+++ b/lib/connectors/animated_image/plugins/still-frame.ts
@@ -14,6 +14,7 @@ import {
 	type NodeSpec,
 } from "@/lib/generation/graph";
 import type { GenerationQueue } from "@/lib/generation/queue";
+import type { NodeBuilder } from "@/lib/generation/resolveGraph";
 import type { ElementSnapshot } from "@/lib/generation/snapshots";
 
 /**
@@ -59,6 +60,22 @@ export const stillSnapshot = (
 	node: GenerationNode,
 	queue: GenerationQueue,
 ): ElementSnapshot => queue.getElementSnapshot(stillDependency(node)?.id);
+
+/**
+ * Moves an image's own result onto the still it is about to become, so animating
+ * an image animates the frame the user already has instead of a fresh one. The
+ * still stays a node with its own inputs, so editing it still stales the animation.
+ */
+export function carryOverStill(
+	element: CanvasContentElement,
+	queue: GenerationQueue,
+	buildNode: NodeBuilder,
+): void {
+	const { result } = queue.getElementSnapshot(element.id);
+	if (!result) return;
+	queue.commitResult(buildNode(forStillOf(element)), result);
+	queue.discard(element.id);
+}
 
 const stillFrame = (
 	ctx?: PluginContext<AnimatedImageGenerateParams, AssetResult>,

--- a/lib/connectors/animated_image/plugins/still-frame.ts
+++ b/lib/connectors/animated_image/plugins/still-frame.ts
@@ -9,12 +9,12 @@ import {
 } from "@/lib/connectors/types";
 import { buildImagePlugins } from "@/lib/connectors/image/plugins/imageChain";
 import {
+	derivedDependency,
 	derivedNodeId,
 	type GenerationNode,
 	type NodeSpec,
 } from "@/lib/generation/graph";
 import type { GenerationQueue } from "@/lib/generation/queue";
-import type { NodeBuilder } from "@/lib/generation/resolveGraph";
 import type { ElementSnapshot } from "@/lib/generation/snapshots";
 
 /**
@@ -23,8 +23,10 @@ import type { ElementSnapshot } from "@/lib/generation/snapshots";
  */
 const VIDEO_ONLY_KEYS = ["videoPrompt", "duration", "model"] as const;
 
+const STILL = "still";
+
 export const stillElementId = (elementId: string) =>
-	derivedNodeId("still", elementId);
+	derivedNodeId(STILL, elementId);
 
 /**
  * The frame an animated image animates. Being a node of its own is what makes it
@@ -51,7 +53,7 @@ export const forStillOf =
 
 /** The still node behind an animated image, when the element has one. */
 export const stillDependency = (node: GenerationNode) =>
-	node.dependsOn.find((dep) => dep.id === stillElementId(node.id));
+	derivedDependency(node, STILL);
 
 /**
  * The snapshot of the still a node depends on
@@ -60,22 +62,6 @@ export const stillSnapshot = (
 	node: GenerationNode,
 	queue: GenerationQueue,
 ): ElementSnapshot => queue.getElementSnapshot(stillDependency(node)?.id);
-
-/**
- * Moves an image's own result onto the still it is about to become, so animating
- * an image animates the frame the user already has instead of a fresh one. The
- * still stays a node with its own inputs, so editing it still stales the animation.
- */
-export function carryOverStill(
-	element: CanvasContentElement,
-	queue: GenerationQueue,
-	buildNode: NodeBuilder,
-): void {
-	const { result } = queue.getElementSnapshot(element.id);
-	if (!result) return;
-	queue.commitResult(buildNode(forStillOf(element)), result);
-	queue.discard(element.id);
-}
 
 const stillFrame = (
 	ctx?: PluginContext<AnimatedImageGenerateParams, AssetResult>,

--- a/lib/generation/__tests__/generateForElement.test.ts
+++ b/lib/generation/__tests__/generateForElement.test.ts
@@ -34,6 +34,7 @@ const config: ConnectorConfig = {
 function makeJob(connectorType: AssetConnectorType): GenerationJob {
 	return {
 		elementId: "el-1",
+		elementType: "image",
 		connectorType,
 		provider: "openslop",
 		config,

--- a/lib/generation/__tests__/graph.test.ts
+++ b/lib/generation/__tests__/graph.test.ts
@@ -33,6 +33,7 @@ function node(
 ): GenerationNode {
 	const job: GenerationJob = {
 		elementId: id,
+		elementType: "image",
 		connectorType: "image",
 		provider: "openslop",
 		config,

--- a/lib/generation/__tests__/queue.test.ts
+++ b/lib/generation/__tests__/queue.test.ts
@@ -46,6 +46,7 @@ function makeJob(id: string, overrides: JobOverrides = {}): GenerationNode {
 	} = overrides;
 	const job: GenerationJob = {
 		elementId: id,
+		elementType: "image",
 		connectorType: "image",
 		provider: "openslop",
 		config,
@@ -725,6 +726,16 @@ describe("GenerationQueue", () => {
 					pinned: false,
 					result: { url: "first.png", durationSec: 0 },
 				}),
+			);
+		});
+
+		// A version is restored onto the element, so it has to remember the type it
+		// was generated as, not just the connector that ran it.
+		it("announces the element type the version was generated as", async () => {
+			await generate("v3", "third.png");
+
+			expect(committed).toHaveBeenCalledWith(
+				expect.objectContaining({ elementId: "v3", elementType: "image" }),
 			);
 		});
 

--- a/lib/generation/__tests__/queueDependencies.test.ts
+++ b/lib/generation/__tests__/queueDependencies.test.ts
@@ -26,6 +26,7 @@ const config: ConnectorConfig = {
 function node(id: string, dependsOn: GenerationNode[] = []): GenerationNode {
 	const job: GenerationJob = {
 		elementId: id,
+		elementType: "image",
 		connectorType: "image",
 		provider: "openslop",
 		config,

--- a/lib/generation/__tests__/scriptEdit.test.ts
+++ b/lib/generation/__tests__/scriptEdit.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { createEditor, type Descendant } from "slate";
+import {
+	stillDependency,
+	stillElementId,
+} from "@/lib/connectors/animated_image/plugins/still-frame";
+import { DEFAULT_CONNECTOR_REGISTRY } from "@/lib/connectors/registry";
+import { MetadataSchema } from "@/lib/project/types";
+import { splitAttributes } from "@/lib/video/elementAttributes";
+import { forElement, needsGeneration } from "../graph";
+import { GenerationQueue } from "../queue";
+import { nodeBuilder } from "../resolveGraph";
+import { applyScriptEdit, type ScriptEditContext } from "../scriptEdit";
+
+const ID = "n1";
+const STILL_ID = stillElementId(ID);
+const IMAGE_URL = "https://example.com/frame.png";
+
+const state = {
+	hydrated: true,
+	metadata: MetadataSchema.parse({}),
+	referenceImages: [],
+};
+
+const buildNode = nodeBuilder(DEFAULT_CONNECTOR_REGISTRY, state);
+
+const image = {
+	id: ID,
+	type: "image" as const,
+	...splitAttributes({ provider: "openslop" }),
+	children: [{ id: "t", type: "image" as const, text: "a forest" }],
+};
+
+const context = ({ generated = true, pinned = false } = {}) => {
+	const editor = createEditor();
+	editor.children = [
+		{ id: "s1", type: "scene", children: [image] } as unknown as Descendant,
+	];
+	const queue = new GenerationQueue();
+	if (generated)
+		queue.commitResult(
+			buildNode(forElement(image)),
+			{ imageUrl: IMAGE_URL, durationSec: 0 },
+			{ pinned },
+		);
+	return {
+		editor,
+		queue,
+		connectors: DEFAULT_CONNECTOR_REGISTRY,
+		state,
+	} satisfies ScriptEditContext;
+};
+
+const animate = (
+	ctx: ScriptEditContext,
+	deps: Record<string, string> = { still: ID },
+) =>
+	applyScriptEdit(ctx, [
+		{
+			op: "set",
+			id: ID,
+			type: "animated_image",
+			attrs: { videoPrompt: "slow push-in" },
+			deps,
+		},
+	]);
+
+const stillResult = (ctx: ScriptEditContext) =>
+	ctx.queue.getElementSnapshot(STILL_ID);
+
+describe("applyScriptEdit", () => {
+	it("seeds a dependency of the element the edit just made", () => {
+		const ctx = context();
+
+		expect(animate(ctx)).toEqual({ applied: 1, failures: [] });
+		expect(stillResult(ctx).result?.imageUrl).toBe(IMAGE_URL);
+	});
+
+	it("leaves the seeded still off the work the animation still needs", () => {
+		const ctx = context();
+		animate(ctx);
+		const node = buildNode(forElement({ ...image, type: "animated_image" }));
+		const still = stillDependency(node);
+
+		expect(still && needsGeneration(still, ctx.queue)).toBe(false);
+		expect(needsGeneration(node, ctx.queue)).toBe(true);
+	});
+
+	// An uploaded frame must stay supplied, or the next bit of drift regenerates
+	// over the user's own image.
+	it("keeps a supplied result supplied", () => {
+		const ctx = context({ pinned: true });
+		animate(ctx);
+
+		expect(stillResult(ctx).pinned).toBe(true);
+	});
+
+	it("leaves the source result where it is", () => {
+		const ctx = context();
+		animate(ctx);
+
+		expect(ctx.queue.getElementSnapshot(ID).result?.imageUrl).toBe(IMAGE_URL);
+	});
+
+	it("applies the edit even when the seed cannot be done", () => {
+		const ctx = context({ generated: false });
+
+		expect(animate(ctx)).toEqual({
+			applied: 1,
+			failures: [`deps: "${ID}" has generated nothing to seed "still"`],
+		});
+	});
+
+	it("reports a dependency the element does not have", () => {
+		const ctx = context();
+
+		expect(animate(ctx, { poster: ID }).failures).toEqual([
+			`deps: "${ID}" has no "poster" to seed`,
+		]);
+	});
+
+	it("reports an edit against a missing element once", () => {
+		const ctx = context();
+
+		expect(
+			applyScriptEdit(ctx, [{ op: "set", id: "gone", deps: { still: ID } }])
+				.failures,
+		).toEqual(['set: no element "gone"']);
+	});
+
+	it("seeds nothing for an edit that declared nothing", () => {
+		const ctx = context();
+
+		expect(
+			applyScriptEdit(ctx, [{ op: "set", id: ID, text: "a meadow" }]),
+		).toEqual({ applied: 1, failures: [] });
+		expect(stillResult(ctx).result).toBeNull();
+	});
+});

--- a/lib/generation/__tests__/snapshots.test.ts
+++ b/lib/generation/__tests__/snapshots.test.ts
@@ -15,7 +15,14 @@ const result = (imageUrl: string): AssetResult => ({
 });
 
 const commit = (store: SnapshotStore, id: string, url: string) =>
-	store.commit(id, result(url), inputs(url), "image", false);
+	store.commit({
+		elementId: id,
+		elementType: "image",
+		connectorType: "image",
+		inputs: inputs(url),
+		result: result(url),
+		pinned: false,
+	});
 
 describe("SnapshotStore", () => {
 	it("reports an unknown element as idle and empty", () => {
@@ -87,7 +94,14 @@ describe("SnapshotStore", () => {
 	it("reports each commit as the version it produced", () => {
 		const store = new SnapshotStore();
 		expect(
-			store.commit("a", result("a.png"), inputs("a.png"), "image", false),
+			store.commit({
+				elementId: "a",
+				elementType: "image",
+				connectorType: "image",
+				inputs: inputs("a.png"),
+				result: result("a.png"),
+				pinned: false,
+			}),
 		).toMatchObject({ elementId: "a", connectorType: "image", pinned: false });
 	});
 

--- a/lib/generation/graph.ts
+++ b/lib/generation/graph.ts
@@ -1,6 +1,9 @@
 import compact from "lodash/compact";
 import isEqual from "lodash/isEqual";
-import type { CanvasContentElement } from "@/lib/canvas/types";
+import type {
+	CanvasContentElement,
+	CanvasElementType,
+} from "@/lib/canvas/types";
 import { ASSET_URL_FIELDS } from "@/lib/connectors/assetUrl";
 import type {
 	AssetConnectorType,
@@ -21,6 +24,7 @@ export type NodeId = string;
 /** Everything the queue needs to run one node. */
 export type GenerationJob = {
 	elementId: string;
+	elementType: CanvasElementType;
 	connectorType: AssetConnectorType;
 	provider: ProviderKey;
 	config: ConnectorConfig;

--- a/lib/generation/graph.ts
+++ b/lib/generation/graph.ts
@@ -90,6 +90,10 @@ const DERIVED_PREFIX = "~";
 export const derivedNodeId = (kind: string, key: string): NodeId =>
 	`${DERIVED_PREFIX}${kind}:${key}`;
 
+/** The dependency a node derives for `kind`, when its plugins declare one. */
+export const derivedDependency = (node: GenerationNode, kind: string) =>
+	node.dependsOn.find((dep) => dep.id === derivedNodeId(kind, node.id));
+
 const DERIVED_ID = new RegExp(`^\\${DERIVED_PREFIX}[^:]+:(.+)$`);
 
 /** The node a derived id was minted from, if it was derived at all. */

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -147,13 +147,14 @@ export class GenerationQueue {
 		if (isSourceNode(node))
 			throw new Error(`Source node "${node.id}" cannot hold a result`);
 		this.cancel(node.id);
-		this.commit(
-			node.id,
+		this.commit({
+			elementId: node.id,
+			elementType: node.job.elementType,
+			connectorType: node.job.connectorType,
+			inputs: nodeInputs(node, this),
 			result,
-			nodeInputs(node, this),
-			node.job.connectorType,
 			pinned,
-		);
+		});
 	}
 
 	restoreResult({ elementId, inputs, result, pinned }: CommittedVersion): void {
@@ -166,20 +167,8 @@ export class GenerationQueue {
 		this.snapshots.notify();
 	}
 
-	private commit(
-		elementId: string,
-		result: AssetResult,
-		inputs: GenerationInputs,
-		connectorType: GenerationJob["connectorType"],
-		pinned = false,
-	): void {
-		const version = this.snapshots.commit(
-			elementId,
-			result,
-			inputs,
-			connectorType,
-			pinned,
-		);
+	private commit(version: CommittedVersion): void {
+		this.snapshots.commit(version);
 		this.snapshots.notify();
 		for (const listener of this.commitListeners) listener(version);
 	}
@@ -281,7 +270,14 @@ export class GenerationQueue {
 		controller: AbortController,
 	) {
 		if (controller.signal.aborted) return;
-		this.commit(job.elementId, result, inputs, job.connectorType);
+		this.commit({
+			elementId: job.elementId,
+			elementType: job.elementType,
+			connectorType: job.connectorType,
+			inputs,
+			result,
+			pinned: false,
+		});
 	}
 
 	private handleJobError(

--- a/lib/generation/resolveGraph.ts
+++ b/lib/generation/resolveGraph.ts
@@ -34,6 +34,7 @@ const toNode = (
 	dependsOn,
 	job: {
 		elementId: element.id,
+		elementType: element.type,
 		connectorType: connector.type,
 		provider: connector.provider,
 		config: { ...connector.config, plugins },

--- a/lib/generation/scriptEdit.ts
+++ b/lib/generation/scriptEdit.ts
@@ -1,0 +1,55 @@
+import type { Editor } from "slate";
+import { findNodeById } from "@/lib/canvas/editorOps";
+import type { ConnectorRegistry } from "@/lib/connectors/registry";
+import type { ProjectData } from "@/lib/project/store";
+import { applyRefineOps } from "@/lib/script/refine/applyOps";
+import type { RefineOp } from "@/lib/script/refine/types";
+import { derivedDependency, forElement } from "./graph";
+import type { GenerationQueue } from "./queue";
+import { nodeBuilder } from "./resolveGraph";
+
+export type ScriptEditContext = {
+	editor: Editor;
+	queue: GenerationQueue;
+	connectors: ConnectorRegistry;
+	state: ProjectData;
+};
+
+function seedDependencies(
+	{ editor, queue, connectors, state }: ScriptEditContext,
+	elementId: string,
+	deps: Record<string, string>,
+): string[] {
+	const element = findNodeById(editor, elementId)?.[0];
+	if (!element) return [];
+
+	const node = nodeBuilder(connectors, state)(forElement(element));
+	return Object.entries(deps).flatMap(([name, sourceId]) => {
+		const target = derivedDependency(node, name);
+		if (!target) return [`deps: "${elementId}" has no "${name}" to seed`];
+
+		const { result, pinned } = queue.getElementSnapshot(sourceId);
+		if (!result)
+			return [`deps: "${sourceId}" has generated nothing to seed "${name}"`];
+
+		queue.commitResult(target, result, { pinned });
+		return [];
+	});
+}
+
+/** Seeding runs after the edit, against the element the whole edit left behind. */
+export function applyScriptEdit(
+	ctx: ScriptEditContext,
+	ops: RefineOp[],
+): { applied: number; failures: string[] } {
+	const { applied, failures } = applyRefineOps(ctx.editor, ops, ctx.connectors);
+	return {
+		applied,
+		failures: [
+			...failures,
+			...ops.flatMap((op) =>
+				op.op === "set" && op.deps ? seedDependencies(ctx, op.id, op.deps) : [],
+			),
+		],
+	};
+}

--- a/lib/generation/snapshots.ts
+++ b/lib/generation/snapshots.ts
@@ -120,14 +120,9 @@ export class SnapshotStore {
 		}
 	}
 
-	commit(
-		id: string,
-		result: AssetResult,
-		inputs: GenerationInputs,
-		connectorType: AssetConnectorType,
-		pinned: boolean,
-	): CommittedVersion {
-		this.update(id, {
+	commit(version: CommittedVersion): CommittedVersion {
+		const { elementId, result, inputs, connectorType, pinned } = version;
+		this.update(elementId, {
 			status: "idle",
 			seconds: 0,
 			result,
@@ -136,6 +131,6 @@ export class SnapshotStore {
 			connectorType,
 			pinned,
 		});
-		return { elementId: id, connectorType, inputs, result, pinned };
+		return version;
 	}
 }

--- a/lib/generation/versions.ts
+++ b/lib/generation/versions.ts
@@ -1,5 +1,6 @@
 import keyBy from "lodash/keyBy";
 import sortBy from "lodash/sortBy";
+import type { CanvasElementType } from "@/lib/canvas/types";
 import type { AssetConnectorType, AssetResult } from "../connectors/types";
 import { serializeInputs, type GenerationInputs } from "./inputs";
 
@@ -7,6 +8,8 @@ export type ElementVersion = {
 	elementId: string;
 	createdAt: string;
 	connectorType: AssetConnectorType;
+	/** Absent on versions stored before the element type was recorded. */
+	elementType?: CanvasElementType;
 	inputs: GenerationInputs;
 	result: AssetResult;
 	/** The result was supplied rather than generated. */

--- a/lib/project/__tests__/elementHistory.test.ts
+++ b/lib/project/__tests__/elementHistory.test.ts
@@ -38,6 +38,18 @@ describe("parseElementVersions", () => {
 		]);
 	});
 
+	it("reads the element type a version was generated as", () => {
+		const [version] = parseElementVersions([
+			row({ element_type: "animated_image" }),
+		]);
+		expect(version?.elementType).toBe("animated_image");
+	});
+
+	it("leaves the element type unset on a row written without one", () => {
+		const [version] = parseElementVersions([row()]);
+		expect(version?.elementType).toBeUndefined();
+	});
+
 	it("treats a project with no history as empty", () => {
 		expect(parseElementVersions(null)).toEqual([]);
 	});
@@ -110,6 +122,14 @@ describe("saveElementVersion", () => {
 		const theirs = await savedRow("p2", makeVersion());
 
 		expect(theirs.id).not.toBe(mine.id);
+	});
+
+	it("writes the element type the version was generated as", async () => {
+		const saved = await savedRow(
+			"p1",
+			makeVersion({ elementType: "animated_image" }),
+		);
+		expect(saved.element_type).toBe("animated_image");
 	});
 
 	it("throws when the write fails", async () => {

--- a/lib/project/elementHistory.ts
+++ b/lib/project/elementHistory.ts
@@ -1,5 +1,9 @@
 import { v5 as uuidv5 } from "uuid";
 import { z } from "zod";
+import {
+	CANVAS_ELEMENT_TYPES,
+	type CanvasElementType,
+} from "@/lib/canvas/types";
 import { ASSET_CONNECTOR_TYPES } from "@/lib/connectors/types";
 import type { AssetResult } from "@/lib/connectors/types";
 import type { VersionStorage } from "@/lib/generation/history";
@@ -26,10 +30,16 @@ const ResultSchema = z.object({
 		.optional(),
 }) satisfies z.ZodType<AssetResult>;
 
+const ElementTypeSchema = z.enum([...CANVAS_ELEMENT_TYPES] as [
+	CanvasElementType,
+	...CanvasElementType[],
+]);
+
 const RowSchema = z.object({
 	element_id: z.string(),
 	created_at: z.string(),
 	connector_type: z.enum(ASSET_CONNECTOR_TYPES),
+	element_type: ElementTypeSchema.nullish(),
 	inputs: InputsSchema,
 	result: ResultSchema,
 	pinned: z.boolean(),
@@ -39,6 +49,7 @@ const toVersion = (row: z.infer<typeof RowSchema>): ElementVersion => ({
 	elementId: row.element_id,
 	createdAt: row.created_at,
 	connectorType: row.connector_type,
+	elementType: row.element_type ?? undefined,
 	inputs: row.inputs,
 	result: row.result,
 	pinned: row.pinned,
@@ -49,13 +60,14 @@ const toRow = (projectId: string, version: ElementVersion) => ({
 	project_id: projectId,
 	element_id: version.elementId,
 	connector_type: version.connectorType,
+	element_type: version.elementType ?? null,
 	inputs: version.inputs,
 	result: version.result,
 	pinned: version.pinned,
 });
 
 const COLUMNS =
-	"element_id, created_at, connector_type, inputs, result, pinned";
+	"element_id, created_at, connector_type, element_type, inputs, result, pinned";
 
 /** Changing this re-keys every row, so it is fixed for the table's lifetime. */
 const ROW_ID_NAMESPACE = "5673ca03-e04d-4279-b92d-df493e2b9150";

--- a/lib/project/serialize.ts
+++ b/lib/project/serialize.ts
@@ -1,6 +1,6 @@
 import type { CanvasContentElement, SceneElement } from "@/lib/canvas/types";
 import { SCENE_TYPE } from "@/lib/canvas/types";
-import { SCENE_MARKER_PATTERN } from "@/lib/canvas/osmlSerializer";
+import { SCENE_MARKER_PATTERN } from "@/lib/canvas/constants";
 import { parseOSML } from "@/lib/canvas/osmlStreamParser";
 import { makeNodeId } from "@/lib/canvas/nodeUtils";
 import type { ConnectorRegistry } from "@/lib/connectors/registry";

--- a/lib/providers/llm/mock.ts
+++ b/lib/providers/llm/mock.ts
@@ -7,8 +7,9 @@ import type {
 	LLMGenerateParams,
 	LLMGenerateResult,
 } from "@/lib/connectors/types";
+import { SCENE_MARKER_PATTERN } from "@/lib/canvas/constants";
 import { OUTLINE_INSTRUCTION } from "@/lib/script/prompt/outline";
-import { isAnimateImageRequest } from "@/lib/script/refine/animatePrompt";
+import { animateImageScene } from "@/lib/script/refine/animatePrompt";
 import type { AgentModel } from "./agentModel";
 
 const MOCK_SCRIPT = `<metadata_title>Little Red</metadata_title>
@@ -175,6 +176,10 @@ export class MockLLM {
 
 const ELEMENT_ID = /id="([^"]+)"/;
 const IMAGE_ID = /<image[^>]*\bid="([^"]+)"/;
+
+/** What a script reads as between one scene marker and the next. */
+const sceneSection = (script: string, scene: number): string =>
+	script.split(SCENE_MARKER_PATTERN)[scene] ?? "";
 const EDIT_REQUEST =
 	/\b(add|remove|delete|change|edit|rewrite|shorten|lengthen|make|replace|move|swap|fix|tweak|animate|shorter|longer|warmer|colder)\b/i;
 
@@ -235,7 +240,7 @@ function parts(
  */
 function mockCall(prompt: LanguageModelV3Prompt) {
 	const asked = lastUserText(prompt);
-	const animating = isAnimateImageRequest(asked);
+	const scene = animateImageScene(asked);
 	const last = lastToolResult(prompt);
 
 	// The canvas is never in the prompt, so a step that has not read it, or that
@@ -250,9 +255,11 @@ function mockCall(prompt: LanguageModelV3Prompt) {
 		};
 	}
 
-	const elementId = (animating ? IMAGE_ID : ELEMENT_ID).exec(
-		last?.text ?? "",
-	)?.[1];
+	const script = last?.text ?? "";
+	const elementId =
+		scene === null
+			? ELEMENT_ID.exec(script)?.[1]
+			: IMAGE_ID.exec(sceneSection(script, scene))?.[1];
 
 	if (!elementId) {
 		return {
@@ -262,7 +269,7 @@ function mockCall(prompt: LanguageModelV3Prompt) {
 		};
 	}
 
-	if (!animating && !EDIT_REQUEST.test(asked)) {
+	if (scene === null && !EDIT_REQUEST.test(asked)) {
 		return {
 			say: "No API key is set, so I am a mock. Ask me to change the script and I will edit it.",
 		};
@@ -273,7 +280,7 @@ function mockCall(prompt: LanguageModelV3Prompt) {
 		toolName: "edit_script",
 		input: {
 			ops: [
-				animating
+				scene !== null
 					? {
 							op: "set",
 							id: elementId,

--- a/lib/providers/llm/mock.ts
+++ b/lib/providers/llm/mock.ts
@@ -8,7 +8,7 @@ import type {
 	LLMGenerateResult,
 } from "@/lib/connectors/types";
 import { OUTLINE_INSTRUCTION } from "@/lib/script/prompt/outline";
-import { matchAnimateImagePrompt } from "@/lib/script/refine/animatePrompt";
+import { isAnimateImageRequest } from "@/lib/script/refine/animatePrompt";
 import type { AgentModel } from "./agentModel";
 
 const MOCK_SCRIPT = `<metadata_title>Little Red</metadata_title>
@@ -174,6 +174,7 @@ export class MockLLM {
 }
 
 const ELEMENT_ID = /id="([^"]+)"/;
+const IMAGE_ID = /<image[^>]*\bid="([^"]+)"/;
 const EDIT_REQUEST =
 	/\b(add|remove|delete|change|edit|rewrite|shorten|lengthen|make|replace|move|swap|fix|tweak|animate|shorter|longer|warmer|colder)\b/i;
 
@@ -234,12 +235,12 @@ function parts(
  */
 function mockCall(prompt: LanguageModelV3Prompt) {
 	const asked = lastUserText(prompt);
-	const animateId = matchAnimateImagePrompt(asked);
+	const animating = isAnimateImageRequest(asked);
 	const last = lastToolResult(prompt);
 
 	// The canvas is never in the prompt, so a step that has not read it, or that
 	// just replaced it, has nothing to work from.
-	if (!animateId && (!last || last.toolName === "write_script")) {
+	if (!last || last.toolName === "write_script") {
 		return { say: "Reading the script. ", toolName: "read_script", input: {} };
 	}
 
@@ -249,7 +250,9 @@ function mockCall(prompt: LanguageModelV3Prompt) {
 		};
 	}
 
-	const elementId = animateId ?? ELEMENT_ID.exec(last?.text ?? "")?.[1];
+	const elementId = (animating ? IMAGE_ID : ELEMENT_ID).exec(
+		last?.text ?? "",
+	)?.[1];
 
 	if (!elementId) {
 		return {
@@ -259,7 +262,7 @@ function mockCall(prompt: LanguageModelV3Prompt) {
 		};
 	}
 
-	if (!animateId && !EDIT_REQUEST.test(asked)) {
+	if (!animating && !EDIT_REQUEST.test(asked)) {
 		return {
 			say: "No API key is set, so I am a mock. Ask me to change the script and I will edit it.",
 		};
@@ -270,12 +273,13 @@ function mockCall(prompt: LanguageModelV3Prompt) {
 		toolName: "edit_script",
 		input: {
 			ops: [
-				animateId
+				animating
 					? {
 							op: "set",
 							id: elementId,
 							type: "animated_image",
 							attrs: { videoPrompt: "slow cinematic push-in" },
+							deps: { still: elementId },
 						}
 					: {
 							op: "set",

--- a/lib/script/refine/__tests__/animatePrompt.test.ts
+++ b/lib/script/refine/__tests__/animatePrompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { animateImagePrompt, isAnimateImageRequest } from "../animatePrompt";
+import { animateImagePrompt, animateImageScene } from "../animatePrompt";
 
 describe("animateImagePrompt", () => {
 	it("names the scene the user is looking at", () => {
@@ -12,13 +12,13 @@ describe("animateImagePrompt", () => {
 		expect(animateImagePrompt(9)).not.toMatch(/deps|still|id=/);
 	});
 
-	it("is recognised by the matcher", () => {
-		expect(isAnimateImageRequest(animateImagePrompt(1))).toBe(true);
-		expect(isAnimateImageRequest(animateImagePrompt(42))).toBe(true);
+	it("reads back the scene it named", () => {
+		expect(animateImageScene(animateImagePrompt(1))).toBe(1);
+		expect(animateImageScene(animateImagePrompt(42))).toBe(42);
 	});
 
 	it("does not claim an unrelated request", () => {
-		expect(isAnimateImageRequest("make scene 3 funnier")).toBe(false);
-		expect(isAnimateImageRequest("animate the image")).toBe(false);
+		expect(animateImageScene("make scene 3 funnier")).toBeNull();
+		expect(animateImageScene("animate the image")).toBeNull();
 	});
 });

--- a/lib/script/refine/__tests__/animatePrompt.test.ts
+++ b/lib/script/refine/__tests__/animatePrompt.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { animateImagePrompt, isAnimateImageRequest } from "../animatePrompt";
+
+describe("animateImagePrompt", () => {
+	it("names the scene the user is looking at", () => {
+		expect(animateImagePrompt(9)).toBe(
+			"Animate the image in scene 9, reusing the frame it has already generated.",
+		);
+	});
+
+	it("says nothing about ids or tool arguments", () => {
+		expect(animateImagePrompt(9)).not.toMatch(/deps|still|id=/);
+	});
+
+	it("is recognised by the matcher", () => {
+		expect(isAnimateImageRequest(animateImagePrompt(1))).toBe(true);
+		expect(isAnimateImageRequest(animateImagePrompt(42))).toBe(true);
+	});
+
+	it("does not claim an unrelated request", () => {
+		expect(isAnimateImageRequest("make scene 3 funnier")).toBe(false);
+		expect(isAnimateImageRequest("animate the image")).toBe(false);
+	});
+});

--- a/lib/script/refine/animatePrompt.ts
+++ b/lib/script/refine/animatePrompt.ts
@@ -1,7 +1,10 @@
-const ANIMATE_IMAGE_PATTERN = /animate the image in scene \d+/i;
+const ANIMATE_IMAGE_PATTERN = /animate the image in scene (\d+)/i;
 
 export const animateImagePrompt = (scene: number): string =>
 	`Animate the image in scene ${scene}, reusing the frame it has already generated.`;
 
-export const isAnimateImageRequest = (prompt: string): boolean =>
-	ANIMATE_IMAGE_PATTERN.test(prompt);
+/** The scene an animate request names, or null when it is not one. */
+export const animateImageScene = (prompt: string): number | null => {
+	const scene = ANIMATE_IMAGE_PATTERN.exec(prompt)?.[1];
+	return scene === undefined ? null : Number(scene);
+};

--- a/lib/script/refine/animatePrompt.ts
+++ b/lib/script/refine/animatePrompt.ts
@@ -1,13 +1,7 @@
-const ANIMATE_IMAGE_INSTRUCTION = "animate the image element with id";
-const ANIMATE_IMAGE_PATTERN = new RegExp(
-	`${ANIMATE_IMAGE_INSTRUCTION}="([^"]+)"`,
-	"i",
-);
+const ANIMATE_IMAGE_PATTERN = /animate the image in scene \d+/i;
 
-export function animateImagePrompt(id: string): string {
-	return `${ANIMATE_IMAGE_INSTRUCTION}="${id}"`;
-}
+export const animateImagePrompt = (scene: number): string =>
+	`Animate the image in scene ${scene}, reusing the frame it has already generated.`;
 
-export function matchAnimateImagePrompt(prompt: string): string | null {
-	return ANIMATE_IMAGE_PATTERN.exec(prompt)?.[1] ?? null;
-}
+export const isAnimateImageRequest = (prompt: string): boolean =>
+	ANIMATE_IMAGE_PATTERN.test(prompt);

--- a/lib/script/refine/types.ts
+++ b/lib/script/refine/types.ts
@@ -29,6 +29,12 @@ const setOp = z.object({
 	type: canvasElementType.optional(),
 	attrs: z.record(z.string(), z.string().nullable()).optional().nullable(),
 	text: z.string().optional(),
+	deps: z
+		.record(z.string(), z.string())
+		.optional()
+		.describe(
+			'Reuse a result instead of making a new one, as input name to element id. Example: {"still": "abc123"}.',
+		),
 });
 
 export const refineOpSchema = z.discriminatedUnion("op", [

--- a/lib/video/captionStyle.ts
+++ b/lib/video/captionStyle.ts
@@ -77,7 +77,7 @@ export const DEFAULT_CAPTION_STYLE: CaptionStyle = {
 	font: "inter",
 	fontSize: 40,
 	casing: "none",
-	alignX: "left",
+	alignX: "center",
 	alignY: "bottom",
 	maxWordsPerLine: 4,
 	reveal: "word",

--- a/supabase/migrations/005_create_element_history.sql
+++ b/supabase/migrations/005_create_element_history.sql
@@ -5,6 +5,7 @@ create table if not exists element_history (
   project_id uuid not null references projects(id) on delete cascade,
   element_id text not null,
   connector_type text not null,
+  element_type text,
   inputs jsonb not null,
   result jsonb not null,
   pinned boolean not null default false,


### PR DESCRIPTION
## Summary
- Animating an already-generated image reuses that image as the animation's still instead of regenerating it. The reuse is declared by the edit rather than performed ahead of it: a `set` op carries `deps`, a map of an input of the element it produces to the id of the element whose existing result should fill it. `applyScriptEdit` applies the ops, then seeds those dependencies against the element the whole edit left behind. The still stays a node with its own inputs, so it still regenerates (and stales the animation) when the element's prompt changes.
- The whole `AssetResult` moves rather than its url, so `pinned` and `durationSec` come with it. A frame the user uploaded stays pinned instead of coming back as an ordinary generated result that the next bit of drift overwrites. No url has to survive a trip through the model.
- Nothing is discarded. An edit that omits `deps` regenerates the still; it cannot leave a blank card with the blob reachable only from version history.
- Fixes the follow-on restore bug: restoring a version from before the animate threw "animated_image element is missing required videoPrompt attribute". Versions now record the element type they were generated as (`GenerationJob.elementType` → `CommittedVersion` → `element_history.element_type`), and restoring one retypes the element back to it. The column is nullable and the field optional, so a version stored without a type restores its inputs alone.
- `element_type` is folded into migration `005_create_element_history.sql` rather than added by a new one; if 005 already ran on a database, drop `element_history` and re-run it.
- The Animate button's message reads as a request rather than a tool call: "Animate the image in scene 9, reusing the frame it has already generated." Scene normalization keeps at most one visual per scene, so the scene number names the image without exposing an id.
- Unrelated one-liner bundled in at request: captions now default to `alignX: "center"`.

Closes #564

## Test plan
- [ ] Generate an image, click Animate: the still is not regenerated and the Still toggle shows the original frame immediately.
- [ ] Hit Generate on the resulting animated image; only the video generates.
- [ ] Edit the animated image's prompt; the still goes stale and regenerates.
- [ ] Upload a still, then animate: the carried-over frame stays pinned and is not overwritten by later drift.
- [ ] Stop the turn mid-animate, or have it fail: the element is still an image showing its picture, not a blank card.
- [ ] Open the animated image's history, restore the pre-animate version: the element becomes an image again with its original prompt, and Generate regenerates the image.
- [ ] Restore the animated version afterwards: the element retypes back to animated_image with its videoPrompt.
- [ ] Click Animate on an image with no result; behaves as before (still generates, then animates).
- [ ] `npm run lint && npm run format:check && npm run typecheck && npm run knip && npm run build && npm test` pass locally (1370 tests).

## Notes for review
- The reuse now depends on the agent emitting `deps`. If it does not, the still is generated a second time. That is a soft failure by design, and it replaces a hard one.
- `deps` resolves a name to a derived node id via `derivedNodeId(name, elementId)`, the same function that mints them. Today `still` is the only dependency keyed that way, so it is the only name a fill can take. A second one would want a real name on the plugin dependency contract rather than an id convention.
- `applyRefineOps` is still exported and ignores `deps`; `applyScriptEdit` is the entry point that does both, and `applyRefineOps` now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DprVAGVo4hfWaR5BdDoajJ
