### PR TITLE
fix: crossfade looping SFX so repeats don't click

### DIFF
--- a/app/components/video/timeline/__tests__/timelineRows.test.ts
+++ b/app/components/video/timeline/__tests__/timelineRows.test.ts
@@ -165,10 +165,14 @@ describe("buildTimelineRows", () => {
 		const effects = buildTimelineRows(layout).filter(
 			(row) => row.id === "effect",
 		);
-		// Copies at 0 and 4 fall inside a 5s video; the one at 8 does not.
-		expect(
-			effects.flatMap((row) => row.clips).map((clip) => clip.start),
-		).toEqual([0, 4]);
+		// Two copies fall inside a 5s video; the third starts past the end. The
+		// second starts a crossfade early, so it lands short of the 4s clip length.
+		const starts = effects
+			.flatMap((row) => row.clips)
+			.map((clip) => clip.start);
+		expect(starts).toHaveLength(2);
+		expect(starts[0]).toBe(0);
+		expect(starts[1]).toBeCloseTo(4 - 4 / 24, 5);
 	});
 
 	it("draws a clip that overruns the end only as far as the video goes", () => {

--- a/lib/video/__tests__/audioFade.test.ts
+++ b/lib/video/__tests__/audioFade.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+	audioFadeSec,
+	LOOP_CROSSFADE_SEC,
+	loopCrossfadeSec,
+	loopStrideSec,
+} from "../audioFade";
+import { AUDIO_FADE_SEC } from "../transitions";
+import type { ResolvedElement } from "../types";
+
+function el(overrides: Partial<ResolvedElement>): ResolvedElement {
+	return {
+		id: "e1",
+		type: "sound",
+		role: "effect",
+		layer: "audio",
+		sceneId: "s1",
+		sceneNumber: 1,
+		prompt: "",
+		url: "https://example.com/e1",
+		durationSec: 4,
+		loops: 1,
+		volume: 10,
+		motion: "none",
+		...overrides,
+	};
+}
+
+describe("loopCrossfadeSec", () => {
+	it("crossfades a looping effect", () => {
+		expect(loopCrossfadeSec(el({ loops: 3 }))).toBe(LOOP_CROSSFADE_SEC);
+	});
+
+	it("leaves a one-shot alone", () => {
+		expect(loopCrossfadeSec(el({ loops: 1 }))).toBe(0);
+	});
+
+	it("leaves looping audio that isn't an effect alone", () => {
+		expect(
+			loopCrossfadeSec(el({ type: "music", role: "background", loops: 4 })),
+		).toBe(0);
+	});
+
+	it("never overlaps more than half a copy", () => {
+		expect(loopCrossfadeSec(el({ loops: 3, durationSec: 0.1 }))).toBe(0.05);
+	});
+});
+
+describe("loopStrideSec", () => {
+	it("pulls each copy of a loop back by the crossfade", () => {
+		expect(loopStrideSec(el({ loops: 3 }))).toBeCloseTo(
+			4 - LOOP_CROSSFADE_SEC,
+			5,
+		);
+	});
+
+	it("is the full clip when nothing crossfades", () => {
+		expect(loopStrideSec(el({ loops: 1 }))).toBe(4);
+	});
+});
+
+describe("audioFadeSec", () => {
+	it("eases a background bed in and out at its own edges", () => {
+		expect(
+			audioFadeSec(el({ type: "music", role: "background", loops: 4 })),
+		).toBe(AUDIO_FADE_SEC);
+	});
+
+	it("fades a looping effect across its seam", () => {
+		expect(audioFadeSec(el({ loops: 3 }))).toBe(LOOP_CROSSFADE_SEC);
+	});
+
+	it("holds a one-shot effect and narration at full volume", () => {
+		expect(audioFadeSec(el({ loops: 1 }))).toBe(0);
+		expect(audioFadeSec(el({ type: "narration", role: "overlay" }))).toBe(0);
+	});
+});

--- a/lib/video/__tests__/scene-builder.test.ts
+++ b/lib/video/__tests__/scene-builder.test.ts
@@ -8,6 +8,9 @@ import type { CanvasElementType } from "@/lib/canvas/types";
 // The rendered transition overlap: TRANSITION_DURATION_SEC (0.4s) snapped to the
 // 24fps frame grid, which is what <TransitionSeries> actually lays down.
 const OVERLAP = 10 / 24;
+// LOOP_CROSSFADE_SEC (0.15s) on the same grid: how far each copy of a looping
+// effect slides back so it overlaps the tail of the one before it.
+const LOOP_OVERLAP = 4 / 24;
 
 function seqs(layout: VideoLayout, type: CanvasElementType): Sequence[] {
 	const s = layout.sequences[type];
@@ -369,7 +372,7 @@ describe("buildVideoLayout", () => {
 			expect(seqs(layout, "sound")[1].duration).toBe(20);
 		});
 
-		it("emits N consecutive copies of a looped effect at the native clip duration", () => {
+		it("emits N copies of a looped effect at the native clip duration, overlapping by the crossfade", () => {
 			const layout = untrimmed([
 				el({ id: "clip1", type: "clip", durationSec: 12 }),
 				el({ id: "s1", type: "sound", durationSec: 4, loops: 3 }),
@@ -378,9 +381,9 @@ describe("buildVideoLayout", () => {
 			expect(sound).toHaveLength(3);
 			expect(sound[0].start).toBe(0);
 			expect(sound[0].duration).toBe(4);
-			expect(sound[1].start).toBe(4);
+			expect(sound[1].start).toBeCloseTo(4 - LOOP_OVERLAP, 5);
 			expect(sound[1].duration).toBe(4);
-			expect(sound[2].start).toBe(8);
+			expect(sound[2].start).toBeCloseTo(8 - 2 * LOOP_OVERLAP, 5);
 			expect(sound[2].duration).toBe(4);
 			expect(sound.every((s) => s.element?.id === "s1")).toBe(true);
 		});
@@ -394,9 +397,9 @@ describe("buildVideoLayout", () => {
 			expect(sound).toHaveLength(3);
 			expect(sound[0].start).toBe(0);
 			expect(sound[0].duration).toBe(4);
-			expect(sound[1].start).toBe(4);
-			expect(sound[1].duration).toBe(1);
-			expect(sound[2].start).toBe(8);
+			expect(sound[1].start).toBeCloseTo(4 - LOOP_OVERLAP, 5);
+			expect(sound[1].duration).toBeCloseTo(1 + LOOP_OVERLAP, 5);
+			expect(sound[2].start).toBeCloseTo(8 - 2 * LOOP_OVERLAP, 5);
 			expect(sound[2].duration).toBe(1);
 		});
 

--- a/lib/video/audioFade.ts
+++ b/lib/video/audioFade.ts
@@ -1,0 +1,35 @@
+import { AUDIO_FADE_SEC } from "./transitions";
+import type { ResolvedElement } from "./types";
+
+/**
+ * How long consecutive copies of a looping effect overlap. Butted end to end
+ * they meet at a waveform discontinuity, which is audible as a click on every
+ * repeat; overlapping them by a fade this long turns the seam into a crossfade.
+ */
+export const LOOP_CROSSFADE_SEC = 0.15;
+
+/**
+ * The overlap `element`'s loop copies share. Half a copy is the ceiling, past
+ * which the copies would fade through each other end to end rather than at the
+ * seam. One-shots and non-effect audio don't loop into anything, so they get none.
+ */
+export function loopCrossfadeSec(element: ResolvedElement): number {
+	if (element.role !== "effect" || element.loops < 2) return 0;
+	return Math.min(LOOP_CROSSFADE_SEC, element.durationSec / 2);
+}
+
+/** How far apart consecutive copies of `element` start. */
+export function loopStrideSec(element: ResolvedElement): number {
+	return element.durationSec - loopCrossfadeSec(element);
+}
+
+/**
+ * The fade envelope a copy of `element` carries: a bed eases in and out at its
+ * own edges, a looping effect fades across the overlap it shares with the next
+ * copy so the two sum to a constant.
+ */
+export function audioFadeSec(element: ResolvedElement): number {
+	return element.role === "background"
+		? AUDIO_FADE_SEC
+		: loopCrossfadeSec(element);
+}

--- a/lib/video/scene-builder.ts
+++ b/lib/video/scene-builder.ts
@@ -9,6 +9,7 @@ import { DEFAULT_CONFIG } from "./types";
 import { type AspectRatio, ASPECT_RATIO_DIMENSIONS } from "./aspectRatio";
 import { DEFAULT_CAPTION_STYLE, type CaptionStyle } from "./captionStyle";
 import { blankScene } from "./blankScene";
+import { loopStrideSec } from "./audioFade";
 import { toFrames, toSeconds } from "./frames";
 import {
 	DEFAULT_TRANSITION,
@@ -46,20 +47,20 @@ function createSequence(
 
 type SequenceMap = Partial<Record<CanvasElementType, Sequence[]>>;
 
+/**
+ * Lays down `element.loops` copies, each `stride` after the last. A stride
+ * shorter than the copy overlaps them, which is how a looping effect crossfades
+ * across its seam rather than cutting.
+ */
 function pushSequence(
 	sequences: SequenceMap,
 	element: ResolvedElement,
 	start: number,
+	stride: number,
 ) {
 	const list = (sequences[element.type] ??= []);
 	for (let i = 0; i < element.loops; i++) {
-		list.push(
-			createSequence(
-				element,
-				start + i * element.durationSec,
-				element.durationSec,
-			),
-		);
+		list.push(createSequence(element, start + i * stride, element.durationSec));
 	}
 }
 
@@ -113,17 +114,18 @@ export function buildVideoLayout(
 
 	for (const raw of elements) {
 		const element = { ...raw, durationSec: onGrid(raw.durationSec) };
+		const stride = onGrid(loopStrideSec(element));
 		const current = series.at(-1);
 		const foregroundCursor = getForegroundCursor(current, cursor);
 
 		switch (element.role) {
 			case "effect": {
-				pushSequence(sequences, element, cursor);
+				pushSequence(sequences, element, cursor, stride);
 				break;
 			}
 			case "background": {
 				trimSequencesAt(sequences[element.type], foregroundCursor);
-				pushSequence(sequences, element, foregroundCursor);
+				pushSequence(sequences, element, foregroundCursor, stride);
 				break;
 			}
 			case "foreground": {
@@ -148,7 +150,7 @@ export function buildVideoLayout(
 						cursor + element.durationSec - current.start,
 					);
 				}
-				pushSequence(sequences, element, cursor);
+				pushSequence(sequences, element, cursor, stride);
 				cursor += element.durationSec;
 				break;
 			}

--- a/remotion/compositions/VideoComposition.tsx
+++ b/remotion/compositions/VideoComposition.tsx
@@ -11,10 +11,10 @@ import { linearTiming, TransitionSeries } from "@remotion/transitions";
 import type { VideoLayout, ResolvedElement } from "@/lib/video/types";
 import { toFrames } from "@/lib/video/frames";
 import {
-	AUDIO_FADE_SEC,
 	TRANSITION_DURATION_SEC,
 	VIDEO_PREMOUNT_SEC,
 } from "@/lib/video/transitions";
+import { audioFadeSec } from "@/lib/video/audioFade";
 import { getPresentation } from "@/lib/video/transitionPresentations";
 import { audioVolume } from "@/lib/video/audioVolume";
 import { volumeToGain } from "@/lib/video/elementAttributes";
@@ -33,8 +33,7 @@ const blackBg: React.CSSProperties = { backgroundColor: "black" };
 function AudioSequence({ element }: { element: ResolvedElement }) {
 	const { durationInFrames, fps } = useVideoConfig();
 	const gain = volumeToGain(element.volume);
-	const hasFadeEnvelope = element.role === "background";
-	const fadeFrames = hasFadeEnvelope ? toFrames(AUDIO_FADE_SEC, fps) : 0;
+	const fadeFrames = toFrames(audioFadeSec(element), fps);
 	const volume = useMemo(
 		() => audioVolume(gain, durationInFrames, fadeFrames),
 		[gain, durationInFrames, fadeFrames],


### PR DESCRIPTION
## Summary

Looping sound effects restarted with a hard cut. `pushSequence` laid down `element.loops` copies butted end to end (`start + i * durationSec`), so each repeat began at a waveform discontinuity — the audible click/gap in the issue. Nothing faded: `AudioSequence` only built a fade envelope for `role === "background"`, so effects played at flat gain right through the seam.

Now each copy starts one crossfade early and carries a matching fade envelope, so the tail of one iteration sums with the head of the next across the overlap.

- **`lib/video/audioFade.ts` (new)** owns the whole policy: `LOOP_CROSSFADE_SEC` (0.15s default), `loopCrossfadeSec` (gated on `role === "effect" && loops > 1`, capped at half a copy), `loopStrideSec`, and `audioFadeSec`. One home means the builder's stride and the composition's envelope cannot drift apart — if they disagree, the crossfade doesn't sum to unity.
- **`lib/video/scene-builder.ts`** — `pushSequence` takes a stride instead of assuming the clip length. The stride is snapped to the frame grid the same way durations are.
- **`remotion/compositions/VideoComposition.tsx`** — `AudioSequence` asks `audioFadeSec(element)` for its fade instead of branching on the role inline. `audioVolume` already returns a flat scalar for a zero fade, so one-shots are byte-for-byte unchanged.

Music beds keep their existing `AUDIO_FADE_SEC` edge fade and their existing back-to-back loop stride; only effects flagged as looping change.

## Selected issue

#316 — `size: M`, `bug`, `priority: low`. Picked because the fix is a localized behaviour change in `lib/video` + `remotion/` with an unambiguous outcome, the fade machinery it needs (`fadeRamp`, `audioVolume`) already exists, and it is fully verifiable from the existing test suite without auth, secrets or a render.

## Acceptance criteria

- [x] No audible gap or click when a looping SFX repeats — copies overlap by the crossfade and fade through it rather than cutting.
- [x] Crossfade is applied only to looping SFX, not one-shots — `loopCrossfadeSec` returns 0 unless `role === "effect" && loops > 1`; covered by tests.
- [x] Crossfade duration is configurable with a reasonable default — `LOOP_CROSSFADE_SEC`, read by both the builder and the composition, clamped to half a copy so a short clip can't fade through itself end to end.

## Validation

All CI-equivalent checks from `.github/workflows/ci.yml`, all green:

| Check | Result |
| --- | --- |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm run knip` | pass |
| `npm run build` | pass |
| `npm run test:coverage` | 168 files, 1522 tests passed |
| `npm run test:e2e` | 3 passed |

New coverage in `lib/video/__tests__/audioFade.test.ts` for the gate, the half-copy cap and the background/one-shot cases. Existing loop-position expectations in `scene-builder.test.ts` and `timelineRows.test.ts` updated to the new stride.

## Open PR overlap check

Checked #701, #703, #704, #705, #706 at selection time and again before pushing. No file in this diff appears in any of them. #706 touches `app/components/video/timeline/timelineRows.ts`; this PR touches only that module's test file, and only the two loop-position assertions.

## Skipped candidates

- #667, #254 — `good first issue`, reserved for outside contributors.
- #461 — already shipped on master.
- #694 (cancel doesn't stop the poll loop) — the best bug on the board, but threading the signal runs straight through `lib/gateway/openslop/base.ts` and `lib/connectors/types.ts`, both of which #701 rewrites (it deletes the former outright).
- #631, #398, #345 — overlap #706, #701 and #703 respectively.
- #653 — architecture migration, too large.
- #594, #702, #695, #685, #610, #632 — product/design direction, or acceptance criteria that can only be judged on generated output.

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)