### PR TITLE
fix(ui): pin Sloppy rail item in project loading skeleton

### DIFF
--- a/app/projects/[id]/loading.tsx
+++ b/app/projects/[id]/loading.tsx
@@ -136,6 +136,11 @@ export default function Loading() {
 					<div className="my-1 h-px w-full bg-border" />
 					<RailItemSkeleton />
 					<RailItemSkeleton />
+					<RailItemSkeleton />
+					<div className="mt-auto flex w-full flex-col items-center gap-1 pb-3">
+						<div className="my-1 h-px w-full bg-border" />
+						<RailItemSkeleton />
+					</div>
 				</nav>
 
 				<div className="relative mr-2 mb-2 flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl bg-element-card shadow-elevation-5">


### PR DESCRIPTION
## Summary
The project loading skeleton left rail only rendered Home + two panel placeholders, with nothing pinned at the bottom. The real `EditorSidebar` has three `RAIL_KEYS` items and a `mt-auto` pinned Sloppy entry (divider + item), so the bottom-left corner popped in when the real sidebar mounted.

## Changes
In `app/projects/[id]/loading.tsx`:
- Add a third top-group `RailItemSkeleton` so the count matches `RAIL_KEYS` (Layout, Captions, Properties)
- Add the pinned bottom block mirroring `EditorSidebar`: `mt-auto` container, divider, and one `RailItemSkeleton` for Sloppy

No new components or styles — reuses `RailItemSkeleton` and the existing divider class.

## Test plan
- [ ] Open a project route and observe the loading skeleton left rail
- [ ] Confirm a shimmer rail item is pinned at the bottom with a divider above it
- [ ] Confirm three shimmer items appear in the top group after Home/divider
- [ ] Confirm no layout shift in the bottom-left when the real sidebar mounts

Fixes #650