### PR TITLE
fix: nightly security audit 2026-08-27

### DIFF
--- a/app/api/render/progress/__tests__/progress.test.ts
+++ b/app/api/render/progress/__tests__/progress.test.ts
@@ -25,7 +25,10 @@ function makeRequest(body: unknown) {
 	);
 }
 
-const validBody = { renderId: "render-1", bucketName: "bucket-1" };
+const validBody = {
+	renderId: "render-1",
+	bucketName: "remotionlambda-useast1-abc123",
+};
 
 describe("POST /api/render/progress", () => {
 	beforeEach(() => {
@@ -45,6 +48,24 @@ describe("POST /api/render/progress", () => {
 		const res = await POST(makeRequest({ renderId: "render-1" }));
 
 		expect(res.status).toBe(400);
+	});
+
+	it("rejects a bucket the renderer never minted", async () => {
+		const res = await POST(
+			makeRequest({ ...validBody, bucketName: "someone-elses-bucket" }),
+		);
+
+		expect(res.status).toBe(400);
+		expect(mockGetRenderProgress).not.toHaveBeenCalled();
+	});
+
+	it("rejects a renderId that walks out of its key prefix", async () => {
+		const res = await POST(
+			makeRequest({ ...validBody, renderId: "../../secrets" }),
+		);
+
+		expect(res.status).toBe(400);
+		expect(mockGetRenderProgress).not.toHaveBeenCalled();
 	});
 
 	it("reports fatal errors with the first error message", async () => {

--- a/lib/video/render-api.ts
+++ b/lib/video/render-api.ts
@@ -6,9 +6,13 @@ export const RenderRequest = z.object({
 	scale: z.number().positive().optional(),
 });
 
+// Both fields are forwarded to AWS as the bucket and key prefix the render is
+// read from, so they are parsed down to the shapes Remotion actually mints.
 export const RenderHandleRequest = z.object({
-	renderId: z.string(),
-	bucketName: z.string(),
+	renderId: z.string().regex(/^[A-Za-z0-9-]{1,64}$/, "Invalid renderId"),
+	bucketName: z
+		.string()
+		.regex(/^remotionlambda-[a-z0-9-]{1,48}$/, "Invalid bucketName"),
 });
 
 /** Identifies an in-flight Lambda render: returned by `/api/render`, polled by progress. */


### PR DESCRIPTION
Nightly security audit pass. One real, exploitable issue found and fixed.

## Credentialed S3 read pointed at an attacker-chosen bucket

`app/api/render/progress/route.ts` forwards `bucketName` and `renderId` straight into `getRenderProgress`, which invokes our Remotion Lambda to read `renders/<renderId>/...` from `<bucketName>` using our AWS role and returns the parsed contents (including `outputFile`) to the caller.

Both fields came in as bare `z.string()` (`lib/video/render-api.ts`). The route is only session-gated, and the client just echoes back what `/api/render` handed it, so nothing legitimate ever sends anything else. Any authenticated user could:

- aim a credentialed S3 read at any bucket name they choose, and
- inject `../` into `renderId`, which is interpolated into the S3 key prefix.

Fix: parse both down to the shapes Remotion actually mints. Verified against the installed package — `makeBucketName` produces `remotionlambda-<region-no-dashes>-<10 lowercase alnum>`, and render ids are `<deleteAfter>-<10 lowercase alnum>`. Rejections return the existing typed 400, so it fails loudly rather than degrading. Added tests asserting the AWS call is never reached for a foreign bucket or a traversing `renderId`.

## Checked and clean

- **Auth/authz** — `withApiAccess` gates on `app_metadata.api_access`, which users cannot write. `proxy.ts` excludes `/api/` deliberately; every route under `app/api/**` authenticates itself via a guarded handler factory. Not renamed.
- **IDOR** — `getJob` and `findConversation` scope by `user_id`; RLS policies exist on projects, jobs, conversations, messages, element_history, with messages joining through conversations.
- **`/api/dev/impersonate`** — 404s on `NODE_ENV === "production"`, which also covers preview deploys.
- **SSRF** — the only user-URL fetch path, `fetchAllowedVoicePreview`, checks full origin against a constant host with `redirect: "manual"`; `https://cartesia.ai@evil.com` correctly resolves to the evil origin and is rejected.
- **Secrets** — service-role key is server-only. The three `NEXT_PUBLIC_*` vars are all legitimately public. No hardcoded credentials in tracked source.
- **Insecure patterns** — no `dangerouslySetInnerHTML`, `eval`, or `new Function`. The only `fs` use is a static `public/icons` read. Both `lodash/merge` calls take zod-parsed objects, and zod strips unknown keys, so `__proto__` never survives. Upload filenames are sanitized against traversal.
- **Headers/CORS** — `next.config.ts` sets nosniff/SAMEORIGIN/HSTS/Referrer-Policy globally; no CORS wildcards.

## Skipped

- **`npm audit`: 1 moderate** — `uuid` <11.1.1 buffer bounds check, transitive via `@runware/sdk-js`, no upstream fix available. Only reachable when `buf` is passed to v3/v5/v6, which nothing here does. Forcing an override would be speculative.
- **No rate limiting exists anywhere in the repo.** `/api/render`, `/api/upload/image`, and the `/api/v1/*` generation routes are paid and only session-gated. Real abuse exposure, but it needs shared infra, not a security patch. Worth its own issue.
- **`/api/upload/image` accepts `image/svg+xml`** — nothing sniffs the bytes, so an uploaded SVG executes script on the public blob origin. That origin is cross-origin to the app and hosts only public data, so impact is limited to phishing on a `*.vercel-storage.com` host. Blocking SVG is a behavior change, not a fix.

## Open PR overlap check

Considered #654 (canvas version history), #657 (timecode styling), #658 (side player), #659 (nightly bugs). This PR touches only `lib/video/render-api.ts` and `app/api/render/progress/__tests__/progress.test.ts`, neither of which appears in any open PR diff. Non-overlapping.

## Validation

`npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run knip`, `npm run build` all clean. `npm test`: 1393 passed / 156 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)