### PR TITLE
refactor: nightly maintainability 2026-09-01

### DIFF
--- a/app/components/canvas/dnd/DragTransferContext.tsx
+++ b/app/components/canvas/dnd/DragTransferContext.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useSyncExternalStore } from "react";
-import { createRequiredContext } from "@/lib/components/createRequiredContext";
+import { createStoreContext } from "@/lib/store/createStoreContext";
+import { createEmitter, type Emitter } from "@/lib/store/emitter";
 
 export type DragTransfer = {
 	itemId: string;
@@ -11,7 +11,7 @@ export type DragTransfer = {
 export type DragTransferStore = {
 	get: () => DragTransfer;
 	set: (next: DragTransfer) => void;
-	subscribe: (onChange: () => void) => () => void;
+	subscribe: Emitter["subscribe"];
 };
 
 /**
@@ -21,21 +21,16 @@ export type DragTransferStore = {
  * re-render only when its own answer flips.
  */
 export function createDragTransferStore(): DragTransferStore {
+	const { subscribe, notify } = createEmitter();
 	let transfer: DragTransfer = null;
-	const listeners = new Set<() => void>();
 	return {
 		get: () => transfer,
 		set: (next) => {
 			if (transfer === next) return;
 			transfer = next;
-			for (const listener of listeners) listener();
+			notify();
 		},
-		subscribe: (onChange) => {
-			listeners.add(onChange);
-			return () => {
-				listeners.delete(onChange);
-			};
-		},
+		subscribe,
 	};
 }
 
@@ -49,18 +44,11 @@ export function dropIndexIn(
 	return transfer.atIndex;
 }
 
-const [DragTransferContext, useDragTransferStore] =
-	createRequiredContext<DragTransferStore>("DragTransferContext");
+const [DragTransferContext, , useDragTransfer] =
+	createStoreContext<DragTransferStore>("DragTransferContext");
 export { DragTransferContext };
-
-const noDrop = () => null;
 
 /** Where an incoming cross-scene drag would land in this scene, if anywhere. */
 export function useDropIndex(sceneId: string): number | null {
-	const store = useDragTransferStore();
-	const getSnapshot = useCallback(
-		() => dropIndexIn(store.get(), sceneId),
-		[store, sceneId],
-	);
-	return useSyncExternalStore(store.subscribe, getSnapshot, noDrop);
+	return useDragTransfer((store) => dropIndexIn(store.get(), sceneId));
 }

--- a/app/components/canvas/elements/ElementHistoryPopover.tsx
+++ b/app/components/canvas/elements/ElementHistoryPopover.tsx
@@ -26,7 +26,7 @@ import {
 } from "../hooks/useElementHistory";
 import { AudioPlayer } from "./AudioPlayer";
 import { HeaderIconButton } from "./HeaderIconButton";
-import { MediaWithSkeleton } from "./MediaWithSkeleton";
+import { MediaWithSkeleton } from "@/lib/components/MediaWithSkeleton";
 
 const PROMPT_LENGTH = 72;
 

--- a/app/components/canvas/elements/ForegroundPreview.tsx
+++ b/app/components/canvas/elements/ForegroundPreview.tsx
@@ -1,7 +1,7 @@
 import { ELEMENT_TYPES, type CanvasContentElement } from "@/lib/canvas/types";
 import { useGenerate } from "../hooks/useGenerate";
 import { PlaceholderBallsLoader } from "./preview/placeholderBalls";
-import { MediaWithSkeleton } from "./MediaWithSkeleton";
+import { MediaWithSkeleton } from "@/lib/components/MediaWithSkeleton";
 import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 
 export function ForegroundPreview({

--- a/app/components/canvas/elements/SceneContainer.tsx
+++ b/app/components/canvas/elements/SceneContainer.tsx
@@ -29,21 +29,15 @@ interface SceneProps {
 	children: React.ReactNode;
 }
 
-function useSceneState(element: SceneElement) {
-	const childIds = useMemo(
-		() => element.children.map((c) => c.id),
-		[element.children],
-	);
-
+/** Opens a gap at the end of the scene while a cross-scene drag would land there. */
+function useDropPadding(element: SceneElement): React.CSSProperties {
 	const dropIndex = useDropIndex(element.id);
-
 	return {
-		childIds,
-		dropPadding: {
-			paddingBottom:
-				dropIndex !== null && dropIndex >= childIds.length ? "3rem" : undefined,
-			transition: "padding-bottom 200ms ease",
-		} as React.CSSProperties,
+		paddingBottom:
+			dropIndex !== null && dropIndex >= element.children.length
+				? "3rem"
+				: undefined,
+		transition: "padding-bottom 200ms ease",
 	};
 }
 
@@ -88,7 +82,7 @@ function CollapsedScene({
 	sceneIndex,
 	children,
 }: SceneProps) {
-	const { dropPadding } = useSceneState(element);
+	const dropPadding = useDropPadding(element);
 	const { toggle } = useViewMode();
 
 	const foregroundElement = useMemo(
@@ -152,8 +146,12 @@ function ExpandedScene({
 	sceneIndex,
 	children,
 }: SceneProps) {
-	const { childIds, dropPadding } = useSceneState(element);
+	const dropPadding = useDropPadding(element);
 	const { toggle } = useViewMode();
+	const childIds = useMemo(
+		() => element.children.map((child) => child.id),
+		[element.children],
+	);
 
 	return (
 		<div

--- a/app/components/canvas/elements/preview/results.tsx
+++ b/app/components/canvas/elements/preview/results.tsx
@@ -1,7 +1,7 @@
 import { useState, type CSSProperties } from "react";
 import { isGenerationActive } from "@/lib/generation/snapshots";
 import { AudioPlayer } from "../AudioPlayer";
-import { MediaWithSkeleton } from "../MediaWithSkeleton";
+import { MediaWithSkeleton } from "@/lib/components/MediaWithSkeleton";
 import { GenerationIndicator } from "../GenerationIndicator";
 import type {
 	GenerationState,
@@ -11,7 +11,7 @@ import type {
 import { PlaceholderBallsLoader } from "./placeholderBalls";
 import {
 	AUDIO_SAMPLE_COUNT,
-	buildSoundwaveMask,
+	soundwaveMaskStyle,
 } from "@/lib/components/soundwave";
 import {
 	ErrorMessage,
@@ -52,13 +52,11 @@ export function AudioPlaceholder({
 	topRight,
 	...props
 }: PlaceholderProps & PreviewOverlays) {
-	const [mask] = useState(() => {
-		const bars = Array.from(
-			{ length: AUDIO_SAMPLE_COUNT },
-			() => 20 + Math.random() * 80,
-		);
-		return buildSoundwaveMask(bars);
-	});
+	const [mask] = useState(() =>
+		soundwaveMaskStyle(
+			Array.from({ length: AUDIO_SAMPLE_COUNT }, () => 20 + Math.random() * 80),
+		),
+	);
 
 	return (
 		<div
@@ -66,15 +64,7 @@ export function AudioPlaceholder({
 			style={{ "--cancel-offset": "calc(50% - 0.75rem)" } as CSSProperties}
 		>
 			<div className="absolute inset-0 blur-[6px]" aria-hidden="true">
-				<div
-					className="absolute inset-0"
-					style={{
-						maskImage: mask,
-						WebkitMaskImage: mask,
-						maskSize: "100% 100%",
-						WebkitMaskSize: "100% 100%",
-					}}
-				>
+				<div className="absolute inset-0" style={mask}>
 					<PlaceholderBallsLoader generating={props.status === "generating"} />
 				</div>
 			</div>

--- a/app/components/video/timeline/ClipWaveform.tsx
+++ b/app/components/video/timeline/ClipWaveform.tsx
@@ -3,11 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { loadPeaks } from "@/lib/components/peaks";
-import {
-	buildSoundwaveMask,
-	SOUNDWAVE_MASK_STYLE,
-	toBarHeights,
-} from "@/lib/components/soundwave";
+import { soundwaveMaskStyle, toBarHeights } from "@/lib/components/soundwave";
 import { clamp, cn } from "@/lib/utils";
 
 const SAMPLE_SPACING_PX = 2;
@@ -63,15 +59,10 @@ export function ClipWaveform({
 	);
 
 	const peaks = decode.status === "ready" ? decode.peaks : null;
-	const style = useMemo(() => {
-		if (!peaks) return null;
-		const mask = buildSoundwaveMask(toBarHeights(peaks, sampleCount));
-		return {
-			...SOUNDWAVE_MASK_STYLE,
-			maskImage: mask,
-			WebkitMaskImage: mask,
-		};
-	}, [peaks, sampleCount]);
+	const style = useMemo(
+		() => (peaks ? soundwaveMaskStyle(toBarHeights(peaks, sampleCount)) : null),
+		[peaks, sampleCount],
+	);
 
 	// A failed decode stops shimmering: the clip is there, its audio is not.
 	if (decode.status === "failed")

--- a/app/components/video/timeline/TimelineClip.tsx
+++ b/app/components/video/timeline/TimelineClip.tsx
@@ -1,6 +1,6 @@
 import type { IconComponent } from "@/components/ui/icon";
 import { SimpleTooltip } from "@/components/ui/tooltip";
-import { MediaWithSkeleton } from "@/app/components/canvas/elements/MediaWithSkeleton";
+import { MediaWithSkeleton } from "@/lib/components/MediaWithSkeleton";
 import { ELEMENT_CONFIGS } from "@/lib/canvas/elementConfigs";
 import { truncateMiddle } from "@/lib/format";
 import { formatTimeRange } from "@/lib/video/timestamps";

--- a/lib/components/MediaWithSkeleton.tsx
+++ b/lib/components/MediaWithSkeleton.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 import { useState } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ImageWithShimmer } from "@/lib/components/ImageWithShimmer";
+import { ImageWithShimmer } from "./ImageWithShimmer";
 import type { ResultKind } from "@/lib/canvas/types";
 
 interface MediaWithSkeletonProps {

--- a/lib/components/soundwave.ts
+++ b/lib/components/soundwave.ts
@@ -10,6 +10,12 @@ export const SOUNDWAVE_MASK_STYLE: CSSProperties = {
 	WebkitMaskRepeat: "no-repeat",
 };
 
+/** The whole style a soundwave needs: the mask for `heights`, stretched to fit. */
+export function soundwaveMaskStyle(heights: number[]): CSSProperties {
+	const mask = buildSoundwaveMask(heights);
+	return { ...SOUNDWAVE_MASK_STYLE, maskImage: mask, WebkitMaskImage: mask };
+}
+
 /** Silence still draws a hairline, so an empty stretch reads as audio, not a gap. */
 const MIN_HEIGHT = 4;
 


### PR DESCRIPTION
No behavior changes. Four pieces of shared knowledge that had more than one home, or no home at all.

## Architecture

**`DragTransferContext` moves onto the `lib/store` seam.** It was the last hand-rolled observable store in the tree: its own `Set<() => void>`, its own notify loop, and its own `useSyncExternalStore` + `useCallback` wiring in `useDropIndex`. It now composes `createEmitter` and `createStoreContext`, so `useDropIndex` is one selector call and how a store reaches React stays decided in one place. Public API (`createDragTransferStore`, `dropIndexIn`, `useDropIndex`, `DragTransferContext`) is unchanged, and `dragTransfer.test.ts` covers it as-is.

**`MediaWithSkeleton` gets a shared home.** It lived in `app/components/canvas/elements/`, but `app/components/video/timeline/TimelineClip.tsx` imported it across features via `@/app/components/canvas/elements/MediaWithSkeleton`. It is the media sibling of `ImageWithShimmer` and is now beside it in `lib/components/`, marked `"use client"` to match. Four call sites updated; the canvas→video reach-in is gone.

## Simplification

**`soundwaveMaskStyle(heights)` owns "the style a soundwave needs".** Two call sites spread `SOUNDWAVE_MASK_STYLE` and then restated `maskImage`/`WebkitMaskImage` themselves, and the audio placeholder had drifted off it entirely — hand-writing `maskSize`/`WebkitMaskSize` and silently dropping `maskRepeat`. One helper in `lib/components/soundwave.ts` now returns the whole style, and the placeholder picks up the repeat rule it had lost (a no-op at `maskSize: 100% 100%`, which is why the drift went unnoticed).

**`SceneContainer.useSceneState` splits into `useDropPadding`.** The hook returned two unrelated things, so the collapsed scene built and memoized a `childIds` array on every render that only the expanded scene ever read. Each path now computes what it uses.

## Complexity delta

- 4 files simplified, 1 moved, 1 helper added.
- One hand-rolled subscription store removed (~12 lines of listener bookkeeping).
- `useDropIndex`: 7 lines and two React primitives down to one selector.
- One cross-feature `app/` → `app/` import removed.
- Net −24 lines.

## Skipped

- **A payload-carrying emitter for `GenerationQueue.commitListeners` and `Autosaver.savedListeners`.** Two hand-rolled `Set<(payload) => void>` remain, but two uses is under the rule of three and the shapes differ; a generic `createPayloadEmitter<T>` would be speculative today.
- **Timeline geometry context.** `pxPerSec` threads to five children in `Timeline.tsx`. It is one prop each and reads clearly; a context here would be churn, not a boundary.
- **A shared async-list shell for `CanvasHistoryPanel` and `ElementHistoryPopover`.** Same loading/failed/empty/list shape, but only two uses and different row semantics.
- **`AssetTile`'s `removeAffordance`/`fallback` string props.** Boolean-prop-ish, but both are genuinely presentational variants of one tile; splitting it would duplicate more than it saves.

## Open PR overlap check

One open PR: **#701** (BYOK connectors and a third-party gateway), which touches the connector/gateway/API/settings surface plus `app/components/canvas/dnd/SortableContent.tsx` and `app/components/video/storyboard/Storyboard.tsx`. Every file in this PR was checked against `gh pr diff 701 --name-only`: zero intersection. `SortableContent.tsx` consumes `useDropIndex` but is not modified here — the hook's signature is unchanged.

## Validation

`lint`, `format:check`, `typecheck`, `knip`, `build`, and `npm test` (1513 tests, 167 files) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)