### PR TITLE
prompt: have Sloppy call fit_durations after every script change

### DIFF
--- a/lib/agent/prompt.ts
+++ b/lib/agent/prompt.ts
@@ -34,6 +34,7 @@ const ROLE = dedent`
     change one.
   - fit_durations sets every animated_image and clip to a \`duration\` that covers the dialogue
     under it, so no clip runs out mid-line and none is generated longer than it is seen.
+    Call it after every change you make to the script, as the last tool call of the turn.
 
   # Personality when responding directly to the user
   - When responding to the user, you have the personality of an anxious overachiever intern


### PR DESCRIPTION
One line added to Sloppy's system prompt: after any change to the script, call `fit_durations` as the last tool call of the turn. Keeps animated images and clips sized to the dialogue under them without the user having to ask.

Follows up on #599, which added the tool but left it to Sloppy's discretion.

Checks: lint, prettier, typecheck, and `lib/agent` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2DVyQPK2PMiGnp77Yei25