### PR TITLE
feat: suggested prompts behind a lightbulb in the Sloppy composer

### DIFF
--- a/app/components/sloppy/SloppyComposer.tsx
+++ b/app/components/sloppy/SloppyComposer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import {
 	ChevronDown,
 	Codesandbox,
@@ -8,14 +8,13 @@ import {
 	Lightbulb,
 	SquareFilled,
 } from "@/components/ui/icon";
-import { ActionMenu } from "@/components/ui/action-menu";
 import { SelectMenu } from "@/components/ui/select-menu";
 import { cn } from "@/lib/utils";
 import { PanelCard } from "../canvas/panel/PanelCard";
 import { ActionButton } from "../copilot/ActionButton";
 import { useSloppyModel } from "./SloppyModelProvider";
 import { useSloppy } from "./SloppyProvider";
-import { SUGGESTIONS } from "./suggestions";
+import { nextSuggestion, SUGGESTIONS } from "./suggestions";
 
 const controlClassName =
 	"focus-ring inline-flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-label text-muted-foreground transition-colors hover:bg-button-hover hover:text-foreground disabled:pointer-events-none disabled:opacity-40";
@@ -56,33 +55,24 @@ function ModelPicker({
 	);
 }
 
-function SuggestionPicker({
+function SuggestionButton({
 	onPick,
 	disabled,
 }: {
-	onPick: (suggestion: string) => void;
+	onPick: () => void;
 	disabled: boolean;
 }) {
 	return (
-		<ActionMenu
-			side="top"
-			items={SUGGESTIONS.map((suggestion) => ({
-				key: suggestion,
-				label: suggestion,
-				onSelect: () => onPick(suggestion),
-			}))}
-			contentClassName="max-w-72"
+		<button
+			type="button"
+			aria-label="Suggest a prompt"
+			disabled={disabled}
+			onMouseDown={(event) => event.preventDefault()}
+			onClick={onPick}
+			className={controlClassName}
 		>
-			<button
-				type="button"
-				aria-label="Suggested prompts"
-				disabled={disabled}
-				onMouseDown={(event) => event.preventDefault()}
-				className={controlClassName}
-			>
-				<Lightbulb className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-			</button>
-		</ActionMenu>
+			<Lightbulb className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+		</button>
 	);
 }
 
@@ -90,7 +80,14 @@ export function SloppyComposer() {
 	const { send, stop, loading } = useSloppy();
 	const { model, setModel, models } = useSloppyModel();
 	const [value, setValue] = useState("");
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const hasText = value.trim().length > 0;
+	const showsSuggestion = SUGGESTIONS.includes(value);
+
+	const suggest = () => {
+		setValue(nextSuggestion(value));
+		textareaRef.current?.focus();
+	};
 
 	const submit = () => {
 		if (!hasText || loading) return;
@@ -102,6 +99,7 @@ export function SloppyComposer() {
 	return (
 		<PanelCard>
 			<textarea
+				ref={textareaRef}
 				rows={2}
 				name="message"
 				autoComplete="off"
@@ -121,7 +119,10 @@ export function SloppyComposer() {
 			<div className="flex items-center justify-between gap-2">
 				<div className="flex min-w-0 items-center gap-1">
 					<ModelPicker model={model} onChange={setModel} options={models} />
-					<SuggestionPicker onPick={send} disabled={loading} />
+					<SuggestionButton
+						onPick={suggest}
+						disabled={loading || (hasText && !showsSuggestion)}
+					/>
 				</div>
 				{loading ? (
 					<ActionButton

--- a/app/components/sloppy/SloppyComposer.tsx
+++ b/app/components/sloppy/SloppyComposer.tsx
@@ -5,13 +5,20 @@ import {
 	ChevronDown,
 	Codesandbox,
 	CornerDownLeft,
+	Lightbulb,
 	SquareFilled,
 } from "@/components/ui/icon";
+import { ActionMenu } from "@/components/ui/action-menu";
 import { SelectMenu } from "@/components/ui/select-menu";
+import { cn } from "@/lib/utils";
 import { PanelCard } from "../canvas/panel/PanelCard";
 import { ActionButton } from "../copilot/ActionButton";
 import { useSloppyModel } from "./SloppyModelProvider";
 import { useSloppy } from "./SloppyProvider";
+import { SUGGESTIONS } from "./suggestions";
+
+const controlClassName =
+	"focus-ring inline-flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-label text-muted-foreground transition-colors hover:bg-button-hover hover:text-foreground disabled:pointer-events-none disabled:opacity-40";
 
 function ModelPicker({
 	model,
@@ -36,7 +43,7 @@ function ModelPicker({
 				type="button"
 				aria-label={`Model: ${model}`}
 				onMouseDown={(event) => event.preventDefault()}
-				className="focus-ring inline-flex max-w-[140px] cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-label text-muted-foreground transition-colors hover:bg-button-hover hover:text-foreground"
+				className={cn(controlClassName, "max-w-[140px]")}
 			>
 				<Codesandbox
 					className="h-3 w-3 shrink-0 opacity-70"
@@ -46,6 +53,36 @@ function ModelPicker({
 				<ChevronDown className="h-3 w-3 shrink-0" aria-hidden="true" />
 			</button>
 		</SelectMenu>
+	);
+}
+
+function SuggestionPicker({
+	onPick,
+	disabled,
+}: {
+	onPick: (suggestion: string) => void;
+	disabled: boolean;
+}) {
+	return (
+		<ActionMenu
+			side="top"
+			items={SUGGESTIONS.map((suggestion) => ({
+				key: suggestion,
+				label: suggestion,
+				onSelect: () => onPick(suggestion),
+			}))}
+			contentClassName="max-w-72"
+		>
+			<button
+				type="button"
+				aria-label="Suggested prompts"
+				disabled={disabled}
+				onMouseDown={(event) => event.preventDefault()}
+				className={controlClassName}
+			>
+				<Lightbulb className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+			</button>
+		</ActionMenu>
 	);
 }
 
@@ -82,7 +119,10 @@ export function SloppyComposer() {
 				className="max-h-40 w-full resize-none overflow-y-auto bg-transparent font-body text-label text-panel-fg caret-accent outline-none placeholder:text-muted-foreground focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-ring/30"
 			/>
 			<div className="flex items-center justify-between gap-2">
-				<ModelPicker model={model} onChange={setModel} options={models} />
+				<div className="flex min-w-0 items-center gap-1">
+					<ModelPicker model={model} onChange={setModel} options={models} />
+					<SuggestionPicker onPick={send} disabled={loading} />
+				</div>
 				{loading ? (
 					<ActionButton
 						label="Stop Sloppy"

--- a/app/components/sloppy/__tests__/suggestions.test.ts
+++ b/app/components/sloppy/__tests__/suggestions.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { nextSuggestion, SUGGESTIONS } from "../suggestions";
+
+describe("nextSuggestion", () => {
+	it("returns a known suggestion", () => {
+		expect(SUGGESTIONS).toContain(nextSuggestion(""));
+	});
+
+	it("never repeats the current suggestion", () => {
+		for (const current of SUGGESTIONS) {
+			for (let attempt = 0; attempt < 50; attempt++) {
+				expect(nextSuggestion(current)).not.toBe(current);
+			}
+		}
+	});
+});

--- a/app/components/sloppy/suggestions.ts
+++ b/app/components/sloppy/suggestions.ts
@@ -1,0 +1,13 @@
+/**
+ * Starter prompts offered behind the composer's lightbulb. Each one must be
+ * answerable by a tool in `lib/agent/tools/registry.ts`, and worded plainly:
+ * under ~9 words, no product jargon.
+ */
+export const SUGGESTIONS = [
+	"Make every video long enough for its words",
+	"Make each scene about 5 seconds long",
+	"Tell me how to make this video better",
+	"Make this video more fun to watch",
+	"End every third scene on a cliffhanger",
+	"Match the caption style to the mood",
+];

--- a/app/components/sloppy/suggestions.ts
+++ b/app/components/sloppy/suggestions.ts
@@ -1,5 +1,5 @@
 /**
- * Starter prompts offered behind the composer's lightbulb. Each one must be
+ * Starter prompts offered by the composer's lightbulb. Each one must be
  * answerable by a tool in `lib/agent/tools/registry.ts`, and worded plainly:
  * under ~9 words, no product jargon.
  */
@@ -11,3 +11,8 @@ export const SUGGESTIONS = [
 	"End every third scene on a cliffhanger",
 	"Match the caption style to the mood",
 ];
+
+export function nextSuggestion(current: string): string {
+	const pool = SUGGESTIONS.filter((suggestion) => suggestion !== current);
+	return pool[Math.floor(Math.random() * pool.length)];
+}

--- a/components/ui/icon.tsx
+++ b/components/ui/icon.tsx
@@ -77,6 +77,7 @@ export const Image = icon("image");
 export const ImagePlus = icon("add-image");
 export const Italic = icon("italic");
 export const Layout = icon("layout");
+export const Lightbulb = icon("lightbulb");
 export const Loader2 = icon("spinner");
 export const Lock = icon("lock");
 export const LogOut = icon("log-out");


### PR DESCRIPTION
## Summary

A lightbulb button in the Sloppy composer control row drops a random starter prompt into the textarea. Clicking again rerolls. The prompt is left there to edit, so nothing sends until the user hits send.

- `app/components/sloppy/suggestions.ts` — six starters, each answerable by a tool that exists today (`fit_durations`, `edit_script`, `read_script`, `adapt_script`, `set_caption_style`), plus `nextSuggestion(current)`, which never hands back the one already in the box.
- `app/components/sloppy/SloppyComposer.tsx` — `SuggestionButton` next to `ModelPicker`. Disabled while Sloppy is loading, and disabled once the user has typed anything of their own, so a click can never destroy real input. The trigger styling the model picker already used is now a shared `controlClassName`.
- `components/ui/icon.tsx` — exports `Lightbulb`; `--lightbulb-icon` already existed in the token set.

## Why fill instead of a menu

A menu asks the user to read six prompts and pick one before they know what any of them do. Fill-and-edit gets a concrete sentence in front of them in one click, and treats the suggestion as a starting point rather than a command. Not sending on pick also means a suggestion is never an accidental agent turn.

## Validation

- `npm run lint`, `format:check`, `typecheck`, `knip`, `build` — pass
- `npm run test:run` — pass, including a new `suggestions.test.ts` covering the no-repeat guarantee

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)