### PR TITLE
refactor: nightly maintainability 2026-09-03

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,24 +1,31 @@
 # Copy to `.env.local` and fill in. Do not commit secrets.
 
-# --- Supabase (public; safe to expose to the browser) ---
+# --- Supabase: required for auth and the database ---
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SECRET_KEY=            # generation jobs read and write with it
 
-# --- Vercel Blob storage ---
-BLOB_READ_WRITE_TOKEN=
-NEXT_PUBLIC_BLOB_URL=
+# --- Vercel Blob: where real providers store what they generate ---
+# BLOB_READ_WRITE_TOKEN=
+# NEXT_PUBLIC_BLOB_URL=
 
-# --- Embeddings (used by voice similarity ranking) ---
-OPENAI_API_KEY=
+# --- Providers: any that is unset falls back to a mock ---
+# ANTHROPIC_API_KEY=            # LLM
+# RUNWARE_API_KEY=              # image and video
+# ELEVENLABS_API_KEY=           # music and SFX
+# CARTESIA_API_KEY=             # text-to-speech
 
-# --- Remotion rendering AWS keys ---
-REMOTION_AWS_ACCESS_KEY_ID=
-REMOTION_AWS_SECRET_ACCESS_KEY=
+# --- Embeddings: voice similarity ranking and the music/SFX cache ---
+# OPENAI_API_KEY=
 
-# --- Optional providers ---
-# ANTHROPIC_API_KEY=
-# RUNWARE_API_KEY=
-# CARTESIA_API_KEY=
+# --- Pinecone: reuses similar past music/SFX generations; unset disables the cache ---
+# PINECONE_API_KEY=
+# PINECONE_MUSIC_INDEX=         # defaults to "music"
+# PINECONE_SFX_INDEX=           # defaults to "sfx"
+
+# --- Remotion Lambda: rendering and the deploy scripts ---
+# REMOTION_AWS_ACCESS_KEY_ID=
+# REMOTION_AWS_SECRET_ACCESS_KEY=
 
 # --- Vercel-managed (auto-populated by `vercel env pull`; do not set by hand) ---
 # VERCEL_OIDC_TOKEN=

--- a/README.md
+++ b/README.md
@@ -65,27 +65,13 @@ cd openslop
 npm install
 ```
 
-3. Create a `.env.local` file with your environment variables:
+3. Copy the annotated env template and fill it in:
 
-Required (auth and database):
-
-```
-NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
-SUPABASE_SECRET_KEY=your-service-role-key   # generation jobs read/write with it
+```bash
+cp .env.example .env.local
 ```
 
-Without provider keys, the app falls back to mock providers. To use real ones, add any of:
-
-```
-ANTHROPIC_API_KEY=        # LLM
-RUNWARE_API_KEY=          # Image + video
-ELEVENLABS_API_KEY=       # Music + SFX
-CARTESIA_API_KEY=         # Text-to-speech
-BLOB_READ_WRITE_TOKEN=    # Vercel Blob (asset storage)
-NEXT_PUBLIC_BLOB_URL=     # Vercel Blob public URL
-PINECONE_API_KEY=         # Reuses similar past music/SFX generations; unset disables the cache
-```
+The Supabase variables are required. Everything else is optional: a provider whose key is unset falls back to a mock.
 
 4. Run the database migrations:
 

--- a/app/components/canvas/elements/GenerationIndicator.tsx
+++ b/app/components/canvas/elements/GenerationIndicator.tsx
@@ -6,10 +6,7 @@ import {
 } from "@/components/ui/icon";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import {
-	isGenerationActive,
-	type ElementSnapshot,
-} from "@/lib/generation/snapshots";
+import type { ElementSnapshot } from "@/lib/generation/snapshots";
 
 type Status = ElementSnapshot["status"];
 
@@ -36,31 +33,26 @@ const SIZE_CLASSES: Record<Size, { wrapper: string; icon: string }> = {
 	},
 };
 
-function statusLabel(status: Status, seconds: number, idleLabel: string) {
+function statusLabel(status: Status, seconds: number) {
 	if (status === "queued") return "Queued…";
 	if (status === "generating") return `Generating ${seconds}s`;
-	return idleLabel;
+	return "Generate";
 }
 
 export function GenerationIndicator({
 	status,
 	seconds = 0,
-	idleLabel = "Generate",
 	size = "md",
-	onClick,
 	className = "",
 }: {
 	status: Status;
 	seconds?: number;
-	idleLabel?: string;
 	size?: Size;
-	onClick?: () => void;
 	className?: string;
 }) {
 	const Icon = ICONS[status];
 	const sizes = SIZE_CLASSES[size];
-	const label = statusLabel(status, seconds, idleLabel);
-	const active = isGenerationActive(status);
+	const label = statusLabel(status, seconds);
 	const iconEl = (
 		<Icon
 			className={cn(sizes.icon, "text-foreground", ICON_ANIMATION[status])}
@@ -81,8 +73,7 @@ export function GenerationIndicator({
 					baseWrapper,
 					"transition-[opacity,background-color] disabled:cursor-not-allowed",
 				)}
-				disabled={active || !onClick}
-				onClick={onClick}
+				disabled
 			>
 				{iconEl}
 			</button>

--- a/app/components/video/ResizeHandle.tsx
+++ b/app/components/video/ResizeHandle.tsx
@@ -2,8 +2,34 @@
 
 import type { PointerDragProps } from "@/lib/components/usePointerDrag";
 
+type ResizeAxis = "vertical" | "horizontal";
+
+const fade = (direction: "to right" | "to bottom") =>
+	`linear-gradient(${direction}, transparent, black 20%, black 80%, transparent)`;
+
+// A "vertical" axis resizes top/bottom panels, so the handle itself is a
+// horizontal line (shadow on its bottom); "horizontal" is a vertical line
+// (shadow on its right).
+const LINES: Record<
+	ResizeAxis,
+	{ handle: string; line: string; bar: string; mask: string }
+> = {
+	vertical: {
+		handle: "h-2 w-full cursor-row-resize",
+		line: "h-0.5 w-full flex-col",
+		bar: "h-px w-full",
+		mask: fade("to right"),
+	},
+	horizontal: {
+		handle: "h-full w-4 cursor-col-resize",
+		line: "h-full w-0.5",
+		bar: "h-full w-px",
+		mask: fade("to bottom"),
+	},
+};
+
 type ResizeHandleProps = {
-	axis: "vertical" | "horizontal";
+	axis: ResizeAxis;
 	resizing: boolean;
 	handleProps: PointerDragProps;
 };
@@ -13,41 +39,21 @@ export function ResizeHandle({
 	resizing,
 	handleProps,
 }: ResizeHandleProps) {
-	// A "vertical" axis resizes top/bottom panels, so the handle itself is a
-	// horizontal line (shadow on its bottom); "horizontal" is a vertical line
-	// (shadow on its right).
-	const isHorizontalLine = axis === "vertical";
+	const { handle, line, bar, mask } = LINES[axis];
 
 	return (
 		<div
 			{...handleProps}
-			className={`group relative flex shrink-0 touch-none items-center justify-center ${
-				isHorizontalLine
-					? "h-2 w-full cursor-row-resize"
-					: "h-full w-4 cursor-col-resize"
-			} ${resizing ? "select-none" : ""}`}
+			className={`group relative flex shrink-0 touch-none items-center justify-center ${handle} ${resizing ? "select-none" : ""}`}
 		>
 			<div
-				className={`flex ${isHorizontalLine ? "h-0.5 w-full flex-col" : "h-full w-0.5"}`}
-				style={{
-					maskImage: `linear-gradient(${
-						isHorizontalLine ? "to right" : "to bottom"
-					}, transparent, black 20%, black 80%, transparent)`,
-					WebkitMaskImage: `linear-gradient(${
-						isHorizontalLine ? "to right" : "to bottom"
-					}, transparent, black 20%, black 80%, transparent)`,
-				}}
+				className={`flex ${line}`}
+				style={{ maskImage: mask, WebkitMaskImage: mask }}
 			>
 				<div
-					className={`bg-resizer transition-colors group-hover:bg-resizer-hover ${
-						isHorizontalLine ? "h-px w-full" : "h-full w-px"
-					}`}
+					className={`bg-resizer transition-colors group-hover:bg-resizer-hover ${bar}`}
 				/>
-				<div
-					className={`bg-resizer-shadow ${
-						isHorizontalLine ? "h-px w-full" : "h-full w-px"
-					}`}
-				/>
+				<div className={`bg-resizer-shadow ${bar}`} />
 			</div>
 		</div>
 	);

--- a/app/components/video/useRendering.ts
+++ b/app/components/video/useRendering.ts
@@ -2,14 +2,13 @@
 
 import { useCallback, useState } from "react";
 import { errorMessage } from "@/lib/errors";
-import { runRender } from "@/lib/video/render-client";
+import { runRender, type RenderUpdate } from "@/lib/video/render-client";
 import type { VideoLayout } from "@/lib/video/types";
 
 type RenderState =
 	| { status: "idle" }
 	| { status: "invoking" }
-	| { status: "rendering"; progress: number }
-	| { status: "done"; url: string; size: number }
+	| RenderUpdate
 	| { status: "error"; message: string };
 
 export function useRendering() {

--- a/lib/agent/tools/registry.ts
+++ b/lib/agent/tools/registry.ts
@@ -52,21 +52,27 @@ export type ToolInput<TName extends AgentToolName> = z.output<
 	(typeof TOOLS)[TName]["input"]
 >;
 
+export type ToolOutput<TName extends AgentToolName> = Awaited<
+	ReturnType<(typeof TOOLS)[TName]["execute"]>
+>;
+
+/** How a call reads in the transcript. */
+export type ToolPresentation = { icon: IconComponent; label: string };
+
 // The record's inferred type does not correlate a name with its schema and
-// executor, so calls go through this mapped view of the same object.
-const DISPATCH = TOOLS as unknown as {
+// executor, so calls go through this mapped view of the same object. The
+// input is read as the SDK streams it, so each label reads its own fields
+// optionally.
+const BY_NAME = TOOLS as unknown as {
 	[TName in AgentToolName]: {
 		input: z.ZodType<ToolInput<TName>>;
 		execute: (
 			input: ToolInput<TName>,
 			ctx: AgentToolContext,
 		) => Promise<ToolOutput<TName>>;
+		present: { icon: IconComponent; label: (input: unknown) => string };
 	};
 };
-
-export type ToolOutput<TName extends AgentToolName> = Awaited<
-	ReturnType<(typeof TOOLS)[TName]["execute"]>
->;
 
 /** Any tool's output: what an executor hands back for the model to read. */
 export type AgentToolOutput = {
@@ -75,23 +81,13 @@ export type AgentToolOutput = {
 
 const isToolName = (name: string): name is AgentToolName => name in TOOLS;
 
-/** How a call reads in the transcript. */
-export type ToolPresentation = { icon: IconComponent; label: string };
-
-// Same widening as DISPATCH, and the input is read as the SDK streams it, so
-// each label reads its own fields optionally.
-const PRESENT = TOOLS as unknown as Record<
-	AgentToolName,
-	{ present: { icon: IconComponent; label: (input: unknown) => string } }
->;
-
 /** Null for a tool this build no longer offers, which a stored transcript still holds. */
 export function presentToolCall(
 	toolName: string,
 	input: unknown,
 ): ToolPresentation | null {
 	if (!isToolName(toolName)) return null;
-	const { icon, label } = PRESENT[toolName].present;
+	const { icon, label } = BY_NAME[toolName].present;
 	return { icon, label: label(input ?? {}) };
 }
 
@@ -120,7 +116,7 @@ const run = async <TName extends AgentToolName>(
 	input: unknown,
 	ctx: AgentToolContext,
 ): Promise<ToolOutcome> => {
-	const parsed = DISPATCH[toolName].input.safeParse(input);
+	const parsed = BY_NAME[toolName].input.safeParse(input);
 	if (!parsed.success) {
 		return {
 			ok: false,
@@ -129,7 +125,7 @@ const run = async <TName extends AgentToolName>(
 	}
 	return {
 		ok: true,
-		output: await DISPATCH[toolName].execute(parsed.data, ctx),
+		output: await BY_NAME[toolName].execute(parsed.data, ctx),
 	};
 };
 

--- a/lib/api/__tests__/sse.test.ts
+++ b/lib/api/__tests__/sse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatSSE, createSSEResponse, readSSE } from "../sse";
+import { formatSSE, readSSE } from "../sse";
 
 function makeSSEStream(chunks: string[]): ReadableStream {
 	const encoder = new TextEncoder();
@@ -22,63 +22,6 @@ describe("formatSSE", () => {
 
 	it("formats null", () => {
 		expect(formatSSE(null)).toBe("data: null\n\n");
-	});
-});
-
-describe("createSSEResponse", () => {
-	it("returns a Response with SSE headers", () => {
-		const response = createSSEResponse(async () => {});
-		expect(response.headers.get("Content-Type")).toBe("text/event-stream");
-		expect(response.headers.get("Cache-Control")).toBe("no-cache");
-		expect(response.headers.get("Connection")).toBe("keep-alive");
-	});
-
-	it("streams messages sent by handler", async () => {
-		const response = createSSEResponse(async (send) => {
-			await send({ type: "phase", phase: "loading", progress: 50 });
-			await send({ type: "done", url: "https://example.com", size: 100 });
-		});
-
-		const text = await response.text();
-		expect(text).toContain('"type":"phase"');
-		expect(text).toContain('"type":"done"');
-	});
-
-	it("closes the stream after handler completes", async () => {
-		const response = createSSEResponse(async (send) => {
-			await send("ok");
-		});
-
-		const body = response.body;
-		if (!body) throw new Error("expected response body");
-		const reader = body.getReader();
-
-		const chunks: string[] = [];
-		const decoder = new TextDecoder();
-		for (;;) {
-			const { done, value } = await reader.read();
-			if (done) break;
-			chunks.push(decoder.decode(value));
-		}
-		expect(chunks.length).toBeGreaterThan(0);
-	});
-
-	it("emits an error event and closes when handler rejects with an Error", async () => {
-		const response = createSSEResponse(async () => {
-			throw new Error("boom");
-		});
-		const text = await response.text();
-		expect(text).toContain('"type":"error"');
-		expect(text).toContain("boom");
-	});
-
-	it("emits the stringified message when handler rejects with a non-Error", async () => {
-		const response = createSSEResponse(async () => {
-			throw "string failure";
-		});
-		const text = await response.text();
-		expect(text).toContain('"type":"error"');
-		expect(text).toContain("string failure");
 	});
 });
 

--- a/lib/api/sse.ts
+++ b/lib/api/sse.ts
@@ -1,4 +1,3 @@
-import { stringifyError } from "../errors";
 import { logger } from "./logger";
 
 export function formatSSE(data: unknown): string {
@@ -10,37 +9,6 @@ const SSE_HEADERS = {
 	"Cache-Control": "no-cache",
 	Connection: "keep-alive",
 } as const;
-
-export function createSSEResponse(
-	handler: (send: (message: unknown) => Promise<void>) => Promise<void>,
-): Response {
-	const encoder = new TextEncoder();
-	const stream = new TransformStream();
-	const writer = stream.writable.getWriter();
-
-	const send = async (message: unknown) => {
-		await writer.write(encoder.encode(formatSSE(message)));
-	};
-
-	handler(send)
-		.catch((err) =>
-			send({
-				type: "error",
-				message: stringifyError(err),
-			}).catch((sendErr) =>
-				logger.warn({ err: sendErr }, "SSE: failed to deliver error frame"),
-			),
-		)
-		.finally(() =>
-			writer
-				.close()
-				.catch((closeErr) =>
-					logger.warn({ err: closeErr }, "SSE: writer close failed"),
-				),
-		);
-
-	return new Response(stream.readable, { headers: SSE_HEADERS });
-}
 
 export function createSSEStreamResponse<T>(
 	iter: AsyncIterable<T>,

--- a/lib/generation/history.ts
+++ b/lib/generation/history.ts
@@ -7,11 +7,6 @@ export interface ElementVersionStorage {
 	write(version: ElementVersion): void;
 }
 
-export const SESSION_ONLY: ElementVersionStorage = {
-	read: () => Promise.resolve([]),
-	write: () => {},
-};
-
 /** A version list is either still arriving, readable, or unreadable. */
 export type ElementHistoryStatus = "loading" | "ready" | "failed";
 
@@ -21,7 +16,7 @@ export class ElementHistory {
 	private loading = new Map<string, Promise<void>>();
 	private failed = new Set<string>();
 
-	constructor(private readonly storage: ElementVersionStorage = SESSION_ONLY) {}
+	constructor(private readonly storage: ElementVersionStorage) {}
 
 	subscribe = this.emitter.subscribe;
 

--- a/lib/project/api.ts
+++ b/lib/project/api.ts
@@ -1,13 +1,16 @@
+import { z } from "zod";
 import { createClient } from "@/lib/supabase/client";
 import type { ElementSnapshot } from "@/lib/generation/snapshots";
 import type { ProjectStoreSnapshot } from "./storeSnapshot";
 
-export type ProjectRow = {
-	id: string;
-	name: string;
-	thumbnail_url: string | null;
-	updated_at: string;
-};
+const ProjectRowSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	thumbnail_url: z.string().nullable(),
+	updated_at: z.string(),
+});
+
+export type ProjectRow = z.infer<typeof ProjectRowSchema>;
 
 export type SaveProjectInput = {
 	name: string;
@@ -29,7 +32,7 @@ export async function createProject(): Promise<ProjectRow> {
 		.select("id, name, thumbnail_url, updated_at")
 		.single();
 	if (error) throw error;
-	return data;
+	return ProjectRowSchema.parse(data);
 }
 
 export async function deleteProject(id: string): Promise<void> {

--- a/lib/project/thumbnail.ts
+++ b/lib/project/thumbnail.ts
@@ -1,5 +1,12 @@
+import type { AssetConnectorType } from "@/lib/connectors/types";
+import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 import type { ElementSnapshot } from "@/lib/generation/snapshots";
 import { isCharacterAvatarId } from "./characterAvatar";
+
+const PICTURED_BY: ReadonlySet<AssetConnectorType | null> = new Set([
+	"image",
+	"animated_image",
+]);
 
 export function pickThumbnailUrl(
 	entries: Iterable<[string, ElementSnapshot]>,
@@ -7,12 +14,8 @@ export function pickThumbnailUrl(
 	for (const [id, snap] of entries) {
 		// A character portrait is not what the project looks like.
 		if (isCharacterAvatarId(id)) continue;
-		if (
-			snap.connectorType !== "image" &&
-			snap.connectorType !== "animated_image"
-		)
-			continue;
-		const url = snap.result?.imageUrl;
+		if (!PICTURED_BY.has(snap.connectorType)) continue;
+		const url = getPrimaryUrl(snap.result, "image");
 		if (url) return url;
 	}
 	return null;

--- a/lib/providers/stream.ts
+++ b/lib/providers/stream.ts
@@ -1,25 +1,3 @@
-export async function streamToBuffer(
+export const streamToBuffer = (
 	stream: ReadableStream<Uint8Array>,
-): Promise<ArrayBuffer> {
-	const chunks: Uint8Array[] = [];
-	const reader = stream.getReader();
-	try {
-		for (;;) {
-			const { done, value } = await reader.read();
-			if (done) break;
-			chunks.push(value);
-		}
-	} finally {
-		reader.releaseLock();
-	}
-
-	const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
-	const buffer = new Uint8Array(totalLength);
-	let offset = 0;
-	for (const chunk of chunks) {
-		buffer.set(chunk, offset);
-		offset += chunk.length;
-	}
-
-	return buffer.buffer as ArrayBuffer;
-}
+): Promise<ArrayBuffer> => new Response(stream).arrayBuffer();

--- a/lib/video/__tests__/motionEffects.test.ts
+++ b/lib/video/__tests__/motionEffects.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { coverScale, motionTransform } from "../motionEffects";
 import {
-	coverScale,
 	DEFAULT_MOTION,
 	isMotionEffect,
-	motionTransform,
-} from "../motionEffects";
-import { MOTION_EFFECTS, type MotionEffect } from "../motionEffectNames";
+	MOTION_EFFECTS,
+	type MotionEffect,
+} from "../motionEffectNames";
 
 const ACTIVE: ReadonlyArray<Exclude<MotionEffect, "none">> =
 	MOTION_EFFECTS.filter((e) => e !== "none") as Exclude<MotionEffect, "none">[];

--- a/lib/video/elementAttributes.ts
+++ b/lib/video/elementAttributes.ts
@@ -8,8 +8,11 @@ import {
 	type SplitAttributes,
 } from "@/lib/canvas/types";
 import { clamp } from "@/lib/utils";
-import { DEFAULT_MOTION, isMotionEffect } from "./motionEffects";
-import type { MotionEffect } from "./motionEffectNames";
+import {
+	DEFAULT_MOTION,
+	isMotionEffect,
+	type MotionEffect,
+} from "./motionEffectNames";
 
 /** Raw attribute keys that, when changed, require a layout recompute but are omitted from generation inputs */
 export const LAYOUT_ATTRIBUTE_KEYS = ["loops", "volume", "motion"] as const;

--- a/lib/video/lambda-config.ts
+++ b/lib/video/lambda-config.ts
@@ -1,16 +1,19 @@
 import { type AwsRegion, speculateFunctionName } from "@remotion/lambda/client";
 
 export const REGION: AwsRegion = "us-east-1";
-export const RAM = 3008;
-export const DISK = 10240;
-export const TIMEOUT = 240;
+const RAM = 3008;
+const DISK = 10240;
+const TIMEOUT = 240;
+
+/** The deployed function is named from this spec, so deploys and callers share it. */
+export const LAMBDA_FUNCTION_SPEC = {
+	memorySizeInMb: RAM,
+	diskSizeInMb: DISK,
+	timeoutInSeconds: TIMEOUT,
+} as const;
 
 export function getFunctionName(): string {
-	return speculateFunctionName({
-		diskSizeInMb: DISK,
-		memorySizeInMb: RAM,
-		timeoutInSeconds: TIMEOUT,
-	});
+	return speculateFunctionName(LAMBDA_FUNCTION_SPEC);
 }
 
 export function getSiteName(): string {

--- a/lib/video/motionEffectNames.ts
+++ b/lib/video/motionEffectNames.ts
@@ -21,3 +21,11 @@ export const MOTION_EFFECTS = [
 
 export type MotionEffect = (typeof MOTION_EFFECTS)[number];
 export type ActiveMotionEffect = Exclude<MotionEffect, "none">;
+
+export const DEFAULT_MOTION: MotionEffect = "none";
+
+const MOTION_SET: ReadonlySet<string> = new Set(MOTION_EFFECTS);
+
+export function isMotionEffect(value: unknown): value is MotionEffect {
+	return typeof value === "string" && MOTION_SET.has(value);
+}

--- a/lib/video/motionEffects.ts
+++ b/lib/video/motionEffects.ts
@@ -1,17 +1,5 @@
 import { Easing, interpolate } from "remotion";
-import {
-	MOTION_EFFECTS,
-	type ActiveMotionEffect,
-	type MotionEffect,
-} from "./motionEffectNames";
-
-export const DEFAULT_MOTION: MotionEffect = "none";
-
-const MOTION_SET: ReadonlySet<string> = new Set(MOTION_EFFECTS);
-
-export function isMotionEffect(value: unknown): value is MotionEffect {
-	return typeof value === "string" && MOTION_SET.has(value);
-}
+import type { ActiveMotionEffect, MotionEffect } from "./motionEffectNames";
 
 /**
  * Per-frame motion components. `tx`/`ty` are percentages of the frame (CSS

--- a/scripts/deploy-remotion-function.ts
+++ b/scripts/deploy-remotion-function.ts
@@ -1,11 +1,9 @@
 import { deployFunction } from "@remotion/lambda";
-import { DISK, RAM, REGION, TIMEOUT } from "../lib/video/lambda-config";
+import { LAMBDA_FUNCTION_SPEC, REGION } from "../lib/video/lambda-config";
 
 const { functionName, alreadyExisted } = await deployFunction({
 	region: REGION,
-	memorySizeInMb: RAM,
-	diskSizeInMb: DISK,
-	timeoutInSeconds: TIMEOUT,
+	...LAMBDA_FUNCTION_SPEC,
 	createCloudWatchLogGroup: true,
 });
 


### PR DESCRIPTION
## Summary
- `.env.example` is now the one annotated env contract (it was missing the required `SUPABASE_SECRET_KEY` plus the ElevenLabs and Pinecone keys; the README was missing the OpenAI embedding and Remotion AWS keys). The README points at it instead of restating a second, drifting list.
- `DEFAULT_MOTION` and `isMotionEffect` move from `motionEffects.ts` (imports `remotion`) to `motionEffectNames.ts`, so reading element attributes no longer pulls Remotion into the canvas and server bundles. That is the split the names module exists to enforce.
- `LAMBDA_FUNCTION_SPEC` is the one home for the Lambda function's identity; the deploy script and `getFunctionName` both read it, so they cannot drift into a name that does not exist.
- Dead or duplicated app-internal logic removed: `createSSEResponse` (orphaned since #194), the hand-rolled `streamToBuffer` (now `Response.arrayBuffer`), the second `TOOLS` widening in the tool registry, `GenerationIndicator`'s never-passed `onClick`/`idleLabel`, `ElementHistory`'s unreachable `SESSION_ONLY` default, and `useRendering`'s re-typed `RenderUpdate` members.
- `pickThumbnailUrl` reads through `getPrimaryUrl` like every other result reader; `createProject` parses its Supabase row with zod and infers `ProjectRow` from the schema; `ResizeHandle` reads its axis from a two-row table instead of six ternaries.

No behavior change. The only observable difference is that a malformed `projects` row now throws at the boundary instead of flowing through untyped.

## Test plan
- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run knip`
- [x] `npm run build`
- [x] `npx vitest run --coverage`: 167 files, 1508 tests pass

## Merge-conflict guard
```
PR #713: clean
PR #712: clean
PR #711: clean
PR #710: clean
PR #709: clean
PR #707: clean
PR #706: clean
PR #705: clean
PR #704: clean
PR #703: clean
PR #701: clean
OK: no file overlap or merge conflict with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)