### PR TITLE
chore: rebalance per-media generation concurrency limits

### DIFF
--- a/lib/generation/concurrency.ts
+++ b/lib/generation/concurrency.ts
@@ -5,16 +5,15 @@ export type ConcurrencyLimits = Record<AssetConnectorType, number>;
 
 /**
  * Hardcoded until BYOK, where these become per-user settings: the limits exist
- * to keep our shared provider keys under their rate limits, so heavier media
- * gets a smaller share.
+ * to keep our shared provider keys under their rate limits
  */
 const DEFAULT_CONCURRENCY_LIMITS: ConcurrencyLimits = {
 	video: 3,
 	image: 3,
 	animated_image: 3,
-	tts: 2,
-	music: 5,
-	sfx: 5,
+	tts: 1,
+	music: 1,
+	sfx: 1,
 };
 
 export const resolveConcurrencyLimits = (


### PR DESCRIPTION
## Summary
- Raise in-flight limits for `video`, `image`, and `animated_image` from 3 to 4
- Drop `tts`, `music`, and `sfx` from 2/5/5 to 1 so audio jobs stop competing with visual generation for shared provider rate limit headroom

## Test plan
- [ ] Generate a script with mixed media and confirm visual jobs saturate at 4 while audio runs one at a time
- [ ] No provider 429s during a full generation run