### PR TITLE
perf: nightly performance optimizations 2026-08-28

### DIFF
--- a/app/components/canvas/hooks/useScriptSync.ts
+++ b/app/components/canvas/hooks/useScriptSync.ts
@@ -18,7 +18,10 @@ export function useScriptSync(editor: Editor): void {
 				const nextText = getElementBodyText(node);
 				if (!nextText) continue;
 
-				const entry = findNodeById(editor, node.id);
+				// The script streams in order, so a node already on the canvas is
+				// one of the last written. Searching forward would re-cross the whole
+				// document for every chunk, growing with the script as it arrives.
+				const entry = findNodeById(editor, node.id, { reverse: true });
 				if (entry) {
 					const [, path] = entry;
 					updateNodeText(editor, path, nextText);

--- a/lib/canvas/__tests__/editorOps.test.ts
+++ b/lib/canvas/__tests__/editorOps.test.ts
@@ -63,6 +63,20 @@ describe("findNodeById", () => {
 		const editor = makeEditor([scene([content("narration", "n1")], "s1")]);
 		expect(findNodeById(editor, "s1")).toBeNull();
 	});
+
+	it("finds the same node searching from the tail", () => {
+		const editor = makeEditor([
+			scene([content("narration", "n1"), content("image", "img1")], "s1"),
+			scene([content("narration", "n2")], "s2"),
+		]);
+
+		for (const id of ["n1", "img1", "n2"]) {
+			expect(findNodeById(editor, id, { reverse: true })).toEqual(
+				findNodeById(editor, id),
+			);
+		}
+		expect(findNodeById(editor, "nope", { reverse: true })).toBeNull();
+	});
 });
 
 describe("findElementById", () => {

--- a/lib/canvas/editorOps.ts
+++ b/lib/canvas/editorOps.ts
@@ -19,12 +19,19 @@ export function findElementById(
 	return entry ?? null;
 }
 
+/**
+ * Ids are unique, so `reverse` only picks the search direction. Callers looking
+ * up something they just appended pass it to stop the walk at the tail instead
+ * of crossing the whole document to reach it.
+ */
 export function findNodeById(
 	editor: Editor,
 	id: string,
+	{ reverse = false }: { reverse?: boolean } = {},
 ): NodeEntry<CanvasContentElement> | null {
 	const [entry] = Editor.nodes<CanvasContentElement>(editor, {
 		at: [],
+		reverse,
 		match: (n) => isContentElement(n) && n.id === id,
 	});
 	return entry ?? null;


### PR DESCRIPTION
Script streaming re-crossed the whole canvas on every chunk. It no longer does.

## What was wrong

`useScriptSync` runs on every parsed chunk the LLM streams in, and for each of the (up to 3) tail nodes the parser hands it, it asks `findNodeById` where that node lives. `findNodeById` walks forward from the document root:

```ts
Editor.nodes(editor, { at: [], match: (n) => isContentElement(n) && n.id === id })
```

The nodes being synced are the ones just written, so they sit at the very end. Every lookup therefore visited every scene, element and text leaf already on the canvas before reaching its target — and the document grows as the script arrives, so the per-chunk cost grows with it. The work is quadratic in script length, landing on the main thread during the one stretch where the user is watching the canvas fill in.

## The change

The script streams in order, so a node already on the canvas is one of the last written. Slate already takes a search direction; the sync now says which end to start from, and `findNodeById` passes it through. Ids are unique, so the entry found is identical either way — this only picks where the walk begins. Everything else keeps the existing forward default.

## Measured

Vitest, 3 tail-node lookups per pass (what one streamed chunk does), against documents of the given size:

| elements | 300 sync passes, forward | reverse | |
|---|---|---|---|
| 50  | 150ms  | 17ms | 8.8x |
| 240 | 554ms  | 12ms | 45x |
| 480 | 1084ms | 13ms | 81x |

Match-callback invocations per lookup on a 480-element document: **1020 → 3**. Reverse is flat in document size; forward is linear, and a real stream does far more than 300 passes.

## Open PR overlap check

Considered #669 (`Editor.tsx`, `CanvasProviders`, `ElementHistoryPopover`, `useElementHistory`, `lib/generation/history.ts`, `ARCHITECTURE.md`), #668 (`osmlStreamParser`, `lib/generation/queue.ts`, `lib/video/sceneSegments.ts`), #663 (`app/not-found.tsx`), #662 (`AttributeBadge`, `ElementContainer`, `ModelBadge`, `lib/connectors/animated_image/*`). This PR touches `lib/canvas/editorOps.ts`, `app/components/canvas/hooks/useScriptSync.ts` and `lib/canvas/__tests__/editorOps.test.ts` — no file, module or theme overlap. In particular it does not touch the streaming parser #668 is working in.

## Checks

`lint`, `format:check`, `typecheck`, `knip`, `build`, `test:run` (1431 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)