### PR TITLE
refactor: give the dot grid one home

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -47,7 +47,7 @@ Eases `--ease-casual` / `--ease-productive` / `--ease-expressive`, durations `--
 Two opt-in treatments, both quiet:
 
 - `.grain`: film grain (`--grain-opacity`) on raised surfaces (dialogs, panel cards, the canvas card, onboarding, the inline copilot). Needs a positioned element and paints through `::after`. Not on dense element cards.
-- `.dot-grid-bg`: the "+" grid behind the editor and gallery. Render it `aria-hidden` and `pointer-events-none`, behind content.
+- `.dot-grid-bg`: the "+" grid behind the editor and gallery. Reach for `<DotGrid />` (`components/ui/dot-grid.tsx`), which renders it `aria-hidden` and `pointer-events-none`, behind content.
 
 ## Components
 

--- a/app/components/PostPromptView.tsx
+++ b/app/components/PostPromptView.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { DotGrid } from "@/components/ui/dot-grid";
 import UserProfile from "./UserProfile";
 import { EditorToolbar } from "./EditorToolbar";
 import Canvas from "./canvas/Canvas";
@@ -15,10 +16,7 @@ export default function PostPromptView() {
 
 	return (
 		<div className="relative flex h-screen w-full flex-col overflow-hidden">
-			<div
-				aria-hidden
-				className="dot-grid-bg pointer-events-none fixed inset-0 -z-10"
-			/>
+			<DotGrid />
 			<UserProfile />
 
 			<EditorToolbar />

--- a/app/components/PrePromptView.tsx
+++ b/app/components/PrePromptView.tsx
@@ -1,15 +1,13 @@
 "use client";
 
+import { DotGrid } from "@/components/ui/dot-grid";
 import ComposerHero from "./ComposerHero";
 import UserProfile from "./UserProfile";
 
 export default function PrePromptView() {
 	return (
 		<>
-			<div
-				aria-hidden
-				className="dot-grid-bg pointer-events-none fixed inset-0 -z-10"
-			/>
+			<DotGrid />
 			<UserProfile />
 			<ComposerHero />
 		</>

--- a/app/components/projects/ProjectsList.tsx
+++ b/app/components/projects/ProjectsList.tsx
@@ -9,6 +9,7 @@ import type { ProjectRow } from "@/lib/project/api";
 import UserProfile from "@/app/components/UserProfile";
 import { Button } from "@/components/ui/button";
 import { ConfirmDeleteDialog } from "@/components/ui/confirm-delete-dialog";
+import { DotGrid } from "@/components/ui/dot-grid";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ProjectCard } from "./ProjectCard";
 
@@ -47,10 +48,7 @@ export default function ProjectsList({
 	return (
 		<TooltipProvider>
 			<div className="relative min-h-screen bg-background text-foreground">
-				<div
-					aria-hidden
-					className="dot-grid-bg pointer-events-none absolute inset-0 z-0"
-				/>
+				<DotGrid placement="container" />
 				<UserProfile />
 				<div className="relative z-10 mx-auto max-w-7xl px-6 pt-20 pb-16">
 					<header className="mb-10 flex items-end justify-between">

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { DotGrid } from "@/components/ui/dot-grid";
 import SlopYard from "./components/not-found/SlopYard";
 
 export const metadata: Metadata = {
@@ -11,10 +12,7 @@ export const metadata: Metadata = {
 export default function NotFound() {
 	return (
 		<div className="relative min-h-screen bg-background text-foreground">
-			<div
-				className="dot-grid-bg pointer-events-none fixed inset-0 -z-10"
-				aria-hidden
-			/>
+			<DotGrid />
 
 			<main className="mx-auto flex min-h-screen w-full max-w-3xl flex-col items-center justify-center gap-6 px-6 py-16 text-center">
 				<SlopYard />

--- a/app/projects/[id]/loading.tsx
+++ b/app/projects/[id]/loading.tsx
@@ -2,6 +2,7 @@ import {
 	PINNED_PANEL_KEYS,
 	RAIL_PANEL_KEYS,
 } from "@/app/components/canvas/panel/panelKeys";
+import { DotGrid } from "@/components/ui/dot-grid";
 import { Skeleton } from "@/components/ui/skeleton";
 
 const SCENES = [3, 2, 4];
@@ -113,10 +114,7 @@ function SceneSkeleton({
 export default function Loading() {
 	return (
 		<div className="relative flex h-screen w-full flex-col overflow-hidden text-foreground">
-			<div
-				aria-hidden
-				className="dot-grid-bg pointer-events-none fixed inset-0 -z-10"
-			/>
+			<DotGrid />
 
 			{/* Profile avatar */}
 			<div className="fixed top-4 left-5 z-[100]">

--- a/components/ui/dot-grid.tsx
+++ b/components/ui/dot-grid.tsx
@@ -1,0 +1,24 @@
+/**
+ * The "+" grid behind the editor and the gallery. `viewport` pins it to the
+ * screen for pages that do not scroll; `container` paints it over the full
+ * height of a scrolling ancestor, whose content then needs its own `z-10`.
+ */
+const PLACEMENT = {
+	viewport: "fixed inset-0 -z-10",
+	container: "absolute inset-0 z-0",
+} as const;
+
+function DotGrid({
+	placement = "viewport",
+}: {
+	placement?: keyof typeof PLACEMENT;
+}) {
+	return (
+		<div
+			aria-hidden
+			className={`dot-grid-bg pointer-events-none ${PLACEMENT[placement]}`}
+		/>
+	);
+}
+
+export { DotGrid };


### PR DESCRIPTION
## What

The `.dot-grid-bg` texture was hand-written at five call sites as a bare `div` carrying `aria-hidden`, `pointer-events-none` and one of two placement class sets. DESIGN.md stated the rule in prose (`Render it aria-hidden and pointer-events-none, behind content`) precisely because no component held it. That is CONVENTIONS' "each piece of knowledge gets one home", and the rule of three is met twice over.

`components/ui/dot-grid.tsx` now owns it, with the two placements named rather than spelled out per site:

- `viewport` (`fixed inset-0 -z-10`) — pages that do not scroll: `not-found`, `PrePromptView`, `PostPromptView`, `projects/[id]/loading`.
- `container` (`absolute inset-0 z-0`) — `ProjectsList`, where the grid paints over the full height of a scrolling ancestor whose content carries its own `z-10`.

Every call site keeps the exact classes it had, so this is a no-behavior-change refactor.

## Flagged, not fixed

`app/not-found.tsx` renders the grid at `-z-10` inside a `relative … bg-background` parent. Per the CSS paint order, a negative-z-index descendant paints before its ancestor's own background, so the grid is very likely invisible on the 404 page. The other three `viewport` sites have no background on the positioned parent, so they are fine. Changing 404 to the `container` placement would make the grid appear, which is a visual change, not a refactor — leaving it for a human call.

## Audit context

This is the sixteenth nightly CONVENTIONS.md sweep. The delta since the last one was a single commit (#700, five source files across `app/components/sloppy/*` and `lib/providers/llm/mock.ts`) and it audits clean — `Reasoning` taking `open` as a prop instead of deriving it is the policy/mechanism split done right. Repo-wide invariant greps are unchanged for the tenth run: three intentional bare `catch {}` (`lib/supabase/server.ts:18`, `lib/api/parse.ts:31,46`), three exhaustive discriminated-union `switch`es, zero catch-return-null, zero `as any`, zero non-null assertions, zero provider-string sniffing.

Checks: lint, typecheck, `format:check`, `build`, and 1513 tests across 167 files all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)