### PR TITLE
refactor: nightly maintainability 2026-08-28

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -71,21 +71,23 @@ Staleness falls out of the graph: a node needs generating when it has no result,
 - `MetadataSchema` (`lib/project/types.ts`) is where a metadata default lives, not the reader. `videoSettings` in particular is total once parsed — `VideoSettingsSchema` fills every knob — so the aspect ratio, transition, length, and caption settings are read straight off the store (`useVideoSetting`) with no fallback in sight, and written back through `useUpdateVideoSettings` rather than a hand-assembled metadata patch.
 - `lib/canvas/elementConnector.ts` answers "which connector, provider and model does this element use?" for both the UI and the queue. An element pins its provider when created, so this is also where a pin that no longer resolves falls back to the registry default.
 - `lib/script/` provides script context and refinement utilities.
-- `app/components/canvas/hooks/useEditorSession.ts` is the one place the Slate editor gets wired to a project: initial hydration, streaming script sync, metadata sync, and autosave. Views call it and render the editor; they never assemble it.
-- The editor instance is a prop in exactly one place: `Editor` hands it to `CanvasProviders`, which puts it in `<Slate>`. Everything below reaches it with `useSlateStatic()`, so no component takes it just to pass it on.
+- `app/components/canvas/hooks/useEditorSession.ts` is the one place the Slate editor gets wired to a project: initial hydration, streaming script sync, metadata sync, autosave and version history. `CanvasProviders` opens the session and composes every canvas-scoped provider around it; views render the editor and never assemble it.
+- The editor instance is never a prop. `CanvasProviders` puts it straight into `<Slate>`, and everything below reaches it with `useSlateStatic()`.
+- `lib/project/projectDocument.ts` is the live project as one readable, writable unit (script, store snapshot, generation snapshot), so a version is never half applied. `canvasHistory.ts` is the state machine over it: saves fold into the newest version for `FOLD_WINDOW_MS`, previewing stashes the live content and suspends autosave, and restoring adopts whatever is on screen.
 - `lib/project/autosave.ts` owns saving: it builds the row from the store snapshot, script and generation snapshot, then debounces and serializes writes so a slow save can't land after a newer one. `useAutosave` only subscribes the editor value, the store, and the queue to it, and turns the result into a toast.
 
 ## Data
 
 Supabase Postgres with RLS (users only read their own rows; queue workers use the service role):
 
-| Table           | Purpose                                                                              |
-| --------------- | ------------------------------------------------------------------------------------ |
-| `auth.users`    | Supabase auth users                                                                  |
-| `projects`      | One row per project: `script` (text) plus `store` and `generation` snapshots (JSONB) |
-| `jobs`          | Async generation jobs: `pending → processing → completed \| failed`                  |
-| `conversations` | One Sloppy conversation per project                                                  |
-| `messages`      | Its turns: `parts` (text / reasoning / tool-call / tool-result) plus usage           |
+| Table             | Purpose                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------ |
+| `auth.users`      | Supabase auth users                                                                  |
+| `projects`        | One row per project: `script` (text) plus `store` and `generation` snapshots (JSONB) |
+| `canvas_versions` | Autosaved history of those same three columns, one row per folded checkpoint         |
+| `jobs`            | Async generation jobs: `pending → processing → completed \| failed`                  |
+| `conversations`   | One Sloppy conversation per project                                                  |
+| `messages`        | Its turns: `parts` (text / reasoning / tool-call / tool-result) plus usage           |
 
 Generated assets live in Vercel Blob under `assets/{type}/{provider}/{id}/`, served as public CDN URLs.
 

--- a/app/components/Editor.tsx
+++ b/app/components/Editor.tsx
@@ -1,32 +1,27 @@
 "use client";
 
-import { CanvasHistoryProvider } from "@/lib/project/CanvasHistoryProvider";
 import { useShowWorkspace } from "@/lib/script/ScriptProvider";
 import PrePromptView from "./PrePromptView";
 import PostPromptView from "./PostPromptView";
 import { CanvasProviders } from "./canvas/CanvasProviders";
-import { useEditorSession } from "./canvas/hooks/useEditorSession";
 import { BottomViewProvider } from "./video/BottomViewContext";
 import { PlayerPositionProvider } from "./video/PlayerPositionContext";
 
 export default function Editor() {
-	const { editor, onDocumentChange, history } = useEditorSession();
 	const showWorkspace = useShowWorkspace();
 
 	return (
 		<PlayerPositionProvider>
 			<BottomViewProvider>
-				<CanvasHistoryProvider history={history}>
-					<CanvasProviders editor={editor} onDocumentChange={onDocumentChange}>
-						<div
-							className={`flex min-h-screen flex-col items-center transition-[padding] duration-700 ease-out ${
-								showWorkspace ? "" : "pt-[22vh]"
-							}`}
-						>
-							{showWorkspace ? <PostPromptView /> : <PrePromptView />}
-						</div>
-					</CanvasProviders>
-				</CanvasHistoryProvider>
+				<CanvasProviders>
+					<div
+						className={`flex min-h-screen flex-col items-center transition-[padding] duration-700 ease-out ${
+							showWorkspace ? "" : "pt-[22vh]"
+						}`}
+					>
+						{showWorkspace ? <PostPromptView /> : <PrePromptView />}
+					</div>
+				</CanvasProviders>
 			</BottomViewProvider>
 		</PlayerPositionProvider>
 	);

--- a/app/components/canvas/CanvasProviders.tsx
+++ b/app/components/canvas/CanvasProviders.tsx
@@ -3,7 +3,7 @@
 import type { ReactNode } from "react";
 import type { Descendant } from "slate";
 import { Slate } from "slate-react";
-import type { CanvasEditor } from "@/lib/canvas/types";
+import { CanvasHistoryProvider } from "@/lib/project/CanvasHistoryProvider";
 import { VideoLayoutProvider } from "../video/VideoLayoutContext";
 import { PlayerControlProvider } from "../video/PlayerControlContext";
 import { RenderProvider } from "../video/RenderProvider";
@@ -14,50 +14,48 @@ import { ActiveCaptionFont } from "./CaptionFonts";
 import { SloppyModelProvider } from "../sloppy/SloppyModelProvider";
 import { SloppyProvider } from "../sloppy/SloppyProvider";
 import { EditorPanelProvider } from "./panel/EditorPanelContext";
+import { useEditorSession } from "./hooks/useEditorSession";
 
 const EMPTY_DOCUMENT: Descendant[] = [];
 
 /**
- * Composes the editor's canvas-scoped providers (document, render, video
- * layout, player control, scene selection, auto-scroll, collapse state) into a
- * single boundary so the top-level view stays a flat orchestrator rather than a
- * provider pyramid. The document lives in `<Slate>`, so consumers subscribe to
- * the slices they need and a keystroke never re-renders the shell, and they
- * reach the editor itself with `useSlateStatic()` rather than a drilled prop.
+ * Opens the editor session and composes every canvas-scoped provider (document,
+ * version history, render, video layout, player control, scene selection,
+ * auto-scroll, collapse state) into a single boundary, so the top-level view
+ * stays a flat orchestrator rather than a provider pyramid. The document lives
+ * in `<Slate>`, so consumers subscribe to the slices they need and a keystroke
+ * never re-renders the shell, and they reach the editor itself with
+ * `useSlateStatic()` rather than a drilled prop.
  */
-export function CanvasProviders({
-	editor,
-	onDocumentChange,
-	children,
-}: {
-	editor: CanvasEditor;
-	onDocumentChange: () => void;
-	children: ReactNode;
-}) {
+export function CanvasProviders({ children }: { children: ReactNode }) {
+	const { editor, onDocumentChange, history } = useEditorSession();
+
 	return (
 		<Slate
 			editor={editor}
 			initialValue={EMPTY_DOCUMENT}
 			onValueChange={onDocumentChange}
 		>
-			<RenderProvider>
-				<ActiveCaptionFont />
-				<VideoLayoutProvider>
-					<PlayerControlProvider>
-						<ActiveSceneProvider>
-							<AutoScrollProvider>
-								<ViewModeProvider>
-									<SloppyModelProvider>
-										<SloppyProvider>
-											<EditorPanelProvider>{children}</EditorPanelProvider>
-										</SloppyProvider>
-									</SloppyModelProvider>
-								</ViewModeProvider>
-							</AutoScrollProvider>
-						</ActiveSceneProvider>
-					</PlayerControlProvider>
-				</VideoLayoutProvider>
-			</RenderProvider>
+			<CanvasHistoryProvider history={history}>
+				<RenderProvider>
+					<ActiveCaptionFont />
+					<VideoLayoutProvider>
+						<PlayerControlProvider>
+							<ActiveSceneProvider>
+								<AutoScrollProvider>
+									<ViewModeProvider>
+										<SloppyModelProvider>
+											<SloppyProvider>
+												<EditorPanelProvider>{children}</EditorPanelProvider>
+											</SloppyProvider>
+										</SloppyModelProvider>
+									</ViewModeProvider>
+								</AutoScrollProvider>
+							</ActiveSceneProvider>
+						</PlayerControlProvider>
+					</VideoLayoutProvider>
+				</RenderProvider>
+			</CanvasHistoryProvider>
 		</Slate>
 	);
 }

--- a/app/components/canvas/elements/ElementHistoryPopover.tsx
+++ b/app/components/canvas/elements/ElementHistoryPopover.tsx
@@ -132,8 +132,8 @@ function LoadingRows() {
 }
 
 /**
- * Versions are read on open, and read here rather than in the body so no card
- * subscribes to versions it never shows.
+ * Versions are read on open, and the list that subscribes to them only mounts
+ * while the popover is open, so no card watches versions it never shows.
  */
 export function ElementHistoryPopover({
 	elementId,
@@ -144,6 +144,7 @@ export function ElementHistoryPopover({
 }) {
 	const loadHistory = useLoadElementHistory();
 	const [open, setOpen] = useState(false);
+	const close = () => setOpen(false);
 
 	return (
 		<Popover
@@ -165,17 +166,27 @@ export function ElementHistoryPopover({
 				aria-label="Generation history"
 				className="w-80 font-medium"
 			>
-				<ElementHistoryBody
-					elementId={elementId}
-					onRestore={onRestore}
-					onClose={() => setOpen(false)}
-				/>
+				<div className="flex items-center justify-between">
+					<span className="text-label font-semibold">Generation history</span>
+					<CloseButton onClick={close} />
+				</div>
+				<Separator className={RULE} />
+				<div
+					aria-live="polite"
+					className="-mx-1 flex max-h-80 flex-col overflow-y-auto overscroll-contain"
+				>
+					<ElementVersionList
+						elementId={elementId}
+						onRestore={onRestore}
+						onClose={close}
+					/>
+				</div>
 			</PopoverContent>
 		</Popover>
 	);
 }
 
-function ElementHistoryBody({
+function ElementVersionList({
 	elementId,
 	onRestore,
 	onClose,
@@ -184,8 +195,7 @@ function ElementHistoryBody({
 	onRestore: (version: ElementVersion) => void;
 	onClose: () => void;
 }) {
-	const { versions, loaded, failed, activeIndex } =
-		useElementHistory(elementId);
+	const { versions, status, activeIndex } = useElementHistory(elementId);
 	const queue = useGenerationQueue();
 	const history = useElementHistoryStore();
 
@@ -197,44 +207,36 @@ function ElementHistoryBody({
 		onClose();
 	};
 
+	if (status === "failed")
+		return (
+			<p className="flex items-center gap-1.5 px-2 py-1.5 text-label-xs text-destructive">
+				<AlertCircle className="h-3.5 w-3.5" />
+				Could not load history. Close and reopen to try again.
+			</p>
+		);
+
+	if (status === "loading") return <LoadingRows />;
+
+	if (versions.length === 0)
+		return (
+			<p className="px-2 py-1.5 text-label-xs text-muted-foreground">
+				No versions yet.
+			</p>
+		);
+
 	return (
-		<>
-			<div className="flex items-center justify-between">
-				<span className="text-label font-semibold">Generation history</span>
-				<CloseButton onClick={onClose} />
-			</div>
-			<Separator className={RULE} />
-			<div
-				aria-live="polite"
-				className="-mx-1 flex max-h-80 flex-col overflow-y-auto overscroll-contain"
-			>
-				{failed ? (
-					<p className="flex items-center gap-1.5 px-2 py-1.5 text-label-xs text-destructive">
-						<AlertCircle className="h-3.5 w-3.5" />
-						Could not load history. Close and reopen to try again.
-					</p>
-				) : !loaded ? (
-					<LoadingRows />
-				) : versions.length === 0 ? (
-					<p className="px-2 py-1.5 text-label-xs text-muted-foreground">
-						No versions yet.
-					</p>
-				) : (
-					<ul className="flex flex-col">
-						{versions
-							.map((version, index) => (
-								<ElementVersionRow
-									key={versionKey(version)}
-									version={version}
-									label={String(index + 1)}
-									active={index === activeIndex}
-									onRestore={() => restore(version)}
-								/>
-							))
-							.reverse()}
-					</ul>
-				)}
-			</div>
-		</>
+		<ul className="flex flex-col">
+			{versions
+				.map((version, index) => (
+					<ElementVersionRow
+						key={versionKey(version)}
+						version={version}
+						label={String(index + 1)}
+						active={index === activeIndex}
+						onRestore={() => restore(version)}
+					/>
+				))
+				.reverse()}
+		</ul>
 	);
 }

--- a/app/components/canvas/hooks/useElementHistory.ts
+++ b/app/components/canvas/hooks/useElementHistory.ts
@@ -4,20 +4,19 @@ import {
 	useElementHistoryStore,
 	useElementHistorySelector,
 } from "@/lib/generation/ElementHistoryProvider";
+import type { ElementHistoryStatus } from "@/lib/generation/history";
 import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
 import { versionKey, type ElementVersion } from "@/lib/generation/versions";
 
 export type ElementVersionHistory = {
 	versions: readonly ElementVersion[];
-	loaded: boolean;
-	failed: boolean;
+	status: ElementHistoryStatus;
 	activeIndex: number;
 };
 
 export function useElementHistory(elementId: string): ElementVersionHistory {
 	const versions = useElementHistorySelector((h) => h.get(elementId));
-	const loaded = useElementHistorySelector((h) => h.isLoaded(elementId));
-	const failed = useElementHistorySelector((h) => h.isFailed(elementId));
+	const status = useElementHistorySelector((h) => h.status(elementId));
 	const snapshot = useQueueSelector((q) => q.getElementSnapshot(elementId));
 	const activeKey = snapshot.resultInputs
 		? versionKey({ inputs: snapshot.resultInputs, pinned: snapshot.pinned })
@@ -25,8 +24,7 @@ export function useElementHistory(elementId: string): ElementVersionHistory {
 
 	return {
 		versions,
-		loaded,
-		failed,
+		status,
 		activeIndex: versions.findIndex(
 			(version) => versionKey(version) === activeKey,
 		),

--- a/lib/generation/__tests__/history.test.ts
+++ b/lib/generation/__tests__/history.test.ts
@@ -67,12 +67,12 @@ describe("ElementHistory", () => {
 		const [storage] = storageOf(read);
 		const history = new ElementHistory(storage);
 
-		expect(history.isLoaded("a")).toBe(false);
+		expect(history.status("a")).toBe("loading");
 		await Promise.all([history.load("a"), history.load("a")]);
 		await history.load("a");
 
 		expect(read).toHaveBeenCalledTimes(1);
-		expect(history.isLoaded("a")).toBe(true);
+		expect(history.status("a")).toBe("ready");
 		expect(history.get("a")).toEqual([stored]);
 	});
 
@@ -85,10 +85,10 @@ describe("ElementHistory", () => {
 		const history = new ElementHistory(storage);
 
 		await expect(history.load("a")).rejects.toThrow("offline");
-		expect(history.isFailed("a")).toBe(true);
+		expect(history.status("a")).toBe("failed");
 
 		await history.load("a");
-		expect(history.isFailed("a")).toBe(false);
+		expect(history.status("a")).toBe("ready");
 		expect(history.get("a")).toEqual([stored]);
 	});
 

--- a/lib/generation/history.ts
+++ b/lib/generation/history.ts
@@ -11,6 +11,9 @@ export const SESSION_ONLY: ElementVersionStorage = {
 	write: () => {},
 };
 
+/** A version list is either still arriving, readable, or unreadable. */
+export type ElementHistoryStatus = "loading" | "ready" | "failed";
+
 export class ElementHistory {
 	private readonly log = new VersionLog();
 	private readonly listeners = new Set<() => void>();
@@ -33,12 +36,13 @@ export class ElementHistory {
 	get = (elementId: string): readonly ElementVersion[] =>
 		this.log.get(elementId);
 
-	isLoaded = (elementId: string): boolean => this.log.isHydrated(elementId);
-
-	isFailed = (elementId: string): boolean => this.failed.has(elementId);
+	status = (elementId: string): ElementHistoryStatus => {
+		if (this.log.isHydrated(elementId)) return "ready";
+		return this.failed.has(elementId) ? "failed" : "loading";
+	};
 
 	load = (elementId: string): Promise<void> => {
-		if (this.isLoaded(elementId)) return Promise.resolve();
+		if (this.log.isHydrated(elementId)) return Promise.resolve();
 		const inFlight = this.loading.get(elementId);
 		if (inFlight) return inFlight;
 		this.failed.delete(elementId);


### PR DESCRIPTION
No behavior changes. Three related cleanups around the two history features, plus the docs they left stale.

## `CanvasProviders` owns the editor session

`CanvasHistoryProvider` landed with #654 at the top level, so `Editor` had gone back to destructuring the session and assembling a provider itself — the exact shape `CanvasProviders` exists to prevent, per its own doc comment.

`CanvasProviders` now calls `useEditorSession()` and composes `CanvasHistoryProvider` with the rest of the stack. `Editor` is down to the view switch and takes no props from the session at all, so the editor instance is no longer a prop anywhere.

## Element history: one status, not two booleans

`ElementHistory` exposed `isLoaded` and `isFailed` as independent booleans tracked in two structures, which made `loaded && failed` representable and pushed a four-arm nested ternary into the popover. The sibling feature added a week later (`CanvasHistory`) and `ClipWaveform` both already model this as a `status` union.

`ElementHistory.status(elementId)` now returns `"loading" | "ready" | "failed"`, `useElementHistory` returns it instead of the pair, and the popover reads it with early returns. The forwarding `ElementHistoryBody` layer is gone: the popover holds its own chrome and mounts `ElementVersionList` (which owns the state machine and the subscription) only while open, as before.

## Docs

`ARCHITECTURE.md` claimed the editor is a prop handed to `CanvasProviders`, didn't mention version history in the editor-state section, and was missing `canvas_versions` from the data table. Fixed, plus one line on `projectDocument` / `canvasHistory`.

## Checks

`lint`, `format:check`, `typecheck`, `knip`, `build`, and `vitest run` (159 files / 1430 tests) all green.

## Open PR overlap check

Considered #668 (`osmlStreamParser`, `generation/queue`, `video/sceneSegments`), #663 (`app/not-found.tsx`), #662 (`animated_image` still-frame, `AttributeBadge` / `ElementContainer` / `ModelBadge`, `connectors/types`). No file or theme here overlaps any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)