### PR TITLE
Restore side player when viewport widens

### DIFF
--- a/app/components/video/PlayerPositionContext.tsx
+++ b/app/components/video/PlayerPositionContext.tsx
@@ -29,9 +29,9 @@ export function PlayerPositionProvider({ children }: { children: ReactNode }) {
 		const mql = window.matchMedia(NARROW_QUERY);
 		const onChange = (e: MediaQueryListEvent | MediaQueryList) => {
 			setNarrowViewport(e.matches);
-			if (e.matches) {
-				setPosition((prev) => (prev === "right" ? "top" : prev));
-			}
+if (e.matches) {
+  setPosition((prev) => (prev === "right" ? "left" : prev));
+}
 		};
 		onChange(mql);
 		mql.addEventListener("change", onChange);

--- a/app/components/video/PlayerPositionContext.tsx
+++ b/app/components/video/PlayerPositionContext.tsx
@@ -19,7 +19,7 @@ const [PlayerPositionContext, usePlayerPosition] = createRequiredContext<{
 export { usePlayerPosition };
 
 export function PlayerPositionProvider({ children }: { children: ReactNode }) {
-	const [position, setPosition] = useState<PlayerPosition>("right");
+	const [preferredPosition, setPosition] = useState<PlayerPosition>("right");
 	const [visible, setVisible] = useState(true);
 	const [narrowViewport, setNarrowViewport] = useState(false);
 
@@ -27,16 +27,14 @@ export function PlayerPositionProvider({ children }: { children: ReactNode }) {
 
 	useEffect(() => {
 		const mql = window.matchMedia(NARROW_QUERY);
-		const onChange = (e: MediaQueryListEvent | MediaQueryList) => {
+		const onChange = (e: MediaQueryListEvent | MediaQueryList) =>
 			setNarrowViewport(e.matches);
-if (e.matches) {
-  setPosition((prev) => (prev === "right" ? "left" : prev));
-}
-		};
 		onChange(mql);
 		mql.addEventListener("change", onChange);
 		return () => mql.removeEventListener("change", onChange);
 	}, []);
+
+	const position = narrowViewport ? "top" : preferredPosition;
 
 	return (
 		<PlayerPositionContext


### PR DESCRIPTION
## What was broken
When the viewport crosses below the narrow breakpoint (1066px), `PlayerPositionProvider` flips a side player to the top dock. Going the other way, it does nothing: once the viewport is wide again, the player stays docked on top even though there is now room for the side layout, and the user has to reopen the layout panel and switch it back by hand.

## What changed
The position is derived from the viewport instead of being flipped imperatively. State holds the user's preferred position; the breakpoint overrides the rendered value while narrow and stops overriding it when wide:

```ts
const [preferredPosition, setPosition] = useState<PlayerPosition>("right");
...
const position = narrowViewport ? "top" : preferredPosition;
```

The `matchMedia` effect only tracks `narrowViewport` now. Because the preference is never destroyed, there is no need to track whether a top dock was forced by the breakpoint or chosen deliberately, and no widening transition to get wrong.

- Narrow to wide restores the side player.
- A top dock chosen at a wide width survives a narrow to wide round trip.
- `LayoutPanel` is unchanged: the side option stays disabled while narrow, both options are enabled when wide.
- The breakpoint stays defined once in `PlayerPositionContext.tsx`.

Closes #655.
