### PR TITLE
perf: nightly performance optimizations 2026-09-02

### DIFF
--- a/app/components/canvas/elements/CharacterPill.tsx
+++ b/app/components/canvas/elements/CharacterPill.tsx
@@ -1,10 +1,14 @@
 "use client";
 
+import { getImageProps } from "next/image";
 import { User } from "@/components/ui/icon";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useQueueSelector } from "@/lib/generation/GenerationQueueProvider";
 import { characterAvatarUrl } from "@/lib/project/characterAvatar";
 import { RemoveCrossButton } from "./RemoveCrossButton";
+
+/** `size-6` in CSS pixels. */
+const AVATAR_PX = 24;
 
 function useCharacterAvatarUrl(name?: string) {
 	return useQueueSelector((queue) =>
@@ -24,10 +28,16 @@ function CharacterAvatar({
 	const initial = name?.trim().charAt(0).toUpperCase();
 	return (
 		<Avatar size="sm" className={className}>
+			{/* Radix preloads whatever `src` it is handed, so it gets the optimizer's
+			    candidates for a 24px box rather than the full-size generated original. */}
 			{avatarUrl && (
 				<AvatarImage
-					src={avatarUrl}
-					alt={name ?? "Character"}
+					{...getImageProps({
+						src: avatarUrl,
+						alt: name ?? "Character",
+						width: AVATAR_PX,
+						height: AVATAR_PX,
+					}).props}
 					className="object-cover object-center"
 				/>
 			)}

--- a/app/components/video/SeekTooltip.tsx
+++ b/app/components/video/SeekTooltip.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { clamp } from "@/lib/utils";
 import { formatTime } from "@/lib/video/timestamps";
 import type { SeekThumbnail } from "@/lib/video/sceneSegments";
@@ -27,14 +28,15 @@ export function SeekTooltip({
 			className="pointer-events-none absolute bottom-full z-50 mb-2 -translate-x-1/2"
 			style={{ left, width: TOOLTIP_WIDTH }}
 		>
-			<div className="aspect-video w-full overflow-hidden rounded-md bg-on-media/80 ring-1 ring-border">
+			<div className="relative aspect-video w-full overflow-hidden rounded-md bg-on-media/80 ring-1 ring-border">
 				{thumbnail ? (
 					thumbnail.kind === "image" ? (
-						// eslint-disable-next-line @next/next/no-img-element
-						<img
+						<Image
 							src={thumbnail.url}
 							alt=""
-							className="h-full w-full object-contain"
+							fill
+							sizes={`${TOOLTIP_WIDTH}px`}
+							className="object-contain"
 						/>
 					) : (
 						<video


### PR DESCRIPTION
## What

Two surfaces still painted full-size generated images into tiny boxes, the same over-fetch PR #698 fixed for element cards:

- **Character pills** (`CharacterPill.tsx`): every image card with characters, and every character card, showed the avatar through Radix Avatar's raw `img` at 24px. Avatars are generated at the standard image size (2560x1440), so each unique avatar cost the full original download and a ~15 MB decoded bitmap. Radix preloads whatever `src` it is handed before painting, so the pill now passes it `getImageProps`' `src` and `srcSet` for a 24px box. Its load/fallback state machine is untouched.
- **Seek-bar tooltip** (`SeekTooltip.tsx`): the 160px hover thumbnail was a raw `img` of each scene's full still. Since #698 the card no longer fetches the original, so a hover sweep across the seek bar was pulling every scene's full still fresh. Now `next/image` with `fill` and `sizes="160px"`.

Both are declarative work-shrinking with no behavior change. No memoization or caching layers.

## Measured

Production build, `/_next/image` against the mock fixtures:

| Fixture | Original | w=48 (pill) | w=256 (tooltip) |
|---|---|---|---|
| image/mock/2 (jpg) | 519,034 B | 648 B | 3,800 B |
| image/mock/1 (webp) | 14,870 B | 912 B | 7,873 B |

## Checks

lint, format:check, typecheck, knip, `npm run build`, `npm test` (1513 passed).

## Merge-conflict guard

```
PR #710: clean
PR #709: clean
PR #707: clean
PR #706: clean
PR #705: clean
PR #704: clean
PR #703: clean
PR #701: clean
OK: no file overlap or merge conflict with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
