### PR TITLE
feat: upload a script as a PDF from the composer

### DIFF
--- a/app/api/upload/__tests__/script.test.ts
+++ b/app/api/upload/__tests__/script.test.ts
@@ -1,0 +1,97 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetUser = vi.fn();
+vi.mock("@/lib/api/auth", () => ({
+	getUser: () => mockGetUser(),
+}));
+
+const mockExtractText = vi.fn();
+vi.mock("unpdf", () => ({
+	getDocumentProxy: async (data: Uint8Array) => ({ data }),
+	extractText: (...args: unknown[]) => mockExtractText(...args),
+}));
+
+const { POST } = await import("@/app/api/upload/script/route");
+
+function makeRequest(formData: FormData) {
+	return new NextRequest(
+		new URL("/api/upload/script", "http://localhost:3000"),
+		{ method: "POST", body: formData },
+	);
+}
+
+function makeFile(
+	name = "script.pdf",
+	type = "application/pdf",
+	size = 1024,
+): File {
+	return new File([new Uint8Array(size)], name, { type });
+}
+
+function withFile(file: File) {
+	const formData = new FormData();
+	formData.set("file", file);
+	return makeRequest(formData);
+}
+
+describe("POST /api/upload/script", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetUser.mockResolvedValue({ id: "user-1" });
+		mockExtractText.mockResolvedValue({ totalPages: 1, text: "EXT. NIGHT" });
+	});
+
+	it("returns 401 when unauthenticated", async () => {
+		mockGetUser.mockResolvedValue(null);
+
+		expect((await POST(makeRequest(new FormData()))).status).toBe(401);
+	});
+
+	it("returns 400 when no file is provided", async () => {
+		const res = await POST(makeRequest(new FormData()));
+
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "No file provided" });
+	});
+
+	it("returns 400 for non-PDF files", async () => {
+		const res = await POST(withFile(makeFile("photo.png", "image/png")));
+
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "File must be a PDF" });
+	});
+
+	it("returns 400 for files over 10 MB", async () => {
+		const res = await POST(
+			withFile(makeFile("big.pdf", "application/pdf", 10 * 1024 * 1024 + 1)),
+		);
+
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ error: "File must be under 10 MB" });
+	});
+
+	it("returns the extracted text", async () => {
+		mockExtractText.mockResolvedValue({
+			totalPages: 2,
+			text: "\n EXT. NIGHT STARRY SKY \n",
+		});
+
+		const res = await POST(withFile(makeFile()));
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ text: "EXT. NIGHT STARRY SKY" });
+		expect(mockExtractText).toHaveBeenCalledWith(expect.anything(), {
+			mergePages: true,
+		});
+	});
+
+	it("rejects a PDF with no readable text instead of returning an empty script", async () => {
+		mockExtractText.mockResolvedValue({ totalPages: 1, text: "  \n  " });
+
+		const res = await POST(withFile(makeFile()));
+
+		expect(res.status).toBe(400);
+		expect((await res.json()).error).toMatch(/No text found/);
+	});
+});

--- a/app/api/upload/script/route.ts
+++ b/app/api/upload/script/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { extractText, getDocumentProxy } from "unpdf";
+import { z } from "zod";
+import { pdfFile } from "@/lib/api/request-schema-fields";
+import { badRequest } from "@/lib/api/response";
+import { createSessionFormRouteHandler } from "@/lib/api/route-handler";
+import { MAX_SCRIPT_UPLOAD_BYTES } from "@/lib/upload/scriptPdf";
+
+const UploadScriptForm = z.object(
+	{ file: pdfFile(MAX_SCRIPT_UPLOAD_BYTES) },
+	{ error: "No file provided" },
+);
+
+export const POST = createSessionFormRouteHandler({
+	schema: UploadScriptForm,
+	label: "upload/script",
+	handle: async ({ input: { file } }) => {
+		const pdf = await getDocumentProxy(
+			new Uint8Array(await file.arrayBuffer()),
+		);
+		const { text } = await extractText(pdf, { mergePages: true });
+		const script = text.trim();
+		if (!script)
+			return badRequest(
+				"No text found in that PDF. Scanned or image-only pages can't be read.",
+			);
+		return NextResponse.json({ text: script });
+	},
+});

--- a/app/components/copilot/ComposerCopilot.tsx
+++ b/app/components/copilot/ComposerCopilot.tsx
@@ -11,6 +11,7 @@ import {
 	Palette,
 	Plus,
 	Proportions,
+	TextBox,
 	Translate,
 	User,
 	X,
@@ -46,6 +47,7 @@ import {
 	type VideoLength,
 } from "@/lib/video/videoLength";
 import { useImageUpload } from "@/lib/upload/useImageUpload";
+import { useScriptUpload } from "@/lib/upload/useScriptUpload";
 import { cn } from "@/lib/utils";
 import { useSloppyModel } from "@/app/components/sloppy/SloppyModelProvider";
 import { ActionButton } from "./ActionButton";
@@ -90,9 +92,11 @@ const TEMPLATE_OPTIONS: SettingPillOption<string>[] = TEMPLATES.map((t) => ({
 
 function AttachMenu({
 	openPicker,
+	openScriptPicker,
 	uploading,
 }: {
 	openPicker: () => void;
+	openScriptPicker: () => void;
 	uploading: boolean;
 }) {
 	const { openCreateCharacter, openNarrator, openArtStyle } = useAssetEditors();
@@ -103,6 +107,12 @@ function AttachMenu({
 			label: "Upload reference images",
 			icon: <ImagePlus className={iconClass} />,
 			onSelect: openPicker,
+		},
+		{
+			key: "script",
+			label: "Upload script (PDF)",
+			icon: <TextBox className={iconClass} />,
+			onSelect: openScriptPicker,
 		},
 		{
 			key: "character",
@@ -196,6 +206,12 @@ function Composer({ value, onValueChange, onSubmit }: ComposerCopilotProps) {
 	const [language, setLanguage] = useScriptLanguage();
 	const { model, setModel, models } = useSloppyModel();
 
+	/** A pasted script sets its own length, so the target goes back to auto. */
+	const chooseIntent = (next: ComposerIntent) => {
+		setIntent(next);
+		if (next === "script") updateVideoSettings({ length: "auto" });
+	};
+
 	const {
 		openPicker,
 		uploading,
@@ -204,15 +220,19 @@ function Composer({ value, onValueChange, onSubmit }: ComposerCopilotProps) {
 		dropZoneProps,
 		isDraggingOver,
 	} = useImageUpload({ multiple: true, onUpload: addReferenceImages });
+	const {
+		openPicker: openScriptPicker,
+		extracting,
+		inputElement: scriptInputElement,
+	} = useScriptUpload({
+		onExtract: (text) => {
+			chooseIntent("script");
+			onValueChange(text);
+		},
+	});
 	const hasText = value.trim().length > 0;
 	const pasting = intent === "script";
 	const activeTemplate = pasting ? undefined : template;
-
-	/** A pasted script sets its own length, so the target goes back to auto. */
-	const chooseIntent = (next: ComposerIntent) => {
-		setIntent(next);
-		if (next === "script") updateVideoSettings({ length: "auto" });
-	};
 
 	const handleSubmit = () => {
 		if (hasText) onSubmit(templateBrief(activeTemplate, value));
@@ -264,7 +284,12 @@ function Composer({ value, onValueChange, onSubmit }: ComposerCopilotProps) {
 				<div className="flex items-center justify-between pt-2">
 					<div className="flex min-w-0 flex-wrap items-center gap-2">
 						{inputElement}
-						<AttachMenu openPicker={openPicker} uploading={uploading} />
+						{scriptInputElement}
+						<AttachMenu
+							openPicker={openPicker}
+							openScriptPicker={openScriptPicker}
+							uploading={uploading || extracting}
+						/>
 						<SettingPill
 							name="Aspect ratio"
 							icon={<Proportions className="mr-1 h-3 w-3" />}

--- a/lib/api/request-schema-fields.ts
+++ b/lib/api/request-schema-fields.ts
@@ -46,6 +46,16 @@ export const imageFile = (maxBytes: number) =>
 			message: `File must be under ${maxBytes / 1024 / 1024} MB`,
 		});
 
+export const pdfFile = (maxBytes: number) =>
+	z
+		.instanceof(File, { error: "No file provided" })
+		.refine((file) => file.type === "application/pdf", {
+			message: "File must be a PDF",
+		})
+		.refine((file) => file.size <= maxBytes, {
+			message: `File must be under ${maxBytes / 1024 / 1024} MB`,
+		});
+
 export const requiredVoiceId = z
 	.string({ error: "voiceId is required" })
 	.min(1, {

--- a/lib/upload/__tests__/scriptPdf.test.ts
+++ b/lib/upload/__tests__/scriptPdf.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { extractScriptText } from "../scriptPdf";
+
+const file = new File(["x"], "script.pdf", { type: "application/pdf" });
+
+describe("extractScriptText", () => {
+	const fetchMock = vi.fn();
+
+	beforeEach(() => {
+		fetchMock.mockReset();
+		vi.stubGlobal("fetch", fetchMock);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("returns the extracted text on success", async () => {
+		fetchMock.mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({ text: "EXT. NIGHT" }),
+		});
+		await expect(extractScriptText(file)).resolves.toBe("EXT. NIGHT");
+	});
+
+	it("throws the route's error message when the response is not ok", async () => {
+		fetchMock.mockResolvedValue({
+			ok: false,
+			status: 400,
+			statusText: "Bad Request",
+			json: async () => ({ error: "File must be a PDF" }),
+		});
+		await expect(extractScriptText(file)).rejects.toThrow("File must be a PDF");
+	});
+
+	it("propagates network failures", async () => {
+		fetchMock.mockRejectedValue(new TypeError("network down"));
+		await expect(extractScriptText(file)).rejects.toThrow("network down");
+	});
+});

--- a/lib/upload/scriptPdf.ts
+++ b/lib/upload/scriptPdf.ts
@@ -1,0 +1,15 @@
+import { apiJson } from "@/lib/clients/http";
+
+export const MAX_SCRIPT_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+/** Hands a script PDF to the server and gets its plain text back. */
+export async function extractScriptText(file: File): Promise<string> {
+	const formData = new FormData();
+	formData.append("file", file);
+
+	const { text } = await apiJson<{ text: string }>("/api/upload/script", {
+		method: "POST",
+		body: formData,
+	});
+	return text;
+}

--- a/lib/upload/useScriptUpload.tsx
+++ b/lib/upload/useScriptUpload.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { toastError } from "@/lib/toastError";
+import { extractScriptText } from "@/lib/upload/scriptPdf";
+
+/**
+ * Picks a script PDF and hands its extracted text to `onExtract`. The file
+ * never reaches the caller: a script enters the app as text, the same as one
+ * that was typed or pasted.
+ */
+export function useScriptUpload({
+	onExtract,
+}: {
+	onExtract: (text: string) => void;
+}) {
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [extracting, setExtracting] = useState(false);
+
+	const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		e.target.value = "";
+		if (!file) return;
+
+		setExtracting(true);
+		try {
+			onExtract(await extractScriptText(file));
+		} catch (error) {
+			toastError(error, "Could not read that PDF");
+		} finally {
+			setExtracting(false);
+		}
+	};
+
+	return {
+		openPicker: () => inputRef.current?.click(),
+		extracting,
+		inputElement: (
+			<input
+				ref={inputRef}
+				type="file"
+				accept="application/pdf"
+				className="hidden"
+				onChange={handleFileChange}
+			/>
+		),
+	};
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
 				"slate-react": "^0.123.0",
 				"sonner": "^2.0.7",
 				"tailwind-merge": "^3.5.0",
+				"unpdf": "^1.8.1",
 				"uuid": "^14.0.2",
 				"zod": "4.3.6",
 				"zustand": "^5.0.12"
@@ -19453,6 +19454,23 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/unpdf": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.8.1.tgz",
+			"integrity": "sha512-xkURhy2SoGpOIH0a1gLHNkASPIQYonadDJs2AQwPEfUakafeD9EA1WTWWsaR++gfTCXJpV27W7tU1nXuk82UKQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=22"
+			},
+			"peerDependencies": {
+				"@napi-rs/canvas": "^0.1.69 || ^1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@napi-rs/canvas": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
 		"slate-react": "^0.123.0",
 		"sonner": "^2.0.7",
 		"tailwind-merge": "^3.5.0",
+		"unpdf": "^1.8.1",
 		"uuid": "^14.0.2",
 		"zod": "4.3.6",
 		"zustand": "^5.0.12"


### PR DESCRIPTION
## Summary

Users who already have a finished script as a PDF had to copy-paste it out by hand — a script could only enter the app as text typed into the hero composer. This adds an **Upload script (PDF)** entry to the composer's attach menu, alongside the existing reference-image upload.

The file posts to a new `POST /api/upload/script`, which validates it and extracts the text with [`unpdf`](https://github.com/unjs/unpdf). The composer then drops into "Paste a script" mode with the extracted text in the textarea, so the user reviews and edits before submitting rather than generating blind.

- `lib/upload/scriptPdf.ts` — `extractScriptText(file)`, mirroring `uploadImage`
- `lib/upload/useScriptUpload.tsx` — picker hook mirroring `useImageUpload`; hands back text, never the file
- `app/api/upload/script/route.ts` — `createSessionFormRouteHandler`, same shape as `upload/image`
- `lib/api/request-schema-fields.ts` — `pdfFile(maxBytes)` next to the existing `imageFile(maxBytes)`

Validation lives only on the route, so the accept/size rule has one home. Failures surface through the existing `apiJson` error envelope → `toastError`, and a PDF with no readable text (a scan) is a loud 400 rather than an empty script. The attach button reuses its existing spinner while extraction is in flight.

`unpdf` is a new dependency (1 package, no transitive deps). PDF text extraction is not something to hand-roll, and `unpdf` is the serverless-friendly pdfjs wrapper.

## Why this issue was safe and small

`size: M`, `priority: medium`, unambiguous acceptance criteria, an existing upload pattern to mirror, and no product or design decisions left open. Not labeled `good first issue` or `size: XS`.

## Validation

All CI-equivalent checks from `.github/workflows/ci.yml`, all passing:

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run knip`
- `npm run build`
- `npm run test:coverage` — 162 files, 1444 tests passed (9 new)
- `npm run test:e2e` — 3 passed

Extraction was also verified end to end against a real one-page PDF outside the test suite. `npm audit`'s 2 moderate findings are pre-existing (`@runware/sdk-js` → `uuid`), not from `unpdf`.

## Open PR overlap check

Diffed against the file lists of all 12 open PRs (#690, #689, #688, #687, #684, #683, #682, #681, #680, #674, #668, #662). No file in this change appears in any of them.

## Issues skipped

- Claimed by open PRs: #598 (#684), #666 (#683), #366 (#674), #492 (#662)
- Overlapping open-PR files: #632 and #610 (agent tool surface, #684; TTS/connectors, #662), #316 (`lib/video/scene-builder.ts`, #687), #345 / #398 / #537 / #631 (canvas + timeline files in #662/#668/#682)
- Product/design decisions left open in the issue: #296 (needs a new composer toggle and a default policy), #594 (explicitly defers whether clearing wipes user text; conflicting unmerged branch), #535, #361, #257, #255, #267
- Already implemented: **#461** — per-word caption spans, an `activeWord` style, presets and a `set_caption_style` tool all landed since it was filed. Only the *default* style leaves active == base, which is a design call, not an implementation gap. Worth closing or re-scoping.
- Requires paid third-party service: #333
- Reserved for outside contributors (`good first issue` / `size: XS`), passed over: #667, #254, #676, #675, #643

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)