### PR TITLE
fix: don't leave an interrupted Sloppy turn spinning forever

### DIFF
--- a/app/components/sloppy/Reasoning.tsx
+++ b/app/components/sloppy/Reasoning.tsx
@@ -2,18 +2,16 @@
 
 import { Sparkles } from "@/components/ui/icon";
 import { Disclosure, DisclosureText } from "@/components/ui/disclosure";
-import { reasoningOpen } from "./turnDisplay";
 
 export function Reasoning({
 	text,
 	streaming,
-	superseded,
+	open,
 }: {
 	text: string;
 	streaming: boolean;
-	superseded: boolean;
+	open: boolean;
 }) {
-	const open = reasoningOpen(superseded, text);
 	return (
 		<Disclosure
 			// Keyed on the auto state so reasoning that streams in open shuts itself

--- a/app/components/sloppy/SloppyMessage.tsx
+++ b/app/components/sloppy/SloppyMessage.tsx
@@ -6,7 +6,7 @@ import { PanelCard } from "../canvas/panel/PanelCard";
 import { Reasoning } from "./Reasoning";
 import { Tool } from "./Tool";
 import { WorkedStatus } from "./TurnStatus";
-import { userText, type TurnPart } from "./turnDisplay";
+import { reasoningOpen, userText, type TurnPart } from "./turnDisplay";
 
 export function UserMessage({ message }: { message: SloppyMessage }) {
 	return (
@@ -26,14 +26,23 @@ function ReplyText({ text }: { text: string }) {
 	);
 }
 
-function Step({ part, superseded }: { part: TurnPart; superseded: boolean }) {
+function Step({
+	part,
+	live,
+	superseded,
+}: {
+	part: TurnPart;
+	/** A restored transcript is never live, however its parts were stored. */
+	live: boolean;
+	superseded: boolean;
+}) {
 	if (isTextUIPart(part)) return <ReplyText text={part.text} />;
 	if (part.type === "reasoning") {
 		return (
 			<Reasoning
 				text={part.text}
-				streaming={part.state === "streaming"}
-				superseded={superseded}
+				streaming={live && part.state === "streaming"}
+				open={reasoningOpen(live, superseded, part.text)}
 			/>
 		);
 	}
@@ -57,6 +66,7 @@ export function AgentTurn({
 				<Step
 					key={`${message.id}-${index}`}
 					part={part}
+					live={streaming}
 					superseded={part !== newest}
 				/>
 			))}

--- a/app/components/sloppy/__tests__/SloppyMessage.test.tsx
+++ b/app/components/sloppy/__tests__/SloppyMessage.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { SloppyMessage } from "@/lib/agent/types";
+import { AgentTurn } from "../SloppyMessage";
+
+const interrupted: SloppyMessage = {
+	id: "m2",
+	role: "assistant",
+	parts: [
+		{ type: "step-start" },
+		{ type: "reasoning", text: "half a thought", state: "streaming" },
+	],
+};
+
+const render = (message: SloppyMessage, streaming: boolean) =>
+	renderToStaticMarkup(<AgentTurn message={message} streaming={streaming} />);
+
+describe("AgentTurn", () => {
+	it("shows a restored half-open turn as finished, not as still thinking", () => {
+		const markup = render(interrupted, false);
+
+		expect(markup).toContain("Done thinking");
+		expect(markup).not.toContain("Thinking…");
+		expect(markup).not.toContain("shimmer");
+	});
+
+	it("leaves the abandoned half-thought collapsed rather than expanded", () => {
+		expect(render(interrupted, false)).not.toContain("half a thought");
+		expect(render(interrupted, true)).toContain("half a thought");
+	});
+
+	it("still shows the turn in flight as thinking", () => {
+		expect(render(interrupted, true)).toContain("Thinking…");
+	});
+});

--- a/app/components/sloppy/__tests__/turnDisplay.test.ts
+++ b/app/components/sloppy/__tests__/turnDisplay.test.ts
@@ -40,15 +40,19 @@ describe("turnStatus", () => {
 });
 
 describe("reasoningOpen", () => {
-	it("opens the thought while it is the newest thing in the turn", () => {
-		expect(reasoningOpen(false, "weighing")).toBe(true);
+	it("opens the thought while it is the newest thing in a live turn", () => {
+		expect(reasoningOpen(true, false, "weighing")).toBe(true);
 	});
 
 	it("shuts it once Sloppy has moved on", () => {
-		expect(reasoningOpen(true, "weighing")).toBe(false);
+		expect(reasoningOpen(true, true, "weighing")).toBe(false);
 	});
 
 	it("shuts a long thought even while it is the newest thing", () => {
-		expect(reasoningOpen(false, "x".repeat(601))).toBe(false);
+		expect(reasoningOpen(true, false, "x".repeat(601))).toBe(false);
+	});
+
+	it("shuts a restored thought the turn was interrupted in the middle of", () => {
+		expect(reasoningOpen(false, false, "half a thought")).toBe(false);
 	});
 });

--- a/app/components/sloppy/turnDisplay.ts
+++ b/app/components/sloppy/turnDisplay.ts
@@ -22,6 +22,11 @@ export function userText(message: SloppyMessage): string {
 
 const LONG_REASONING = 600;
 
-export function reasoningOpen(superseded: boolean, text: string): boolean {
-	return !superseded && text.length <= LONG_REASONING;
+/** Opening is a live-streaming affordance, so a restored thought stays shut whatever state it was stored in. */
+export function reasoningOpen(
+	live: boolean,
+	superseded: boolean,
+	text: string,
+): boolean {
+	return live && !superseded && text.length <= LONG_REASONING;
 }

--- a/lib/providers/llm/mock.ts
+++ b/lib/providers/llm/mock.ts
@@ -234,6 +234,10 @@ function parts(
 	] as LanguageModelV3StreamPart[];
 }
 
+/** Long-winded so the mock thinks for a couple of seconds, the way a real model does. */
+const MOCK_THOUGHT =
+	"Reading the canvas to see what is already on it. Working out which scene the request points at, which elements sit inside that scene, and what the script currently says about each of them. Weighing whether this reads as a question to answer or as an edit to make, since the two want different tools, and a wrong guess there means an edit nobody asked for. Then picking the smallest change that does what was asked, so nothing else in the script has to move around, and nothing already on the canvas gets rewritten by accident. ";
+
 /**
  * Only edits when the message reads like a request to change something, so a
  * plain question gets a plain answer the way a real model would give one.
@@ -308,7 +312,7 @@ function mockAgentModel() {
 			const { say, toolName, input } = mockCall(prompt);
 			const chunks: LanguageModelV3StreamPart[] = [
 				{ type: "stream-start", warnings: [] },
-				...parts("reasoning", "r0", "Reading the canvas. "),
+				...parts("reasoning", "r0", MOCK_THOUGHT),
 				...parts("text", "t0", say),
 				...(toolName
 					? ([


### PR DESCRIPTION
## Summary

A Sloppy turn that died mid-stream (abort, navigation away, provider error before `finish`) left the panel showing a **"Thinking…" disclosure forever**, across reloads, with no error and no way to clear it. Nothing was actually running: the spinner was a stale render of a *persisted* stub row.

**A restored part can never be pending.** `SloppyMessage`'s `Step` read `part.state === "streaming"` directly and ignored the turn-level `streaming` flag `AgentTurn` already receives. It now takes a `live` prop and only shows the pending label when the turn is genuinely in flight, so stub rows already in the database render inert with no migration needed.

**A restored thought can never auto-open, either.** `reasoningOpen` opened the newest thought in a turn, and an interrupted turn's newest part *is* the half-finished thought. Killing only the spinner would have left the abandoned half-thought force-expanded as the largest thing in the panel — the same "this didn't finish cleanly" impression, minus the shimmer. Auto-opening is a live-streaming affordance, so `reasoningOpen` now takes `live` as well. A normally-completed turn ends in a text part, so its reasoning is superseded and collapses either way; nothing about live streaming changes.

**`Reasoning` is handed its open state instead of deriving it.** It called `reasoningOpen(superseded, text)` itself, which is now the one place that needs `live`. Passing `open` down keeps the policy next to the flag it depends on and leaves the component purely presentational — same prop count, one less thing it knows.

**Mock LLM thinks for longer.** The mock's reasoning phase was three deltas wide, so there was no practical way to interrupt a turn mid-thought by hand. `MOCK_THOUGHT` now streams ~2s per step at the existing 20ms cadence. Deliberately *not* by raising `chunkDelayInMs`: that is paid on every chunk of every step, so a bump to 60ms made a whole mock turn ~7x slower (and the `MAX_TOOL_CALLS` worst case ~72s) to buy a window the text alone buys for free. The string also stays under `LONG_REASONING`, so the thought still streams visibly.

## Scope

An earlier revision also normalized turns at the persistence boundary (`settleTurn` in `lib/agent/messages.ts`, called from `onEnd`) so a half-open turn never got written in the first place. That half is dropped: the client fix already makes both existing and future stub rows render correctly, and the stored data stays a faithful record of what the provider actually sent.

Known and deliberately left alone: an interrupt can also strand a tool part in `input-streaming`/`input-available`. That renders as a bare collapsed disclosure with no outcome row — silent rather than misleading-in-motion, and no spinner — so it is a separate design call, not this bug.

## Validation

Full CI-equivalent suite from `.github/workflows/ci.yml`, all green:

- `npm run lint` — clean
- `npm run format:check` — clean
- `npm run typecheck` — clean
- `npm run knip` — clean
- `npm run build` — succeeded
- `npm run test` — 167 files, 1513 tests passed
- `npm run test:e2e` — 3 Playwright smoke tests passed

New and updated tests:

- `app/components/sloppy/__tests__/SloppyMessage.test.tsx` — a restored transcript ending in a `state: "streaming"` reasoning part renders "Done thinking" with no shimmer and leaves the half-thought collapsed, while the same parts render as "Thinking…" and expanded when the turn really is live.
- `app/components/sloppy/__tests__/turnDisplay.test.ts` — `reasoningOpen` shuts a restored thought the turn was interrupted in the middle of.

Closes #693
