### PR TITLE
refactor: rethink openslop architecture 2026-08-28

### DIFF
--- a/app/components/sloppy/toolPresentation.tsx
+++ b/app/components/sloppy/toolPresentation.tsx
@@ -1,98 +1,22 @@
 "use client";
 
 import type { ToolUIPart } from "ai";
+import { Robot } from "@/components/ui/icon";
 import {
-	Eye,
-	Film,
-	Hourglass,
-	Mic,
-	Pencil,
-	Robot,
-	SlidersHorizontal,
-	TextBox,
-	Translate,
-	User,
-	type IconComponent,
-} from "@/components/ui/icon";
-import { SLOPPY_TOOLS } from "@/lib/agent/tools/registry";
+	presentToolCall,
+	type ToolPresentation,
+} from "@/lib/agent/tools/registry";
 import type { SloppyTools } from "@/lib/agent/types";
 
-type ToolPresentation = { icon: IconComponent; label: string };
-
-type ToolPart = ToolUIPart<SloppyTools>;
-
-const OFFERED: ReadonlySet<string> = new Set(
-	Object.keys(SLOPPY_TOOLS).map((name) => `tool-${name}`),
-);
-
 /** A stored transcript can hold a tool this build has renamed away, and it still has to render. */
-const pastTool = (type: string): ToolPresentation => ({
-	icon: Robot,
-	label: type.replace(/^tool-/, "").replaceAll("_", " "),
-});
-
-export function toolPresentation(part: ToolPart): ToolPresentation {
-	return OFFERED.has(part.type) ? offeredTool(part) : pastTool(part.type);
-}
-
-/** Exhaustive over the tools this build offers: a new one without a case is a type error. */
-function offeredTool(part: ToolPart): ToolPresentation {
-	switch (part.type) {
-		case "tool-read_script":
-			return { icon: Eye, label: "Reading the script" };
-		case "tool-edit_script": {
-			const count = part.input?.ops?.length ?? 0;
-			return {
-				icon: Pencil,
-				label:
-					count === 1
-						? "Editing the script (1 change)"
-						: `Editing the script (${count} changes)`,
-			};
+export function toolPresentation(
+	part: ToolUIPart<SloppyTools>,
+): ToolPresentation {
+	const name = part.type.replace(/^tool-/, "");
+	return (
+		presentToolCall(name, part.input) ?? {
+			icon: Robot,
+			label: name.replaceAll("_", " "),
 		}
-		case "tool-write_script":
-			return { icon: Film, label: "Writing a new script" };
-		case "tool-adapt_script":
-			return { icon: Film, label: "Putting your script on the canvas" };
-		case "tool-set_video_settings":
-			return { icon: Hourglass, label: "Adjusting the video settings" };
-		case "tool-view_reference_images":
-			return { icon: Eye, label: "Looking at the reference images" };
-		case "tool-view_avatar": {
-			const name = part.input?.name;
-			return {
-				icon: Eye,
-				label: name ? `Looking at ${name}'s avatar` : "Looking at an avatar",
-			};
-		}
-		case "tool-outline_story":
-			return { icon: Pencil, label: "Outlining the story" };
-		case "tool-measure_total_length":
-			return { icon: Hourglass, label: "Measuring the video's length" };
-		case "tool-measure_element_lengths":
-			return {
-				icon: Hourglass,
-				label: "Measuring scene lengths",
-			};
-		case "tool-fit_durations":
-			return { icon: Hourglass, label: "Fitting clips to the dialogue" };
-		case "tool-set_caption_style":
-			return { icon: TextBox, label: "Styling the captions" };
-		case "tool-set_language":
-			return { icon: Translate, label: "Setting the language" };
-		case "tool-set_metadata":
-			return {
-				icon: SlidersHorizontal,
-				label: "Setting the project's settings",
-			};
-		case "tool-set_narrator":
-			return { icon: Mic, label: "Adjusting the narrator's voice" };
-		case "tool-set_character": {
-			const name = part.input?.name;
-			return {
-				icon: User,
-				label: name ? `Setting the character ${name}` : "Setting a character",
-			};
-		}
-	}
+	);
 }

--- a/lib/agent/tools/adaptScript.ts
+++ b/lib/agent/tools/adaptScript.ts
@@ -1,5 +1,6 @@
 import dedent from "dedent";
 import { z } from "zod";
+import { Film } from "@/components/ui/icon";
 import { defineTool } from "./defineTool";
 
 export const adaptScript = defineTool({
@@ -42,6 +43,8 @@ export const adaptScript = defineTool({
 			),
 	}),
 	output: z.string(),
+	icon: Film,
+	label: "Putting your script on the canvas",
 	execute: async ({ script, notes }, ctx) => {
 		await ctx.adaptScript(script, notes);
 		return "Put that script onto the canvas. Read it to see what landed.";

--- a/lib/agent/tools/defineTool.ts
+++ b/lib/agent/tools/defineTool.ts
@@ -1,5 +1,6 @@
 import type { Tool } from "ai";
 import type { z } from "zod";
+import type { IconComponent } from "@/components/ui/icon";
 import type { AgentToolContext } from "./context";
 
 /**
@@ -12,6 +13,9 @@ export function defineTool<Input, Output>(def: {
 	description: string;
 	input: z.ZodType<Input>;
 	output: z.ZodType<Output>;
+	icon: IconComponent;
+	/** What the transcript calls the running step. Input arrives as the SDK streams it. */
+	label: string | ((input: Partial<Input>) => string);
 	toModelOutput?: Tool<Input, Output>["toModelOutput"];
 	execute: (input: Input, ctx: AgentToolContext) => Promise<Output>;
 	/** Output that is only true until the next edit, so only its own turn keeps it. */
@@ -19,7 +23,16 @@ export function defineTool<Input, Output>(def: {
 	/** The call rewrites the canvas, so what is rendered from it is mid-change. */
 	rewritesCanvas?: true;
 }) {
-	const { input, output, execute, snapshot, rewritesCanvas, ...rest } = def;
+	const {
+		input,
+		output,
+		execute,
+		snapshot,
+		rewritesCanvas,
+		icon,
+		label,
+		...rest
+	} = def;
 	// Tool's shape is conditional on OUTPUT, which never resolves against a
 	// generic; the def parameter above already checks every field against it.
 	const spec = {
@@ -27,7 +40,11 @@ export function defineTool<Input, Output>(def: {
 		inputSchema: input,
 		outputSchema: output,
 	} as unknown as Tool<Input, Output>;
-	return { input, execute, spec, snapshot, rewritesCanvas };
+	const present = {
+		icon,
+		label: typeof label === "function" ? label : () => label,
+	};
+	return { input, execute, spec, snapshot, rewritesCanvas, present };
 }
 
 /** A tool-result image, handed to the model by URL for the provider to fetch. */

--- a/lib/agent/tools/editScript.ts
+++ b/lib/agent/tools/editScript.ts
@@ -4,6 +4,7 @@ import { CANVAS_ELEMENT_TYPES, DURATION_OPTIONS } from "@/lib/canvas/types";
 import { MusicLength } from "@/lib/connectors/music/enums";
 import { refineOpSchema } from "@/lib/script/refine/types";
 import { MOTION_EFFECTS } from "@/lib/video/motionEffectNames";
+import { Pencil } from "@/components/ui/icon";
 import { defineTool } from "./defineTool";
 
 const ELEMENT_TYPES = [...CANVAS_ELEMENT_TYPES].join(", ");
@@ -53,6 +54,9 @@ export const editScript = defineTool({
 			.describe("Operations to apply, in order."),
 	}),
 	output: z.string(),
+	icon: Pencil,
+	label: ({ ops }) =>
+		`Editing the script (${ops?.length ?? 0} change${ops?.length === 1 ? "" : "s"})`,
 	execute: async ({ ops }, ctx) => {
 		const { applied, failures } = ctx.editScript(ops);
 		if (failures.length === 0) {

--- a/lib/agent/tools/fitDurations.ts
+++ b/lib/agent/tools/fitDurations.ts
@@ -8,6 +8,7 @@ import {
 	type DurationFit,
 } from "@/lib/video/durationFit";
 import type { ElementLength } from "@/lib/video/elementLengths";
+import { Hourglass } from "@/components/ui/icon";
 import { defineTool } from "./defineTool";
 
 const sec = (seconds: number) => `${seconds.toFixed(1)}s`;
@@ -72,6 +73,8 @@ export const fitDurations = defineTool({
 		element_ids: z.array(z.string()).min(1).optional(),
 	}),
 	output: z.string(),
+	icon: Hourglass,
+	label: "Fitting clips to the dialogue",
 	execute: async ({ element_ids }, ctx) => {
 		const { scoped, unknown } = scopeTo(
 			ctx.measureElementLengths(),

--- a/lib/agent/tools/measureElementLengths.ts
+++ b/lib/agent/tools/measureElementLengths.ts
@@ -2,6 +2,7 @@ import dedent from "dedent";
 import { z } from "zod";
 import type { ElementLength } from "@/lib/video/elementLengths";
 import { NARRATION_WORDS_PER_MINUTE } from "@/lib/video/videoLength";
+import { Hourglass } from "@/components/ui/icon";
 import { defineTool } from "./defineTool";
 
 const WORDS_PER_SECOND = Math.round(NARRATION_WORDS_PER_MINUTE / 60);
@@ -30,6 +31,8 @@ export const measureElementLengths = defineTool({
 	`,
 	input: z.object({}),
 	output: z.string(),
+	icon: Hourglass,
+	label: "Measuring scene lengths",
 	execute: async (_input, ctx) => {
 		const lengths = ctx.measureElementLengths();
 		if (lengths.length === 0) return "No visual elements on the canvas yet.";

--- a/lib/agent/tools/measureTotalLength.ts
+++ b/lib/agent/tools/measureTotalLength.ts
@@ -4,6 +4,7 @@ import {
 	NARRATION_WORDS_PER_MINUTE,
 	videoLengthBudget,
 } from "@/lib/video/videoLength";
+import { Hourglass } from "@/components/ui/icon";
 import { defineTool } from "./defineTool";
 
 const minutes = (words: number) =>
@@ -21,6 +22,8 @@ export const measureTotalLength = defineTool({
 	`,
 	input: z.object({}),
 	output: z.string(),
+	icon: Hourglass,
+	label: "Measuring the video's length",
 	execute: async (_input, ctx) => {
 		const words = ctx.countSpokenWords();
 		const { length } = ctx.readMetadata().videoSettings;

--- a/lib/agent/tools/outlineStory.ts
+++ b/lib/agent/tools/outlineStory.ts
@@ -2,6 +2,7 @@ import dedent from "dedent";
 import { z } from "zod";
 import { spokenLanguage } from "@/lib/script/prompt/language";
 import { outlinePrompt } from "@/lib/script/prompt/outline";
+import { Pencil } from "@/components/ui/icon";
 import { defineTool } from "./defineTool";
 
 export const outlineStory = defineTool({
@@ -26,6 +27,8 @@ export const outlineStory = defineTool({
 			),
 	}),
 	output: z.string(),
+	icon: Pencil,
+	label: "Outlining the story",
 	execute: async ({ brief }, ctx) => {
 		const language = spokenLanguage(
 			ctx.readMetadata(),

--- a/lib/agent/tools/readScript.ts
+++ b/lib/agent/tools/readScript.ts
@@ -5,6 +5,7 @@ import {
 	type Metadata,
 	type MetadataVoice,
 } from "@/lib/project/types";
+import { Eye } from "@/components/ui/icon";
 import { defineTool } from "./defineTool";
 
 const UNSET = "unset";
@@ -38,6 +39,8 @@ export const readScript = defineTool({
 	`,
 	input: z.object({}),
 	output: z.string(),
+	icon: Eye,
+	label: "Reading the script",
 	execute: async (_input, ctx) => {
 		const metadata = ctx.readMetadata();
 		const script = ctx.readScript().trim();

--- a/lib/agent/tools/registry.ts
+++ b/lib/agent/tools/registry.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { IconComponent } from "@/components/ui/icon";
 import { errorMessage } from "@/lib/errors";
 import type { AgentToolContext } from "./context";
 import { adaptScript } from "./adaptScript";
@@ -70,6 +71,28 @@ export type AgentToolOutput = {
 	[TName in AgentToolName]: ToolOutput<TName>;
 }[AgentToolName];
 
+const isToolName = (name: string): name is AgentToolName => name in TOOLS;
+
+/** How a call reads in the transcript. */
+export type ToolPresentation = { icon: IconComponent; label: string };
+
+// Same widening as DISPATCH, and the input is read as the SDK streams it, so
+// each label reads its own fields optionally.
+const PRESENT = TOOLS as unknown as Record<
+	AgentToolName,
+	{ present: { icon: IconComponent; label: (input: unknown) => string } }
+>;
+
+/** Null for a tool this build no longer offers, which a stored transcript still holds. */
+export function presentToolCall(
+	toolName: string,
+	input: unknown,
+): ToolPresentation | null {
+	if (!isToolName(toolName)) return null;
+	const { icon, label } = PRESENT[toolName].present;
+	return { icon, label: label(input ?? {}) };
+}
+
 type ToolFlag = "snapshot" | "rewritesCanvas";
 
 const namesFlagged = (flag: ToolFlag): ReadonlySet<string> =>
@@ -89,8 +112,6 @@ export const SCRIPT_TOOLS = namesFlagged("rewritesCanvas");
 export type ToolOutcome =
 	| { ok: true; output: AgentToolOutput }
 	| { ok: false; errorText: string };
-
-const isToolName = (name: string): name is AgentToolName => name in TOOLS;
 
 const run = async <TName extends AgentToolName>(
 	toolName: TName,

--- a/lib/agent/tools/setCaptionStyle.ts
+++ b/lib/agent/tools/setCaptionStyle.ts
@@ -16,6 +16,7 @@ import {
 	CaptionStyleSchema,
 } from "@/lib/video/captionStyle";
 import { CAPTION_FONTS } from "@/lib/video/captionFonts";
+import { TextBox } from "@/components/ui/icon";
 import { defineTool } from "./defineTool";
 import { named, notEmpty } from "./inputs";
 
@@ -61,6 +62,8 @@ export const setCaptionStyle = defineTool({
 		})
 		.refine(notEmpty, named("caption setting")),
 	output: z.string(),
+	icon: TextBox,
+	label: "Styling the captions",
 	execute: async ({ preset, captions, ...overrides }, ctx) => {
 		// Metadata patches are deep-merged, so a partial style lands on the stored one.
 		const captionStyle =

--- a/lib/agent/tools/setCharacter.ts
+++ b/lib/agent/tools/setCharacter.ts
@@ -1,5 +1,6 @@
 import dedent from "dedent";
 import { z } from "zod";
+import { User } from "@/components/ui/icon";
 import { defineTool } from "./defineTool";
 import { VOICE_TRAITS } from "./inputs";
 
@@ -21,6 +22,9 @@ export const setCharacter = defineTool({
 		...VOICE_TRAITS,
 	}),
 	output: z.string(),
+	icon: User,
+	label: ({ name }) =>
+		name ? `Setting the character ${name}` : "Setting a character",
 	execute: async ({ name, ...patch }, ctx) => {
 		const settled = ctx.setCharacter(name, patch);
 

--- a/lib/agent/tools/setLanguage.ts
+++ b/lib/agent/tools/setLanguage.ts
@@ -1,6 +1,7 @@
 import dedent from "dedent";
 import { z } from "zod";
 import { LANGUAGE_CHOICES, languageLabel } from "@/lib/project/language";
+import { Translate } from "@/components/ui/icon";
 import { defineTool } from "./defineTool";
 
 export const setLanguage = defineTool({
@@ -14,6 +15,8 @@ export const setLanguage = defineTool({
 	`,
 	input: z.object({ language: z.enum(LANGUAGE_CHOICES) }),
 	output: z.string(),
+	icon: Translate,
+	label: "Setting the language",
 	execute: async ({ language }, ctx) => {
 		ctx.setMetadata({ language });
 		return `Set the language to ${languageLabel(language)}. It applies to the next script written; what is on the canvas is unchanged.`;

--- a/lib/agent/tools/setMetadata.ts
+++ b/lib/agent/tools/setMetadata.ts
@@ -1,5 +1,6 @@
 import dedent from "dedent";
 import { z } from "zod";
+import { SlidersHorizontal } from "@/components/ui/icon";
 import { defineTool } from "./defineTool";
 import { named, notEmpty } from "./inputs";
 
@@ -18,6 +19,8 @@ export const setMetadata = defineTool({
 		})
 		.refine(notEmpty, named("setting")),
 	output: z.string(),
+	icon: SlidersHorizontal,
+	label: "Setting the project's settings",
 	execute: async ({ title, style }, ctx) => {
 		ctx.setMetadata({
 			...(title !== undefined && { title }),

--- a/lib/agent/tools/setNarrator.ts
+++ b/lib/agent/tools/setNarrator.ts
@@ -1,5 +1,6 @@
 import dedent from "dedent";
 import { z } from "zod";
+import { Mic } from "@/components/ui/icon";
 import { defineTool } from "./defineTool";
 import { named, notEmpty, VOICE_TRAITS } from "./inputs";
 
@@ -12,6 +13,8 @@ export const setNarrator = defineTool({
 	`,
 	input: z.object({ ...VOICE_TRAITS }).refine(notEmpty, named("trait")),
 	output: z.string(),
+	icon: Mic,
+	label: "Adjusting the narrator's voice",
 	execute: async (traits, ctx) => {
 		ctx.setMetadata({ narration: traits });
 		return "Set the narrator's voice.";

--- a/lib/agent/tools/setVideoSettings.ts
+++ b/lib/agent/tools/setVideoSettings.ts
@@ -6,6 +6,7 @@ import {
 	VIDEO_LENGTH_SPECS,
 	VIDEO_LENGTH_TARGETS,
 } from "@/lib/video/videoLength";
+import { Hourglass } from "@/components/ui/icon";
 import { defineTool } from "./defineTool";
 import { named, notEmpty } from "./inputs";
 
@@ -27,6 +28,8 @@ export const setVideoSettings = defineTool({
 		})
 		.refine(notEmpty, named("setting")),
 	output: z.string(),
+	icon: Hourglass,
+	label: "Adjusting the video settings",
 	execute: async ({ length, aspect_ratio }, ctx) => {
 		ctx.setMetadata({
 			videoSettings: {

--- a/lib/agent/tools/viewAvatar.ts
+++ b/lib/agent/tools/viewAvatar.ts
@@ -1,5 +1,6 @@
 import dedent from "dedent";
 import { z } from "zod";
+import { Eye } from "@/components/ui/icon";
 import { defineTool, imagePart } from "./defineTool";
 
 export const viewAvatar = defineTool({
@@ -16,6 +17,9 @@ export const viewAvatar = defineTool({
 			),
 	}),
 	output: z.object({ name: z.string(), url: z.string() }),
+	icon: Eye,
+	label: ({ name }) =>
+		name ? `Looking at ${name}'s avatar` : "Looking at an avatar",
 	toModelOutput: ({ output }) => ({
 		type: "content",
 		value: [

--- a/lib/agent/tools/viewReferenceImages.ts
+++ b/lib/agent/tools/viewReferenceImages.ts
@@ -1,5 +1,6 @@
 import dedent from "dedent";
 import { z } from "zod";
+import { Eye } from "@/components/ui/icon";
 import { defineTool, imagePart } from "./defineTool";
 
 export const viewReferenceImages = defineTool({
@@ -11,6 +12,8 @@ export const viewReferenceImages = defineTool({
 	`,
 	input: z.object({}),
 	output: z.object({ urls: z.array(z.string()) }),
+	icon: Eye,
+	label: "Looking at the reference images",
 	toModelOutput: ({ output }) => ({
 		type: "content",
 		value: [

--- a/lib/agent/tools/writeScript.ts
+++ b/lib/agent/tools/writeScript.ts
@@ -1,5 +1,6 @@
 import dedent from "dedent";
 import { z } from "zod";
+import { Film } from "@/components/ui/icon";
 import { defineTool } from "./defineTool";
 
 export const writeScript = defineTool({
@@ -23,6 +24,8 @@ export const writeScript = defineTool({
 			.describe("What the video is about, in a sentence or a few."),
 	}),
 	output: z.string(),
+	icon: Film,
+	label: "Writing a new script",
 	execute: async ({ brief }, ctx) => {
 		await ctx.writeScript(brief);
 		return "Wrote a new script onto the canvas. Read it to see what landed.";


### PR DESCRIPTION
## App understanding

OpenSlop turns a written brief into a rendered video. A project's script lives in a Slate document on the canvas (`app/components/canvas`). Each element resolves into a dependency graph (`lib/generation`) that fans out through connectors, gateways and vendor providers (`lib/connectors` / `lib/gateway` / `lib/providers`). `lib/video` resolves the document into a `VideoLayout` that both the Remotion player and the Lambda render read. Sloppy (`lib/agent` + `app/components/sloppy`) is a ReAct agent that edits the same document through registered tools. Supabase carries auth, projects, conversations and job rows.

## From-scratch architecture

A rebuild would land close to what is already here. The domain layer is deep modules with narrow interfaces, one registry per variant family, zod parsing confined to the boundary, and one home for every derived value. The repo's canonical way to declare a variant family is a single registry entry that carries behaviour *and* how the thing shows up: `lib/canvas/elementConfigs.tsx` does it for element types, `lib/connectors/attributes/schema.ts` does it for connector attributes (`icon`, `label`, `edit`).

The agent tool registry was the one family that did not follow it. A tool declared its schema, its executor and its flags in one file, then its icon and label lived in a 93-line exhaustive switch under `app/components/sloppy/toolPresentation.tsx`. Adding a tool meant three edits in two layers, and a rename in one place silently changed the other.

## Implemented simplification

`defineTool` now takes the whole tool, including how a call reads while it runs:

- `icon` and `label` join `description`, `input`, `output`, `execute` and the flags. `label` is a string, or a function of the call's input for the three tools that read one (`edit_script`, `view_avatar`, `set_character`). `defineTool` normalises both into one presenter, so callers never branch on the shape.
- The registry gets one seam, `presentToolCall(toolName, input)`, next to the existing `executeToolCall`. It returns null for a name this build no longer offers, which is what a stored transcript can still hold. It reuses the same erased view of `TOOLS` that `DISPATCH` already uses, for the same reason: the SDK widens a streaming call's name and input.
- `app/components/sloppy/toolPresentation.tsx` drops from 98 lines to 22. All it owns now is the fallback for a renamed-away tool, which is a UI decision.

Behaviour is identical. Every icon and every label string is carried over unchanged, including the `1 change` / `N changes` pluralisation and the two "no name yet" fallbacks. Both existing presentation tests pass untouched, which is the point: the seam moved, the behaviour did not.

Adding a tool is now one file plus its line in `TOOLS`. The exhaustiveness that the switch bought is now bought by the required `icon`/`label` fields on `defineTool`, so a new tool without a face is still a type error.

## Validation

| Command | Result |
| --- | --- |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm run knip` | pass |
| `npm run build` | pass |
| `npm run test:coverage` | pass, 159 files / 1430 tests, 79.1% statements, 74.4% branches, 80.4% lines |
| `npm run test:e2e` | pass, 3 smoke tests |

## Open PR overlap check

Considered #671 (`components/ui/number-scrubber.tsx`), #669 (`ARCHITECTURE.md`, `Editor.tsx`, `CanvasProviders.tsx`, `ElementHistoryPopover.tsx`, `useElementHistory.ts`, `lib/generation/history.ts`), #668 (`osmlStreamParser.ts`, `lib/generation/queue.ts`, `lib/video/sceneSegments.ts`), #663 (`app/not-found.tsx`), #662 (`AttributeBadge.tsx`, `ElementContainer.tsx`, `ModelBadge.tsx`, `lib/connectors/animated_image/*`, `lib/connectors/types.ts`). This branch touches only `lib/agent/tools/**` and `app/components/sloppy/toolPresentation.tsx`. Zero intersection.

## Skipped

- **The two-ways-to-reach-the-Slate-editor sweep** carried over from #629. Re-checked and it is already resolved: `Editor` hands the editor to `CanvasProviders` and nothing below takes it as a prop. Nothing left to do.
- **`ARCHITECTURE.md`** would read better with a line saying a tool's face is part of its definition. `ARCHITECTURE.md` belongs to #669, so it is left alone.
- **Model choice has two faces**: `SettingPill` in the hero composer and `ModelPicker` in `SloppyComposer` render the same choice two ways. That is a deliberate difference between a hero and a side panel, not duplication worth collapsing.
- **`app/projects/[id]/loading.tsx` has drifted from the shell it mirrors**, so the project load shifts layout. Still a real gap, still a visible UI fix rather than an architecture change.

## Risks

Low. The change is a move, not a rewrite: no schema, prompt, executor or flag changed, and no tool name changed. The one thing worth a reviewer's eye is that `lib/agent/tools/*` now imports icon components from `@/components/ui/icon`, which the agent route pulls in server-side. They are plain components that are never rendered there, and the same import already exists in `lib/canvas/elementConfigs.tsx` and `lib/connectors/attributes/schema.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)