### PR TITLE
fix: nightly bug fixes 2026-08-29

### DIFF
--- a/lib/supabase/__tests__/middleware.test.ts
+++ b/lib/supabase/__tests__/middleware.test.ts
@@ -3,10 +3,21 @@ import { NextRequest } from "next/server";
 
 const mockGetUser = vi.fn();
 
+type CookieAdapter = {
+	setAll: (
+		cookies: { name: string; value: string; options?: object }[],
+	) => void;
+};
+
+let cookieAdapter: CookieAdapter | null = null;
+
 vi.mock("@supabase/ssr", () => ({
-	createServerClient: vi.fn(() => ({
-		auth: { getUser: mockGetUser },
-	})),
+	createServerClient: vi.fn(
+		(_url: string, _key: string, options: { cookies: CookieAdapter }) => {
+			cookieAdapter = options.cookies;
+			return { auth: { getUser: mockGetUser } };
+		},
+	),
 }));
 
 import { updateSession } from "../middleware";
@@ -15,13 +26,14 @@ function makeRequest(path: string) {
 	return new NextRequest(new URL(path, "http://localhost:3000"));
 }
 
-describe("middleware - session refresh", () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-		process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
-		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
-	});
+beforeEach(() => {
+	vi.clearAllMocks();
+	cookieAdapter = null;
+	process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+	process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+});
 
+describe("middleware - session refresh", () => {
 	it("passes through for non-auth routes when unauthenticated", async () => {
 		mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
 
@@ -65,5 +77,32 @@ describe("middleware - session refresh", () => {
 
 		const res = await updateSession(makeRequest("/login"));
 		expect(res.status).toBe(200);
+	});
+});
+
+describe("middleware - refreshed cookies", () => {
+	/** Mirrors what `getUser()` does when it rotates an expiring token. */
+	const refreshingGetUser = (user: { id: string } | null) => async () => {
+		cookieAdapter?.setAll([
+			{ name: "sb-access-token", value: "refreshed", options: { path: "/" } },
+		]);
+		return { data: { user }, error: null };
+	};
+
+	it("keeps refreshed cookies on a pass-through response", async () => {
+		mockGetUser.mockImplementation(refreshingGetUser(null));
+
+		const res = await updateSession(makeRequest("/"));
+
+		expect(res.cookies.get("sb-access-token")?.value).toBe("refreshed");
+	});
+
+	it("keeps refreshed cookies on the auth-route redirect", async () => {
+		mockGetUser.mockImplementation(refreshingGetUser({ id: "user-1" }));
+
+		const res = await updateSession(makeRequest("/login"));
+
+		expect(res.status).toBe(307);
+		expect(res.cookies.get("sb-access-token")?.value).toBe("refreshed");
 	});
 });

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -30,7 +30,11 @@ export async function updateSession(request: NextRequest) {
 	} = await supabase.auth.getUser();
 
 	if (user && AUTH_ROUTES.includes(request.nextUrl.pathname)) {
-		return NextResponse.redirect(new URL("/", request.url));
+		// Carry over whatever `getUser` rotated, or the redirect signs the user out.
+		const redirect = NextResponse.redirect(new URL("/", request.url));
+		for (const cookie of supabaseResponse.cookies.getAll())
+			redirect.cookies.set(cookie);
+		return redirect;
 	}
 
 	return supabaseResponse;


### PR DESCRIPTION
## The bug

`updateSession` in `lib/supabase/middleware.ts` builds `supabaseResponse` and lets the Supabase SSR client's `setAll` write rotated auth cookies onto it. When an already-authenticated user hits `/login` or `/signup`, the function returned a brand-new `NextResponse.redirect(...)` and threw `supabaseResponse` away.

Any token `getUser()` rotated during that request never reached the browser, so the client held on to a stale, already-consumed refresh token. That is the classic Supabase SSR "random logout" failure: the next request presents a token the server has already invalidated. The pass-through path was always correct, which is why nothing surfaced it.

## The fix

Copy `supabaseResponse`'s cookies onto the redirect before returning it.

## Tests

`lib/supabase/__tests__/middleware.test.ts` now captures the cookie adapter handed to `createServerClient`, so `getUser` can rotate a cookie the way a real refresh does:

- `keeps refreshed cookies on the auth-route redirect` — fails on master (`undefined` instead of `"refreshed"`), passes here.
- `keeps refreshed cookies on a pass-through response` — passed before and after; it pins the path that already worked so the two cannot drift apart.

The shared `beforeEach` was hoisted out of the existing describe rather than duplicated.

## Verification

`npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run knip`, `npm run build` all clean. 160 test files / 1437 tests passing.

## Open PR overlap check

Considered open PRs #679, #674, #668, #662 and their touched files. This PR only touches `lib/supabase/middleware.ts` and its test, neither of which appears in any of them. Non-overlapping.

## Scope note

Two scoped audit passes were run over the non-overlapping surface. The first (video layout, captions, timeline, waveform/peaks, prefetch, agent tools, providers, clients) turned up no reproducible bugs; every suspicion was probed with a scratch test and discarded. The second (render/upload/auth routes, auth libs, proxy, render client) produced the fix above. Suspicions deliberately left alone as speculative rather than defects: `runRender` polling past unmount (bounded, and the fix is an abort-signal design change), and `useElementWidth` measuring border-box on attach vs content-box on resize (both consumers are padding- and border-free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)