### PR TITLE
fix: 404 on malformed ids instead of a cryptic Postgres error

### DIFF
--- a/app/api/v1/__tests__/routes.test.ts
+++ b/app/api/v1/__tests__/routes.test.ts
@@ -92,6 +92,8 @@ function referenceImagesSuite(
 	});
 }
 
+const JOB_ID = "00000000-0000-0000-0000-000000000001";
+
 describe("API routes", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -268,14 +270,16 @@ describe("API routes", () => {
 		it("returns job status", async () => {
 			const { GET } = await import("@/app/api/v1/video/[jobId]/route");
 			mockGetJob.mockResolvedValue({
-				id: "j1",
+				id: JOB_ID,
 				status: "completed",
 				result: { id: "x", provider: "p", result: { video: "v.mp4" } },
 				error: null,
 			});
 
-			const req = makeRequest("/api/v1/video/j1", undefined, "GET");
-			const res = await GET(req, { params: Promise.resolve({ jobId: "j1" }) });
+			const req = makeRequest(`/api/v1/video/${JOB_ID}`, undefined, "GET");
+			const res = await GET(req, {
+				params: Promise.resolve({ jobId: JOB_ID }),
+			});
 			const json = await res.json();
 
 			expect(res.status).toBe(200);
@@ -287,8 +291,10 @@ describe("API routes", () => {
 			const { GET } = await import("@/app/api/v1/video/[jobId]/route");
 			mockGetJob.mockResolvedValue(null);
 
-			const req = makeRequest("/api/v1/video/j1", undefined, "GET");
-			const res = await GET(req, { params: Promise.resolve({ jobId: "j1" }) });
+			const req = makeRequest(`/api/v1/video/${JOB_ID}`, undefined, "GET");
+			const res = await GET(req, {
+				params: Promise.resolve({ jobId: JOB_ID }),
+			});
 			expect(res.status).toBe(404);
 		});
 
@@ -296,8 +302,10 @@ describe("API routes", () => {
 			const { GET } = await import("@/app/api/v1/video/[jobId]/route");
 			mockGetJob.mockRejectedValue(new Error("db error"));
 
-			const req = makeRequest("/api/v1/video/j1", undefined, "GET");
-			const res = await GET(req, { params: Promise.resolve({ jobId: "j1" }) });
+			const req = makeRequest(`/api/v1/video/${JOB_ID}`, undefined, "GET");
+			const res = await GET(req, {
+				params: Promise.resolve({ jobId: JOB_ID }),
+			});
 			expect(res.status).toBe(500);
 		});
 	});

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -37,7 +37,8 @@ export default function NotFound() {
 						The page you asked for was generated, and it came out wrong.
 					</h1>
 					<p className="text-body text-muted-foreground text-balance">
-						The model was very confident about this one.
+						The model was very confident about this one. It may never have
+						existed, or it may belong to someone else.
 					</p>
 				</div>
 

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound, redirect } from "next/navigation";
+import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import ProjectEditor from "./ProjectEditor";
 
@@ -8,6 +9,9 @@ export default async function ProjectPage({
 	params: Promise<{ id: string }>;
 }) {
 	const { id } = await params;
+	// A malformed id makes Postgres throw on the cast; guid() matches every shape it accepts.
+	if (!z.guid().safeParse(id).success) notFound();
+
 	const supabase = await createClient();
 	// Safe to run concurrently: row access is enforced by RLS, not by this user read.
 	const [

--- a/lib/api/__tests__/route-handler.test.ts
+++ b/lib/api/__tests__/route-handler.test.ts
@@ -7,7 +7,15 @@ import {
 	createApiRouteHandler,
 	createSessionFormRouteHandler,
 	createSessionRouteHandler,
+	pollJob,
 } from "../route-handler";
+
+const mockGetJob = vi.fn();
+vi.mock("../jobs", () => ({
+	createJob: vi.fn(),
+	enqueueJob: vi.fn(),
+	getJob: (...args: unknown[]) => mockGetJob(...args),
+}));
 
 vi.mock("../logger", () => ({
 	logger: { warn: vi.fn(), error: vi.fn() },
@@ -19,6 +27,7 @@ vi.mock("../auth", () => ({
 }));
 
 beforeEach(() => {
+	mockGetJob.mockReset();
 	mockGetUser.mockResolvedValue({
 		id: "user-1",
 		app_metadata: { api_access: true },
@@ -234,5 +243,42 @@ describe("createSessionFormRouteHandler", () => {
 		mockGetUser.mockResolvedValue(null);
 		const res = await handler(makeFormRequest({ file: imageOfSize(4) }));
 		expect(res.status).toBe(401);
+	});
+});
+
+describe("pollJob", () => {
+	const request = new NextRequest("http://localhost/api/v1/image/bruh");
+
+	function poll(jobId: string) {
+		return pollJob(request, { params: Promise.resolve({ jobId }) });
+	}
+
+	it("returns 404 for a malformed job id without querying the database", async () => {
+		const res = await poll("bruh");
+		expect(res.status).toBe(404);
+		expect(mockGetJob).not.toHaveBeenCalled();
+	});
+
+	it("returns 404 for a well-formed id with no matching job", async () => {
+		mockGetJob.mockResolvedValue(null);
+		const res = await poll("00000000-0000-0000-0000-000000000000");
+		expect(res.status).toBe(404);
+	});
+
+	it("returns the job view when the job exists", async () => {
+		mockGetJob.mockResolvedValue({
+			id: "00000000-0000-0000-0000-000000000000",
+			status: "pending",
+			result: null,
+			error: null,
+		});
+		const res = await poll("00000000-0000-0000-0000-000000000000");
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			jobId: "00000000-0000-0000-0000-000000000000",
+			status: "pending",
+			result: null,
+			error: null,
+		});
 	});
 });

--- a/lib/api/response.ts
+++ b/lib/api/response.ts
@@ -4,6 +4,10 @@ export function badRequest(message: string) {
 	return NextResponse.json({ error: message }, { status: 400 });
 }
 
+export function notFound() {
+	return NextResponse.json({ error: "Not found" }, { status: 404 });
+}
+
 export function serverError(message: string) {
 	return NextResponse.json({ error: message }, { status: 500 });
 }

--- a/lib/api/route-handler.ts
+++ b/lib/api/route-handler.ts
@@ -11,7 +11,7 @@ import {
 	parseSearchParams,
 	type ParseResult,
 } from "./parse";
-import { badRequest } from "./response";
+import { notFound } from "./response";
 
 type AuthTier = typeof withApiAccess;
 
@@ -123,9 +123,10 @@ export async function pollJob(
 ) {
 	return withApiAccess("Job poll", async (user) => {
 		const { jobId } = await context.params;
-		if (!jobId) return badRequest("jobId is required");
+		// A malformed id makes Postgres throw on the cast; guid() matches every shape it accepts.
+		if (!z.guid().safeParse(jobId).success) return notFound();
 		const job = await getJob(jobId, user.id);
-		if (!job) return NextResponse.json({ error: "Not found" }, { status: 404 });
+		if (!job) return notFound();
 		const view: JobPoll = {
 			jobId: job.id,
 			status: job.status,


### PR DESCRIPTION
## What

`/projects/bruh` threw a cryptic error instead of rendering the 404 page.

`id` is a Postgres `uuid` column, so a non-uuid param never reaches the "no rows" branch. Postgres rejects the cast with `22P02: invalid input syntax for type uuid`, which is a truthy `error`, so `throw error` runs before `notFound()` ever gets a chance. A well-formed but nonexistent uuid was always fine.

## Where else

Path params are the only ids that skip zod. Request bodies already parse `projectId` with `z.uuid()`, so the gap was exactly two places:

- `app/projects/[id]/page.tsx` — threw, rendering the error boundary.
- `pollJob` in `lib/api/route-handler.ts`, behind every `/api/v1/*/[jobId]` route — `getJob` rethrew as `Failed to load job: ...`, surfacing as a 500 where a 404 belongs.

Both now parse the param at the boundary, so a malformed id is a miss rather than a crash. `z.guid()` rather than `z.uuid()`: zod 4's `uuid()` enforces the RFC version and variant nibbles, while Postgres accepts any RFC-shaped id, and the check exists to answer "can Postgres cast this".

Also adds a `notFound()` helper alongside the rest of the response family, replacing the inline 404 in `pollJob`.

## 404 page

Added the permissions hint to the existing copy:

> The model was very confident about this one. It may never have existed, or it may belong to someone else.

The page was already on-system after #663 (`font-title`/`text-display`/`font-numeric`, semantic tokens, `dot-grid-bg`, `Button variant="accent"`), so there was nothing to restyle. Left as is.

## Tests

New `pollJob` coverage: malformed id 404s without touching the database, well-formed miss 404s, and a hit still returns the job view. The existing `[jobId]` route tests used `"j1"` as an id, now real uuids.

Full CI green: lint, format, typecheck, knip, build, 1433 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113RY4XeH2TiXMXZmA5QY4W