### PR TITLE
Revert "perf: fetch card images at the size they render" (#698)

### DIFF
--- a/app/components/canvas/elements/AssetTile.tsx
+++ b/app/components/canvas/elements/AssetTile.tsx
@@ -63,7 +63,7 @@ export function AssetTile({
 						src={previewUrl}
 						alt={name ?? ""}
 						fill
-						sizes="80px"
+						unoptimized
 						className="object-cover"
 					/>
 				) : (

--- a/app/components/canvas/elements/ElementHistoryPopover.tsx
+++ b/app/components/canvas/elements/ElementHistoryPopover.tsx
@@ -51,7 +51,6 @@ function ElementVersionThumbnail({
 				outputKind={result.videoUrl ? "video" : "image"}
 				src={src}
 				alt=""
-				sizes="64px"
 			/>
 		</div>
 	);

--- a/app/components/canvas/elements/ForegroundPreview.tsx
+++ b/app/components/canvas/elements/ForegroundPreview.tsx
@@ -27,7 +27,6 @@ export function ForegroundPreview({
 				outputKind={outputKind}
 				src={url}
 				alt="Scene preview"
-				sizes="128px"
 			/>
 		</div>
 	);

--- a/app/components/canvas/elements/preview/__tests__/cancelOffset.test.tsx
+++ b/app/components/canvas/elements/preview/__tests__/cancelOffset.test.tsx
@@ -45,7 +45,7 @@ describe("cancel button offset", () => {
 			/>,
 		);
 		expect(html).not.toContain('aria-label="Cancel generation"');
-		expect(html).toContain("cdn.example.com");
+		expect(html).toContain("https://cdn.example.com/a.png");
 	});
 
 	it("is pushed below the still/video toggle by AnimatedImageMedia", () => {

--- a/app/components/canvas/elements/preview/results.tsx
+++ b/app/components/canvas/elements/preview/results.tsx
@@ -123,7 +123,6 @@ export function MediaPreview({
 				alt="Generated"
 				videoInteractive
 				objectFit="contain"
-				sizes="(min-width: 1024px) 60vw, 100vw"
 			/>
 			{error && <ErrorMessage message={error} />}
 			<ResultOverlay status={status} seconds={seconds} />

--- a/app/components/video/timeline/TimelineClip.tsx
+++ b/app/components/video/timeline/TimelineClip.tsx
@@ -99,7 +99,6 @@ export function TimelineClip({
 							outputKind={config.outputKind}
 							src={element.url}
 							alt=""
-							sizes="64px"
 						/>
 					</div>
 				) : (

--- a/lib/components/MediaWithSkeleton.tsx
+++ b/lib/components/MediaWithSkeleton.tsx
@@ -11,8 +11,6 @@ interface MediaWithSkeletonProps {
 	alt: string;
 	videoInteractive?: boolean;
 	objectFit?: "cover" | "contain";
-	/** CSS width the media renders at, so an image is fetched at that size and not at the generator's full 2560px output. */
-	sizes: string;
 }
 
 export function MediaWithSkeleton({
@@ -21,7 +19,6 @@ export function MediaWithSkeleton({
 	alt,
 	videoInteractive = false,
 	objectFit = "cover",
-	sizes,
 }: MediaWithSkeletonProps) {
 	const [videoLoaded, setVideoLoaded] = useState(false);
 	const fitClass = objectFit === "contain" ? "object-contain" : "object-cover";
@@ -32,8 +29,8 @@ export function MediaWithSkeleton({
 				src={src}
 				alt={alt}
 				fill
-				sizes={sizes}
 				className={fitClass}
+				unoptimized
 			/>
 		);
 	}


### PR DESCRIPTION
Reverts #698.

Routing generated stills through `next/image`'s optimizer broke image previews on real projects. Runware stills are stored as ~6-7 MB PNGs (2848x1600), and the optimizer's upstream fetch runs under a hard-coded 7 s abort signal that also covers the body read. A blob CDN serving those PNGs at 0.5-2 MB/s trips it constantly, and the abort falls through to the generic catch, so `/_next/image` answers 500 for most stills in a project with a few dozen scenes. There is no config knob for that timeout.

Card, storyboard, history and timeline previews go back to `unoptimized` and load the raw blob URL directly. Confirmed by rendering `MediaWithSkeleton` and checking the markup carries the blob URL with no `/_next/image` or `srcset`.

The size win #698 was after is real but has to come from the source: emitting WebP instead of PNG from the Runware provider, or writing a preview alongside each still at upload time. Either lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaEeuV7HixTfDSRzkR7Q1m