### PR TITLE
refactor: nightly conventions audit 2026-08-30

### DIFF
--- a/app/components/canvas/elements/ElementHistoryPopover.tsx
+++ b/app/components/canvas/elements/ElementHistoryPopover.tsx
@@ -32,8 +32,6 @@ const PROMPT_LENGTH = 72;
 
 const SKELETON_ROWS = [0, 1, 2];
 
-const RULE = "-mx-3 my-2 data-[orientation=horizontal]:w-[calc(100%+1.5rem)]";
-
 const Dot = () => (
 	<span aria-hidden="true" className="text-muted-foreground">
 		·
@@ -170,7 +168,7 @@ export function ElementHistoryPopover({
 					<span className="text-label font-semibold">Generation history</span>
 					<CloseButton onClick={close} />
 				</div>
-				<Separator className={RULE} />
+				<Separator bleed />
 				<div
 					aria-live="polite"
 					className="-mx-1 flex max-h-80 flex-col overflow-y-auto overscroll-contain"

--- a/app/components/canvas/panel/EditorPanelContext.tsx
+++ b/app/components/canvas/panel/EditorPanelContext.tsx
@@ -3,13 +3,7 @@
 import { useMemo, useState, type ReactNode } from "react";
 import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { useScriptInitial } from "@/lib/script/ScriptProvider";
-
-export type PanelKey =
-	| "layout"
-	| "captions"
-	| "properties"
-	| "history"
-	| "sloppy";
+import type { PanelKey } from "./panelKeys";
 
 type EditorPanelValue = {
 	active: PanelKey | null;

--- a/app/components/canvas/panel/EditorSidebar.tsx
+++ b/app/components/canvas/panel/EditorSidebar.tsx
@@ -14,11 +14,11 @@ import {
 	TextBox,
 	TextBoxFill,
 } from "@/components/ui/icon";
-import partition from "lodash/partition";
 import { cn } from "@/lib/utils";
 import { SloppyComposer } from "@/app/components/sloppy/SloppyComposer";
 import { SloppyPanel } from "@/app/components/sloppy/SloppyPanel";
-import { useEditorPanel, type PanelKey } from "./EditorPanelContext";
+import { useEditorPanel } from "./EditorPanelContext";
+import { PINNED_PANEL_KEYS, RAIL_PANEL_KEYS, type PanelKey } from "./panelKeys";
 import { CanvasHistoryPanel } from "./CanvasHistoryPanel";
 import { CaptionsPanel } from "./CaptionsPanel";
 import { LayoutPanel } from "./LayoutPanel";
@@ -29,7 +29,6 @@ type PanelEntry = {
 	icon: IconComponent;
 	iconActive: IconComponent;
 	Panel: () => React.ReactNode;
-	pinned?: boolean;
 	Footer?: () => React.ReactNode;
 };
 
@@ -63,15 +62,9 @@ const PANELS: Record<PanelKey, PanelEntry> = {
 		icon: Robot,
 		iconActive: RobotFill,
 		Panel: SloppyPanel,
-		pinned: true,
 		Footer: SloppyComposer,
 	},
 };
-
-const [PINNED_KEYS, RAIL_KEYS] = partition(
-	Object.keys(PANELS) as PanelKey[],
-	(key) => PANELS[key].pinned,
-);
 
 function RailItem({
 	icon: Icon,
@@ -142,13 +135,13 @@ function EditorSidebarComponent() {
 			>
 				<RailItem icon={Home} label="Home" href="/" />
 				<div className="my-1 h-px w-full bg-border" />
-				{RAIL_KEYS.map((key) => (
+				{RAIL_PANEL_KEYS.map((key) => (
 					<PanelRailItem key={key} panelKey={key} />
 				))}
 
 				<div className="mt-auto flex w-full flex-col items-center gap-1 pb-3">
 					<div className="my-1 h-px w-full bg-border" />
-					{PINNED_KEYS.map((key) => (
+					{PINNED_PANEL_KEYS.map((key) => (
 						<PanelRailItem key={key} panelKey={key} />
 					))}
 				</div>

--- a/app/components/canvas/panel/panelKeys.ts
+++ b/app/components/canvas/panel/panelKeys.ts
@@ -1,0 +1,17 @@
+/**
+ * Which panels the rail offers, in the order it draws them. The loading skeleton
+ * counts rail items from here, so a new panel cannot leave it a slot short.
+ */
+export const RAIL_PANEL_KEYS = [
+	"layout",
+	"captions",
+	"properties",
+	"history",
+] as const;
+
+/** Panels held apart at the foot of the rail. */
+export const PINNED_PANEL_KEYS = ["sloppy"] as const;
+
+export type PanelKey =
+	| (typeof RAIL_PANEL_KEYS)[number]
+	| (typeof PINNED_PANEL_KEYS)[number];

--- a/app/components/video/ExportButton.tsx
+++ b/app/components/video/ExportButton.tsx
@@ -65,7 +65,7 @@ export function ExportButton() {
 					<span className="text-label font-semibold">Export</span>
 					<CloseButton onClick={() => setOpen(false)} />
 				</div>
-				<Separator className="-mx-3 my-2 data-[orientation=horizontal]:w-[calc(100%+1.5rem)]" />
+				<Separator bleed />
 
 				{(state.status === "invoking" || state.status === "rendering") && (
 					<div className="animate-fadeInUp flex flex-col gap-2">
@@ -125,7 +125,7 @@ export function ExportButton() {
 								{state.message}
 							</p>
 						)}
-						<Separator className="-mx-3 my-2 data-[orientation=horizontal]:w-[calc(100%+1.5rem)]" />
+						<Separator bleed />
 						<Button
 							type="button"
 							variant="generate"

--- a/app/projects/[id]/loading.tsx
+++ b/app/projects/[id]/loading.tsx
@@ -1,3 +1,7 @@
+import {
+	PINNED_PANEL_KEYS,
+	RAIL_PANEL_KEYS,
+} from "@/app/components/canvas/panel/panelKeys";
 import { Skeleton } from "@/components/ui/skeleton";
 
 const SCENES = [3, 2, 4];
@@ -134,13 +138,14 @@ export default function Loading() {
 				<nav className="mr-2 flex w-14 shrink-0 flex-col items-center gap-1 pt-4 pr-0.5 pl-1 lg:w-[72px]">
 					<RailItemSkeleton />
 					<div className="my-1 h-px w-full bg-border" />
-					<RailItemSkeleton />
-					<RailItemSkeleton />
-					<RailItemSkeleton />
-					<RailItemSkeleton />
+					{RAIL_PANEL_KEYS.map((key) => (
+						<RailItemSkeleton key={key} />
+					))}
 					<div className="mt-auto flex w-full flex-col items-center gap-1 pb-3">
 						<div className="my-1 h-px w-full bg-border" />
-						<RailItemSkeleton />
+						{PINNED_PANEL_KEYS.map((key) => (
+							<RailItemSkeleton key={key} />
+						))}
 					</div>
 				</nav>
 

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -5,12 +5,18 @@ import { Separator as SeparatorPrimitive } from "radix-ui";
 
 import { cn } from "@/lib/utils";
 
+/** Runs edge to edge inside a `p-3` surface, past the padding its siblings sit in. */
+const BLEED = "-mx-3 my-2 data-[orientation=horizontal]:w-[calc(100%+1.5rem)]";
+
 function Separator({
 	className,
+	bleed = false,
 	orientation = "horizontal",
 	decorative = true,
 	...props
-}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+}: React.ComponentProps<typeof SeparatorPrimitive.Root> & {
+	bleed?: boolean;
+}) {
 	return (
 		<SeparatorPrimitive.Root
 			data-slot="separator"
@@ -18,6 +24,7 @@ function Separator({
 			orientation={orientation}
 			className={cn(
 				"shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+				bleed && BLEED,
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
Nightly CONVENTIONS.md compliance sweep. Files covered by an open PR were left alone.

## Fixed

**The panel rail's shape had three copies.** `PanelKey`'s union in `EditorPanelContext`, the `partition` over `PANELS` in `EditorSidebar`, and one `<RailItemSkeleton />` per panel typed out by hand in `app/projects/[id]/loading.tsx`. The third copy already drifted once — 3ab3a4e1 added the missing History slot after the fact. `panelKeys.ts` now holds the rail order and the pinned keys, and all three read it, so the skeleton counts itself.

**Every `<Separator />` in the app carried the same one-off class.** All three usages hand-wrote `-mx-3 my-2 data-[orientation=horizontal]:w-[calc(100%+1.5rem)]` to bleed past their popover's padding — one of them via a local `RULE` const. That's a `bleed` prop on the design-system component now, per "no one-off Tailwind in higher-level components".

No behavior change. lint, typecheck, format:check, 1435 tests and `npm run build` all pass.

## Flagged, not fixed (blocked by open PRs)

- `lib/project/elementHistory.ts:112` — `elementHistoryStorage.write` catches and toasts, so a failed write resolves; its sibling `canvasVersionStorage` throws and lets the caller decide. Policy in a mechanism module. Fixing it means changing the caller in `lib/generation/history.ts`, which #688 owns.
- `dot-grid-bg pointer-events-none fixed inset-0 -z-10` appears verbatim in `not-found.tsx`, `PrePromptView`, `PostPromptView` and `loading.tsx`. Wants one `<PageBackdrop />`. `PostPromptView` is in #681.
- `-mx-1 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-1` is the scroll body of `CharacterEditModal`, `NarratorEditModal` and `ArtStyleModal`. `ArtStyleModal` is in #687.
- `lib/components/Waveform.tsx:92` — a decode failure is only `console.error`'d, so the waveform silently stays empty. In #682.

## Flagged, design-level

- `lib/project/autosave.ts:89` — an unhydrated store aborts the save with a console line and no `onError`, so the user keeps typing into an autosaver that isn't saving.

## Clean

Rules 1, 2, 3, 4, 6 and 7 turned up nothing else across the 402 non-test source files outside open PRs. No empty catches, no catch-return-null, no `as any`, no provider-sniffing chains (the only `switch` is discriminated-union narrowing), API routes are thin, and the agent-tool and connector layers are registry-driven throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)