### PR TITLE
perf: nightly performance optimizations 2026-08-29

### DIFF
--- a/app/components/video/timeline/ClipWaveform.tsx
+++ b/app/components/video/timeline/ClipWaveform.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { loadPeaks } from "@/lib/components/peaks";
+import { useNearViewport } from "@/lib/components/useNearViewport";
 import {
 	buildSoundwaveMask,
 	SOUNDWAVE_MASK_STYLE,
@@ -21,10 +22,11 @@ type Decode =
 	| { status: "ready"; peaks: number[] }
 	| { status: "failed" };
 
-function usePeaks(src: string): Decode {
+function usePeaks(src: string | null): Decode {
 	const [decode, setDecode] = useState<Decode>({ status: "loading" });
 
 	useEffect(() => {
+		if (!src) return;
 		let cancelled = false;
 		loadPeaks(src)
 			.then((peaks) => {
@@ -55,7 +57,8 @@ export function ClipWaveform({
 	width: number;
 	className?: string;
 }) {
-	const decode = usePeaks(src);
+	const { ref, near } = useNearViewport<HTMLDivElement>();
+	const decode = usePeaks(near ? src : null);
 	const sampleCount = clamp(
 		Math.round(width / SAMPLE_SPACING_PX / SAMPLE_QUANTUM) * SAMPLE_QUANTUM,
 		SAMPLE_RANGE.min,
@@ -76,10 +79,13 @@ export function ClipWaveform({
 	// A failed decode stops shimmering: the clip is there, its audio is not.
 	if (decode.status === "failed")
 		return (
-			<div className={cn("flex items-center", className)}>
+			<div ref={ref} className={cn("flex items-center", className)}>
 				<div className="h-px w-full bg-current opacity-40" />
 			</div>
 		);
-	if (!style) return <Skeleton className={cn("rounded-xs", className)} />;
-	return <div className={cn("bg-current", className)} style={style} />;
+	if (!style)
+		return <Skeleton ref={ref} className={cn("rounded-xs", className)} />;
+	return (
+		<div ref={ref} className={cn("bg-current", className)} style={style} />
+	);
 }

--- a/lib/components/Waveform.tsx
+++ b/lib/components/Waveform.tsx
@@ -13,6 +13,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { toastError } from "@/lib/toastError";
 import { clamp, cn } from "@/lib/utils";
 import { loadPeaks } from "./peaks";
+import { useNearViewport } from "./useNearViewport";
 import {
 	AUDIO_SAMPLE_COUNT,
 	buildSoundwaveMask,
@@ -57,6 +58,7 @@ export function Waveform({
 	const barsRef = useRef<HTMLDivElement>(null);
 	const progressRef = useRef<HTMLDivElement>(null);
 	const peaksRef = useRef<number[]>([]);
+	const { ref: trackRef, near } = useNearViewport<HTMLDivElement>();
 	const [peaksSettledFor, setPeaksSettledFor] = useState<string | null>(null);
 	const [audioSettledFor, setAudioSettledFor] = useState<string | null>(null);
 	const loading = peaksSettledFor !== src || audioSettledFor !== src;
@@ -81,6 +83,7 @@ export function Waveform({
 
 	useEffect(() => {
 		peaksRef.current = [];
+		if (!near) return;
 
 		let cancelled = false;
 		loadPeaks(src)
@@ -96,7 +99,7 @@ export function Waveform({
 		return () => {
 			cancelled = true;
 		};
-	}, [src, paint]);
+	}, [src, paint, near]);
 
 	useImperativeHandle(
 		ref,
@@ -138,6 +141,7 @@ export function Waveform({
 	return (
 		<>
 			<div
+				ref={trackRef}
 				className={cn("relative cursor-pointer", className)}
 				onClick={handleClick}
 			>

--- a/lib/components/useNearViewport.ts
+++ b/lib/components/useNearViewport.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/** How far ahead of the viewport deferred work is worth starting. */
+const ROOT_MARGIN = "300px";
+
+/**
+ * Latches true once the observed element first comes within {@link ROOT_MARGIN}
+ * of the viewport, so a card can hold work back until it is about to be seen —
+ * decoding an audio asset, say, which pulls the whole file down and expands it
+ * to PCM. Latching rather than tracking: that work is one-shot, and scrolling
+ * back past a card should not redo it.
+ */
+export function useNearViewport<T extends Element>() {
+	const ref = useRef<T>(null);
+	const [near, setNear] = useState(false);
+
+	useEffect(() => {
+		const element = ref.current;
+		if (!element || near) return;
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((entry) => entry.isIntersecting)) setNear(true);
+			},
+			{ rootMargin: ROOT_MARGIN },
+		);
+		observer.observe(element);
+		return () => observer.disconnect();
+	}, [near]);
+
+	return { ref, near };
+}


### PR DESCRIPTION
Opening a project downloads and PCM-decodes every audio asset in it, up front. It no longer does.

## What was wrong

Every audio element card with a result renders `AudioPlayer` → `Waveform`, and `Waveform`'s mount effect calls `loadPeaks(src)` unconditionally:

```ts
const response = await fetch(src, { mode: "cors" });
const audio = await getAudioCtx().decodeAudioData(await response.arrayBuffer());
return extractPeaks(audio.getChannelData(0), PEAK_COUNT);
```

That is a full-file fetch plus a full PCM expansion — `decodeAudioData` materialises the entire decoded buffer, roughly 190KB of `Float32` per second of mono 48kHz audio — and the whole thing exists to produce 200 numbers for a mask polygon.

Nothing gated it on visibility. A script with narration on most scenes mounts one of these per scene, so opening the project fans out that many simultaneous downloads and decodes, all landing in the window where the editor is coming up and the canvas is fetching its images. Cards already skip offscreen *rendering* via `content-visibility: auto` on `.sortable`; their asset work was not held to the same rule.

The timeline had the same shape: `ClipWaveform` decodes on mount for every audio clip in the row, including the ones parked far off the end of a zoomed scroller.

## The change

`useNearViewport` — an `IntersectionObserver` that latches true once its element comes within 300px of the viewport. Latching rather than tracking, because the decode is one-shot and scrolling back past a card should not redo it.

Both waveforms hold the decode behind it. The skeleton they already show while decoding covers the wait, so nothing changes visually; the work just follows the scroll instead of arriving in one burst. It composes with `content-visibility` rather than fighting it: contents get laid out as the card becomes relevant, the observer fires, the decode starts.

Playback is untouched — the `<audio preload="metadata">` element still mounts with the card, so durations and the play button behave exactly as before.

## Scope

Three files, one new 30-line hook, no new dependency and no new machinery. `loadPeaks`' own promise cache still de-dupes repeat sources.

## Open PR overlap check

Considered #681, #680, #679, #674, #668, #662. Their combined surface is `lib/connectors/**`, `lib/generation/**`, `lib/canvas/**`, `lib/supabase/middleware.ts`, `lib/project/**`, `app/api/v1/**`, the canvas element/plugin/hook layer, `app/components/canvas/CanvasProviders.tsx`, `app/components/video/{BottomTransportBar,PlayerControlContext,PlayerPlacement*,PlayerPositionContext}.tsx`, `app/components/video/storyboard/Storyboard.tsx` and `app/projects/[id]/loading.tsx`. This PR touches `lib/components/useNearViewport.ts` (new), `lib/components/Waveform.tsx` and `app/components/video/timeline/ClipWaveform.tsx` — none of them, and no shared theme.

## Checks

`npm run lint`, `format:check`, `typecheck`, `knip`, `npm run build`, `npm run test:coverage` (160 files passing, coverage above thresholds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)