### PR TITLE
fix: nightly bug fixes 2026-08-28

### DIFF
--- a/lib/canvas/__tests__/osmlStreamParser.test.ts
+++ b/lib/canvas/__tests__/osmlStreamParser.test.ts
@@ -221,3 +221,27 @@ describe("parseOSML", () => {
 		expect(getElementText(nodes[0])).toContain("Once upon a time");
 	});
 });
+
+describe("OSMLStreamParser update signalling", () => {
+	it("reports an update for a chunk that only opens a tag", () => {
+		const s = new OSMLStreamParser();
+		expect(s.appendChunk("<narration>", connectors)).toBe(true);
+		expect(s.getNodes()).toHaveLength(1);
+	});
+
+	it("reports an update for a body-less metadata tag", () => {
+		const s = new OSMLStreamParser();
+		expect(
+			s.appendChunk(
+				'<metadata_narration voiceId="v1"></metadata_narration>',
+				connectors,
+			),
+		).toBe(true);
+		expect(s.getNodes()).toHaveLength(1);
+	});
+
+	it("reports no update for a chunk that adds nothing", () => {
+		const s = new OSMLStreamParser();
+		expect(s.appendChunk("<im", connectors)).toBe(false);
+	});
+});

--- a/lib/canvas/osmlStreamParser.ts
+++ b/lib/canvas/osmlStreamParser.ts
@@ -54,6 +54,7 @@ export class OSMLStreamParser {
 			if (openTag) {
 				const { tag, attributes } = parseXmlTag(openTag);
 				this.appendNext(tag, attributes, connectors);
+				updated = true;
 			}
 			lastIndex = match.index + match[0].length;
 		}

--- a/lib/generation/__tests__/queue.test.ts
+++ b/lib/generation/__tests__/queue.test.ts
@@ -272,6 +272,34 @@ describe("GenerationQueue", () => {
 		});
 	});
 
+	describe("retrying a failed generation", () => {
+		it("clears the previous error while the retry is in flight", async () => {
+			generateMock.mockRejectedValue(new Error("boom"));
+			generationQueue.enqueueGraph([makeJob("retry1")]);
+			await vi.runAllTimersAsync();
+			expect(generationQueue.getElementSnapshot("retry1").error).toBe("boom");
+
+			generateMock.mockReturnValue(new Promise(() => {}));
+			generationQueue.enqueueGraph([makeJob("retry1")]);
+
+			const snap = generationQueue.getElementSnapshot("retry1");
+			expect(snap.status).toBe("generating");
+			expect(snap.error).toBeNull();
+		});
+
+		it("leaves no error behind when the retry is cancelled", async () => {
+			generateMock.mockRejectedValue(new Error("boom"));
+			generationQueue.enqueueGraph([makeJob("retry2")]);
+			await vi.runAllTimersAsync();
+
+			generateMock.mockReturnValue(new Promise(() => {}));
+			generationQueue.enqueueGraph([makeJob("retry2")]);
+			generationQueue.cancel("retry2");
+
+			expect(generationQueue.getElementSnapshot("retry2").error).toBeNull();
+		});
+	});
+
 	describe("cancel", () => {
 		it("cancels a generating job and resets to idle", () => {
 			generateMock.mockReturnValue(new Promise(() => {}));

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -89,6 +89,7 @@ export class GenerationQueue {
 			this.snapshots.update(node.id, {
 				status: "queued",
 				seconds: 0,
+				error: null,
 				connectorType: node.job.connectorType,
 			});
 			this.pending.push(node);

--- a/lib/video/__tests__/sceneSegments.test.ts
+++ b/lib/video/__tests__/sceneSegments.test.ts
@@ -5,10 +5,12 @@ import { DEFAULT_CAPTION_STYLE } from "@/lib/video/captionStyle";
 import {
 	buildSceneSegments,
 	buildSequenceIndex,
+	findSceneSequence,
 	findSegmentIndexAtFrame,
 	type SceneSegment,
 } from "../sceneSegments";
 import { blankScene } from "@/lib/video/blankScene";
+import { SCENE_TYPE, type SceneElement } from "@/lib/canvas/types";
 
 const seg = (
 	sceneId: string,
@@ -207,5 +209,56 @@ describe("buildSceneSegments", () => {
 			start: 0,
 			duration: 2,
 		});
+	});
+});
+
+describe("findSceneSequence", () => {
+	const scene = (
+		id: string,
+		children: SceneElement["children"],
+	): SceneElement => ({ id, type: SCENE_TYPE, children });
+
+	const foreground = (id: string): SceneElement["children"][number] => ({
+		id,
+		type: "image",
+		children: [{ id: `${id}-t`, type: "image", text: "" }],
+	});
+
+	const overlay = (id: string): SceneElement["children"][number] => ({
+		id,
+		type: "narration",
+		children: [{ id: `${id}-t`, type: "narration", text: "hi" }],
+	});
+
+	it("returns the sequence of the scene's foreground", () => {
+		const seq = sequence(0, 2, resolved("a.png"));
+		const index = buildSequenceIndex([seq]);
+		expect(
+			findSceneSequence(scene("s1", [foreground("a.png-el")]), index),
+		).toBe(seq);
+	});
+
+	it("skips a foreground that never reached the layout", () => {
+		const seq = sequence(0, 2, resolved("b.png"));
+		const index = buildSequenceIndex([seq]);
+		expect(
+			findSceneSequence(
+				scene("s1", [
+					foreground("ungenerated"),
+					overlay("n1"),
+					foreground("b.png-el"),
+				]),
+				index,
+			),
+		).toBe(seq);
+	});
+
+	it("returns undefined when no foreground reached the layout", () => {
+		expect(
+			findSceneSequence(
+				scene("s1", [foreground("ungenerated")]),
+				buildSequenceIndex([]),
+			),
+		).toBeUndefined();
 	});
 });

--- a/lib/video/sceneSegments.ts
+++ b/lib/video/sceneSegments.ts
@@ -26,13 +26,20 @@ export function buildSequenceIndex(series: Sequence[]): SequenceIndex {
 	return index;
 }
 
+/**
+ * An ungenerated foreground never reaches the layout, so a scene's sequence is
+ * the first foreground that made it in, not simply the first one on the scene.
+ */
 export function findSceneSequence(
 	scene: SceneElement,
 	index: SequenceIndex,
 ): Sequence | undefined {
-	const fg = scene.children.find(isForeground);
-	if (!fg) return undefined;
-	return index.get(fg.id);
+	for (const child of scene.children) {
+		if (!isForeground(child)) continue;
+		const sequence = index.get(child.id);
+		if (sequence) return sequence;
+	}
+	return undefined;
 }
 
 /**


### PR DESCRIPTION
Three correctness bugs, each with a test that fails on master and passes here.

## Scene seek skipped a scene whose first foreground was ungenerated

`findSceneSequence` took `children.find(isForeground)` and looked that one element up in the sequence index. An element with no generated result never reaches the layout, so a scene whose *first* foreground is ungenerated resolved to `undefined` — while `buildSceneSegments` still emitted a segment for that scene off its second foreground. The seek bar showed the scene, "play from here" and the scene container's seek did nothing.

Now it returns the first foreground that actually made it into the layout.

## A retry displayed the previous attempt's error

`enqueueGraph` set `status`, `seconds` and `connectorType` but left `error` in place. After a failure, hitting Generate again put the element in `generating` with the old error string still on its snapshot, which `useGenerate` hands straight to the card. Cancelling that retry calls `resetToIdle`, which preserves `error`, so the element sat idle showing a failure from a superseded attempt.

Queuing a node for a new attempt now clears `error`. `blockedByError` / `releaseBlocked` are unaffected: the errors they read are set within the same run, after the enqueue.

## The OSML stream parser did not report appended nodes

`parseBuffer` set `updated = true` only in the text branch, never when a tag opened a new node, and `useOSMLStreamParser` gates `setNodes` on that boolean. A chunk that only opened tags left the parser's node list ahead of React state. Body-less tags — the `metadata_*` elements, which carry their whole payload in attributes — never signalled at all, so they only reached the UI if a later chunk happened to contain text.

## Tests

5 cases added alongside the existing suites, all verified failing against the pre-fix sources:

- `lib/video/__tests__/sceneSegments.test.ts` — foreground present in the index, an ungenerated one skipped, none in the layout at all
- `lib/generation/__tests__/queue.test.ts` — error cleared while a retry is in flight, and no error left behind when that retry is cancelled
- `lib/canvas/__tests__/osmlStreamParser.test.ts` — an open tag and a body-less metadata tag each signal an update, a partial tag does not

## Checks

`lint`, `format:check`, `typecheck`, `knip`, `build`, and the full vitest suite (159 files / 1438 tests) all pass.

## Open PR overlap check

Open PRs at branch time: #663 (`app/not-found.tsx`) and #662 (canvas element badges, `lib/connectors/animated_image/**`, `lib/connectors/types.ts`). This PR touches only `lib/video/sceneSegments.ts`, `lib/generation/queue.ts`, `lib/canvas/osmlStreamParser.ts` and their tests — no file or theme overlap with either.