### PR TITLE
fix: nightly security audit 2026-09-05

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12827,9 +12827,9 @@
 			}
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+			"integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
 			"funding": [
 				{
 					"type": "github",
@@ -16774,13 +16774,14 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.15.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+			"integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"side-channel": "^1.1.0"
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -18117,15 +18118,15 @@
 			}
 		},
 		"node_modules/side-channel": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3",
-				"side-channel-list": "^1.0.0",
+				"object-inspect": "^1.13.4",
+				"side-channel-list": "^1.0.1",
 				"side-channel-map": "^1.0.1",
 				"side-channel-weakmap": "^1.0.2"
 			},


### PR DESCRIPTION
## Summary

Lockfile-only `npm audit fix` that was deferred on 2026-09-03 and 2026-09-04 while open PRs blocked the merge-conflict guard. No `package.json` change.

| Package | Before | After | Advisories |
| --- | --- | --- | --- |
| `fast-uri` (transitive, via `ajv@8` under `@remotion/bundler` and `shadcn`) | 3.1.5 | 3.1.7 | GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp (high); Dependabot #146, #147, #149, #150 |
| `qs` (transitive, via `shadcn` -> `@modelcontextprotocol/sdk` -> `express`) | 6.15.2 | 6.16.0 | GHSA-x5fp-wj9c-mxmx, GHSA-4mjr-xmp4-gh2g (moderate) |

Both packages are build-time only and are not in the runtime bundle.

## Audit findings by category

- **Dependencies:** the two fixes above. Remaining `npm audit` / Dependabot #77 item is `uuid@9` pinned by `@runware/sdk-js@1.3.2` (latest); the bundled SDK only imports `v4`/`validate`, so the `buf` bounds bug on v3/v5/v6 is unreachable. Left as previously accepted.
- **Code surface merged since the 2026-09-04 sweep (#712, #713, #714, #715, #724, #725):** reviewed every server-side diff under `app/api`, `lib/api`, `lib/supabase`, `lib/providers`, `lib/gateway`. All refactors; no auth tier, validation, allow-list, or RLS change. `readProviderKey` and `listProviderKeys` now zod-parse RPC results, which tightens rather than loosens.
- **Secrets / env:** no secret literals; only `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `NEXT_PUBLIC_BLOB_URL` exposed; service key server-only.
- **Headers / CSP:** unchanged (`nosniff`, `SAMEORIGIN`, HSTS preload, referrer policy). No CSP, as before.
- **Routes / Supabase:** all 36 route files go through `createSession*`/`createApi*`/`createPublic*` handlers; `withPublic` is used only by `validate-code` and the prod-404'd `/api/dev/impersonate`. Voice preview remains origin-allow-listed. Provider keys stay in Vault behind service-role-only definer RPCs.
- **DOM sinks / redirects / path traversal:** none found.

## Validation

- `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run knip`: pass
- `npm run test:run`: 176 files, 1589 tests pass
- `npm run build`: pass
- `npm audit`: only the accepted `uuid` item remains

## Merge-conflict guard

```
OK: no file overlap or merge conflict with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)