### PR TITLE
refactor: nightly maintainability 2026-08-26

### DIFF
--- a/app/components/canvas/elements/ElementContainer.tsx
+++ b/app/components/canvas/elements/ElementContainer.tsx
@@ -128,8 +128,7 @@ export function ElementContainer({
 							contentEditable={false}
 						>
 							<ElementStaleIndicator />
-							{(element.type === "image" ||
-								element.type === "animated_image") && <ElementUploadButton />}
+							<ElementUploadButton />
 							<AnimateButton element={element} />
 							<ElementGenerateButton />
 						</div>

--- a/app/components/canvas/elements/ElementUploadButton.tsx
+++ b/app/components/canvas/elements/ElementUploadButton.tsx
@@ -2,15 +2,16 @@
 
 import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
 import { isGenerationActive } from "@/lib/generation/snapshots";
-import { stillDependency } from "@/lib/connectors/animated_image/plugins/still-frame";
+import { pictureNode } from "@/lib/connectors/animated_image/plugins/still-frame";
 import { UploadImageButton } from "@/lib/upload/UploadImageButton";
 import { useElementGeneration } from "./ElementGenerationContext";
 
+/** Supplies the picture an element would otherwise generate, so only the elements that make one offer it. */
 export function ElementUploadButton() {
 	const queue = useGenerationQueue();
 	const { node, status } = useElementGeneration();
-	// An upload replaces the still, leaving the animation stale to re-render.
-	const target = stillDependency(node) ?? node;
+	const target = pictureNode(node);
+	if (!target) return null;
 
 	return (
 		<UploadImageButton

--- a/app/components/video/SegmentedSeekBar.tsx
+++ b/app/components/video/SegmentedSeekBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { clamp } from "@/lib/utils";
 import { findSegmentIndexAtFrame } from "@/lib/video/sceneSegments";
 import { usePlayerControl } from "./PlayerControlContext";
@@ -21,17 +21,18 @@ export function SegmentedSeekBar() {
 	const progress = clamp(frame / Math.max(1, totalFrames - 1), 0, 1);
 
 	const [hover, setHover] = useState<ScrubHover | null>(null);
-	const [hoverIndex, setHoverIndex] = useState<number | null>(null);
-	const [settledIndex, setSettledIndex] = useState<number | null>(null);
-	const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	// Pulling a frame per segment the pointer sweeps across is wasted work, so
+	// the thumbnail follows only once the pointer holds still.
+	const [settled, setSettled] = useState<ScrubHover | null>(null);
 	const scrub = usePlayerScrub();
 
-	useEffect(
-		() => () => {
-			if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
-		},
-		[],
-	);
+	if (!hover && settled) setSettled(null);
+
+	useEffect(() => {
+		if (!hover) return;
+		const timer = setTimeout(() => setSettled(hover), HOVER_SETTLE_MS);
+		return () => clearTimeout(timer);
+	}, [hover]);
 
 	const scrubSegments = useMemo(
 		() =>
@@ -42,29 +43,15 @@ export function SegmentedSeekBar() {
 		[segments, totalDurationSec],
 	);
 
-	const onHoverChange = (h: ScrubHover | null) => {
-		setHover(h);
-		if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
-		if (!h) {
-			setHoverIndex(null);
-			setSettledIndex(null);
-			return;
-		}
-		const index = findSegmentIndexAtFrame(
-			segments,
-			toScrubFrame(h.ratio),
-			layout.fps,
-		);
-		setHoverIndex(index);
-		settleTimerRef.current = setTimeout(
-			() => setSettledIndex(index),
-			HOVER_SETTLE_MS,
-		);
-	};
+	const segmentAt = (at: ScrubHover | null) =>
+		at
+			? (segments[
+					findSegmentIndexAtFrame(segments, toScrubFrame(at.ratio), layout.fps)
+				] ?? null)
+			: null;
 
-	const hoverSegment = hoverIndex != null ? segments[hoverIndex] : null;
-	const thumbnailSegment =
-		settledIndex != null ? (segments[settledIndex] ?? null) : null;
+	const hoverSegment = segmentAt(hover);
+	const thumbnailSegment = segmentAt(settled);
 
 	return (
 		<ScrubBar
@@ -76,7 +63,7 @@ export function SegmentedSeekBar() {
 			onScrub={(ratio) => scrub.seekTo(toScrubFrame(ratio))}
 			onScrubStart={scrub.start}
 			onScrubEnd={scrub.end}
-			onHoverChange={onHoverChange}
+			onHoverChange={setHover}
 		>
 			{hover && hoverSegment ? (
 				<SeekTooltip

--- a/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
@@ -16,6 +16,7 @@ import { nodeBuilder } from "@/lib/generation/resolveGraph";
 import { MetadataSchema } from "@/lib/project/types";
 import {
 	createStillFramePlugin,
+	pictureNode,
 	stillElementId,
 	stillSnapshot,
 } from "../still-frame";
@@ -245,5 +246,41 @@ describe("uploaded still lifetime", () => {
 		const { animation, still } = afterUpload("a forest", "slow pan");
 		expect(still).toBe(false);
 		expect(animation).toBe(false);
+	});
+});
+
+describe("pictureNode", () => {
+	const registry = DEFAULT_CONNECTOR_REGISTRY;
+	const state = {
+		hydrated: true,
+		metadata: MetadataSchema.parse({}),
+		referenceImages: [],
+	};
+
+	const element = (
+		type: "image" | "animated_image" | "clip" | "narration",
+	) => ({
+		id: `el-${type}`,
+		type,
+		...splitAttributes({ provider: "openslop", videoPrompt: "slow pan" }),
+		children: [{ id: `el-${type}-t`, type, text: "a forest" }],
+	});
+
+	const pictureFor = (type: Parameters<typeof element>[0]) =>
+		pictureNode(nodeBuilder(registry, state)(forElement(element(type))));
+
+	it("is the element itself when it generates an image", () => {
+		expect(pictureFor("image")?.id).toBe("el-image");
+	});
+
+	it("is the still behind an animated image, not the animation", () => {
+		expect(pictureFor("animated_image")?.id).toBe(
+			stillElementId("el-animated_image"),
+		);
+	});
+
+	it("is nothing for an element that makes no picture", () => {
+		expect(pictureFor("clip")).toBeNull();
+		expect(pictureFor("narration")).toBeNull();
 	});
 });

--- a/lib/connectors/animated_image/plugins/still-frame.ts
+++ b/lib/connectors/animated_image/plugins/still-frame.ts
@@ -1,5 +1,5 @@
 import omit from "lodash/omit";
-import type { CanvasContentElement } from "@/lib/canvas/types";
+import { ELEMENT_TYPES, type CanvasContentElement } from "@/lib/canvas/types";
 import {
 	DEFAULT_PROVIDER,
 	type AnimatedImageGenerateParams,
@@ -11,7 +11,9 @@ import { buildImagePlugins } from "@/lib/connectors/image/plugins/imageChain";
 import {
 	derivedDependency,
 	derivedNodeId,
+	isSourceNode,
 	type GenerationNode,
+	type JobNode,
 	type NodeSpec,
 } from "@/lib/generation/graph";
 import type { GenerationQueue } from "@/lib/generation/queue";
@@ -54,6 +56,19 @@ export const forStillOf =
 /** The still node behind an animated image, when the element has one. */
 export const stillDependency = (node: GenerationNode) =>
 	derivedDependency(node, STILL);
+
+/**
+ * The node that makes an element's picture: the still behind an animated image,
+ * an image element itself, and nothing at all for an element that makes no
+ * picture. Whoever supplies a picture writes it here.
+ */
+export function pictureNode(node: GenerationNode): JobNode | null {
+	const target = stillDependency(node) ?? node;
+	if (isSourceNode(target)) return null;
+	const makesPicture =
+		ELEMENT_TYPES[target.job.elementType].outputKind === "image";
+	return makesPicture ? target : null;
+}
 
 /**
  * The snapshot of the still a node depends on

--- a/remotion/compositions/VideoComposition.tsx
+++ b/remotion/compositions/VideoComposition.tsx
@@ -74,8 +74,6 @@ function SequenceContent({ element }: { element: ResolvedElement }) {
 			);
 		case "audio":
 			return <AudioSequence element={element} />;
-		default:
-			return null;
 	}
 }
 
@@ -121,18 +119,16 @@ export const VideoComposition: React.FC<VideoLayout> = ({
 	const layeredSequenceNodes = useMemo(
 		() =>
 			Object.entries(sequences).flatMap(([type, seqs]) =>
-				(seqs ?? []).map((seq, i) =>
-					seq.element ? (
-						<Sequence
-							key={`${type}-${seq.element.id}-${i}`}
-							from={toFrames(seq.start, fps)}
-							durationInFrames={toFrames(seq.duration, fps)}
-							premountFor={fps}
-						>
-							<SequenceContent element={seq.element} />
-						</Sequence>
-					) : null,
-				),
+				(seqs ?? []).map((seq, i) => (
+					<Sequence
+						key={`${type}-${seq.element.id}-${i}`}
+						from={toFrames(seq.start, fps)}
+						durationInFrames={toFrames(seq.duration, fps)}
+						premountFor={fps}
+					>
+						<SequenceContent element={seq.element} />
+					</Sequence>
+				)),
 			),
 		[fps, sequences],
 	);


### PR DESCRIPTION
Three cleanups under one theme: let each component own the condition for its own existence, and drop the checks the types already make impossible. No behaviour change.

## The upload button decides for itself whether it applies

`ElementContainer` listed the two element types that can take an uploaded picture:

```tsx
{(element.type === "image" || element.type === "animated_image") && <ElementUploadButton />}
```

while `ElementUploadButton` already resolved its own target generically (`stillDependency(node) ?? node`). So the rule was split: the container knew *which* elements, the button knew *what* to write, and a new picture-bearing type would have to be added in both places.

`pictureNode` in `still-frame.ts` now answers the whole question — the still behind an animated image, an image element itself, `null` for an element that makes no picture — by reading `outputKind` off the element-type registry rather than naming types. It generalises the `stillDependency` helper that already lives there. The container renders `<ElementUploadButton />` unconditionally and the button returns `null` when it doesn't apply.

The set of types that render the button is unchanged: image and animated_image render it, clip and the audio types don't. Three tests cover that.

## The seek bar's settle timer becomes a debounced value

`SegmentedSeekBar` held the hover position, the hovered segment index, the settled segment index, a timer ref and an unmount effect, and rebuilt all of it inside an `onHoverChange` callback. Only two things are ever read: the segment under the pointer (derivable) and the segment the pointer has held for 80ms (a debounce of the hover itself).

It now keeps the hover and a debounced copy of it, derives both segments, and passes `setHover` straight to `ScrubBar`. The timer restarts on every pointer move exactly as before, so the thumbnail still needs 80ms of stillness, and the tooltip still unmounts the instant the pointer leaves.

## Two branches the types make unreachable

`VideoComposition` guarded a `Sequence` without an `element` — `Sequence.element` is required, and `timelineRows.ts` reads it unguarded — and had a `default: return null` on a switch over `LayerType`, which is `"audio" | "visual"` and already exhaustive.

## Checks

`lint`, `format:check`, `typecheck`, `knip`, `build`, `test:coverage` all pass. 155 files, 1382 tests.

## Open PR overlap check

One open PR: #644 (`lib/canvas/createCanvasNode.ts`, `lib/generation/queue.ts` and their tests). Re-checked before committing — no file or theme overlap with this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)