### PR TITLE
refactor: give the dialog scroll body one home

### DIFF
--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -5,6 +5,7 @@ import { Trash2 } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { CloseButton } from "@/components/ui/close-button";
 import {
+	DialogBody,
 	DialogContent,
 	DialogDescription,
 	DialogFooter,
@@ -144,7 +145,7 @@ function CharacterEditDialogBody({
 				</DialogDescription>
 			</DialogHeader>
 
-			<div className="-mx-1 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-1">
+			<DialogBody>
 				<div className="grid gap-4 sm:grid-cols-2">
 					<div className="flex flex-col gap-2">
 						<TextAreaField
@@ -191,7 +192,7 @@ function CharacterEditDialogBody({
 					</div>
 				</div>
 				<VoiceSection voice={character} onChange={update} />
-			</div>
+			</DialogBody>
 
 			<DialogFooter className="shrink-0">
 				<Button

--- a/app/components/canvas/elements/character/NarratorEditModal.tsx
+++ b/app/components/canvas/elements/character/NarratorEditModal.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import {
+	DialogBody,
 	DialogContent,
 	DialogDescription,
 	DialogFooter,
@@ -41,9 +42,9 @@ function NarratorEditDialogBody({ onClose }: { onClose: () => void }) {
 				<DialogDescription>Change how the narrator sounds</DialogDescription>
 			</DialogHeader>
 
-			<div className="-mx-1 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-1">
+			<DialogBody>
 				<VoiceSection voice={narration} onChange={update} />
-			</div>
+			</DialogBody>
 
 			<DialogFooter className="shrink-0">
 				<Button type="button" size="sm" onClick={onClose}>

--- a/app/components/canvas/elements/style/ArtStyleModal.tsx
+++ b/app/components/canvas/elements/style/ArtStyleModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
+	DialogBody,
 	DialogContent,
 	DialogDescription,
 	DialogFooter,
@@ -83,7 +84,7 @@ function ArtStyleDialogBody({ onClose }: { onClose: () => void }) {
 				</DialogDescription>
 			</DialogHeader>
 
-			<div className="-mx-1 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-1">
+			<DialogBody>
 				<section aria-label="Reference images" className="flex flex-col gap-2">
 					<FieldLabel>Reference images</FieldLabel>
 					<div className="flex flex-wrap gap-2">
@@ -122,7 +123,7 @@ function ArtStyleDialogBody({ onClose }: { onClose: () => void }) {
 				</div>
 
 				<ArtStylePresets value={style} onSelect={setStyle} />
-			</div>
+			</DialogBody>
 
 			<DialogFooter className="shrink-0">
 				<Button type="button" size="sm" onClick={onClose}>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -117,6 +117,23 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
 	);
 }
 
+/**
+ * The scrolling middle of a header/body/footer dialog. The negative margin lets
+ * focus rings on the edge of a field survive the `overflow-y-auto` clip.
+ */
+function DialogBody({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="dialog-body"
+			className={cn(
+				"-mx-1 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-1",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
 function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<div
@@ -165,6 +182,7 @@ export {
 	DialogOverlay,
 	DialogContent,
 	DialogHeader,
+	DialogBody,
 	DialogFooter,
 	DialogTitle,
 	DialogDescription,


### PR DESCRIPTION
Nightly CONVENTIONS.md compliance sweep (fifteenth).

## Violation fixed

**Rule 5 (one canonical way / DRY is about knowledge).** The three modals with a scrolling middle each hand-wrote the same class string:

- `app/components/canvas/elements/character/NarratorEditModal.tsx:44`
- `app/components/canvas/elements/style/ArtStyleModal.tsx:86`
- `app/components/canvas/elements/character/CharacterEditModal.tsx:147`

```tsx
<div className="-mx-1 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-1">
```

`components/ui/dialog.tsx` already owns `DialogHeader` and `DialogFooter`, so the body was the one slot of the header/body/footer shape with no home — the layout survived as a convention three files had to remember, and the design system's "no one-off Tailwind in higher-level components" rule was being broken at each site. Adds `DialogBody` and uses it.

Rule of three is met exactly. This was flagged in the 2026-08-30 sweep but blocked on PR #687; that has since merged.

## No behaviour change

`DialogBody` emits the identical class string through the same `cn()` path as its sibling slots, so the rendered output at all three sites is byte-identical. `shrink-0` is left on the headers and footers untouched.

## Rest of the sweep

The delta since the last sweep (15 files from #689 and #692) was clean for all seven rule categories. Repo-wide re-greps are unchanged from the last sweep: 3 bare `catch {}` (the same intentional ones in `lib/supabase/server.ts` and `lib/api/parse.ts`), 3 `switch` statements (all discriminated-union dispatch), zero catch-return-null, zero `as any`, zero non-null assertions, zero provider sniffing.

`npm run lint`, `typecheck`, `format:check`, `test:run` (1509 passed) and `build` all green.