### PR TITLE
perf: nightly performance optimizations 2026-08-25

### DIFF
--- a/app/components/video/VideoLayoutContext.tsx
+++ b/app/components/video/VideoLayoutContext.tsx
@@ -19,7 +19,6 @@ import { useVideoLayout } from "./useVideoLayout";
 type VideoLayoutValue = {
 	layout: VideoLayout;
 	ready: boolean;
-	playerKey: string;
 	segments: SceneSegment[];
 	scenes: SceneElement[];
 	sequenceByElementId: SequenceIndex;
@@ -31,7 +30,7 @@ export { useLayout };
 
 export function VideoLayoutProvider({ children }: { children: ReactNode }) {
 	const editor = useSlateStatic();
-	const { layout, playerKey, scenes } = useVideoLayout(editor);
+	const { layout, scenes } = useVideoLayout(editor);
 	const prefetched = useAssetPrefetch(layout);
 	const busy = useQueueSelector((q) => q.isBusy());
 	const ready = prefetched && !busy;
@@ -41,8 +40,8 @@ export function VideoLayoutProvider({ children }: { children: ReactNode }) {
 	);
 	const segments = useMemo(() => buildSceneSegments(layout), [layout]);
 	const value = useMemo(
-		() => ({ layout, ready, playerKey, segments, scenes, sequenceByElementId }),
-		[layout, ready, playerKey, segments, scenes, sequenceByElementId],
+		() => ({ layout, ready, segments, scenes, sequenceByElementId }),
+		[layout, ready, segments, scenes, sequenceByElementId],
 	);
 	return <VideoLayoutContext value={value}>{children}</VideoLayoutContext>;
 }

--- a/app/components/video/VideoPanel.tsx
+++ b/app/components/video/VideoPanel.tsx
@@ -8,7 +8,7 @@ import { QueueProgressBar } from "./QueueProgressBar";
 import { PlayerShimmer } from "./PlayerShimmer";
 
 function VideoPanelBody() {
-	const { layout, ready, playerKey } = useLayout();
+	const { layout, ready } = useLayout();
 	const { writingScript } = useSloppy();
 	const restoreFrameRef = useRef<number | null>(null);
 
@@ -27,13 +27,7 @@ function VideoPanelBody() {
 		);
 	}
 	if (!ready) return <QueueProgressBar />;
-	return (
-		<VideoPreview
-			key={playerKey}
-			layout={layout}
-			restoreFrameRef={restoreFrameRef}
-		/>
-	);
+	return <VideoPreview layout={layout} restoreFrameRef={restoreFrameRef} />;
 }
 
 export function VideoPanel() {

--- a/app/components/video/usePreservedPlayhead.ts
+++ b/app/components/video/usePreservedPlayhead.ts
@@ -2,7 +2,8 @@ import type { PlayerRef } from "@remotion/player";
 import { useEffect, type MutableRefObject } from "react";
 import { clamp } from "@/lib/utils";
 
-// Carries the playhead across the player's `key` remount via a parent-owned ref.
+// The preview unmounts whenever the queue goes busy or the script is being
+// written, so the frame lives in a ref the panel owns across those swaps.
 export function usePreservedPlayhead(
 	player: PlayerRef | null,
 	frameRef: MutableRefObject<number | null>,

--- a/app/components/video/useVideoLayout.ts
+++ b/app/components/video/useVideoLayout.ts
@@ -16,7 +16,6 @@ import type { VideoLayout } from "@/lib/video/types";
 
 export function useVideoLayout(editor: Editor): {
 	layout: VideoLayout;
-	playerKey: string;
 	scenes: SceneElement[];
 } {
 	const queue = useGenerationQueue();
@@ -60,5 +59,5 @@ export function useVideoLayout(editor: Editor): {
 		queue,
 	]);
 
-	return { layout, playerKey: `${layoutKey}-${resultVersion}`, scenes };
+	return { layout, scenes };
 }


### PR DESCRIPTION
## What was wrong

`VideoPanel` renders the preview as `<VideoPreview key={playerKey} .../>`, where `playerKey` is `` `${layoutKey}-${resultVersion}` ``. `getLayoutKey` covers every element id, type and layout attribute in the document, so the key changes on:

- changing a motion effect, a volume or a loop count
- deleting or duplicating an element
- reordering a scene or an element
- any generation result landing

Each of those tears the entire `<Player>` down and rebuilds it. Every `<Img>`, `<OffthreadVideo>` and `<Html5Audio>` in the composition unmounts and remounts, media is re-decoded, and the ten `numberOfSharedAudioTags` are recreated. `useAssetPrefetch` only flips `ready` to false when a *new* URL appears, so for the attribute-dial edits above the player stays mounted, the assets are already prefetched and unchanged, and the whole rebuild buys nothing.

## Why the key isn't needed

`<Player>` takes `inputProps`, `durationInFrames`, `fps` and `compositionWidth`/`compositionHeight` as ordinary reactive props and threads them straight into its composition-config context (`@remotion/player@4.0.481`, `PlayerFn` → `SharedPlayerContexts`). There is no internal state keyed to those values.

The app already relies on this: caption style and aspect ratio are *not* part of `layoutKey`, so editing either one already updates the player through `inputProps`/`compositionWidth` with no remount, and works.

## What changed

- `VideoPanel` no longer keys the preview. `playerKey` is gone from `useVideoLayout` and from the layout context value.
- `usePreservedPlayhead` and the ref the panel threads into the preview stay. The preview still unmounts whenever the queue goes busy (`ready` goes false, `QueueProgressBar` takes over) or the script is being written, and that ref is what carries the playhead across those swaps. It clamps too: its cleanup re-saves the current frame, so a shortened composition pulls the playhead back in range.

Net -13/+3 lines. No behavior change: the same video plays, the playhead stays where it was, and the panel still swaps to `QueueProgressBar` while assets prefetch.

## Verification

`npm run lint`, `format:check`, `typecheck`, `knip`, `build` and `npm run test:run` (1351 tests, 152 files) all pass.

Not browser-profiled — reproducing it needs an authenticated session against a real project, which this run does not have. The claim is read off the `@remotion/player` source plus the existing caption/aspect-ratio path, which proves the reactive-prop route works in this app today. It removes a teardown that provably has no effect on what is rendered, rather than demonstrating a millisecond delta.

I also measured the pure compute layer on a synthetic 70-scene / 350-element script before landing on this, to check nothing cheaper was hiding there:

| path | per call |
| --- | --- |
| `getLayoutKey` (per keystroke) | 0.25 ms |
| `resolveElements` + `buildVideoLayout` + segment/sequence index | 0.11 ms |
| `isNodeStale` × 350 (per queue tick) | 0.97 ms |
| `sceneIndexOf` × 70 | 0.65 ms |
| `serializeOSMLWithScenes` (debounced autosave) | 1.97 ms |

All sub-millisecond and none of them worth a PR, which is consistent with previous nightlies having already been through them.

## Rebase

Rebased onto master, which now includes #637. The one conflict was the two-line overlap in `VideoLayoutContext.tsx` that #637 introduced: it moved the provider to `useSlateStatic()`, this PR drops `playerKey` from `VideoLayoutValue` and the value memo. Resolved by keeping both.

## Skipped

- The dnd-kit canvas drag path. It is still the biggest real bottleneck, but #628 already took a run at it and was closed as overengineered, and a second unmeasured pass over the same code is not the right follow-up.
- Memoizing `isNodeStale` per queue version. It measures at 0.97 ms for 350 elements once a second, and the fix would land in `lib/generation/graph.ts`, which #634 is rewriting.
- `sceneIndexOf`'s quadratic scan across scenes. Real, but 0.65 ms for 70 scenes is not worth an index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
