### PR TITLE
fix(loading): add 4th RailItemSkeleton in left rail for History panel

### DIFF
--- a/app/projects/[id]/loading.tsx
+++ b/app/projects/[id]/loading.tsx
@@ -137,6 +137,7 @@ export default function Loading() {
 					<RailItemSkeleton />
 					<RailItemSkeleton />
 					<RailItemSkeleton />
+					<RailItemSkeleton />
 					<div className="mt-auto flex w-full flex-col items-center gap-1 pb-3">
 						<div className="my-1 h-px w-full bg-border" />
 						<RailItemSkeleton />


### PR DESCRIPTION
Fixes #678.

### Summary of Changes

- Added a fourth `RailItemSkeleton` to the top rail group in `app/projects/[id]/loading.tsx`.
- Aligns the loading placeholder count with `RAIL_KEYS` (which now has 4 unpinned items: `layout`, `captions`, `properties`, `history`), preventing visual layout shifting when the real `EditorSidebar` mounts.
