### PR TITLE
perf: emit generated stills as WebP instead of PNG

### DIFF
--- a/lib/providers/__tests__/runware-image.test.ts
+++ b/lib/providers/__tests__/runware-image.test.ts
@@ -39,7 +39,7 @@ describe("RunwareImage", () => {
 			width: 2848,
 			height: 1600,
 			outputType: "base64Data",
-			outputFormat: "PNG",
+			outputFormat: "WEBP",
 			numberResults: 1,
 			referenceImages: undefined,
 		});
@@ -52,15 +52,15 @@ describe("RunwareImage", () => {
 		await new RunwareImage("test-key").generate({ prompt: "a cat" });
 
 		expect(mockImageInference).toHaveBeenCalledWith(
-			expect.objectContaining({ outputFormat: "PNG" }),
+			expect.objectContaining({ outputFormat: "WEBP" }),
 		);
 		expect(AssetBundle.upload).toHaveBeenCalledWith(
 			"image",
 			"runware",
 			[
 				expect.objectContaining({
-					filename: "output.png",
-					contentType: "image/png",
+					filename: "output.webp",
+					contentType: "image/webp",
 				}),
 			],
 			undefined,

--- a/lib/providers/image/runware.ts
+++ b/lib/providers/image/runware.ts
@@ -10,7 +10,7 @@ type RawImageResult = {
 } & WithMetadata;
 
 // Runware defaults to JPG when the request names no format.
-const OUTPUT_FORMAT = "PNG";
+const OUTPUT_FORMAT = "WEBP";
 
 export class RunwareImage
 	extends BaseProvider<ImageGenerateParams, RawImageResult>


### PR DESCRIPTION
## Summary

Nightly perf pass for 2026-09-04. Runware stills are emitted as WebP instead of PNG (`OUTPUT_FORMAT` in `lib/providers/image/runware.ts`, plus the matching test expectations). Rebased onto master at 54208ead.

Since #687 named PNG as the output format, every still has been a 5 to 7 MB lossless file for a 2560x1440 frame that the editor paints at 64 to 1100px and the renderer zooms at most 1.3x. That size is also why the image optimizer timed out in #698, reverted in #722. WebP at Runware's default quality (95) lands at the old JPEG size with better quality, so every card, storyboard tile, timeline clip, seek tooltip and Lambda render frame downloads roughly 10x less.

## Measured (Vercel Blob, `assets/image/runware/`, 8384 stills)

| Stills | Format | Mean | p50 | p90 |
| --- | --- | --- | --- | --- |
| Before 2026-08-30 | Runware JPG default, mislabeled `.png` | 0.59 MB | 0.55 MB | 0.92 MB |
| Since #687 (295 stills) | real PNG | 5.88 MB | 6.03 MB | 6.99 MB |
| sharp re-encode of 4 real PNGs | WebP q95 | 0.45 to 1.03 MB | | |

Downstream checked for WebP: Anthropic reference images accept `image/webp`, Runware accepts WebP `referenceImages` and `frameImages`, and Remotion's `<Img>` renders in Chromium.

Lint, format, typecheck, knip, build and the full test suite pass on the rebased branch.

## Merge-conflict guard

This branch shares no files with any open PR. The guard script still reports #712 because #712 conflicts with master itself on `lib/providers/llm/mock.ts`; pushed on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaEeuV7HixTfDSRzkR7Q1m
