### PR TITLE
feat: enqueue messages sent to Sloppy while a turn is in flight

### DIFF
--- a/app/components/sloppy/SloppyComposer.tsx
+++ b/app/components/sloppy/SloppyComposer.tsx
@@ -7,6 +7,7 @@ import {
 	CornerDownLeft,
 	Lightbulb,
 	SquareFilled,
+	X,
 } from "@/components/ui/icon";
 import { SelectMenu } from "@/components/ui/select-menu";
 import { cn } from "@/lib/utils";
@@ -76,6 +77,47 @@ function SuggestionButton({
 	);
 }
 
+/**
+ * Messages typed while a turn was running. Editing one pulls it back out of the
+ * queue and into the textarea, so a pending message is only ever text.
+ */
+function QueuedMessages({ onEdit }: { onEdit: (text: string) => void }) {
+	const { queued, dropQueued } = useSloppy();
+
+	if (queued.length === 0) return null;
+
+	return (
+		<ul aria-label="Queued messages" className="flex flex-col gap-1">
+			{queued.map(({ id, text }) => (
+				<li
+					key={id}
+					className="flex items-center gap-1 rounded-md bg-secondary px-2 py-1"
+				>
+					<button
+						type="button"
+						aria-label={`Edit queued message: ${text}`}
+						onClick={() => {
+							dropQueued(id);
+							onEdit(text);
+						}}
+						className="focus-ring min-w-0 flex-1 cursor-pointer truncate rounded-sm text-left text-label text-muted-foreground transition-colors hover:text-panel-fg"
+					>
+						{text}
+					</button>
+					<button
+						type="button"
+						aria-label={`Remove queued message: ${text}`}
+						onClick={() => dropQueued(id)}
+						className="focus-ring shrink-0 cursor-pointer rounded-sm p-0.5 text-muted-foreground transition-colors hover:text-panel-fg"
+					>
+						<X className="h-3 w-3" aria-hidden="true" />
+					</button>
+				</li>
+			))}
+		</ul>
+	);
+}
+
 export function SloppyComposer() {
 	const { send, stop, loading } = useSloppy();
 	const { model, setModel, models } = useSloppyModel();
@@ -90,14 +132,20 @@ export function SloppyComposer() {
 	};
 
 	const submit = () => {
-		if (!hasText || loading) return;
+		if (!hasText) return;
 		const message = value;
 		setValue("");
 		send(message);
 	};
 
+	const edit = (text: string) => {
+		setValue(text);
+		textareaRef.current?.focus();
+	};
+
 	return (
 		<PanelCard>
+			<QueuedMessages onEdit={edit} />
 			<textarea
 				ref={textareaRef}
 				rows={2}
@@ -121,7 +169,7 @@ export function SloppyComposer() {
 					<ModelPicker model={model} onChange={setModel} options={models} />
 					<SuggestionButton
 						onPick={suggest}
-						disabled={loading || (hasText && !showsSuggestion)}
+						disabled={hasText && !showsSuggestion}
 					/>
 				</div>
 				{loading ? (

--- a/app/components/sloppy/SloppyProvider.tsx
+++ b/app/components/sloppy/SloppyProvider.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
+import { nanoid } from "nanoid";
 import { useSlateStatic } from "slate-react";
 import {
 	DefaultChatTransport,
@@ -19,9 +20,14 @@ import { useConfig } from "@/lib/config/ConfigProvider";
 import { toastError } from "@/lib/toastError";
 import { useSloppyModel } from "./SloppyModelProvider";
 
+type QueuedMessage = { id: string; text: string };
+
 type SloppyControl = {
 	send: (message: string) => void;
 	stop: () => void;
+	/** Typed mid-turn and waiting for its own turn, in the order they were sent. */
+	queued: QueuedMessage[];
+	dropQueued: (id: string) => void;
 	loading: boolean;
 	writingScript: boolean;
 };
@@ -75,6 +81,10 @@ export function SloppyProvider({ children }: { children: ReactNode }) {
 	const turnModel = useRef<string>(undefined);
 	// Stopping should also cancel the tool call in flight
 	const turn = useRef<AbortController>(undefined);
+	const [queued, setQueued] = useState<QueuedMessage[]>([]);
+	// `sendMessage` only reaches "submitted" a microtask later, so a turn can be
+	// under way while the chat still reads as ready.
+	const dispatching = useRef(false);
 
 	const { messages, sendMessage, stop, status, addToolOutput } =
 		useChat<SloppyMessage>({
@@ -116,21 +126,58 @@ export function SloppyProvider({ children }: { children: ReactNode }) {
 		status === "streaming" ||
 		hasPendingToolCall(messages);
 	const writingScript = hasPendingToolCall(messages, SCRIPT_TOOLS);
+
+	const dispatch = useCallback(
+		(text: string) => {
+			dispatching.current = true;
+			turnModel.current = model;
+			turn.current = new AbortController();
+			void sendMessage({ text });
+		},
+		[sendMessage, model],
+	);
+
+	// The chat is the external system this synchronizes against: a queued
+	// message goes out once its predecessor's turn has fully settled. A failed
+	// turn leaves `status` on "error" and holds the queue there until the user
+	// sends something themselves. Between a tool result and the follow-up step
+	// the SDK sends for it the chat also reads as idle, so the same predicate
+	// that continues the loop keeps a queued message out of that gap.
+	useEffect(() => {
+		if (working || status !== "ready") {
+			dispatching.current = false;
+			return;
+		}
+		const next = queued[0];
+		if (!next || dispatching.current) return;
+		if (lastAssistantMessageIsCompleteWithToolCalls({ messages })) return;
+		// eslint-disable-next-line react-hooks/set-state-in-effect -- shifting the queue is the synchronization, not a cascading render
+		setQueued((pending) => pending.slice(1));
+		dispatch(next.text);
+	}, [queued, working, status, messages, dispatch]);
+
 	const control = useMemo<SloppyControl>(
 		() => ({
 			send: (message) => {
-				turnModel.current = model;
-				turn.current = new AbortController();
-				void sendMessage({ text: message });
+				if (working || dispatching.current) {
+					setQueued((pending) => [...pending, { id: nanoid(), text: message }]);
+					return;
+				}
+				dispatch(message);
 			},
 			stop: () => {
 				turn.current?.abort();
 				void stop();
+				dispatching.current = false;
+				setQueued([]);
 			},
+			queued,
+			dropQueued: (id) =>
+				setQueued((pending) => pending.filter((message) => message.id !== id)),
 			loading: working,
 			writingScript,
 		}),
-		[sendMessage, stop, working, writingScript, model],
+		[dispatch, stop, working, writingScript, queued, setQueued],
 	);
 
 	// History sits in front of the chat's own turns rather than being written


### PR DESCRIPTION
## Summary

Pressing Enter mid-turn used to do nothing at all: `submit()` early-returned on `loading`, with no toast and no hint, and the send button had already been swapped for Stop. Typed text just sat there.

The queue now has one home in `SloppyProvider`. `send` dispatches immediately when nothing is in flight and otherwise pushes onto a pending list; when the turn settles the provider shifts the next message off and sends it as its own turn. `SloppyComposer.submit()` no longer looks at `loading` at all.

- **Order is preserved.** One queued message per turn, in the order typed.
- **Stop clears the queue.** Abandoning the direction abandons the follow-ups.
- **Errors halt the queue.** A failed turn leaves `status` on `"error"`, which holds the queue there until the user sends something themselves.
- **The ReAct loop is not a gap.** Between a tool result and the follow-up step the SDK sends for it, the chat briefly reads as idle. The drain reuses `lastAssistantMessageIsCompleteWithToolCalls` — the same predicate `sendAutomaticallyWhen` uses to continue the loop — so a queued message cannot land mid-loop. A `dispatching` ref covers the microtask between `sendMessage` and `status` reaching `"submitted"`.
- **Pending messages are still just text.** Each renders above the textarea with a remove button, and clicking one pulls it back out of the queue and into the composer for editing. Both routes are the same `dropQueued(id)` mechanism; the composer owns the policy of what to do with the text.

The Stop button keeps the button slot while working, as the issue asked. The suggestion lightbulb no longer disables on `loading` either, since the composer is no longer locked mid-turn.

## Why this issue was safe and small

`size: M`, `priority: medium`, unambiguous acceptance criteria, and the whole change is two files in one self-contained component tree. No API, schema, or generation-pipeline surface.

## Validation

- `npm run lint` — pass
- `npm run format:check` — pass
- `npm run typecheck` — pass
- `npm run knip` — pass
- `npm run build` — pass
- `npm run test:run` — 1435 passed / 160 files

Not added: unit tests. The repo has no React Testing Library and no component or hook tests, so the queue's behavior has no existing seam to test against; the change is provider state plus presentation, with no pure helper worth extracting for its own sake. `npm run test:e2e` was skipped locally (needs Supabase env vars); the change touches no public route the smoke tests cover.

One targeted `react-hooks/set-state-in-effect` disable: the chat is the external system this effect synchronizes against, and shifting the queue when a turn settles is the synchronization itself, not an incidental cascading render.

## Open PR overlap check

Diffed against every open PR (#682, #681, #680, #679, #674, #668, #662). Zero file overlap — #662 touches `SloppyModelProvider.tsx` but not the composer, panel, or provider.

Closes #666