### PR TITLE
fix: say why an element is stale instead of always blaming the prompt

### DIFF
--- a/app/components/canvas/elements/GenerateButton.tsx
+++ b/app/components/canvas/elements/GenerateButton.tsx
@@ -10,9 +10,9 @@ import {
 } from "@/lib/generation/snapshots";
 import { useElementGeneration } from "./ElementGenerationContext";
 
-export function StaleIndicator() {
+export function StaleIndicator({ reason }: { reason: string }) {
 	return (
-		<SimpleTooltip label="Prompt changed — regenerate to update">
+		<SimpleTooltip label={reason}>
 			<span className="inline-flex items-center gap-1 rounded-full border border-tertiary/50 bg-tertiary/10 px-2 py-0.5 text-label-xs font-medium text-tertiary">
 				<AlertCircle className="h-3 w-3" />
 				Stale
@@ -22,9 +22,9 @@ export function StaleIndicator() {
 }
 
 export function ElementStaleIndicator() {
-	const { stale } = useElementGeneration();
-	if (!stale) return null;
-	return <StaleIndicator />;
+	const { staleReason } = useElementGeneration();
+	if (!staleReason) return null;
+	return <StaleIndicator reason={staleReason} />;
 }
 
 function generateLabel(status: GenerationStatus, hasResult: boolean) {

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -17,7 +17,7 @@ import {
 	useGenerationQueue,
 	useQueueSelector,
 } from "@/lib/generation/GenerationQueueProvider";
-import { isNodeStale } from "@/lib/generation/graph";
+import { staleReason } from "@/lib/generation/staleReason";
 import { isGenerationActive } from "@/lib/generation/snapshots";
 import { forCharacterAvatar } from "@/lib/connectors/image/plugins/characterAvatarNode";
 import { useNodeBuilder } from "@/lib/generation/useNodeBuilder";
@@ -100,7 +100,8 @@ function CharacterEditDialogBody({
 		queue.enqueueGraph([avatarNode]);
 	};
 
-	const isStale = isNodeStale(avatarNode, queue);
+	const staleWhy = staleReason(avatarNode, queue);
+	const isStale = staleWhy !== null;
 
 	const generating = isGenerationActive(avatarSnapshot.status);
 	const hasAppearance = Boolean(character.appearance?.trim());
@@ -158,7 +159,7 @@ function CharacterEditDialogBody({
 								elementId={avatarElementId}
 								onRestore={restoreAppearance}
 							/>
-							{isStale && <StaleIndicator />}
+							{staleWhy && <StaleIndicator reason={staleWhy} />}
 							<GenerateButton
 								status={avatarSnapshot.status}
 								hasResult={Boolean(avatarUrl)}

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -100,8 +100,8 @@ function CharacterEditDialogBody({
 		queue.enqueueGraph([avatarNode]);
 	};
 
-	const staleWhy = staleReason(avatarNode, queue);
-	const isStale = staleWhy !== null;
+	const reason = staleReason(avatarNode, queue);
+	const isStale = reason !== null;
 
 	const generating = isGenerationActive(avatarSnapshot.status);
 	const hasAppearance = Boolean(character.appearance?.trim());
@@ -159,7 +159,7 @@ function CharacterEditDialogBody({
 								elementId={avatarElementId}
 								onRestore={restoreAppearance}
 							/>
-							{staleWhy && <StaleIndicator reason={staleWhy} />}
+							{reason && <StaleIndicator reason={reason} />}
 							<GenerateButton
 								status={avatarSnapshot.status}
 								hasResult={Boolean(avatarUrl)}

--- a/app/components/canvas/hooks/useGenerate.ts
+++ b/app/components/canvas/hooks/useGenerate.ts
@@ -3,7 +3,8 @@ import {
 	useGenerationQueue,
 	useQueueSelector,
 } from "@/lib/generation/GenerationQueueProvider";
-import { forElement, isNodeStale } from "@/lib/generation/graph";
+import { forElement } from "@/lib/generation/graph";
+import { staleReason } from "@/lib/generation/staleReason";
 import { useNodeBuilder } from "@/lib/generation/useNodeBuilder";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 
@@ -15,7 +16,7 @@ export function useGenerate(element: CanvasContentElement) {
 		() => buildNode(forElement(element)),
 		[buildNode, element],
 	);
-	const stale = useQueueSelector((q) => isNodeStale(node, q));
+	const reason = useQueueSelector((q) => staleReason(node, q));
 
 	const generate = useCallback(() => {
 		if (!node.inputs.prompt) {
@@ -36,7 +37,7 @@ export function useGenerate(element: CanvasContentElement) {
 		result: snapshot.result,
 		error: snapshot.error,
 		pinned: snapshot.pinned,
-		stale,
+		staleReason: reason,
 		hasPrompt: Boolean(node.inputs.prompt),
 		hasResult: Boolean(snapshot.result),
 		generate,

--- a/lib/connectors/animated_image/plugins/still-frame.ts
+++ b/lib/connectors/animated_image/plugins/still-frame.ts
@@ -52,7 +52,11 @@ export function stillElement(
 
 export const forStillOf =
 	(element: CanvasContentElement): NodeSpec =>
-	() => ({ element: stillElement(element), plugins: buildImagePlugins() });
+	() => ({
+		element: stillElement(element),
+		plugins: buildImagePlugins(),
+		label: "the still frame",
+	});
 
 /** The still node behind an animated image, when the element has one. */
 export const stillDependency = (node: GenerationNode) =>

--- a/lib/connectors/image/plugins/characterAvatarNode.ts
+++ b/lib/connectors/image/plugins/characterAvatarNode.ts
@@ -24,6 +24,7 @@ export const forCharacterAvatar =
 	(state) => ({
 		element: characterAvatarElement(state, name),
 		plugins: buildCharacterAvatarPlugins(name),
+		label: `${name}'s avatar`,
 	});
 
 /**

--- a/lib/generation/__tests__/staleReason.test.ts
+++ b/lib/generation/__tests__/staleReason.test.ts
@@ -28,10 +28,12 @@ function node(
 		prompt = id,
 		attributes = {},
 		dependsOn = [],
+		label,
 	}: {
 		prompt?: string;
 		attributes?: Record<string, string>;
 		dependsOn?: GenerationNode[];
+		label?: string;
 	} = {},
 ): GenerationNode {
 	const job: GenerationJob = {
@@ -42,7 +44,7 @@ function node(
 		config,
 		state: EMPTY_STATE,
 	};
-	return { id, inputs: { prompt, attributes }, dependsOn, job };
+	return { id, inputs: { prompt, attributes }, dependsOn, label, job };
 }
 
 const commit = (queue: GenerationQueue, target: GenerationNode, url: string) =>
@@ -90,7 +92,9 @@ describe("staleReason", () => {
 
 	it("names an upstream avatar by its character", () => {
 		const queue = new GenerationQueue();
-		const avatar = node(derivedNodeId("avatar", "Red"));
+		const avatar = node(derivedNodeId("avatar", "Red"), {
+			label: "Red's avatar",
+		});
 		const image = node("a", { dependsOn: [avatar] });
 		commit(queue, avatar, "red.png");
 		commit(queue, image, "a.png");
@@ -101,10 +105,25 @@ describe("staleReason", () => {
 		);
 	});
 
+	it("falls back to a shrug for a dependency with no label", () => {
+		const queue = new GenerationQueue();
+		const dep = node("dep");
+		const image = node("a", { dependsOn: [dep] });
+		commit(queue, dep, "dep.png");
+		commit(queue, image, "a.png");
+
+		commit(queue, dep, "dep-v2.png");
+		expect(staleReason(image, queue)).toBe(
+			"An upstream element changed — regenerate to update",
+		);
+	});
+
 	it("names a project source node", () => {
 		const queue = new GenerationQueue();
 		const withStyle = (style: string) =>
-			node("a", { dependsOn: [sourceNode("project:artStyle", { style })] });
+			node("a", {
+				dependsOn: [sourceNode("project:artStyle", { style }, "the art style")],
+			});
 		commit(queue, withStyle("watercolor"), "a.png");
 
 		expect(staleReason(withStyle("noir"), queue)).toBe(
@@ -115,9 +134,12 @@ describe("staleReason", () => {
 	it("names a dependency that is itself stale, even though its output has not changed", () => {
 		const queue = new GenerationQueue();
 		const refs = (urls: string) =>
-			sourceNode("project:referenceImages", { urls });
+			sourceNode("project:referenceImages", { urls }, "the reference images");
 		const avatar = (urls: string) =>
-			node(derivedNodeId("avatar", "Red"), { dependsOn: [refs(urls)] });
+			node(derivedNodeId("avatar", "Red"), {
+				dependsOn: [refs(urls)],
+				label: "Red's avatar",
+			});
 		const image = (urls: string) => node("a", { dependsOn: [avatar(urls)] });
 
 		commit(queue, avatar("a.png"), "red.png");
@@ -133,7 +155,7 @@ describe("staleReason", () => {
 		const withStyle = (prompt: string, style: string) =>
 			node("a", {
 				prompt,
-				dependsOn: [sourceNode("project:artStyle", { style })],
+				dependsOn: [sourceNode("project:artStyle", { style }, "the art style")],
 			});
 		commit(queue, withStyle("a knight", "watercolor"), "a.png");
 
@@ -152,7 +174,7 @@ describe("staleReason", () => {
 		commit(queue, withAttrs("1"), "a.png");
 
 		expect(staleReason(withAttrs("2"), queue)).toBe(
-			"The prompt, model, duration and 1 more changed — regenerate to update",
+			"The prompt, model, duration, and 1 more changed — regenerate to update",
 		);
 	});
 });

--- a/lib/generation/__tests__/staleReason.test.ts
+++ b/lib/generation/__tests__/staleReason.test.ts
@@ -17,8 +17,6 @@ const EMPTY_STATE = {
 };
 
 const config: ConnectorConfig = {
-	defaultModel: "m",
-	models: ["m"],
 	isDefault: true,
 };
 

--- a/lib/generation/__tests__/staleReason.test.ts
+++ b/lib/generation/__tests__/staleReason.test.ts
@@ -1,0 +1,158 @@
+import { MetadataSchema } from "@/lib/project/types";
+import { describe, expect, it } from "vitest";
+import type { ConnectorConfig } from "@/lib/connectors/types";
+import {
+	derivedNodeId,
+	sourceNode,
+	type GenerationJob,
+	type GenerationNode,
+} from "../graph";
+import { GenerationQueue } from "../queue";
+import { staleReason } from "../staleReason";
+
+const EMPTY_STATE = {
+	hydrated: true,
+	metadata: MetadataSchema.parse({}),
+	referenceImages: [],
+};
+
+const config: ConnectorConfig = {
+	defaultModel: "m",
+	models: ["m"],
+	isDefault: true,
+};
+
+function node(
+	id: string,
+	{
+		prompt = id,
+		attributes = {},
+		dependsOn = [],
+	}: {
+		prompt?: string;
+		attributes?: Record<string, string>;
+		dependsOn?: GenerationNode[];
+	} = {},
+): GenerationNode {
+	const job: GenerationJob = {
+		elementId: id,
+		elementType: "image",
+		connectorType: "image",
+		provider: "openslop",
+		config,
+		state: EMPTY_STATE,
+	};
+	return { id, inputs: { prompt, attributes }, dependsOn, job };
+}
+
+const commit = (queue: GenerationQueue, target: GenerationNode, url: string) =>
+	queue.commitResult(target, { imageUrl: url, durationSec: 0 });
+
+describe("staleReason", () => {
+	it("is null for a node that has never generated", () => {
+		expect(staleReason(node("a"), new GenerationQueue())).toBeNull();
+	});
+
+	it("is null right after a result is committed", () => {
+		const queue = new GenerationQueue();
+		commit(queue, node("a"), "a.png");
+		expect(staleReason(node("a"), queue)).toBeNull();
+	});
+
+	it("names the prompt when only the prompt changed", () => {
+		const queue = new GenerationQueue();
+		commit(queue, node("a", { prompt: "a knight" }), "a.png");
+
+		expect(staleReason(node("a", { prompt: "a wizard" }), queue)).toBe(
+			"The prompt changed — regenerate to update",
+		);
+	});
+
+	it("names the changed attribute rather than blaming the prompt", () => {
+		const queue = new GenerationQueue();
+		const withModel = (model: string) =>
+			node("a", { attributes: { model, videoPrompt: "pan" } });
+		commit(queue, withModel("fast"), "a.png");
+
+		expect(staleReason(withModel("slow"), queue)).toBe(
+			"Model changed — regenerate to update",
+		);
+	});
+
+	it("names an attribute the element no longer carries", () => {
+		const queue = new GenerationQueue();
+		commit(queue, node("a", { attributes: { duration: "5" } }), "a.png");
+
+		expect(staleReason(node("a"), queue)).toBe(
+			"Duration changed — regenerate to update",
+		);
+	});
+
+	it("names an upstream avatar by its character", () => {
+		const queue = new GenerationQueue();
+		const avatar = node(derivedNodeId("avatar", "Red"));
+		const image = node("a", { dependsOn: [avatar] });
+		commit(queue, avatar, "red.png");
+		commit(queue, image, "a.png");
+
+		commit(queue, avatar, "red-v2.png");
+		expect(staleReason(image, queue)).toBe(
+			"Red's avatar changed — regenerate to update",
+		);
+	});
+
+	it("names a project source node", () => {
+		const queue = new GenerationQueue();
+		const withStyle = (style: string) =>
+			node("a", { dependsOn: [sourceNode("project:artStyle", { style })] });
+		commit(queue, withStyle("watercolor"), "a.png");
+
+		expect(staleReason(withStyle("noir"), queue)).toBe(
+			"The art style changed — regenerate to update",
+		);
+	});
+
+	it("names a dependency that is itself stale, even though its output has not changed", () => {
+		const queue = new GenerationQueue();
+		const refs = (urls: string) =>
+			sourceNode("project:referenceImages", { urls });
+		const avatar = (urls: string) =>
+			node(derivedNodeId("avatar", "Red"), { dependsOn: [refs(urls)] });
+		const image = (urls: string) => node("a", { dependsOn: [avatar(urls)] });
+
+		commit(queue, avatar("a.png"), "red.png");
+		commit(queue, image("a.png"), "a.png");
+
+		expect(staleReason(image("b.png"), queue)).toBe(
+			"Red's avatar changed — regenerate to update",
+		);
+	});
+
+	it("lists several causes together", () => {
+		const queue = new GenerationQueue();
+		const withStyle = (prompt: string, style: string) =>
+			node("a", {
+				prompt,
+				dependsOn: [sourceNode("project:artStyle", { style })],
+			});
+		commit(queue, withStyle("a knight", "watercolor"), "a.png");
+
+		expect(staleReason(withStyle("a wizard", "noir"), queue)).toBe(
+			"The prompt and the art style changed — regenerate to update",
+		);
+	});
+
+	it("counts off the causes past the first three", () => {
+		const queue = new GenerationQueue();
+		const withAttrs = (v: string) =>
+			node("a", {
+				prompt: v,
+				attributes: { model: v, duration: v, motion: v },
+			});
+		commit(queue, withAttrs("1"), "a.png");
+
+		expect(staleReason(withAttrs("2"), queue)).toBe(
+			"The prompt, model, duration and 1 more changed — regenerate to update",
+		);
+	});
+});

--- a/lib/generation/graph.ts
+++ b/lib/generation/graph.ts
@@ -94,11 +94,19 @@ export const derivedNodeId = (kind: string, key: string): NodeId =>
 export const derivedDependency = (node: GenerationNode, kind: string) =>
 	node.dependsOn.find((dep) => dep.id === derivedNodeId(kind, node.id));
 
-const DERIVED_ID = new RegExp(`^\\${DERIVED_PREFIX}[^:]+:(.+)$`);
+const DERIVED_ID = new RegExp(`^\\${DERIVED_PREFIX}([^:]+):(.+)$`);
+
+/** The kind and key a derived id was minted from, if it was derived at all. */
+export function parseDerivedId(
+	id: NodeId,
+): { kind: string; key: string } | null {
+	const [, kind, key] = DERIVED_ID.exec(id) ?? [];
+	return kind && key ? { kind, key } : null;
+}
 
 /** The node a derived id was minted from, if it was derived at all. */
 export const derivedFrom = (id: NodeId): NodeId | null =>
-	DERIVED_ID.exec(id)?.[1] ?? null;
+	parseDerivedId(id)?.key ?? null;
 
 export function sourceNode(
 	id: NodeId,

--- a/lib/generation/graph.ts
+++ b/lib/generation/graph.ts
@@ -36,6 +36,8 @@ type NodeBase = {
 	id: NodeId;
 	inputs: NodeInputs;
 	dependsOn: GenerationNode[];
+	/** How the node reads when a dependent has to name it to the user. */
+	label?: string;
 };
 
 /** Project state that is read rather than generated; its identity is its inputs. */
@@ -51,6 +53,7 @@ export type GenerationNode = SourceNode | JobNode;
 export type ElementNode = {
 	element: CanvasContentElement;
 	plugins?: ConnectorPlugin[];
+	label?: string;
 };
 
 /**
@@ -94,28 +97,22 @@ export const derivedNodeId = (kind: string, key: string): NodeId =>
 export const derivedDependency = (node: GenerationNode, kind: string) =>
 	node.dependsOn.find((dep) => dep.id === derivedNodeId(kind, node.id));
 
-const DERIVED_ID = new RegExp(`^\\${DERIVED_PREFIX}([^:]+):(.+)$`);
-
-/** The kind and key a derived id was minted from, if it was derived at all. */
-export function parseDerivedId(
-	id: NodeId,
-): { kind: string; key: string } | null {
-	const [, kind, key] = DERIVED_ID.exec(id) ?? [];
-	return kind && key ? { kind, key } : null;
-}
+const DERIVED_ID = new RegExp(`^\\${DERIVED_PREFIX}[^:]+:(.+)$`);
 
 /** The node a derived id was minted from, if it was derived at all. */
 export const derivedFrom = (id: NodeId): NodeId | null =>
-	parseDerivedId(id)?.key ?? null;
+	DERIVED_ID.exec(id)?.[1] ?? null;
 
 export function sourceNode(
 	id: NodeId,
 	attributes: Record<string, string | number>,
+	label?: string,
 ): SourceNode {
 	return {
 		id,
 		inputs: { prompt: "", attributes },
 		dependsOn: [],
+		label,
 		job: null,
 	};
 }

--- a/lib/generation/resolveGraph.ts
+++ b/lib/generation/resolveGraph.ts
@@ -25,8 +25,10 @@ const toNode = (
 	plugins: ConnectorPlugin[],
 	state: ProjectData,
 	dependsOn: GenerationNode[],
+	label: string | undefined,
 ): JobNode => ({
 	id: element.id,
+	label,
 	inputs: {
 		prompt: getPromptText(element),
 		attributes: element.generationAttributes ?? {},
@@ -57,7 +59,7 @@ export function nodeBuilder(
 		const resolved = new Map<string, JobNode>();
 		const resolving = new Set<string>();
 
-		const build = ({ element, plugins: override }: ElementNode) => {
+		const build = ({ element, plugins: override, label }: ElementNode) => {
 			const { id } = element;
 			const existing = resolved.get(id);
 			if (existing) return existing;
@@ -70,7 +72,7 @@ export function nodeBuilder(
 			const dependsOn = plugins.flatMap(
 				(plugin) => plugin.dependencies?.(element).map(resolve) ?? [],
 			);
-			const node = toNode(element, connector, plugins, state, dependsOn);
+			const node = toNode(element, connector, plugins, state, dependsOn, label);
 
 			resolving.delete(id);
 			resolved.set(id, node);

--- a/lib/generation/sourceNodes.ts
+++ b/lib/generation/sourceNodes.ts
@@ -7,26 +7,36 @@ import { sourceNode, type NodeSpec } from "./graph";
  * change to it, which is what keeps reads from drifting out of the inputs.
  */
 export const forReferenceImages: NodeSpec = (state) =>
-	sourceNode("project:referenceImages", {
-		urls: state.referenceImages.join(","),
-	});
+	sourceNode(
+		"project:referenceImages",
+		{ urls: state.referenceImages.join(",") },
+		"the reference images",
+	);
 
 export const forArtStyle: NodeSpec = (state) =>
-	sourceNode("project:artStyle", { style: state.metadata.style.trim() });
+	sourceNode(
+		"project:artStyle",
+		{ style: state.metadata.style.trim() },
+		"the art style",
+	);
 
 export const forAspectRatio: NodeSpec = (state) =>
-	sourceNode("project:aspectRatio", {
-		aspectRatio: state.metadata.videoSettings.aspectRatio,
-	});
+	sourceNode(
+		"project:aspectRatio",
+		{ aspectRatio: state.metadata.videoSettings.aspectRatio },
+		"the aspect ratio",
+	);
 
 export const forVoice =
 	(characterName?: string): NodeSpec =>
 	(state) => {
 		const { narration, characters } = state.metadata;
 		const voice = characterName ? characters[characterName] : narration;
-		return sourceNode(`project:voice:${characterName ?? "narrator"}`, {
-			voiceId: voice?.voiceId ?? "",
-		});
+		return sourceNode(
+			`project:voice:${characterName ?? "narrator"}`,
+			{ voiceId: voice?.voiceId ?? "" },
+			`${characterName ?? "the narrator"}'s voice`,
+		);
 	};
 
 export const aspectDimensions = (state: ProjectData) =>

--- a/lib/generation/staleReason.ts
+++ b/lib/generation/staleReason.ts
@@ -1,0 +1,96 @@
+import lowerCase from "lodash/lowerCase";
+import upperFirst from "lodash/upperFirst";
+import {
+	isNodeStale,
+	needsGeneration,
+	nodeInputs,
+	parseDerivedId,
+	type GenerationNode,
+	type NodeId,
+	type NodeResults,
+} from "./graph";
+
+/** How many changes are named before the rest are counted off. */
+const MAX_NAMED = 3;
+
+const SOURCE_LABELS: Record<NodeId, string> = {
+	"project:artStyle": "the art style",
+	"project:referenceImages": "the reference images",
+	"project:aspectRatio": "the aspect ratio",
+};
+
+const VOICE_PREFIX = "project:voice:";
+
+const DERIVED_LABELS: Record<string, (key: string) => string> = {
+	avatar: (name) => `${name}'s avatar`,
+	still: () => "the still frame",
+};
+
+/**
+ * A dependency reads as what the user recognizes, not as its node id. Derived
+ * and project-source ids are a closed set; anything else is another element,
+ * whose own id would mean nothing on a badge.
+ */
+function dependencyLabel(id: NodeId): string {
+	const derived = parseDerivedId(id);
+	if (derived) {
+		const label = DERIVED_LABELS[derived.kind];
+		if (label) return label(derived.key);
+	}
+	if (id.startsWith(VOICE_PREFIX)) {
+		const name = id.slice(VOICE_PREFIX.length);
+		return name === "narrator" ? "the narrator's voice" : `${name}'s voice`;
+	}
+	return SOURCE_LABELS[id] ?? "an upstream element";
+}
+
+/** Everything about `node` that no longer matches the result it produced. */
+function changedInputs(node: GenerationNode, results: NodeResults): string[] {
+	const previous = results.getElementSnapshot(node.id).resultInputs;
+	if (!previous) return [];
+	const current = nodeInputs(node, results);
+
+	const changed: string[] = [];
+	if (current.prompt !== previous.prompt) changed.push("the prompt");
+	const keys = new Set([
+		...Object.keys(current.attributes),
+		...Object.keys(previous.attributes),
+	]);
+	for (const key of keys) {
+		if (current.attributes[key] !== previous.attributes[key]) {
+			changed.push(lowerCase(key));
+		}
+	}
+	for (const dep of node.dependsOn) {
+		if (
+			current.dependencies[dep.id] !== previous.dependencies[dep.id] ||
+			needsGeneration(dep, results)
+		) {
+			changed.push(dependencyLabel(dep.id));
+		}
+	}
+	return changed;
+}
+
+function joinChanges(changes: string[]): string {
+	const named = changes.slice(0, MAX_NAMED);
+	const rest = changes.length - named.length;
+	if (rest > 0) return `${named.join(", ")} and ${rest} more`;
+	if (named.length === 1) return named[0] ?? "";
+	return `${named.slice(0, -1).join(", ")} and ${named.at(-1)}`;
+}
+
+/**
+ * Why the badge is lit, in the user's terms. Staleness has three independent
+ * causes and the dependency one has no visible locus, so naming it is the whole
+ * point of the tooltip. `null` means the element is not stale.
+ */
+export function staleReason(
+	node: GenerationNode,
+	results: NodeResults,
+): string | null {
+	if (!isNodeStale(node, results)) return null;
+	const changes = [...new Set(changedInputs(node, results))];
+	const what = changes.length > 0 ? joinChanges(changes) : "its inputs";
+	return `${upperFirst(what)} changed — regenerate to update`;
+}

--- a/lib/generation/staleReason.ts
+++ b/lib/generation/staleReason.ts
@@ -4,45 +4,14 @@ import {
 	isNodeStale,
 	needsGeneration,
 	nodeInputs,
-	parseDerivedId,
 	type GenerationNode,
-	type NodeId,
 	type NodeResults,
 } from "./graph";
 
 /** How many changes are named before the rest are counted off. */
 const MAX_NAMED = 3;
 
-const SOURCE_LABELS: Record<NodeId, string> = {
-	"project:artStyle": "the art style",
-	"project:referenceImages": "the reference images",
-	"project:aspectRatio": "the aspect ratio",
-};
-
-const VOICE_PREFIX = "project:voice:";
-
-const DERIVED_LABELS: Record<string, (key: string) => string> = {
-	avatar: (name) => `${name}'s avatar`,
-	still: () => "the still frame",
-};
-
-/**
- * A dependency reads as what the user recognizes, not as its node id. Derived
- * and project-source ids are a closed set; anything else is another element,
- * whose own id would mean nothing on a badge.
- */
-function dependencyLabel(id: NodeId): string {
-	const derived = parseDerivedId(id);
-	if (derived) {
-		const label = DERIVED_LABELS[derived.kind];
-		if (label) return label(derived.key);
-	}
-	if (id.startsWith(VOICE_PREFIX)) {
-		const name = id.slice(VOICE_PREFIX.length);
-		return name === "narrator" ? "the narrator's voice" : `${name}'s voice`;
-	}
-	return SOURCE_LABELS[id] ?? "an upstream element";
-}
+const list = new Intl.ListFormat("en", { type: "conjunction" });
 
 /** Everything about `node` that no longer matches the result it produced. */
 function changedInputs(node: GenerationNode, results: NodeResults): string[] {
@@ -50,47 +19,39 @@ function changedInputs(node: GenerationNode, results: NodeResults): string[] {
 	if (!previous) return [];
 	const current = nodeInputs(node, results);
 
-	const changed: string[] = [];
-	if (current.prompt !== previous.prompt) changed.push("the prompt");
-	const keys = new Set([
+	const changed = new Set<string>();
+	if (current.prompt !== previous.prompt) changed.add("the prompt");
+	const keys = [
 		...Object.keys(current.attributes),
 		...Object.keys(previous.attributes),
-	]);
+	];
 	for (const key of keys) {
-		if (current.attributes[key] !== previous.attributes[key]) {
-			changed.push(lowerCase(key));
-		}
+		if (current.attributes[key] !== previous.attributes[key])
+			changed.add(lowerCase(key));
 	}
 	for (const dep of node.dependsOn) {
 		if (
 			current.dependencies[dep.id] !== previous.dependencies[dep.id] ||
 			needsGeneration(dep, results)
-		) {
-			changed.push(dependencyLabel(dep.id));
-		}
+		)
+			changed.add(dep.label ?? "an upstream element");
 	}
-	return changed;
-}
-
-function joinChanges(changes: string[]): string {
-	const named = changes.slice(0, MAX_NAMED);
-	const rest = changes.length - named.length;
-	if (rest > 0) return `${named.join(", ")} and ${rest} more`;
-	if (named.length === 1) return named[0] ?? "";
-	return `${named.slice(0, -1).join(", ")} and ${named.at(-1)}`;
+	return [...changed];
 }
 
 /**
- * Why the badge is lit, in the user's terms. Staleness has three independent
- * causes and the dependency one has no visible locus, so naming it is the whole
- * point of the tooltip. `null` means the element is not stale.
+ * Why the badge is lit, in the user's terms. A dependency has no visible locus
+ * on the canvas, so naming it is the whole point. `null` means not stale.
  */
 export function staleReason(
 	node: GenerationNode,
 	results: NodeResults,
 ): string | null {
 	if (!isNodeStale(node, results)) return null;
-	const changes = [...new Set(changedInputs(node, results))];
-	const what = changes.length > 0 ? joinChanges(changes) : "its inputs";
+	const changes = changedInputs(node, results);
+	const named = changes.slice(0, MAX_NAMED);
+	const rest = changes.length - named.length;
+	if (rest > 0) named.push(`${rest} more`);
+	const what = named.length > 0 ? list.format(named) : "its inputs";
 	return `${upperFirst(what)} changed — regenerate to update`;
 }


### PR DESCRIPTION
## Summary

`StaleIndicator`'s tooltip was a hardcoded `"Prompt changed — regenerate to update"`, but staleness has three independent causes and only one of them is the prompt. `needsGeneration` diffs the whole of `nodeInputs` — prompt, attributes, and the resolved identity of every dependency — so an element could go stale because a character's appearance changed three cards away, or the model changed in Settings, and the badge still said the prompt changed.

The dependency case is the one with no visible locus, so it gets a name rather than a shrug.

- New pure `staleReason(node, results)` in `lib/generation/staleReason.ts`. It reuses `isNodeStale` for the boolean and diffs `nodeInputs` against the snapshot's `resultInputs` to describe what actually moved. Returns `null` when the element is not stale, so it replaces the boolean at the two call sites rather than sitting beside it.
- A node carries the `label` a dependent uses to name it, set where the node is minted: `forCharacterAvatar` → "Red's avatar", `forStillOf` → "the still frame", `forArtStyle` → "the art style", `forVoice` → "<name>'s voice". `staleReason` reads `dep.label` and never parses an id.
- Attribute keys are already user-facing names, so they are humanised (`videoPrompt` → "video prompt") rather than mapped.
- Past three causes the rest are counted off ("… and 2 more") so the badge stays a badge.

No visual change: same badge, same tooltip component, only the text is now true.

## Selected issue and why it was safe

#537, `size: M`, `priority: medium`. It was picked because the fix is almost entirely a pure domain function over data that is already recorded (`resultInputs` is the exact input set the current result came from, and `CharacterEditModal` already reads it for its Revert button). No new state, no new surface, no schema change, no design decision — the suggested direction in the issue spells out the shape, and the rendering stays in the badge that already exists.

## Validation

| Check | Result |
| --- | --- |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm run knip` | pass |
| `npm run build` | pass |
| `npm run test:run` | 1446 passed (161 files), incl. 11 new `staleReason` tests |
| `npm run test:e2e` | 3 passed |

New tests cover: not stale → `null`; prompt-only change; attribute change not blamed on the prompt; an attribute the element no longer carries; an upstream avatar named by its character; a project source node; a dependency that is itself stale though its output is unchanged; several causes joined; the count-off past three.

## Open-PR overlap check

Diffed this branch's file list against `gh pr diff --name-only` for all 13 open PRs (#662, #668, #674, #680–#684, #687–#691). Zero overlap. Notably `ElementContainer.tsx` (touched by #662) and `lib/video/sceneSegments.ts` (touched by #668) are untouched here.

## Candidates skipped

- #461 (`size: S`) — already implemented on master (`CaptionWord.active`, `style.activeWord`, `captionPresets`, the Captions panel control). The issue is stale, not open work.
- #667, #254 — `good first issue`, reserved for outside contributors.
- #365, #366, #492, #598, #666 — already claimed by open PRs #691, #674, #662, #684, #683.
- #610, #632 — both would edit `lib/agent/tools/context.ts`, `registry.ts`, `useAgentTools.ts` and `prompt.ts`, all in flight on #684.
- #398 — blocked on its stated prerequisite #370, which establishes the persisted metadata field it writes to.
- #594 — the issue itself says gap 2 "still needs designing", and an unmerged branch already covers gap 1.
- #345, #316 — would edit `ElementContainer.tsx` / the SFX connector files that #662 has open.
- #267, #631, #653, #685 — new product surface or larger architecture than one unattended run should take.

Closes #537