### PR TITLE
refactor: nightly maintainability 2026-08-30

### DIFF
--- a/lib/generation/ElementHistoryProvider.tsx
+++ b/lib/generation/ElementHistoryProvider.tsx
@@ -1,29 +1,16 @@
 "use client";
 
-import {
-	useEffect,
-	useState,
-	useSyncExternalStore,
-	type ReactNode,
-} from "react";
-import { createRequiredContext } from "@/lib/components/createRequiredContext";
+import { useEffect, useState, type ReactNode } from "react";
+import { createStoreContext } from "@/lib/store/createStoreContext";
 import { ElementHistory, type ElementVersionStorage } from "./history";
 import { useGenerationQueue } from "./GenerationQueueProvider";
 
-const [ElementHistoryContext, useElementHistoryStore] =
-	createRequiredContext<ElementHistory>("ElementHistoryContext");
-export { useElementHistoryStore };
-
-export function useElementHistorySelector<T>(
-	selector: (history: ElementHistory) => T,
-): T {
-	const history = useElementHistoryStore();
-	return useSyncExternalStore(
-		history.subscribe,
-		() => selector(history),
-		() => selector(history),
-	);
-}
+const [
+	ElementHistoryContext,
+	useElementHistoryStore,
+	useElementHistorySelector,
+] = createStoreContext<ElementHistory>("ElementHistoryContext");
+export { useElementHistoryStore, useElementHistorySelector };
 
 export function ElementHistoryProvider({
 	storage,

--- a/lib/generation/GenerationQueueProvider.tsx
+++ b/lib/generation/GenerationQueueProvider.tsx
@@ -1,29 +1,13 @@
 "use client";
 
-import {
-	useEffect,
-	useState,
-	useSyncExternalStore,
-	type ReactNode,
-} from "react";
-import { createRequiredContext } from "@/lib/components/createRequiredContext";
+import { useEffect, useState, type ReactNode } from "react";
+import { createStoreContext } from "@/lib/store/createStoreContext";
 import { GenerationQueue } from "./queue";
 import type { ElementSnapshot } from "./snapshots";
 
-const [GenerationQueueContext, useGenerationQueue] =
-	createRequiredContext<GenerationQueue>("GenerationQueueContext");
-export { useGenerationQueue };
-
-export function useQueueSelector<T>(
-	selector: (queue: GenerationQueue) => T,
-): T {
-	const queue = useGenerationQueue();
-	return useSyncExternalStore(
-		queue.subscribe,
-		() => selector(queue),
-		() => selector(queue),
-	);
-}
+const [GenerationQueueContext, useGenerationQueue, useQueueSelector] =
+	createStoreContext<GenerationQueue>("GenerationQueueContext");
+export { useGenerationQueue, useQueueSelector };
 
 export function GenerationQueueProvider({
 	initialState,

--- a/lib/generation/history.ts
+++ b/lib/generation/history.ts
@@ -1,3 +1,4 @@
+import { createEmitter } from "@/lib/store/emitter";
 import type { CommittedVersion, ElementVersion } from "./versions";
 import { VersionLog } from "./versions";
 
@@ -16,22 +17,13 @@ export type ElementHistoryStatus = "loading" | "ready" | "failed";
 
 export class ElementHistory {
 	private readonly log = new VersionLog();
-	private readonly listeners = new Set<() => void>();
+	private readonly emitter = createEmitter();
 	private loading = new Map<string, Promise<void>>();
 	private failed = new Set<string>();
 
 	constructor(private readonly storage: ElementVersionStorage = SESSION_ONLY) {}
 
-	subscribe = (listener: () => void) => {
-		this.listeners.add(listener);
-		return () => {
-			this.listeners.delete(listener);
-		};
-	};
-
-	private notify() {
-		for (const listener of this.listeners) listener();
-	}
+	subscribe = this.emitter.subscribe;
 
 	get = (elementId: string): readonly ElementVersion[] =>
 		this.log.get(elementId);
@@ -57,7 +49,7 @@ export class ElementHistory {
 			})
 			.finally(() => {
 				this.loading.delete(elementId);
-				this.notify();
+				this.emitter.notify();
 			});
 		this.loading.set(elementId, load);
 		return load;
@@ -65,6 +57,6 @@ export class ElementHistory {
 
 	record = (version: CommittedVersion) => {
 		this.storage.write(this.log.record(version, new Date().toISOString()));
-		this.notify();
+		this.emitter.notify();
 	};
 }

--- a/lib/generation/snapshots.ts
+++ b/lib/generation/snapshots.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { createEmitter } from "@/lib/store/emitter";
 import {
 	ASSET_CONNECTOR_TYPES,
 	type AssetConnectorType,
@@ -81,7 +82,7 @@ export const isGenerationActive = (status: GenerationStatus) =>
  */
 export class SnapshotStore {
 	private state: Map<string, ElementSnapshot>;
-	private listeners = new Set<() => void>();
+	private readonly emitter = createEmitter();
 	private resultVersion = 0;
 
 	constructor(initialState: Record<string, ElementSnapshot> = {}) {
@@ -94,18 +95,9 @@ export class SnapshotStore {
 		this.notify();
 	}
 
-	subscribe = (listener: () => void) => {
-		this.listeners.add(listener);
-		return () => {
-			this.listeners.delete(listener);
-		};
-	};
+	subscribe = this.emitter.subscribe;
 
-	notify() {
-		for (const listener of this.listeners) {
-			listener();
-		}
-	}
+	notify = this.emitter.notify;
 
 	get = (id?: string): ElementSnapshot =>
 		(id && this.state.get(id)) || EMPTY_SNAPSHOT;

--- a/lib/project/CanvasHistoryProvider.tsx
+++ b/lib/project/CanvasHistoryProvider.tsx
@@ -1,21 +1,15 @@
 "use client";
 
-import { useSyncExternalStore, type ReactNode } from "react";
-import { createRequiredContext } from "@/lib/components/createRequiredContext";
+import type { ReactNode } from "react";
+import { createStoreContext } from "@/lib/store/createStoreContext";
 import type { CanvasHistory, CanvasHistoryState } from "./canvasHistory";
 
-const [CanvasHistoryContext, useCanvasHistory] =
-	createRequiredContext<CanvasHistory>("CanvasHistoryProvider");
+const [CanvasHistoryContext, useCanvasHistory, useCanvasHistorySelector] =
+	createStoreContext<CanvasHistory>("CanvasHistoryProvider");
 export { useCanvasHistory };
 
-export function useCanvasHistoryState(): CanvasHistoryState {
-	const history = useCanvasHistory();
-	return useSyncExternalStore(
-		history.subscribe,
-		history.getState,
-		history.getState,
-	);
-}
+export const useCanvasHistoryState = (): CanvasHistoryState =>
+	useCanvasHistorySelector((history) => history.getState());
 
 export function CanvasHistoryProvider({
 	history,

--- a/lib/project/canvasHistory.ts
+++ b/lib/project/canvasHistory.ts
@@ -1,3 +1,4 @@
+import { createEmitter } from "@/lib/store/emitter";
 import type { Autosaver } from "./autosave";
 import type { ProjectContent, ProjectDocument } from "./projectDocument";
 
@@ -41,7 +42,7 @@ export class CanvasHistory {
 	private open: { id: string; until: number } | null = null;
 	/** What the canvas returns to, held for as long as a preview lasts. */
 	private stash: ProjectContent | null = null;
-	private readonly listeners = new Set<() => void>();
+	private readonly emitter = createEmitter();
 
 	constructor(
 		private readonly storage: CanvasVersionStorage,
@@ -49,18 +50,13 @@ export class CanvasHistory {
 		private readonly autosaver: Autosaver,
 	) {}
 
-	subscribe = (listener: () => void) => {
-		this.listeners.add(listener);
-		return () => {
-			this.listeners.delete(listener);
-		};
-	};
+	subscribe = this.emitter.subscribe;
 
 	getState = (): CanvasHistoryState => this.state;
 
 	private setState(patch: Partial<CanvasHistoryState>) {
 		this.state = { ...this.state, ...patch };
-		for (const listener of this.listeners) listener();
+		this.emitter.notify();
 	}
 
 	load = async (): Promise<void> => {

--- a/lib/store/__tests__/emitter.test.ts
+++ b/lib/store/__tests__/emitter.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { createEmitter } from "../emitter";
+
+describe("createEmitter", () => {
+	it("notifies every subscriber", () => {
+		const emitter = createEmitter();
+		const first = vi.fn();
+		const second = vi.fn();
+		emitter.subscribe(first);
+		emitter.subscribe(second);
+
+		emitter.notify();
+
+		expect(first).toHaveBeenCalledTimes(1);
+		expect(second).toHaveBeenCalledTimes(1);
+	});
+
+	it("stops notifying once unsubscribed", () => {
+		const emitter = createEmitter();
+		const listener = vi.fn();
+		const unsubscribe = emitter.subscribe(listener);
+
+		unsubscribe();
+		emitter.notify();
+
+		expect(listener).not.toHaveBeenCalled();
+	});
+
+	it("subscribes the same listener once", () => {
+		const emitter = createEmitter();
+		const listener = vi.fn();
+		emitter.subscribe(listener);
+		emitter.subscribe(listener);
+
+		emitter.notify();
+
+		expect(listener).toHaveBeenCalledTimes(1);
+	});
+});

--- a/lib/store/createStoreContext.tsx
+++ b/lib/store/createStoreContext.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { createRequiredContext } from "@/lib/components/createRequiredContext";
+import type { Emitter } from "./emitter";
+
+/**
+ * A required context for an observable store, plus the selector hook that reads
+ * it. Adding a store is a provider and nothing else: how it reaches React is
+ * decided here rather than restated at each one.
+ */
+export function createStoreContext<T extends Pick<Emitter, "subscribe">>(
+	name: string,
+) {
+	const [Context, useStore] = createRequiredContext<T>(name);
+
+	function useStoreSelector<S>(selector: (store: T) => S): S {
+		const store = useStore();
+		const read = () => selector(store);
+		return useSyncExternalStore(store.subscribe, read, read);
+	}
+
+	return [Context, useStore, useStoreSelector] as const;
+}

--- a/lib/store/emitter.ts
+++ b/lib/store/emitter.ts
@@ -1,0 +1,20 @@
+/** A store's subscription list, shaped for `useSyncExternalStore`. */
+export interface Emitter {
+	subscribe: (listener: () => void) => () => void;
+	notify: () => void;
+}
+
+export function createEmitter(): Emitter {
+	const listeners = new Set<() => void>();
+	return {
+		subscribe: (listener) => {
+			listeners.add(listener);
+			return () => {
+				listeners.delete(listener);
+			};
+		},
+		notify: () => {
+			for (const listener of listeners) listener();
+		},
+	};
+}


### PR DESCRIPTION
Four stores hand-roll the same subscription list, and three providers hand-roll the same `useSyncExternalStore` binding over it. This collapses both onto one seam.

## What was duplicated

`SnapshotStore`, `ElementHistory` and `CanvasHistory` each carried their own `listeners` Set with an identical `subscribe`/`notify` pair. On the React side, `GenerationQueueProvider`, `ElementHistoryProvider` and `CanvasHistoryProvider` each restated:

```ts
useSyncExternalStore(store.subscribe, () => selector(store), () => selector(store))
```

Four copies of one mechanism, and a fifth arrives with every new store.

## The change

New `lib/store/`:

- `emitter.ts` — `createEmitter()`, the subscription list. Stores hold one and expose `subscribe = this.emitter.subscribe`.
- `createStoreContext.tsx` — `createRequiredContext` plus the selector hook, returning `[Context, useStore, useStoreSelector]`. Adding a store is now a provider and nothing else.

Composition, not a base class: the stores own an emitter rather than inherit one, so nothing about their own shape changes. `GenerationQueue` already delegated `subscribe` to its `SnapshotStore` and is untouched.

Behaviour is identical — same Set semantics, same `useSyncExternalStore` arguments, same public store surface. 1438 tests pass, including the existing suites over the queue, element history and canvas history.

`DragTransferContext` has a fourth copy of the emitter, and it is left alone: that file is reserved by #687.

## Complexity delta

6 files touched, 87 lines removed against 32 added. Three classes lose a private field and two methods each; three providers lose their `useSyncExternalStore` wiring. New seam is 40 lines with a 3-case test.

## Open PR overlap check

Considered #687 (auth/projects UI, `DragTransferContext`, runware providers, `scene-builder`), #684 (`lib/agent/*`), #683 (Sloppy composer/provider), #682 (waveform/viewport), #681 (`PostPromptView`, video player contexts, `composeProviders`, `ARCHITECTURE.md`), #680 (`lib/supabase/middleware`), #674 (generate-scope hooks), #668 (`osmlStreamParser`, `lib/generation/queue.ts`, `sceneSegments`), #662 (connectors, `lib/canvas`, api routes, `lib/project/{applyScript,serialize,types,characterAvatar,projectDocument}`).

No file overlap: this PR touches `lib/store/*` (new), `lib/generation/{snapshots,history,GenerationQueueProvider,ElementHistoryProvider}` and `lib/project/{canvasHistory,CanvasHistoryProvider}`, none of which appear in any open PR. It deliberately does not touch `lib/generation/queue.ts` (#668, #662) or `lib/components/composeProviders.tsx` (#681) — the nearest themed neighbours.

## Checks

`lint`, `format:check`, `typecheck`, `knip`, `build`, `test:run` (1438 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)