### PR TITLE
fix: nightly bug fixes 2026-08-27

### DIFF
--- a/app/components/AuthForm.tsx
+++ b/app/components/AuthForm.tsx
@@ -41,18 +41,23 @@ export default function AuthForm({
 		setLoading(true);
 		setError("");
 
-		const { error } = await sendMagicLink({
-			email,
-			shouldCreateUser,
-			data: otpData,
-		});
+		try {
+			const { error } = await sendMagicLink({
+				email,
+				shouldCreateUser,
+				data: otpData,
+			});
 
-		if (error) {
-			setError(error);
-		} else {
-			setSent(true);
+			if (error) {
+				setError(error);
+			} else {
+				setSent(true);
+			}
+		} catch (cause) {
+			setError(errorMessage(cause));
+		} finally {
+			setLoading(false);
 		}
-		setLoading(false);
 	};
 
 	const handleGoogle = async () => {

--- a/lib/canvas/__tests__/parseXmlTag.test.ts
+++ b/lib/canvas/__tests__/parseXmlTag.test.ts
@@ -26,6 +26,22 @@ describe("parseXmlTag", () => {
 		});
 	});
 
+	it("preserves runs of whitespace and newlines inside attribute values", () => {
+		expect(parseXmlTag('image prompt="a  b\nc"')).toEqual({
+			tag: "image",
+			attributes: { prompt: "a  b\nc" },
+		});
+	});
+
+	it("parses attributes that follow a newline-separated value", () => {
+		expect(
+			parseXmlTag('image prompt="line one\nline two" style="noir"'),
+		).toEqual({
+			tag: "image",
+			attributes: { prompt: "line one\nline two", style: "noir" },
+		});
+	});
+
 	it("keeps a `tag` attribute separate from the tag name", () => {
 		expect(parseXmlTag('image tag="hero"')).toEqual({
 			tag: "image",

--- a/lib/canvas/parseXmlTag.ts
+++ b/lib/canvas/parseXmlTag.ts
@@ -6,16 +6,18 @@ export type XmlTag = {
 	attributes: Record<string, string>;
 };
 
+const ATTRIBUTE_PATTERN = /(\w+)="([^"]*)"/g;
+
 export function parseXmlTag(tagString: string): XmlTag {
-	const [rawTag, ...rest] = tagString.trim().split(/\s+/);
-	const attributesString = rest.join(" ");
+	const trimmed = tagString.trim();
 	const attributes: Record<string, string> = {};
-	const regex = /(\w+)="([^"]*)"/g;
+	ATTRIBUTE_PATTERN.lastIndex = 0;
 	let match: RegExpExecArray | null;
 
-	while ((match = regex.exec(attributesString)) !== null) {
+	while ((match = ATTRIBUTE_PATTERN.exec(trimmed)) !== null) {
 		attributes[match[1]] = unescapeXml(match[2]);
 	}
 
+	const [rawTag = ""] = trimmed.split(/\s/, 1);
 	return { tag: rawTag.replace(/\/$/, ""), attributes };
 }

--- a/lib/components/Waveform.tsx
+++ b/lib/components/Waveform.tsx
@@ -10,6 +10,7 @@ import {
 	useState,
 } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
+import { toastError } from "@/lib/toastError";
 import { clamp, cn } from "@/lib/utils";
 import { loadPeaks } from "./peaks";
 import {
@@ -26,6 +27,14 @@ export interface WaveformProps {
 	onPause?: () => void;
 	onTimeUpdate?: (time: number, duration: number) => void;
 	onFinish?: () => void;
+}
+
+/** A play cut short by a pause is normal use, not a failure worth surfacing. */
+function startPlayback(audio: HTMLAudioElement): void {
+	audio.play().catch((error: unknown) => {
+		if (error instanceof DOMException && error.name === "AbortError") return;
+		toastError(error, "Could not play audio");
+	});
 }
 
 export interface WaveformHandle {
@@ -93,7 +102,8 @@ export function Waveform({
 		ref,
 		() => ({
 			play() {
-				audioRef.current?.play();
+				const a = audioRef.current;
+				if (a) startPlayback(a);
 			},
 			pause() {
 				audioRef.current?.pause();
@@ -101,7 +111,7 @@ export function Waveform({
 			toggle() {
 				const a = audioRef.current;
 				if (a) {
-					if (a.paused) a.play();
+					if (a.paused) startPlayback(a);
 					else a.pause();
 				}
 			},

--- a/lib/providers/__tests__/cache.test.ts
+++ b/lib/providers/__tests__/cache.test.ts
@@ -485,6 +485,21 @@ describe("audioBundleCache", () => {
 		expect(cache.fromMetadata({ url: "", duration: 5 })).toBe(undefined);
 	});
 
+	it("fromMetadata forces a miss when the row has no usable duration", async () => {
+		const { audioBundleCache } = await loadCache();
+		const cache = audioBundleCache("music");
+		expect(
+			cache.fromMetadata({ url: "https://a/audio.mp3", description: "d" }),
+		).toBe(undefined);
+		expect(
+			cache.fromMetadata({
+				url: "https://a/audio.mp3",
+				duration: "not a number",
+				description: "d",
+			}),
+		).toBe(undefined);
+	});
+
 	it("defaults duration to 0 when metadata missing", async () => {
 		const { audioBundleCache } = await loadCache();
 		const m = audioBundleCache("music").toMetadata(

--- a/lib/providers/cache.ts
+++ b/lib/providers/cache.ts
@@ -121,13 +121,15 @@ export const audioBundleCache = (type: string) => ({
 	fromMetadata: (m: Metadata): BundleResponse | undefined => {
 		const url = m.url || m.audioUrl;
 		if (typeof url !== "string" || url === "") return undefined;
+		const durationSec = Number(m.duration);
+		if (!Number.isFinite(durationSec)) return undefined;
 		return {
 			id: url,
 			type,
 			provider: "pinecone-cache",
 			result: { audio: url },
 			metadata: {
-				durationSec: Number(m.duration),
+				durationSec,
 				cached: true,
 				description: String(m.description),
 			},


### PR DESCRIPTION
Four real correctness bugs plus tests for the two that sit on pure paths.

## Bugs fixed

**`lib/canvas/parseXmlTag.ts` — attribute values lost their whitespace.**
The parser split the tag on `/\s+/` and rejoined with a single space before running the attribute regex, so `prompt="line one\nline two"` round-tripped as `line one line two` and any run of spaces collapsed to one. The regex now scans the trimmed tag directly and the tag name is taken from the first whitespace boundary.

**`lib/providers/cache.ts` — a cache row with no duration rehydrated as `NaN`.**
`audioBundleCache.fromMetadata` did `Number(m.duration)` unguarded. Legacy `audioUrl` rows written before the rename carry no `duration` key, so a hit produced `durationSec: NaN`, which travels into the timeline as a NaN-length sequence. It now forces a miss, which is exactly what the `fromMetadata` contract documents for an unrehydratable row.

**`app/components/AuthForm.tsx` — a thrown magic-link call left the form stuck.**
`setLoading(false)` sat after the await with no `try`. If `sendMagicLink` threw (client construction, network), loading stayed `true` forever, the submit button stayed disabled, and no error was shown. Now wrapped in `try/catch/finally` matching the existing `handleGoogle` shape.

**`lib/components/Waveform.tsx` — unhandled `play()` rejection toasted at the user.**
`audio.play()` was called without handling its promise. `GlobalErrorToaster` listens on `unhandledrejection`, so every pause-during-play raised a spurious "The play() request was interrupted…" toast. The rejection is now handled: `AbortError` is normal use and ignored, anything else goes through `toastError`.

## Tests

- `lib/canvas/__tests__/parseXmlTag.test.ts` — whitespace runs and newlines survive inside an attribute value; attributes following a multi-line value still parse.
- `lib/providers/__tests__/cache.test.ts` — `fromMetadata` misses on a row with a missing or non-numeric `duration`.

Skipped tests for `AuthForm` and `Waveform`: vitest here has no jsdom environment and no rendering harness (all existing tests are pure-function), so covering them would mean standing up a component-test setup, which is out of scope for a bug-fix pass.

## Open PR overlap check

Considered #654 (canvas version history — `lib/project/**`, `lib/generation/**`, canvas hooks/panel/elements, `lib/format.ts`), #657 (timecode styling — `app/components/video/**`, `components/ui/*`, `app/globals.css`, `DESIGN.md`), #658 (`app/components/video/PlayerPositionContext.tsx`). This PR touches `app/components/AuthForm.tsx`, `lib/canvas/parseXmlTag.ts`, `lib/components/Waveform.tsx`, `lib/providers/cache.ts` and their tests — no file or theme overlap.

## Validation

`npm run lint`, `npx tsc --noEmit`, `npm test` (156 files, 1394 tests), and `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)