### PR TITLE
refactor: nightly maintainability 2026-08-25

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -72,6 +72,7 @@ Staleness falls out of the graph: a node needs generating when it has no result,
 - `lib/canvas/elementConnector.ts` answers "which connector, provider and model does this element use?" for both the UI and the queue. An element pins its provider when created, so this is also where a pin that no longer resolves falls back to the registry default.
 - `lib/script/` provides script context and refinement utilities.
 - `app/components/canvas/hooks/useEditorSession.ts` is the one place the Slate editor gets wired to a project: initial hydration, streaming script sync, metadata sync, and autosave. Views call it and render the editor; they never assemble it.
+- The editor instance is a prop in exactly one place: `Editor` hands it to `CanvasProviders`, which puts it in `<Slate>`. Everything below reaches it with `useSlateStatic()`, so no component takes it just to pass it on.
 - `lib/project/autosave.ts` owns saving: it builds the row from the store snapshot, script and generation snapshot, then debounces and serializes writes so a slow save can't land after a newer one. `useAutosave` only subscribes the editor value, the store, and the queue to it, and turns the result into a toast.
 
 ## Data

--- a/app/components/Editor.tsx
+++ b/app/components/Editor.tsx
@@ -21,11 +21,7 @@ export default function Editor() {
 							showWorkspace ? "" : "pt-[22vh]"
 						}`}
 					>
-						{showWorkspace ? (
-							<PostPromptView editor={editor} />
-						) : (
-							<PrePromptView />
-						)}
+						{showWorkspace ? <PostPromptView /> : <PrePromptView />}
 					</div>
 				</CanvasProviders>
 			</BottomViewProvider>

--- a/app/components/EditorToolbar.tsx
+++ b/app/components/EditorToolbar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { memo } from "react";
-import type { Editor } from "slate";
+import { useSlateStatic } from "slate-react";
 import { Lock, Sparkles, X } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
@@ -65,7 +65,8 @@ function getGenerateLabel(loading: boolean, generating: boolean): string {
 	return "Generate All";
 }
 
-function EditorToolbarComponent({ editor }: { editor: Editor }) {
+function EditorToolbarComponent() {
+	const editor = useSlateStatic();
 	const { loading } = useSloppy();
 	const { generateAll } = useGenerateAll(editor);
 	const queue = useGenerationQueue();

--- a/app/components/PostPromptView.tsx
+++ b/app/components/PostPromptView.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { ReactNode } from "react";
-import type { CanvasEditor } from "@/lib/canvas/types";
 
 import UserProfile from "./UserProfile";
 import { EditorToolbar } from "./EditorToolbar";
@@ -15,14 +14,14 @@ import { Timeline } from "./video/timeline/Timeline";
 import { useBottomView, type BottomView } from "./video/BottomViewContext";
 import { usePlayerPosition } from "./video/PlayerPositionContext";
 
-export default function PostPromptView({ editor }: { editor: CanvasEditor }) {
+export default function PostPromptView() {
 	const { position, visible } = usePlayerPosition();
 	const { view } = useBottomView();
 	const isTop = position === "top";
 
 	const bottomPanel: Record<BottomView, ReactNode> = {
 		timeline: <Timeline />,
-		storyboard: <Storyboard editor={editor} />,
+		storyboard: <Storyboard />,
 		hidden: null,
 	};
 
@@ -34,7 +33,7 @@ export default function PostPromptView({ editor }: { editor: CanvasEditor }) {
 			/>
 			<UserProfile />
 
-			<EditorToolbar editor={editor} />
+			<EditorToolbar />
 			<div className="flex min-h-0 flex-1 overflow-hidden">
 				<EditorSidebar />
 				<div className="grain relative mr-2 mb-2 flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl bg-element-card shadow-elevation-5">
@@ -48,7 +47,7 @@ export default function PostPromptView({ editor }: { editor: CanvasEditor }) {
 							>
 								<div className="mx-auto max-w-6xl px-4 py-4">
 									<ProjectTitle />
-									<Canvas editor={editor} />
+									<Canvas />
 								</div>
 							</div>
 

--- a/app/components/canvas/Canvas.tsx
+++ b/app/components/canvas/Canvas.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, KeyboardEvent } from "react";
-import { Editor } from "slate";
-import { Editable, RenderElementProps } from "slate-react";
+import { Editable, RenderElementProps, useSlateStatic } from "slate-react";
 import { DndContext, DragOverlay, pointerWithin } from "@dnd-kit/core";
 import {
 	SortableContext,
@@ -17,7 +16,8 @@ import { SortableContent } from "./dnd/SortableContent";
 import { DragOverlayContent } from "./dnd/DragOverlay";
 import { AssetsSection } from "./elements/AssetsSection";
 
-export default function Canvas({ editor }: { editor: Editor }) {
+export default function Canvas() {
+	const editor = useSlateStatic();
 	const {
 		activeId,
 		sceneItems,

--- a/app/components/canvas/CanvasProviders.tsx
+++ b/app/components/canvas/CanvasProviders.tsx
@@ -22,7 +22,8 @@ const EMPTY_DOCUMENT: Descendant[] = [];
  * layout, player control, scene selection, auto-scroll, collapse state) into a
  * single boundary so the top-level view stays a flat orchestrator rather than a
  * provider pyramid. The document lives in `<Slate>`, so consumers subscribe to
- * the slices they need and a keystroke never re-renders the shell.
+ * the slices they need and a keystroke never re-renders the shell, and they
+ * reach the editor itself with `useSlateStatic()` rather than a drilled prop.
  */
 export function CanvasProviders({
 	editor,
@@ -41,13 +42,13 @@ export function CanvasProviders({
 		>
 			<RenderProvider>
 				<ActiveCaptionFont />
-				<VideoLayoutProvider editor={editor}>
+				<VideoLayoutProvider>
 					<PlayerControlProvider>
 						<ActiveSceneProvider>
 							<AutoScrollProvider>
-								<ViewModeProvider editor={editor}>
+								<ViewModeProvider>
 									<SloppyModelProvider>
-										<SloppyProvider editor={editor}>
+										<SloppyProvider>
 											<EditorPanelProvider>{children}</EditorPanelProvider>
 										</SloppyProvider>
 									</SloppyModelProvider>

--- a/app/components/canvas/ViewModeContext.tsx
+++ b/app/components/canvas/ViewModeContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState, type ReactNode } from "react";
-import type { Editor } from "slate";
+import { useSlateStatic } from "slate-react";
 import type { CanvasElement } from "@/lib/canvas/types";
 import { isSceneElement } from "@/lib/canvas/scenes";
 import { createRequiredContext } from "@/lib/components/createRequiredContext";
@@ -18,13 +18,8 @@ const [ViewModeContext, useViewMode] =
 	createRequiredContext<ViewModeValue>("ViewModeContext");
 export { useViewMode };
 
-export function ViewModeProvider({
-	editor,
-	children,
-}: {
-	editor: Editor;
-	children: ReactNode;
-}) {
+export function ViewModeProvider({ children }: { children: ReactNode }) {
+	const editor = useSlateStatic();
 	const [collapsedScenes, setCollapsedScenes] = useState<Set<string>>(
 		() => new Set(),
 	);

--- a/app/components/sloppy/SloppyProvider.tsx
+++ b/app/components/sloppy/SloppyProvider.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
-import type { Editor } from "slate";
+import { useSlateStatic } from "slate-react";
 import {
 	DefaultChatTransport,
 	lastAssistantMessageIsCompleteWithToolCalls,
@@ -65,13 +65,8 @@ function useTranscript(projectId: string): SloppyMessage[] | null {
  * canvas, and the result goes straight back as the next step, until the model
  * answers with text instead of another call.
  */
-export function SloppyProvider({
-	editor,
-	children,
-}: {
-	editor: Editor;
-	children: ReactNode;
-}) {
+export function SloppyProvider({ children }: { children: ReactNode }) {
+	const editor = useSlateStatic();
 	const { projectId } = useConfig();
 	const runTool = useAgentTools(editor);
 	const readContext = useAgentContext(editor);

--- a/app/components/video/VideoLayoutContext.tsx
+++ b/app/components/video/VideoLayoutContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, type ReactNode } from "react";
-import type { Editor } from "slate";
+import { useSlateStatic } from "slate-react";
 import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
 import type { SceneElement } from "@/lib/canvas/types";
@@ -29,13 +29,8 @@ const [VideoLayoutContext, useLayout] =
 	createRequiredContext<VideoLayoutValue>("VideoLayoutContext");
 export { useLayout };
 
-export function VideoLayoutProvider({
-	editor,
-	children,
-}: {
-	editor: Editor;
-	children: ReactNode;
-}) {
+export function VideoLayoutProvider({ children }: { children: ReactNode }) {
+	const editor = useSlateStatic();
 	const { layout, playerKey, scenes } = useVideoLayout(editor);
 	const prefetched = useAssetPrefetch(layout);
 	const busy = useQueueSelector((q) => q.isBusy());

--- a/app/components/video/storyboard/Storyboard.tsx
+++ b/app/components/video/storyboard/Storyboard.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { Fragment, useMemo, useState } from "react";
-import type { Editor } from "slate";
-import { ReactEditor } from "slate-react";
+import { ReactEditor, useSlateStatic } from "slate-react";
 import { ConfirmDeleteDialog } from "@/components/ui/confirm-delete-dialog";
 import { useSetActiveSceneId } from "@/app/components/scene-selection/ActiveSceneContext";
 import { removeElement } from "@/app/components/canvas/utils/nodeOps";
@@ -19,7 +18,8 @@ import {
 } from "./storyboardScenes";
 import { StoryboardScene } from "./StoryboardScene";
 
-export function Storyboard({ editor }: { editor: Editor }) {
+export function Storyboard() {
+	const editor = useSlateStatic();
 	const { layout, segments, scenes } = useLayout();
 	const { player } = usePlayerControl();
 	const { connectorConfig } = useConfig();

--- a/lib/supabase/__tests__/env.test.ts
+++ b/lib/supabase/__tests__/env.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { supabaseAnonKey, supabaseSecretKey, supabaseUrl } from "../env";
+
+const CASES = [
+	["NEXT_PUBLIC_SUPABASE_URL", supabaseUrl],
+	["NEXT_PUBLIC_SUPABASE_ANON_KEY", supabaseAnonKey],
+	["SUPABASE_SECRET_KEY", supabaseSecretKey],
+] as const;
+
+const original = Object.fromEntries(
+	CASES.map(([name]) => [name, process.env[name]]),
+);
+
+afterEach(() => {
+	for (const [name, value] of Object.entries(original)) {
+		if (value === undefined) delete process.env[name];
+		else process.env[name] = value;
+	}
+});
+
+describe("supabase env", () => {
+	it.each(CASES)("names %s when it is missing", (name, read) => {
+		delete process.env[name];
+		expect(read).toThrow(name);
+	});
+
+	it.each(CASES)("returns %s when it is set", (name, read) => {
+		process.env[name] = "value";
+		expect(read()).toBe("value");
+	});
+});

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,6 +1,6 @@
 import { createBrowserClient } from "@supabase/ssr";
-import { SUPABASE_ANON_KEY, SUPABASE_URL } from "./env";
+import { supabaseAnonKey, supabaseUrl } from "./env";
 
 export function createClient() {
-	return createBrowserClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+	return createBrowserClient(supabaseUrl(), supabaseAnonKey());
 }

--- a/lib/supabase/env.ts
+++ b/lib/supabase/env.ts
@@ -1,3 +1,18 @@
-export const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
-export const SUPABASE_ANON_KEY =
-	process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+const required = (name: string, value: string | undefined): string => {
+	if (!value) throw new Error(`${name} is required`);
+	return value;
+};
+
+// Read at call time, not import time: a missing variable then fails where a
+// client is built, with the variable's name, instead of at module load.
+export const supabaseUrl = () =>
+	required("NEXT_PUBLIC_SUPABASE_URL", process.env.NEXT_PUBLIC_SUPABASE_URL);
+
+export const supabaseAnonKey = () =>
+	required(
+		"NEXT_PUBLIC_SUPABASE_ANON_KEY",
+		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+	);
+
+export const supabaseSecretKey = () =>
+	required("SUPABASE_SECRET_KEY", process.env.SUPABASE_SECRET_KEY);

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,13 +1,13 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
-import { SUPABASE_ANON_KEY, SUPABASE_URL } from "./env";
+import { supabaseAnonKey, supabaseUrl } from "./env";
 
 const AUTH_ROUTES = ["/login", "/signup"];
 
 export async function updateSession(request: NextRequest) {
 	let supabaseResponse = NextResponse.next({ request });
 
-	const supabase = createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+	const supabase = createServerClient(supabaseUrl(), supabaseAnonKey(), {
 		cookies: {
 			getAll() {
 				return request.cookies.getAll();

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,11 +1,11 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
-import { SUPABASE_ANON_KEY, SUPABASE_URL } from "./env";
+import { supabaseAnonKey, supabaseUrl } from "./env";
 
 export async function createClient() {
 	const cookieStore = await cookies();
 
-	return createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+	return createServerClient(supabaseUrl(), supabaseAnonKey(), {
 		cookies: {
 			getAll() {
 				return cookieStore.getAll();

--- a/lib/supabase/service.ts
+++ b/lib/supabase/service.ts
@@ -1,5 +1,5 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
-import { SUPABASE_URL } from "./env";
+import { supabaseSecretKey, supabaseUrl } from "./env";
 
 let cached: SupabaseClient | null = null;
 
@@ -7,9 +7,7 @@ let cached: SupabaseClient | null = null;
 // `sb_secret_*` key (legacy `SUPABASE_SERVICE_ROLE_KEY` is deprecated).
 export function createServiceClient(): SupabaseClient {
 	if (cached) return cached;
-	const key = process.env.SUPABASE_SECRET_KEY;
-	if (!key) throw new Error("SUPABASE_SECRET_KEY is required");
-	cached = createClient(SUPABASE_URL, key, {
+	cached = createClient(supabaseUrl(), supabaseSecretKey(), {
 		auth: { autoRefreshToken: false, persistSession: false },
 	});
 	return cached;


### PR DESCRIPTION
## One way to reach the Slate editor

Twelve components already read the editor with `useSlateStatic()`. Seven others took it as a prop, and every one of them renders inside the same `<Slate>`, so both paths reached the identical object. The prop path also made `PostPromptView` and `CanvasProviders` accept an `editor` they only forwarded.

Now the editor is a prop in exactly one position: `Editor` hands it to `CanvasProviders`, which puts it in `<Slate>`. `VideoLayoutProvider`, `ViewModeProvider`, `SloppyProvider`, `PostPromptView`, `EditorToolbar`, `Canvas` and `Storyboard` each call `useSlateStatic()`. No component takes the editor just to pass it on.

`useSlateStatic` returns the same stable instance without subscribing to document changes, which is exactly what a prop gave them, so render behavior is unchanged.

## Supabase env fails loudly

`lib/supabase/env.ts` defaulted `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` to `""`. A deploy missing either one built a client against an empty URL and surfaced as an opaque fetch failure inside supabase-js. `service.ts` already threw a named error for its own key, so the two halves of the same config disagreed on what a missing variable means.

The module now exports `supabaseUrl()`, `supabaseAnonKey()` and `supabaseSecretKey()`, each throwing `"<NAME> is required"`. They read at call time rather than import time, so the failure lands where a client is constructed instead of at module load. `service.ts` drops its hand-rolled check and uses the same helper. Covered by `lib/supabase/__tests__/env.test.ts`.

## Docs

One line in `ARCHITECTURE.md` recording where the editor instance enters the tree, next to the existing `useEditorSession` entry.

## Checks

`lint`, `format:check`, `typecheck`, `knip`, `build`, and 1357 tests across 153 files all pass.

## Open PR overlap check

Open PRs considered: #634 (animate-the-still: `lib/generation/**`, `lib/canvas/editorOps`, `lib/connectors/animated_image`, `lib/project/elementHistory`, canvas element buttons, `lib/video/captionStyle`) and #630 (`ComposerCopilot.tsx`). No file, module or theme in this PR is touched by either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)