### PR TITLE
refactor: nightly CONVENTIONS sweep, declarative reads and dead guards

### DIFF
--- a/app/api/validate-code/route.ts
+++ b/app/api/validate-code/route.ts
@@ -34,7 +34,7 @@ export const POST = createPublicRouteHandler({
 		}
 		if (data !== "valid") {
 			return NextResponse.json(
-				{ error: ERROR_MESSAGES[data] ?? "Invalid access code" },
+				{ error: ERROR_MESSAGES[data] ?? ERROR_MESSAGES.invalid },
 				{ status: 401 },
 			);
 		}

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -6,15 +6,16 @@ export async function GET(request: Request) {
 	const { searchParams, origin } = new URL(request.url);
 	const code = searchParams.get("code");
 
-	if (code) {
-		const supabase = await createClient();
-		const { error } = await supabase.auth.exchangeCodeForSession(code);
-		if (!error) {
-			return NextResponse.redirect(`${origin}/`);
-		} else {
-			logger.error(error, "Auth callback failed");
-		}
-	}
+	const failed = NextResponse.redirect(
+		`${origin}/login?error=auth_callback_failed`,
+	);
+	if (!code) return failed;
 
-	return NextResponse.redirect(`${origin}/login?error=auth_callback_failed`);
+	const supabase = await createClient();
+	const { error } = await supabase.auth.exchangeCodeForSession(code);
+	if (error) {
+		logger.error(error, "Auth callback failed");
+		return failed;
+	}
+	return NextResponse.redirect(`${origin}/`);
 }

--- a/app/components/canvas/elements/attributes/TextAttributePopover.tsx
+++ b/app/components/canvas/elements/attributes/TextAttributePopover.tsx
@@ -42,13 +42,8 @@ export function TextAttributePopover({
 	);
 
 	const handleOpenChange = (next: boolean) => {
-		if (next) {
-			setDraft(value);
-		} else if (cancelRef.current) {
-			setDraft(value);
-		} else {
-			commit(draft);
-		}
+		if (next || cancelRef.current) setDraft(value);
+		else commit(draft);
 		cancelRef.current = false;
 		setOpen(next);
 	};

--- a/app/components/canvas/plugins/withNodeId.ts
+++ b/app/components/canvas/plugins/withNodeId.ts
@@ -14,16 +14,8 @@ export const withNodeId = (editor: ReactEditor): CanvasEditor => {
 	};
 
 	editor.apply = (operation) => {
-		if (operation.type === "insert_node") {
-			assignIdRecursively(operation.node);
-			return apply(operation);
-		}
-
-		if (operation.type === "split_node") {
-			operation.properties.id = makeNodeId();
-			return apply(operation);
-		}
-
+		if (operation.type === "insert_node") assignIdRecursively(operation.node);
+		if (operation.type === "split_node") operation.properties.id = makeNodeId();
 		return apply(operation);
 	};
 

--- a/app/components/video/ActiveSceneSync.tsx
+++ b/app/components/video/ActiveSceneSync.tsx
@@ -19,8 +19,7 @@ export function ActiveSceneSync() {
 	const { enabled: autoScrollEnabled } = useAutoScroll();
 	const playing = usePlayerPlaying();
 	const activeIndex = useActiveSegmentIndex();
-	const activeId =
-		activeIndex >= 0 ? (segments[activeIndex]?.sceneId ?? null) : null;
+	const activeId = segments[activeIndex]?.sceneId ?? null;
 
 	useEffect(() => {
 		setActiveSceneId(activeId);

--- a/app/components/video/QueueProgressBar.tsx
+++ b/app/components/video/QueueProgressBar.tsx
@@ -9,9 +9,7 @@ export function QueueProgressBar() {
 	const done = useQueueSelector((q) => q.getGeneratedCount());
 	const total = active + done;
 	// A reloaded project seeds its finished results back into the queue, so `done`
-	// is already > 0 before anything runs. Only report progress while something is
-	// actually generating — otherwise reopening a generated project flashes
-	// "N of N generated" at 100% during the prefetch window.
+	// is nonzero before anything runs; only report progress while generating.
 	const generating = active > 0;
 	const pct = generating ? (done / total) * 100 : 0;
 

--- a/app/components/video/startPlaybackAt.ts
+++ b/app/components/video/startPlaybackAt.ts
@@ -9,9 +9,8 @@ export type PlaybackTarget = Pick<
 /**
  * The play has to land a whole frame after the seek. In the same tick the
  * Player parks its frame driver on the seek's buffering block while `play()`
- * starts the shared audio tags anyway, so audio runs against a frozen picture
- * (#425); a `setTimeout` fires too early and freezes the same way. `pause()`
- * keeps `seekTo` off its own pause-and-resume path, which also stalls.
+ * starts the shared audio tags anyway, so audio runs against a frozen picture.
+ * `pause()` keeps `seekTo` off its own pause-and-resume path, which also stalls.
  */
 export function startPlaybackAt(player: PlaybackTarget, frame: number) {
 	player.pause();

--- a/lib/agent/messages.ts
+++ b/lib/agent/messages.ts
@@ -39,6 +39,10 @@ export function hasPendingToolCall(
 	);
 }
 
+const isPruned = (part: SloppyMessage["parts"][number]) =>
+	part.type === "reasoning" ||
+	(isToolUIPart(part) && SNAPSHOT_TOOLS.has(getToolName(part)));
+
 /**
  * Remove all prior reasoning blocks and snapshots tool results
  */
@@ -47,12 +51,7 @@ export function pruneTranscript(messages: SloppyMessage[]): SloppyMessage[] {
 		if (idx !== messages.length - 1 && message.role === "assistant") {
 			return {
 				...message,
-				parts: message.parts.filter((part) => {
-					if (part.type === "reasoning") {
-						return false;
-					}
-					return !(isToolUIPart(part) && SNAPSHOT_TOOLS.has(getToolName(part)));
-				}),
+				parts: message.parts.filter((part) => !isPruned(part)),
 			};
 		}
 		return message;

--- a/lib/api/asset-bundle.ts
+++ b/lib/api/asset-bundle.ts
@@ -118,10 +118,9 @@ export class AssetBundle {
 			}),
 		);
 
-		const result: Record<string, string> = {};
-		for (const file of files) {
-			result[file.key] = file.filename;
-		}
+		const result = Object.fromEntries(
+			files.map((file) => [file.key, file.filename]),
+		);
 
 		const manifest: AssetManifest = {
 			version: 1,

--- a/lib/api/jobs.ts
+++ b/lib/api/jobs.ts
@@ -45,8 +45,7 @@ export async function createJob(input: {
 		})
 		.select("id")
 		.single();
-	if (error || !data)
-		throw new Error(`Failed to create job: ${error?.message}`);
+	if (error) throw new Error(`Failed to create job: ${error.message}`);
 	return { id: data.id };
 }
 
@@ -72,8 +71,7 @@ export async function loadJobForProcessing(jobId: string): Promise<JobRow> {
 		.select("*")
 		.eq("id", jobId)
 		.single();
-	if (error || !data)
-		throw new Error(`Job ${jobId} not found: ${error?.message}`);
+	if (error) throw new Error(`Job ${jobId} not found: ${error.message}`);
 	return data as JobRow;
 }
 

--- a/lib/canvas/osmlSerializer.ts
+++ b/lib/canvas/osmlSerializer.ts
@@ -31,16 +31,12 @@ export function serializeOSML(descendants: Descendant[]): string {
 }
 
 export function serializeOSMLWithScenes(descendants: Descendant[]): string {
-	let osml = "";
-	let sceneNum = 0;
-	for (const node of descendants) {
-		if (isSceneElement(node)) {
-			sceneNum++;
-			osml += sceneMarker(sceneNum);
-			for (const child of node.children) {
-				osml += serializeElement(child);
-			}
-		}
-	}
-	return osml.trim();
+	return descendants
+		.filter(isSceneElement)
+		.map(
+			(scene, index) =>
+				sceneMarker(index + 1) + scene.children.map(serializeElement).join(""),
+		)
+		.join("")
+		.trim();
 }

--- a/lib/canvas/parseXmlTag.ts
+++ b/lib/canvas/parseXmlTag.ts
@@ -10,14 +10,12 @@ const ATTRIBUTE_PATTERN = /(\w+)="([^"]*)"/g;
 
 export function parseXmlTag(tagString: string): XmlTag {
 	const trimmed = tagString.trim();
-	const attributes: Record<string, string> = {};
-	ATTRIBUTE_PATTERN.lastIndex = 0;
-	let match: RegExpExecArray | null;
-
-	while ((match = ATTRIBUTE_PATTERN.exec(trimmed)) !== null) {
-		attributes[match[1]] = unescapeXml(match[2]);
-	}
-
+	const attributes = Object.fromEntries(
+		Array.from(trimmed.matchAll(ATTRIBUTE_PATTERN), ([, key, value]) => [
+			key,
+			unescapeXml(value),
+		]),
+	);
 	const [rawTag = ""] = trimmed.split(/\s/, 1);
 	return { tag: rawTag.replace(/\/$/, ""), attributes };
 }

--- a/lib/canvas/preservedAttributes.ts
+++ b/lib/canvas/preservedAttributes.ts
@@ -1,13 +1,11 @@
+import pickBy from "lodash/pickBy";
 import { REFERENCE_IMAGES_ATTR } from "@/lib/connectors/attributes/referenceImages";
 import { CHARACTERS_ATTR } from "./characterNames";
 import type { CanvasContentElement, CanvasElementType } from "./types";
 
 type ElementTypeGroup = readonly CanvasElementType[];
 
-/**
- * A map of attribute name and the types within which it's preserved
- */
-const PRESERVED_ATTRIBUTE_TYPES: Record<string, ElementTypeGroup> = {
+const PRESERVED_ATTRIBUTE_TYPES: Partial<Record<string, ElementTypeGroup>> = {
 	[CHARACTERS_ATTR]: ["image", "animated_image"],
 	[REFERENCE_IMAGES_ATTR]: ["image", "animated_image"],
 };
@@ -16,13 +14,7 @@ export function preservedAttributes(
 	source: CanvasContentElement,
 	targetType: CanvasElementType,
 ): Record<string, string> {
-	const attrs = source.generationAttributes ?? {};
-	const preserved: Record<string, string> = {};
-	for (const [attribute, types] of Object.entries(PRESERVED_ATTRIBUTE_TYPES)) {
-		const value = attrs[attribute];
-		if (value !== undefined && types.includes(targetType)) {
-			preserved[attribute] = value;
-		}
-	}
-	return preserved;
+	return pickBy(source.generationAttributes ?? {}, (_, attribute) =>
+		PRESERVED_ATTRIBUTE_TYPES[attribute]?.includes(targetType),
+	);
 }

--- a/lib/canvas/scenes.ts
+++ b/lib/canvas/scenes.ts
@@ -32,11 +32,5 @@ export const isScriptEmpty = (nodes: Descendant[]): boolean =>
 	);
 
 export function sceneIndexOf(nodes: Descendant[], sceneId: string): number {
-	let count = 0;
-	for (const node of nodes) {
-		if (!isSceneElement(node)) continue;
-		count += 1;
-		if (node.id === sceneId) return count;
-	}
-	return 0;
+	return nodes.filter(isSceneElement).findIndex((n) => n.id === sceneId) + 1;
 }

--- a/lib/color/hexAlpha.ts
+++ b/lib/color/hexAlpha.ts
@@ -1,3 +1,4 @@
+import { clamp } from "@/lib/utils";
 /** Opacity lives in the trailing pair of an 8-digit hex; a 6-digit one is opaque. */
 const OPAQUE = "ff";
 
@@ -21,7 +22,7 @@ export const alphaPercent = (color: string): number => {
 export const withAlphaPercent = (color: string, percent: number): string => {
 	if (Number.isNaN(percent)) return color;
 
-	const clamped = Math.min(100, Math.max(0, percent));
+	const clamped = clamp(percent, 0, 100);
 	const pair = Math.round((clamped / 100) * 255)
 		.toString(16)
 		.padStart(2, "0");

--- a/lib/connectors/tts/plugins/voice-search.ts
+++ b/lib/connectors/tts/plugins/voice-search.ts
@@ -1,4 +1,5 @@
 import omit from "lodash/omit";
+import pick from "lodash/pick";
 import type {
 	ConnectorPlugin,
 	TTSGenerateParams,
@@ -25,12 +26,7 @@ export function createVoiceSearchPlugin(): ConnectorPlugin<TTSGenerateParams> {
 				);
 			}
 			const voices = await ctx.searchVoices({
-				query: params.query,
-				gender: params.gender,
-				age: params.age,
-				pitch: params.pitch,
-				accent: params.accent,
-				description: params.description,
+				...pick(params, VOICE_DESCRIPTOR_KEYS),
 				language: params.language || "en",
 			});
 			if (!voices.length) throw new Error("No matching voice found");

--- a/lib/generation/staleReason.ts
+++ b/lib/generation/staleReason.ts
@@ -1,4 +1,6 @@
 import lowerCase from "lodash/lowerCase";
+import union from "lodash/union";
+import uniq from "lodash/uniq";
 import upperFirst from "lodash/upperFirst";
 import {
 	isNodeStale,
@@ -19,24 +21,23 @@ function changedInputs(node: GenerationNode, results: NodeResults): string[] {
 	if (!previous) return [];
 	const current = nodeInputs(node, results);
 
-	const changed = new Set<string>();
-	if (current.prompt !== previous.prompt) changed.add("the prompt");
-	const keys = [
-		...Object.keys(current.attributes),
-		...Object.keys(previous.attributes),
-	];
-	for (const key of keys) {
-		if (current.attributes[key] !== previous.attributes[key])
-			changed.add(lowerCase(key));
-	}
-	for (const dep of node.dependsOn) {
-		if (
-			current.dependencies[dep.id] !== previous.dependencies[dep.id] ||
-			needsGeneration(dep, results)
-		)
-			changed.add(dep.label ?? "an upstream element");
-	}
-	return [...changed];
+	const attributeKeys = union(
+		Object.keys(current.attributes),
+		Object.keys(previous.attributes),
+	);
+	return uniq([
+		...(current.prompt !== previous.prompt ? ["the prompt"] : []),
+		...attributeKeys
+			.filter((key) => current.attributes[key] !== previous.attributes[key])
+			.map(lowerCase),
+		...node.dependsOn
+			.filter(
+				(dep) =>
+					current.dependencies[dep.id] !== previous.dependencies[dep.id] ||
+					needsGeneration(dep, results),
+			)
+			.map((dep) => dep.label ?? "an upstream element"),
+	]);
 }
 
 /**

--- a/lib/providers/cache.ts
+++ b/lib/providers/cache.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import minBy from "lodash/minBy";
 import { Pinecone } from "@pinecone-database/pinecone";
 import { AssetBundle, type BundleResponse } from "@/lib/api/asset-bundle";
 import { logger } from "@/lib/api/logger";
@@ -96,14 +97,11 @@ export const rankByNearestDuration = <P extends { durationSeconds?: number }>(
 	candidates: CacheMatch[],
 	params: P,
 ): CacheMatch | undefined => {
-	if (candidates.length === 0) return undefined;
 	const target = params.durationSeconds;
 	if (target == null) return candidates[0];
-	return candidates.reduce((best, c) => {
-		const bd = Math.abs(Number(best.metadata?.duration ?? 0) - target);
-		const cd = Math.abs(Number(c.metadata?.duration ?? 0) - target);
-		return cd < bd ? c : best;
-	});
+	return minBy(candidates, (c) =>
+		Math.abs(Number(c.metadata?.duration ?? 0) - target),
+	);
 };
 
 /**

--- a/lib/providers/tts/voiceSimilarity.ts
+++ b/lib/providers/tts/voiceSimilarity.ts
@@ -1,4 +1,5 @@
 import { cosineSimilarity } from "ai";
+import sortBy from "lodash/sortBy";
 import type { VoiceInfo, VoiceSearchParams } from "@/lib/connectors/types";
 import { embedText, embedTexts } from "../embed";
 
@@ -28,10 +29,9 @@ export async function rankBySimilarity(
 		embedTexts(voices.map((v) => `${v.name} ${v.description ?? ""}`)),
 	]);
 
-	const scores = new Map(
-		voices.map((v, i) => [v.id, cosineSimilarity(query, voiceVecs[i])]),
-	);
-	return [...voices].sort(
-		(a, b) => (scores.get(b.id) ?? -Infinity) - (scores.get(a.id) ?? -Infinity),
-	);
+	const scored = voices.map((voice, i) => ({
+		voice,
+		score: cosineSimilarity(query, voiceVecs[i]),
+	}));
+	return sortBy(scored, (s) => -s.score).map((s) => s.voice);
 }

--- a/lib/video/fadeRamp.ts
+++ b/lib/video/fadeRamp.ts
@@ -9,8 +9,8 @@ export type FadeRamp = {
  * full volume).
  *
  * Remotion's interpolate() requires strictly increasing input values, so when
- * the fade windows would touch or overlap we collapse to a triangle peaking at
- * the midpoint instead of a trapezoid with equal adjacent values.
+ * the duration leaves no room for a plateau we collapse to a triangle peaking
+ * at the midpoint instead of a trapezoid with equal adjacent values.
  */
 export function fadeRamp(
 	durationInFrames: number,
@@ -18,7 +18,7 @@ export function fadeRamp(
 ): FadeRamp | null {
 	if (durationInFrames <= 1 || fadeFrames <= 0) return null;
 	const f = Math.min(fadeFrames, Math.floor((durationInFrames - 1) / 2));
-	if (f <= 0 || 2 * f >= durationInFrames) {
+	if (f <= 0) {
 		return {
 			input: [0, durationInFrames / 2, durationInFrames],
 			output: [0, 1, 0],


### PR DESCRIPTION
## Summary

Nightly CONVENTIONS.md compliance sweep over the 344 non-test source files not under an open PR. Twenty files, no behavior change. Lint, typecheck, format, 1513 tests, and `npm run build` all pass.

**Auto-fixed (rule 7, declarative reads like config):**
- `lib/canvas/osmlSerializer.ts` scene loop → `filter/map/join`
- `lib/canvas/parseXmlTag.ts` `exec` loop with `lastIndex` reset → `matchAll` + `Object.fromEntries`
- `lib/canvas/scenes.ts` `sceneIndexOf` counter loop → `findIndex + 1`
- `lib/canvas/preservedAttributes.ts` accumulator → `pickBy`, restating comment removed
- `lib/generation/staleReason.ts` three Set accumulations → one `uniq([...])` list
- `lib/api/asset-bundle.ts` manifest result loop → `Object.fromEntries`
- `lib/agent/messages.ts` nested filter predicate hoisted to `isPruned`

**Auto-fixed (rule 5, one canonical way):**
- `lib/providers/cache.ts` hand-rolled `reduce` → `lodash/minBy`
- `lib/providers/tts/voiceSimilarity.ts` id-keyed Map with `?? -Infinity` fallbacks → index-paired `sortBy`
- `lib/connectors/tts/plugins/voice-search.ts` seven keys listed twice → `pick(params, VOICE_DESCRIPTOR_KEYS)`
- `lib/color/hexAlpha.ts` inline min/max → `clamp` from `lib/utils`

**Auto-fixed (rules 1 and 4, dead guards and duplicate branches):**
- `lib/api/jobs.ts` `error || !data` after `.single()` → `error`
- `lib/video/fadeRamp.ts` unreachable `2 * f >= durationInFrames` disjunct dropped, doc reworded
- `app/components/video/ActiveSceneSync.tsx` double guard on a negative index
- `app/components/canvas/plugins/withNodeId.ts` three identical `return apply(operation)` tails
- `app/components/canvas/elements/attributes/TextAttributePopover.tsx` two branches with identical bodies
- `app/auth/callback/route.ts` nested if/else → guard clauses
- `app/api/validate-code/route.ts` fallback string → `ERROR_MESSAGES.invalid`

**Comments (rule 7, never narrate history):** `startPlaybackAt.ts` issue reference and failed-attempt sentence, `QueueProgressBar.tsx` symptom narration.

## Considered and reverted

- `lib/auth/session.ts` conditional spreads and `lib/agent/tools/fitDurations.ts` empty-ops ternary: both are pinned by explicit contract tests, so left as is.
- `app/components/sloppy/suggestions.ts` → `lodash/sample`: would need a `?? current` fallback that contradicts the function's contract.
- `BottomTransportBar` direct `player.seekTo`: `usePlayerScrub` is for scrub surfaces, prev/next is not one.

## New design-level flags (not applied)

- #37 `app/components/canvas/elements/MediaWithSkeleton.tsx:7` takes `ResultKind` but has no audio path; an `"audio"` value silently renders a `<video>`. Narrow the prop to the visual kinds.
- #38 `lib/connectors/image/plugins/character-references.ts:23` `ctx?.dependencies?.[...]?.imageUrl` silently `compact`s a missing declared avatar dependency; sibling uses `requireState`. Needs a `requireDependencies` in `plugins.ts` (locked by #701).
- #39 `lib/connectors/tts/plugins/voice-search.ts:22` hand-rolled `requireSearchVoices` guard; the canonical shape lives in `plugins.ts` (locked by #701).
- #40 `lib/connectors/image/plugins/character-avatar.ts:10` re-derives `appearance` from project state when `characterAvatarElement` already puts it in `generationAttributes` → `params`.
- #41 `lib/upload/imageFiles.ts:8` duplicates the `imageFile(maxBytes)` zod schema from `lib/api/request-schema-fields.ts` with different wording.
- #42 `lib/project/canvasVersionStorage.ts` and 7 other files: `{ data, error }` + `if (error) throw` could be `.throwOnError()` as a single sweep.
- #43 `lib/api/conversations.ts:24` read-insert-reread race workaround; the table has a unique `(user_id, project_id)` index, so an upsert removes the race.
- #44 `lib/agent/tools/{setMetadata,setVideoSettings,setCaptionStyle}` `!== undefined` spreads guard nothing since `updateMetadata` is a lodash `merge` over always-present keys.
- #45 `app/components/video/PlayerControlContext.tsx:10` nullable `player` leaks to 13 guarded call sites; a bound no-op command surface would remove them.
- #46 `components/ui/number-scrubber.tsx:101` hand-rolls pointer capture instead of `usePointerDrag`, missing the button-0 and pointercancel handling.
- #47 `remotion/components/MotionLayer.tsx:17` re-checks the `"none"` sentinel that `motionTransform` already owns.
- #48 `app/components/video/useAssetPrefetch.ts:70` a failed remotion import logs and reports `ready = true`.

Re-confirmed standing flags #28 (element-type sniffing in `ElementCharacters`/`AnimateButton`), #30 (`asset-bundle.baseUrl ?? ""`), #31 (`Waveform:92` console.error catch).

## Merge-conflict guard

```
PR #714: clean
PR #713: clean
PR #712: clean
PR #711: clean
PR #710: clean
PR #709: clean
PR #707: clean
PR #706: clean
PR #705: clean
PR #704: clean
PR #703: clean
PR #701: clean
OK: no file overlap or merge conflict with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
