### PR TITLE
perf: nightly performance optimizations 2026-08-26

### DIFF
--- a/app/components/canvas/dnd/SortableContent.tsx
+++ b/app/components/canvas/dnd/SortableContent.tsx
@@ -76,7 +76,7 @@ export function SortableContent({
 				/>
 			}
 			menuOpen={isMenuOpen}
-			disabled={collapsed}
+			disabled={{ draggable: collapsed, droppable: collapsed }}
 			readOnly={collapsed}
 			attributes={attributes}
 			element={element}

--- a/app/components/canvas/dnd/SortableItem.tsx
+++ b/app/components/canvas/dnd/SortableItem.tsx
@@ -16,7 +16,11 @@ interface SortableItemProps {
 	contentClassName?: string;
 	insertMenu?: React.ReactNode;
 	menuOpen?: boolean;
-	disabled?: boolean;
+	/**
+	 * Both axes, always: `useSortable` reads a bare boolean as draggable-only and
+	 * leaves the card a drop target, which is never what a caller means here.
+	 */
+	disabled: { draggable: boolean; droppable: boolean };
 	readOnly?: boolean;
 	attributes: RenderElementProps["attributes"];
 	element: CanvasElement;
@@ -73,7 +77,7 @@ export function SortableItem({
 				<div
 					className={`${styles.hoverTarget} align-middle${menuOpen ? ` ${styles.menuOpen}` : ""}`}
 				>
-					{!disabled && (
+					{!disabled.draggable && (
 						<div
 							className={`self-center ${styles.actions}`}
 							contentEditable={false}

--- a/app/components/canvas/dnd/SortableScene.tsx
+++ b/app/components/canvas/dnd/SortableScene.tsx
@@ -26,7 +26,10 @@ export function SortableScene({
 		<SortableItem
 			sceneId={element.id}
 			sortableType="scene"
-			disabled={!isCollapsed(element.id)}
+			disabled={{
+				draggable: !isCollapsed(element.id),
+				droppable: false,
+			}}
 			wrapperClassName={`${styles.scene} border-t pt-3 mt-3 first:border-t-0 first:pt-0 first:mt-0 ${isActive ? "border-transparent" : "border-border"}`}
 			contentClassName={isActive ? ACTIVE_SCENE_CLASS : undefined}
 			attributes={attributes}


### PR DESCRIPTION
Cuts the per-pointer-move cost of dragging a scene on a long document. One change, three call sites, no new machinery.

## What was wrong

`useSortable` takes `disabled` as either a boolean or `{draggable, droppable}`, and the boolean form is not what it looks like:

```js
if (typeof localDisabled === 'boolean') {
  return { draggable: localDisabled, droppable: false }; // "Backwards compatibility"
}
```

Both canvas call sites passed a boolean, so **every card in the document stayed registered as a droppable regardless of view mode**. With all scenes collapsed, that is 71 scenes plus 213 cards = 284 enabled droppables, when only the 71 scenes can receive the drag.

That matters because of what dnd-kit does with an enabled droppable:

- `pointerWithin` walks every one of them on every collision pass, and `isPointWithinRect` reads `top`/`left`/`bottom`/`right`. Those are getters on dnd-kit's `Rect`, and each one re-walks the element's scroll-ancestor chain reading `scrollTop`/`scrollLeft` off the DOM.
- The measuring pass (`MeasuringFrequency.Optimized`, so roughly once a second while dragging) re-measures all of them: a `getBoundingClientRect` each, plus `getScrollableAncestors`, which calls `getComputedStyle` per ancestor.

Counted in the browser on a 71-scene document, mid-drag: **3,138 `scrollLeft` + 3,220 `scrollTop` reads per pointer move**, and 12,356 `getComputedStyle` calls across the drag. Stack-attributing the scroll reads put 97% of them under `pointerWithin -> isPointWithinRect -> Rect.get top/bottom`.

## The change

A collapsed scene is one unit. Its cards are not distinct drop targets — `moveDraggedElement` already says so, resolving a scene dropped on a card to `Path.parent(overPath)`, that card's scene. So the cards can say they are inert on both axes, and drop out of the hit-test and the measuring pass.

The prop now takes both axes at every call site, which is also the honest reading of what each caller means:

- `SortableScene`: an expanded scene cannot be picked up, but is always a drop target (dropping a card on a scene appends it to that scene).
- `SortableContent`: a collapsed card is inert.

## Measured

Production build, Playwright driving a real pointer drag of a scene handle on a 71-scene document (3 elements per scene) with every scene collapsed. Both arms on the same bundle, flipped by a localStorage flag. Medians of 5 interleaved runs.

Per pointer move:

| | master | this branch |
| --- | --- | --- |
| droppables hit-tested | 284 | 71 |
| `getBoundingClientRect` | 10 | 3 |
| `getComputedStyle` | 206 | 51 |
| `scrollLeft` + `scrollTop` reads | 6,358 | 1,745 |

Over one drag, at 4x CPU throttle:

| | master | this branch |
| --- | --- | --- |
| script time | 4.82 s | 3.71 s |
| style recalc | 0.78 s | 0.77 s |
| p95 frame gap | 133 ms | 117 ms |
| fps | 27.1 | 28.6 |
| drop commit | 1062 ms | 1095 ms |

So: about a quarter of the drag's JS is gone and the worst frame gaps shrink ~12%, but this does **not** turn a janky drag smooth on its own. The remaining cost is React re-render churn — dnd-kit hands every `useSortable` a fresh sortable-context value each time `over` changes — plus `scrollBy` from the auto-scroller. That is the next target, and it is a bigger, riskier change than this one.

## Behaviour

Verified equivalent in the browser rather than asserted: same protocol, both arms, drag scene 1 down five slots. Both land the scene at the same index, both produce the same set of displaced scenes mid-drag, both show the drag overlay. Expanded mode is untouched — cards stay droppable there, and scenes stay droppable in every mode, so dropping a card onto a scene still appends to it.

No unit test: the change introduces no new logic or pure seam, only corrects a prop shape, and the repo's canvas tests cover pure helpers rather than mounting the dnd wrappers.

## Checks

`lint`, `format:check`, `typecheck`, `knip`, `build`, `test:coverage` all pass. 155 files, 1376 tests.

## Open PR overlap check

Open PRs at start and re-checked before committing: #644 (`lib/canvas/createCanvasNode.ts`, `lib/generation/queue.ts` + tests) and #645 (`ElementContainer.tsx`, `ElementUploadButton.tsx`, `SegmentedSeekBar.tsx`, `still-frame.ts` + test, `VideoComposition.tsx`). This branch touches only `app/components/canvas/dnd/` — no file or theme overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)