### PR TITLE
feat: let Sloppy look at a generated image element

### DIFF
--- a/lib/agent/__tests__/registry.test.ts
+++ b/lib/agent/__tests__/registry.test.ts
@@ -558,6 +558,26 @@ describe("executeToolCall", () => {
 		});
 	});
 
+	it("hands over the still frame an animated image animates", async () => {
+		const outcome = await executeToolCall(
+			{ toolName: "view_image", input: { id: "anim-1" } },
+			context({
+				elementImage: () => ({
+					type: "animated_image",
+					prompt: "a wolf at the door",
+					status: "idle",
+					url: "https://example.com/still.png",
+				}),
+			}),
+		);
+
+		expect(outcome.ok && outcome.output).toEqual({
+			id: "anim-1",
+			prompt: "a wolf at the door",
+			url: "https://example.com/still.png",
+		});
+	});
+
 	it("says an element id is not on the canvas rather than inventing a result", async () => {
 		const outcome = await executeToolCall(
 			{ toolName: "view_image", input: { id: "nope" } },

--- a/lib/agent/__tests__/registry.test.ts
+++ b/lib/agent/__tests__/registry.test.ts
@@ -545,8 +545,7 @@ describe("executeToolCall", () => {
 				elementImage: () => ({
 					type: "image",
 					prompt: "a wolf at the door",
-					status: "idle",
-					url: "https://example.com/wolf.png",
+					picture: { status: "idle", url: "https://example.com/wolf.png" },
 				}),
 			}),
 		);
@@ -565,8 +564,7 @@ describe("executeToolCall", () => {
 				elementImage: () => ({
 					type: "animated_image",
 					prompt: "a wolf at the door",
-					status: "idle",
-					url: "https://example.com/still.png",
+					picture: { status: "idle", url: "https://example.com/still.png" },
 				}),
 			}),
 		);
@@ -588,15 +586,14 @@ describe("executeToolCall", () => {
 		expect(!outcome.ok && outcome.errorText).toContain("no element nope");
 	});
 
-	it("refuses an element whose result is not an image", async () => {
+	it("refuses an element that generates no picture", async () => {
 		const outcome = await executeToolCall(
 			{ toolName: "view_image", input: { id: "clip-1" } },
 			context({
 				elementImage: () => ({
 					type: "clip",
 					prompt: "a wolf running",
-					status: "idle",
-					url: undefined,
+					picture: null,
 				}),
 			}),
 		);
@@ -612,8 +609,7 @@ describe("executeToolCall", () => {
 				elementImage: () => ({
 					type: "image",
 					prompt: "a wolf at the door",
-					status: "generating",
-					url: undefined,
+					picture: { status: "generating", url: undefined },
 				}),
 			}),
 		);

--- a/lib/agent/__tests__/registry.test.ts
+++ b/lib/agent/__tests__/registry.test.ts
@@ -28,6 +28,7 @@ const context = (over: Partial<AgentToolContext> = {}): AgentToolContext => ({
 	generateText: async () => "an outline",
 	referenceImages: () => [],
 	avatarUrl: () => undefined,
+	elementImage: () => undefined,
 	readMetadata: () => metadata,
 	editScript: () => ({ applied: 0, failures: [] }),
 	writeScript: async () => {},
@@ -537,6 +538,70 @@ describe("executeToolCall", () => {
 		expect(!outcome.ok && outcome.errorText).toContain("no avatar image yet");
 	});
 
+	it("hands over a generated image with the prompt that made it", async () => {
+		const outcome = await executeToolCall(
+			{ toolName: "view_image", input: { id: "img-1" } },
+			context({
+				elementImage: () => ({
+					type: "image",
+					prompt: "a wolf at the door",
+					status: "idle",
+					url: "https://example.com/wolf.png",
+				}),
+			}),
+		);
+
+		expect(outcome.ok && outcome.output).toEqual({
+			id: "img-1",
+			prompt: "a wolf at the door",
+			url: "https://example.com/wolf.png",
+		});
+	});
+
+	it("says an element id is not on the canvas rather than inventing a result", async () => {
+		const outcome = await executeToolCall(
+			{ toolName: "view_image", input: { id: "nope" } },
+			context(),
+		);
+
+		expect(outcome.ok).toBe(false);
+		expect(!outcome.ok && outcome.errorText).toContain("no element nope");
+	});
+
+	it("refuses an element whose result is not an image", async () => {
+		const outcome = await executeToolCall(
+			{ toolName: "view_image", input: { id: "clip-1" } },
+			context({
+				elementImage: () => ({
+					type: "clip",
+					prompt: "a wolf running",
+					status: "idle",
+					url: undefined,
+				}),
+			}),
+		);
+
+		expect(outcome.ok).toBe(false);
+		expect(!outcome.ok && outcome.errorText).toContain("is a clip");
+	});
+
+	it("reports how far along an image is when there is nothing to look at yet", async () => {
+		const outcome = await executeToolCall(
+			{ toolName: "view_image", input: { id: "img-1" } },
+			context({
+				elementImage: () => ({
+					type: "image",
+					prompt: "a wolf at the door",
+					status: "generating",
+					url: undefined,
+				}),
+			}),
+		);
+
+		expect(outcome.ok).toBe(false);
+		expect(!outcome.ok && outcome.errorText).toContain("is still generating");
+	});
+
 	it("outlines a brief through one focused generation", async () => {
 		const prompts: string[] = [];
 		const outcome = await executeToolCall(
@@ -567,6 +632,7 @@ describe("SLOPPY_TOOLS", () => {
 			"set_language",
 			"view_reference_images",
 			"view_avatar",
+			"view_image",
 			"outline_story",
 			"measure_total_length",
 			"measure_element_lengths",
@@ -612,6 +678,7 @@ describe("tool flags", () => {
 		expect([...SNAPSHOT_TOOLS].sort()).toEqual([
 			"read_script",
 			"view_avatar",
+			"view_image",
 			"view_reference_images",
 		]);
 	});

--- a/lib/agent/__tests__/registry.test.ts
+++ b/lib/agent/__tests__/registry.test.ts
@@ -557,25 +557,6 @@ describe("executeToolCall", () => {
 		});
 	});
 
-	it("hands over the still frame an animated image animates", async () => {
-		const outcome = await executeToolCall(
-			{ toolName: "view_image", input: { id: "anim-1" } },
-			context({
-				elementImage: () => ({
-					type: "animated_image",
-					prompt: "a wolf at the door",
-					picture: { status: "idle", url: "https://example.com/still.png" },
-				}),
-			}),
-		);
-
-		expect(outcome.ok && outcome.output).toEqual({
-			id: "anim-1",
-			prompt: "a wolf at the door",
-			url: "https://example.com/still.png",
-		});
-	});
-
 	it("says an element id is not on the canvas rather than inventing a result", async () => {
 		const outcome = await executeToolCall(
 			{ toolName: "view_image", input: { id: "nope" } },
@@ -593,7 +574,7 @@ describe("executeToolCall", () => {
 				elementImage: () => ({
 					type: "clip",
 					prompt: "a wolf running",
-					picture: null,
+					picture: undefined,
 				}),
 			}),
 		);

--- a/lib/agent/prompt.ts
+++ b/lib/agent/prompt.ts
@@ -18,9 +18,10 @@ const ROLE = dedent`
     first with view_reference_images, otherwise an uploaded character avatar with
     view_avatar. Look, then persist it with set_metadata in the same turn. An art style
     that is already set stands.
-  - Look at an image element's result with view_image before saying anything about how it
-    turned out. It hands back the image and the prompt that made it, so judge one against
-    the other; only image elements have a result you can see.
+  - Look at what an element generated with view_image before saying anything about how it
+    turned out. It hands back the picture and the prompt that made it, so judge one against
+    the other. An image element has one, and so does an animated_image: you see the still
+    frame it animates. A clip does not.
   - Check what a tool reports back. When an edit fails, read the script and fix the call
     rather than repeating it. After two failed attempts at the same change, stop and tell
     the user plainly what went wrong.

--- a/lib/agent/prompt.ts
+++ b/lib/agent/prompt.ts
@@ -19,9 +19,7 @@ const ROLE = dedent`
     view_avatar. Look, then persist it with set_metadata in the same turn. An art style
     that is already set stands.
   - Look at what an element generated with view_image before saying anything about how it
-    turned out. It hands back the picture and the prompt that made it, so judge one against
-    the other. An image element has one, and so does an animated_image: you see the still
-    frame it animates. A clip does not.
+    turned out, and judge the picture against the prompt it comes back with.
   - Check what a tool reports back. When an edit fails, read the script and fix the call
     rather than repeating it. After two failed attempts at the same change, stop and tell
     the user plainly what went wrong.

--- a/lib/agent/prompt.ts
+++ b/lib/agent/prompt.ts
@@ -18,6 +18,9 @@ const ROLE = dedent`
     first with view_reference_images, otherwise an uploaded character avatar with
     view_avatar. Look, then persist it with set_metadata in the same turn. An art style
     that is already set stands.
+  - Look at an image element's result with view_image before saying anything about how it
+    turned out. It hands back the image and the prompt that made it, so judge one against
+    the other; only image elements have a result you can see.
   - Check what a tool reports back. When an edit fails, read the script and fix the call
     rather than repeating it. After two failed attempts at the same change, stop and tell
     the user plainly what went wrong.

--- a/lib/agent/tools/context.ts
+++ b/lib/agent/tools/context.ts
@@ -8,12 +8,12 @@ import type {
 	MetadataCharacter,
 } from "@/lib/project/types";
 
-/** An element's generated image and the prompt behind it, never the rest of the result. */
+/** An element's generated picture and the prompt behind it, never the rest of the result. */
 export type ElementImage = {
 	type: CanvasElementType;
 	prompt: string;
-	status: GenerationStatus;
-	url: string | undefined;
+	/** Null when the element's type makes no picture at all, so there is never one to wait for. */
+	picture: { status: GenerationStatus; url: string | undefined } | null;
 };
 
 /** What a tool can do to the canvas, never the parts it is built from. */

--- a/lib/agent/tools/context.ts
+++ b/lib/agent/tools/context.ts
@@ -12,8 +12,8 @@ import type {
 export type ElementImage = {
 	type: CanvasElementType;
 	prompt: string;
-	/** Null when the element's type makes no picture at all, so there is never one to wait for. */
-	picture: { status: GenerationStatus; url: string | undefined } | null;
+	/** Absent when the element's type makes no picture, so there is never one to wait for. */
+	picture: { status: GenerationStatus; url: string | undefined } | undefined;
 };
 
 /** What a tool can do to the canvas, never the parts it is built from. */

--- a/lib/agent/tools/context.ts
+++ b/lib/agent/tools/context.ts
@@ -1,3 +1,5 @@
+import type { CanvasElementType } from "@/lib/canvas/types";
+import type { GenerationStatus } from "@/lib/generation/snapshots";
 import type { ElementLength } from "@/lib/video/elementLengths";
 import type { RefineOp } from "@/lib/script/refine/types";
 import type {
@@ -6,6 +8,14 @@ import type {
 	MetadataCharacter,
 } from "@/lib/project/types";
 
+/** An element's generated image and the prompt behind it, never the rest of the result. */
+export type ElementImage = {
+	type: CanvasElementType;
+	prompt: string;
+	status: GenerationStatus;
+	url: string | undefined;
+};
+
 /** What a tool can do to the canvas, never the parts it is built from. */
 export type AgentToolContext = {
 	readScript: () => string;
@@ -13,6 +23,7 @@ export type AgentToolContext = {
 	measureElementLengths: () => ElementLength[];
 	referenceImages: () => string[];
 	avatarUrl: (name: string) => string | undefined;
+	elementImage: (id: string) => ElementImage | undefined;
 	/** One focused LLM call, for tools whose whole job is a generation. */
 	generateText: (
 		prompt: string,

--- a/lib/agent/tools/defineTool.ts
+++ b/lib/agent/tools/defineTool.ts
@@ -48,8 +48,14 @@ export function defineTool<Input, Output>(def: {
 }
 
 /** A tool-result image, handed to the model by URL for the provider to fetch. */
-export const imagePart = (url: string) => ({
+const imagePart = (url: string) => ({
 	type: "file" as const,
 	mediaType: "image",
 	data: { type: "url" as const, url: new URL(url) },
+});
+
+/** What a look-at tool hands back: what the model is about to see, then the images. */
+export const imageOutput = (text: string, ...urls: string[]) => ({
+	type: "content" as const,
+	value: [{ type: "text" as const, text }, ...urls.map(imagePart)],
 });

--- a/lib/agent/tools/registry.ts
+++ b/lib/agent/tools/registry.ts
@@ -16,6 +16,7 @@ import { setMetadata } from "./setMetadata";
 import { setNarrator } from "./setNarrator";
 import { setVideoSettings } from "./setVideoSettings";
 import { viewAvatar } from "./viewAvatar";
+import { viewImage } from "./viewImage";
 import { viewReferenceImages } from "./viewReferenceImages";
 import { writeScript } from "./writeScript";
 
@@ -30,6 +31,7 @@ const TOOLS = {
 	set_language: setLanguage,
 	view_reference_images: viewReferenceImages,
 	view_avatar: viewAvatar,
+	view_image: viewImage,
 	outline_story: outlineStory,
 	measure_total_length: measureTotalLength,
 	measure_element_lengths: measureElementLengths,

--- a/lib/agent/tools/useAgentTools.ts
+++ b/lib/agent/tools/useAgentTools.ts
@@ -2,14 +2,18 @@
 
 import { useCallback } from "react";
 import type { Editor } from "slate";
-import { clearEditor } from "@/lib/canvas/editorOps";
-import { serializeOSMLWithScenes } from "@/lib/canvas/osmlSerializer";
+import { clearEditor, findNodeById } from "@/lib/canvas/editorOps";
+import {
+	getElementBodyText,
+	serializeOSMLWithScenes,
+} from "@/lib/canvas/osmlSerializer";
 import { countSpokenWords } from "@/lib/canvas/spokenWords";
 import { measureElementLengths } from "@/lib/video/elementLengths";
 import { DEFAULT_TRIM_VISUALS_TO_DIALOGUE } from "@/lib/video/scene-builder";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
 import { characterAvatarUrl } from "@/lib/project/characterAvatar";
+import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 import { createDefaultConnector } from "@/lib/connectors/registry";
 import { applyScriptEdit } from "@/lib/generation/scriptEdit";
 import { normalizeCharacterName } from "@/lib/project/characterName";
@@ -36,6 +40,18 @@ export function useAgentTools(editor: Editor) {
 					),
 				referenceImages: () => store.getState().referenceImages,
 				avatarUrl: (name) => characterAvatarUrl(queue, name),
+				elementImage: (id) => {
+					const entry = findNodeById(editor, id);
+					if (!entry) return undefined;
+					const [element] = entry;
+					const { status, result } = queue.getElementSnapshot(id);
+					return {
+						type: element.type,
+						prompt: getElementBodyText(element),
+						status,
+						url: getPrimaryUrl(result, "image"),
+					};
+				},
 				generateText: async (prompt, options) => {
 					const llm = createDefaultConnector(connectorConfig, "llm");
 					const { text } = await llm.generate({ prompt, ...options });

--- a/lib/agent/tools/useAgentTools.ts
+++ b/lib/agent/tools/useAgentTools.ts
@@ -3,21 +3,17 @@
 import { useCallback } from "react";
 import type { Editor } from "slate";
 import { clearEditor, findNodeById } from "@/lib/canvas/editorOps";
-import {
-	getElementBodyText,
-	serializeOSMLWithScenes,
-} from "@/lib/canvas/osmlSerializer";
+import { serializeOSMLWithScenes } from "@/lib/canvas/osmlSerializer";
 import { countSpokenWords } from "@/lib/canvas/spokenWords";
 import { measureElementLengths } from "@/lib/video/elementLengths";
 import { DEFAULT_TRIM_VISUALS_TO_DIALOGUE } from "@/lib/video/scene-builder";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
 import { characterAvatarUrl } from "@/lib/project/characterAvatar";
-import { pictureNode } from "@/lib/connectors/animated_image/plugins/still-frame";
+import { pictureElementId } from "@/lib/connectors/animated_image/plugins/still-frame";
 import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 import { createDefaultConnector } from "@/lib/connectors/registry";
-import { forElement } from "@/lib/generation/graph";
-import { nodeBuilder } from "@/lib/generation/resolveGraph";
+import { getPromptText } from "@/lib/generation/inputs";
 import { applyScriptEdit } from "@/lib/generation/scriptEdit";
 import { normalizeCharacterName } from "@/lib/project/characterName";
 import { useProjectStoreHandle } from "@/lib/project/ProjectStoreProvider";
@@ -44,22 +40,16 @@ export function useAgentTools(editor: Editor) {
 				referenceImages: () => store.getState().referenceImages,
 				avatarUrl: (name) => characterAvatarUrl(queue, name),
 				elementImage: (id) => {
-					const entry = findNodeById(editor, id);
-					if (!entry) return undefined;
-					const [element] = entry;
-					const node = nodeBuilder(
-						connectorConfig,
-						store.getState(),
-					)(forElement(element));
-					const picture = pictureNode(node);
-					const { status, result } = queue.getElementSnapshot(picture?.id);
+					const element = findNodeById(editor, id)?.[0];
+					if (!element) return undefined;
+					const pictureId = pictureElementId(element);
+					const { status, result } = queue.getElementSnapshot(pictureId);
 					return {
 						type: element.type,
-						prompt: getElementBodyText(element),
-						picture: picture && {
-							status,
-							url: getPrimaryUrl(result, "image"),
-						},
+						prompt: getPromptText(element),
+						picture: pictureId
+							? { status, url: getPrimaryUrl(result, "image") }
+							: undefined,
 					};
 				},
 				generateText: async (prompt, options) => {

--- a/lib/agent/tools/useAgentTools.ts
+++ b/lib/agent/tools/useAgentTools.ts
@@ -13,6 +13,7 @@ import { DEFAULT_TRIM_VISUALS_TO_DIALOGUE } from "@/lib/video/scene-builder";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
 import { characterAvatarUrl } from "@/lib/project/characterAvatar";
+import { pictureElementId } from "@/lib/connectors/animated_image/plugins/still-frame";
 import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 import { createDefaultConnector } from "@/lib/connectors/registry";
 import { applyScriptEdit } from "@/lib/generation/scriptEdit";
@@ -44,7 +45,9 @@ export function useAgentTools(editor: Editor) {
 					const entry = findNodeById(editor, id);
 					if (!entry) return undefined;
 					const [element] = entry;
-					const { status, result } = queue.getElementSnapshot(id);
+					const { status, result } = queue.getElementSnapshot(
+						pictureElementId(element),
+					);
 					return {
 						type: element.type,
 						prompt: getElementBodyText(element),

--- a/lib/agent/tools/useAgentTools.ts
+++ b/lib/agent/tools/useAgentTools.ts
@@ -13,9 +13,11 @@ import { DEFAULT_TRIM_VISUALS_TO_DIALOGUE } from "@/lib/video/scene-builder";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { useGenerationQueue } from "@/lib/generation/GenerationQueueProvider";
 import { characterAvatarUrl } from "@/lib/project/characterAvatar";
-import { pictureElementId } from "@/lib/connectors/animated_image/plugins/still-frame";
+import { pictureNode } from "@/lib/connectors/animated_image/plugins/still-frame";
 import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 import { createDefaultConnector } from "@/lib/connectors/registry";
+import { forElement } from "@/lib/generation/graph";
+import { nodeBuilder } from "@/lib/generation/resolveGraph";
 import { applyScriptEdit } from "@/lib/generation/scriptEdit";
 import { normalizeCharacterName } from "@/lib/project/characterName";
 import { useProjectStoreHandle } from "@/lib/project/ProjectStoreProvider";
@@ -45,14 +47,19 @@ export function useAgentTools(editor: Editor) {
 					const entry = findNodeById(editor, id);
 					if (!entry) return undefined;
 					const [element] = entry;
-					const { status, result } = queue.getElementSnapshot(
-						pictureElementId(element),
-					);
+					const node = nodeBuilder(
+						connectorConfig,
+						store.getState(),
+					)(forElement(element));
+					const picture = pictureNode(node);
+					const { status, result } = queue.getElementSnapshot(picture?.id);
 					return {
 						type: element.type,
 						prompt: getElementBodyText(element),
-						status,
-						url: getPrimaryUrl(result, "image"),
+						picture: picture && {
+							status,
+							url: getPrimaryUrl(result, "image"),
+						},
 					};
 				},
 				generateText: async (prompt, options) => {

--- a/lib/agent/tools/viewAvatar.ts
+++ b/lib/agent/tools/viewAvatar.ts
@@ -1,7 +1,7 @@
 import dedent from "dedent";
 import { z } from "zod";
 import { Eye } from "@/components/ui/icon";
-import { defineTool, imagePart } from "./defineTool";
+import { defineTool, imageOutput } from "./defineTool";
 
 export const viewAvatar = defineTool({
 	description: dedent`
@@ -20,13 +20,8 @@ export const viewAvatar = defineTool({
 	icon: Eye,
 	label: ({ name }) =>
 		name ? `Looking at ${name}'s avatar` : "Looking at an avatar",
-	toModelOutput: ({ output }) => ({
-		type: "content",
-		value: [
-			{ type: "text", text: `${output.name}'s avatar:` },
-			imagePart(output.url),
-		],
-	}),
+	toModelOutput: ({ output }) =>
+		imageOutput(`${output.name}'s avatar:`, output.url),
 	execute: async ({ name }, ctx) => {
 		const url = ctx.avatarUrl(name);
 		if (!url)

--- a/lib/agent/tools/viewImage.ts
+++ b/lib/agent/tools/viewImage.ts
@@ -1,7 +1,6 @@
 import dedent from "dedent";
 import { z } from "zod";
 import { Eye } from "@/components/ui/icon";
-import { hasPicture } from "@/lib/connectors/animated_image/plugins/still-frame";
 import type { GenerationStatus } from "@/lib/generation/snapshots";
 import { defineTool, imagePart } from "./defineTool";
 
@@ -16,8 +15,8 @@ export const viewImage = defineTool({
 	  Look at the picture an element generated: an image element's result, or the still
 	  frame an animated_image animates. You receive the picture itself alongside the prompt
 	  that made it, so you can say whether the result matches what was asked for. Take the
-	  id from read_script. Only image and animated_image elements have a picture; clip and
-	  audio ones do not.
+	  id from read_script. Only image and animated_image elements have a picture; a clip
+	  and the audio ones do not.
 	  What you see is gone next turn, so act on it in this one.
 	`,
 	input: z.object({
@@ -45,15 +44,16 @@ export const viewImage = defineTool({
 			throw new Error(
 				`There is no element ${id} on the canvas. Read the script for the ids there are.`,
 			);
-		if (!hasPicture(element.type))
+		const { picture } = element;
+		if (!picture)
 			throw new Error(
-				`${id} is a ${element.type}, and only an image or animated_image has a picture to look at.`,
+				`${id} is a ${element.type}, which generates no picture to look at.`,
 			);
-		if (!element.url)
+		if (!picture.url)
 			throw new Error(
-				`${id} ${NOT_READY[element.status]}, so there is nothing to look at.`,
+				`${id} ${NOT_READY[picture.status]}, so there is nothing to look at.`,
 			);
-		return { id, prompt: element.prompt, url: element.url };
+		return { id, prompt: element.prompt, url: picture.url };
 	},
 	snapshot: true,
 });

--- a/lib/agent/tools/viewImage.ts
+++ b/lib/agent/tools/viewImage.ts
@@ -1,0 +1,58 @@
+import dedent from "dedent";
+import { z } from "zod";
+import { Eye } from "@/components/ui/icon";
+import { ELEMENT_TYPES } from "@/lib/canvas/types";
+import type { GenerationStatus } from "@/lib/generation/snapshots";
+import { defineTool, imagePart } from "./defineTool";
+
+const NOT_READY: Record<GenerationStatus, string> = {
+	idle: "has not been generated yet",
+	queued: "is waiting to generate",
+	generating: "is still generating",
+};
+
+export const viewImage = defineTool({
+	description: dedent`
+	  Look at what an image element generated. You receive the image itself alongside the
+	  prompt that made it, so you can say whether the result matches what was asked for.
+	  Take the id from read_script. Only image elements have a result you can see; video
+	  and audio ones do not.
+	  What you see is gone next turn, so act on it in this one.
+	`,
+	input: z.object({
+		id: z
+			.string()
+			.min(1)
+			.describe("The element's id, exactly as read_script gives it."),
+	}),
+	output: z.object({ id: z.string(), prompt: z.string(), url: z.string() }),
+	icon: Eye,
+	label: ({ id }) => (id ? `Looking at ${id}` : "Looking at a generated image"),
+	toModelOutput: ({ output }) => ({
+		type: "content",
+		value: [
+			{
+				type: "text",
+				text: `${output.id}, generated from "${output.prompt}":`,
+			},
+			imagePart(output.url),
+		],
+	}),
+	execute: async ({ id }, ctx) => {
+		const element = ctx.elementImage(id);
+		if (!element)
+			throw new Error(
+				`There is no element ${id} on the canvas. Read the script for the ids there are.`,
+			);
+		if (ELEMENT_TYPES[element.type].outputKind !== "image")
+			throw new Error(
+				`${id} is a ${element.type}, and only an image element's result can be looked at.`,
+			);
+		if (!element.url)
+			throw new Error(
+				`${id} ${NOT_READY[element.status]}, so there is nothing to look at.`,
+			);
+		return { id, prompt: element.prompt, url: element.url };
+	},
+	snapshot: true,
+});

--- a/lib/agent/tools/viewImage.ts
+++ b/lib/agent/tools/viewImage.ts
@@ -1,7 +1,7 @@
 import dedent from "dedent";
 import { z } from "zod";
 import { Eye } from "@/components/ui/icon";
-import { ELEMENT_TYPES } from "@/lib/canvas/types";
+import { hasPicture } from "@/lib/connectors/animated_image/plugins/still-frame";
 import type { GenerationStatus } from "@/lib/generation/snapshots";
 import { defineTool, imagePart } from "./defineTool";
 
@@ -13,10 +13,11 @@ const NOT_READY: Record<GenerationStatus, string> = {
 
 export const viewImage = defineTool({
 	description: dedent`
-	  Look at what an image element generated. You receive the image itself alongside the
-	  prompt that made it, so you can say whether the result matches what was asked for.
-	  Take the id from read_script. Only image elements have a result you can see; video
-	  and audio ones do not.
+	  Look at the picture an element generated: an image element's result, or the still
+	  frame an animated_image animates. You receive the picture itself alongside the prompt
+	  that made it, so you can say whether the result matches what was asked for. Take the
+	  id from read_script. Only image and animated_image elements have a picture; clip and
+	  audio ones do not.
 	  What you see is gone next turn, so act on it in this one.
 	`,
 	input: z.object({
@@ -44,9 +45,9 @@ export const viewImage = defineTool({
 			throw new Error(
 				`There is no element ${id} on the canvas. Read the script for the ids there are.`,
 			);
-		if (ELEMENT_TYPES[element.type].outputKind !== "image")
+		if (!hasPicture(element.type))
 			throw new Error(
-				`${id} is a ${element.type}, and only an image element's result can be looked at.`,
+				`${id} is a ${element.type}, and only an image or animated_image has a picture to look at.`,
 			);
 		if (!element.url)
 			throw new Error(

--- a/lib/agent/tools/viewImage.ts
+++ b/lib/agent/tools/viewImage.ts
@@ -2,7 +2,7 @@ import dedent from "dedent";
 import { z } from "zod";
 import { Eye } from "@/components/ui/icon";
 import type { GenerationStatus } from "@/lib/generation/snapshots";
-import { defineTool, imagePart } from "./defineTool";
+import { defineTool, imageOutput } from "./defineTool";
 
 const NOT_READY: Record<GenerationStatus, string> = {
 	idle: "has not been generated yet",
@@ -15,8 +15,7 @@ export const viewImage = defineTool({
 	  Look at the picture an element generated: an image element's result, or the still
 	  frame an animated_image animates. You receive the picture itself alongside the prompt
 	  that made it, so you can say whether the result matches what was asked for. Take the
-	  id from read_script. Only image and animated_image elements have a picture; a clip
-	  and the audio ones do not.
+	  id from read_script.
 	  What you see is gone next turn, so act on it in this one.
 	`,
 	input: z.object({
@@ -28,16 +27,8 @@ export const viewImage = defineTool({
 	output: z.object({ id: z.string(), prompt: z.string(), url: z.string() }),
 	icon: Eye,
 	label: ({ id }) => (id ? `Looking at ${id}` : "Looking at a generated image"),
-	toModelOutput: ({ output }) => ({
-		type: "content",
-		value: [
-			{
-				type: "text",
-				text: `${output.id}, generated from "${output.prompt}":`,
-			},
-			imagePart(output.url),
-		],
-	}),
+	toModelOutput: ({ output }) =>
+		imageOutput(`${output.id}, generated from "${output.prompt}":`, output.url),
 	execute: async ({ id }, ctx) => {
 		const element = ctx.elementImage(id);
 		if (!element)

--- a/lib/agent/tools/viewReferenceImages.ts
+++ b/lib/agent/tools/viewReferenceImages.ts
@@ -1,7 +1,7 @@
 import dedent from "dedent";
 import { z } from "zod";
 import { Eye } from "@/components/ui/icon";
-import { defineTool, imagePart } from "./defineTool";
+import { defineTool, imageOutput } from "./defineTool";
 
 export const viewReferenceImages = defineTool({
 	description: dedent`
@@ -14,16 +14,11 @@ export const viewReferenceImages = defineTool({
 	output: z.object({ urls: z.array(z.string()) }),
 	icon: Eye,
 	label: "Looking at the reference images",
-	toModelOutput: ({ output }) => ({
-		type: "content",
-		value: [
-			{
-				type: "text",
-				text: `${output.urls.length} reference image(s), in upload order:`,
-			},
-			...output.urls.map((url) => imagePart(url)),
-		],
-	}),
+	toModelOutput: ({ output }) =>
+		imageOutput(
+			`${output.urls.length} reference image(s), in upload order:`,
+			...output.urls,
+		),
 	execute: async (_input, ctx) => {
 		const urls = ctx.referenceImages();
 		if (urls.length === 0)

--- a/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
@@ -16,8 +16,6 @@ import { nodeBuilder } from "@/lib/generation/resolveGraph";
 import { MetadataSchema } from "@/lib/project/types";
 import {
 	createStillFramePlugin,
-	hasPicture,
-	pictureElementId,
 	pictureNode,
 	stillElementId,
 	stillSnapshot,
@@ -79,33 +77,6 @@ describe("still-frame plugin", () => {
 				ctx(),
 			),
 		).toThrow(/still frame/);
-	});
-});
-
-describe("an element's picture", () => {
-	const element = (type: "image" | "animated_image" | "clip") => ({
-		id: ELEMENT_ID,
-		type,
-		children: [{ id: "t", type, text: "a forest" }],
-	});
-
-	it("is an image element's own result", () => {
-		expect(hasPicture("image")).toBe(true);
-		expect(pictureElementId(element("image"))).toBe(ELEMENT_ID);
-	});
-
-	// The animation's own result carries the frame it rendered from, which goes
-	// stale the moment the still is replaced.
-	it("is the still node for an animated image, not the animation", () => {
-		expect(hasPicture("animated_image")).toBe(true);
-		expect(pictureElementId(element("animated_image"))).toBe(
-			stillElementId(ELEMENT_ID),
-		);
-	});
-
-	it("does not exist for a clip or a sound", () => {
-		expect(hasPicture("clip")).toBe(false);
-		expect(hasPicture("narration")).toBe(false);
 	});
 });
 

--- a/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
@@ -16,6 +16,8 @@ import { nodeBuilder } from "@/lib/generation/resolveGraph";
 import { MetadataSchema } from "@/lib/project/types";
 import {
 	createStillFramePlugin,
+	hasPicture,
+	pictureElementId,
 	pictureNode,
 	stillElementId,
 	stillSnapshot,
@@ -77,6 +79,33 @@ describe("still-frame plugin", () => {
 				ctx(),
 			),
 		).toThrow(/still frame/);
+	});
+});
+
+describe("an element's picture", () => {
+	const element = (type: "image" | "animated_image" | "clip") => ({
+		id: ELEMENT_ID,
+		type,
+		children: [{ id: "t", type, text: "a forest" }],
+	});
+
+	it("is an image element's own result", () => {
+		expect(hasPicture("image")).toBe(true);
+		expect(pictureElementId(element("image"))).toBe(ELEMENT_ID);
+	});
+
+	// The animation's own result carries the frame it rendered from, which goes
+	// stale the moment the still is replaced.
+	it("is the still node for an animated image, not the animation", () => {
+		expect(hasPicture("animated_image")).toBe(true);
+		expect(pictureElementId(element("animated_image"))).toBe(
+			stillElementId(ELEMENT_ID),
+		);
+	});
+
+	it("does not exist for a clip or a sound", () => {
+		expect(hasPicture("clip")).toBe(false);
+		expect(hasPicture("narration")).toBe(false);
 	});
 });
 

--- a/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
@@ -16,6 +16,7 @@ import { nodeBuilder } from "@/lib/generation/resolveGraph";
 import { MetadataSchema } from "@/lib/project/types";
 import {
 	createStillFramePlugin,
+	pictureElementId,
 	pictureNode,
 	stillElementId,
 	stillSnapshot,
@@ -249,7 +250,7 @@ describe("uploaded still lifetime", () => {
 	});
 });
 
-describe("pictureNode", () => {
+describe("an element's picture", () => {
 	const registry = DEFAULT_CONNECTOR_REGISTRY;
 	const state = {
 		hydrated: true,
@@ -271,16 +272,19 @@ describe("pictureNode", () => {
 
 	it("is the element itself when it generates an image", () => {
 		expect(pictureFor("image")?.id).toBe("el-image");
+		expect(pictureElementId(element("image"))).toBe("el-image");
 	});
 
 	it("is the still behind an animated image, not the animation", () => {
-		expect(pictureFor("animated_image")?.id).toBe(
-			stillElementId("el-animated_image"),
-		);
+		const still = stillElementId("el-animated_image");
+		expect(pictureFor("animated_image")?.id).toBe(still);
+		expect(pictureElementId(element("animated_image"))).toBe(still);
 	});
 
 	it("is nothing for an element that makes no picture", () => {
 		expect(pictureFor("clip")).toBeNull();
 		expect(pictureFor("narration")).toBeNull();
+		expect(pictureElementId(element("clip"))).toBeUndefined();
+		expect(pictureElementId(element("narration"))).toBeUndefined();
 	});
 });

--- a/lib/connectors/animated_image/plugins/still-frame.ts
+++ b/lib/connectors/animated_image/plugins/still-frame.ts
@@ -1,5 +1,9 @@
 import omit from "lodash/omit";
-import { ELEMENT_TYPES, type CanvasContentElement } from "@/lib/canvas/types";
+import {
+	ELEMENT_TYPES,
+	type CanvasContentElement,
+	type CanvasElementType,
+} from "@/lib/canvas/types";
 import {
 	DEFAULT_PROVIDER,
 	type AnimatedImageGenerateParams,
@@ -57,17 +61,24 @@ export const forStillOf =
 export const stillDependency = (node: GenerationNode) =>
 	derivedDependency(node, STILL);
 
+const makesPicture = (type: CanvasElementType) =>
+	ELEMENT_TYPES[type].outputKind === "image";
+
 /**
- * The node that makes an element's picture: the still behind an animated image,
- * an image element itself, and nothing at all for an element that makes no
- * picture. Whoever supplies a picture writes it here.
+ * Where an element's picture comes from: the still behind an animated image, an
+ * image element itself, and nowhere at all for a type that makes none. Whoever
+ * reads or supplies a picture goes through here.
  */
+export function pictureElementId(element: CanvasContentElement) {
+	if (element.type === "animated_image") return stillElementId(element.id);
+	return makesPicture(element.type) ? element.id : undefined;
+}
+
+/** The same answer off a built node, which is what supplying a picture needs. */
 export function pictureNode(node: GenerationNode): JobNode | null {
 	const target = stillDependency(node) ?? node;
 	if (isSourceNode(target)) return null;
-	const makesPicture =
-		ELEMENT_TYPES[target.job.elementType].outputKind === "image";
-	return makesPicture ? target : null;
+	return makesPicture(target.job.elementType) ? target : null;
 }
 
 /**

--- a/lib/connectors/animated_image/plugins/still-frame.ts
+++ b/lib/connectors/animated_image/plugins/still-frame.ts
@@ -1,9 +1,5 @@
 import omit from "lodash/omit";
-import {
-	ELEMENT_TYPES,
-	type CanvasContentElement,
-	type CanvasElementType,
-} from "@/lib/canvas/types";
+import { ELEMENT_TYPES, type CanvasContentElement } from "@/lib/canvas/types";
 import {
 	DEFAULT_PROVIDER,
 	type AnimatedImageGenerateParams,
@@ -60,14 +56,6 @@ export const forStillOf =
 /** The still node behind an animated image, when the element has one. */
 export const stillDependency = (node: GenerationNode) =>
 	derivedDependency(node, STILL);
-
-/** Whether a type ends up with a picture: an image's own result, or an animated image's still. */
-export const hasPicture = (type: CanvasElementType) =>
-	type === "animated_image" || ELEMENT_TYPES[type].outputKind === "image";
-
-/** The element whose result holds that picture. */
-export const pictureElementId = (element: CanvasContentElement) =>
-	element.type === "animated_image" ? stillElementId(element.id) : element.id;
 
 /**
  * The node that makes an element's picture: the still behind an animated image,

--- a/lib/connectors/animated_image/plugins/still-frame.ts
+++ b/lib/connectors/animated_image/plugins/still-frame.ts
@@ -1,5 +1,9 @@
 import omit from "lodash/omit";
-import { ELEMENT_TYPES, type CanvasContentElement } from "@/lib/canvas/types";
+import {
+	ELEMENT_TYPES,
+	type CanvasContentElement,
+	type CanvasElementType,
+} from "@/lib/canvas/types";
 import {
 	DEFAULT_PROVIDER,
 	type AnimatedImageGenerateParams,
@@ -56,6 +60,14 @@ export const forStillOf =
 /** The still node behind an animated image, when the element has one. */
 export const stillDependency = (node: GenerationNode) =>
 	derivedDependency(node, STILL);
+
+/** Whether a type ends up with a picture: an image's own result, or an animated image's still. */
+export const hasPicture = (type: CanvasElementType) =>
+	type === "animated_image" || ELEMENT_TYPES[type].outputKind === "image";
+
+/** The element whose result holds that picture. */
+export const pictureElementId = (element: CanvasContentElement) =>
+	element.type === "animated_image" ? stillElementId(element.id) : element.id;
 
 /**
  * The node that makes an element's picture: the still behind an animated image,


### PR DESCRIPTION
## Summary

Sloppy could see uploaded reference images and a character's avatar, but nothing the project actually generated. It wrote an image prompt, the image came back wrong, and it had no way to know.

`view_image` closes that loop. Given an element id from `read_script`, it hands the model the generated picture alongside the prompt that produced it, so intent and result are comparable in one turn.

- New `elementImage(id)` capability on `AgentToolContext`, implemented in `useAgentTools` off the same `queue` handle `avatarUrl` already uses. It projects the element down to `{ type, prompt, status, url }`: no urls beyond the picture itself, no `resultInputs`, no internal identity strings.
- The tool guards the three distinct cases separately, so each is an observation the model can act on: no such id (read the script again), an element with no picture at all (clip and audio results stay out of scope), and a result that is not there yet (the error names the status, so "still generating" reads differently from "never generated").
- Registered with `snapshot: true`, like `view_avatar` and `view_reference_images`: a viewed image is only true for its own turn, since a node can regenerate underneath the agent.
- One ROLE bullet in `prompt.ts` tells Sloppy to look before commenting on how an image turned out.

## Animated images

The first cut gated on `ELEMENT_TYPES[type].outputKind === "image"`, which excluded `animated_image` (its output kind is `video`). That read as a missing feature from the outside: asked to look at the first scene, the model was refused, said nothing about it, and quietly went and looked at the first scene that held a plain image instead.

An animated image does have a picture, the still frame it animates, so it is now viewable. There is no ready-made set of "visual" types to gate on: `layer: "visual"` and `FOREGROUND_TYPES` both include `clip`, which has no still and no poster frame, so either one would promise a picture that does not exist.

`pictureElementId(element)` in `still-frame.ts` answers it instead: the still node for an animated image, the element itself for an image, nothing for anything else. It sits beside the `pictureNode(node)` the upload button already uses, which gives the same answer off a built node, and the two now share the one `outputKind` rule.

Reading the still node matters beyond the type check. The animation's own result carries the frame it rendered from, which goes stale the moment the still is replaced or an uploaded one takes over, so the tool reads the same source the card preview does, for the same reason.

`ElementImage.picture` is absent rather than empty when a type makes no picture, so "generates no picture" and "not generated yet" are two shapes rather than two readings of a missing url, and each keeps its own error.

## Cleanups this pulled in

- `imageOutput` in `defineTool.ts` replaces the `{ type: "content", value: [...] }` literal that `view_avatar`, `view_reference_images` and now `view_image` had each written out. Third occurrence, so it earned a helper.
- The prompt shown beside the picture comes from `getPromptText`, the same text the generator feeds the connector, rather than the serializer's `getElementBodyText`, which differs by a trim.
- The ROLE bullet in `prompt.ts` is one line again; the type rules live in the tool description, which the model sees in the same request.

## Why this issue was safe to take

#598 is `size: M`, `priority: high`, with unambiguous acceptance criteria and an existing tool (`view_avatar`) named as the exact pattern to generalize. The change is additive: one new tool file plus one context capability, no existing behavior altered.

## Validation

- `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run knip` — clean
- `npm run build` — succeeded
- `npm test` — 160 test files, 1439 tests passing, including 4 `view_image` cases (image handed over with its prompt, unknown id, an element with no picture, not-generated-yet reporting the status); the animated-image mapping is asserted where it lives, in `still-frame.test.ts`
- Playwright smoke tests not run locally; this change adds no route or page copy, so CI covers it

## Open PR overlap check

Diffed against every open PR (#662, #668, #674, #679, #680, #681, #682, #683). None touches `lib/agent/`; the closest, #683, is confined to `app/components/sloppy/`. No overlap.

## Skipped candidates

- #667, #254 — `good first issue`, reserved for outside contributors
- #461 (karaoke word highlighting) — the only other `size: S`; needs word-level timing design across the player and canvas, not a single focused PR
- #666, #492, #366 — already claimed by open PRs #683, #662, #674
- #632 (agent-changeable voice identity) — `priority: high` but genuinely two features (clearing `resolvedVoiceId` on a trait edit plus a new voice-search tool) with cache-invalidation consequences the issue itself flags; too broad for an unattended run
- #610 (agent reads generation state) — overlaps in-flight unlanded work on `measure_element_lengths` and asks for a projection whose shape is still open

Closes #598
