### PR TITLE
refactor: nightly maintainability 2026-09-05

### DIFF
--- a/app/components/canvas/elements/GenerationIndicator.tsx
+++ b/app/components/canvas/elements/GenerationIndicator.tsx
@@ -1,27 +1,24 @@
-import {
-	Hourglass,
-	Loader2,
-	Wand2,
-	type IconComponent,
-} from "@/components/ui/icon";
+import { Hourglass, Loader2, type IconComponent } from "@/components/ui/icon";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import type { ElementSnapshot } from "@/lib/generation/snapshots";
-
-type Status = ElementSnapshot["status"];
+import type { ActiveGenerationStatus } from "@/lib/generation/snapshots";
 
 type Size = "sm" | "md";
 
-const ICONS: Record<Status, IconComponent> = {
-	idle: Wand2,
-	queued: Hourglass,
-	generating: Loader2,
-};
-
-const ICON_ANIMATION: Record<Status, string> = {
-	idle: "",
-	queued: "animate-pulse",
-	generating: "animate-spin",
+const STATUS: Record<
+	ActiveGenerationStatus,
+	{ icon: IconComponent; animation: string; label: (seconds: number) => string }
+> = {
+	queued: {
+		icon: Hourglass,
+		animation: "animate-pulse",
+		label: () => "Queued…",
+	},
+	generating: {
+		icon: Loader2,
+		animation: "animate-spin",
+		label: (seconds) => `Generating ${seconds}s`,
+	},
 };
 
 const SIZE_CLASSES: Record<Size, { wrapper: string; icon: string }> = {
@@ -33,36 +30,20 @@ const SIZE_CLASSES: Record<Size, { wrapper: string; icon: string }> = {
 	},
 };
 
-function statusLabel(status: Status, seconds: number) {
-	if (status === "queued") return "Queued…";
-	if (status === "generating") return `Generating ${seconds}s`;
-	return "Generate";
-}
-
 export function GenerationIndicator({
 	status,
 	seconds = 0,
 	size = "md",
 	className = "",
 }: {
-	status: Status;
+	status: ActiveGenerationStatus;
 	seconds?: number;
 	size?: Size;
 	className?: string;
 }) {
-	const Icon = ICONS[status];
+	const { icon: Icon, animation, label: labelFor } = STATUS[status];
 	const sizes = SIZE_CLASSES[size];
-	const label = statusLabel(status, seconds);
-	const iconEl = (
-		<Icon
-			className={cn(sizes.icon, "text-foreground", ICON_ANIMATION[status])}
-		/>
-	);
-	const baseWrapper = cn(
-		"relative flex items-center justify-center rounded-full overflow-hidden text-foreground",
-		sizes.wrapper,
-		className,
-	);
+	const label = labelFor(seconds);
 
 	return (
 		<SimpleTooltip label={label}>
@@ -70,12 +51,14 @@ export function GenerationIndicator({
 				type="button"
 				aria-label={label}
 				className={cn(
-					baseWrapper,
+					"relative flex items-center justify-center rounded-full overflow-hidden text-foreground",
+					sizes.wrapper,
+					className,
 					"transition-[opacity,background-color] disabled:cursor-not-allowed",
 				)}
 				disabled
 			>
-				{iconEl}
+				<Icon className={cn(sizes.icon, "text-foreground", animation)} />
 			</button>
 		</SimpleTooltip>
 	);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import AccessCodeInput from "./components/AccessCodeInput";
 import ProjectsList from "./components/projects/ProjectsList";
 import { Button } from "@/components/ui/button";
 import { listProviderKeys } from "@/lib/api/providerKeys";
+import { PROJECT_ROW_COLUMNS, ProjectRowSchema } from "@/lib/project/api";
 import { UserProvider } from "@/lib/user/UserProvider";
 
 const icons = fs
@@ -25,14 +26,16 @@ export default async function Home() {
 		const [{ data: projects, error }, providerKeys] = await Promise.all([
 			supabase
 				.from("projects")
-				.select("id, name, thumbnail_url, updated_at")
+				.select(PROJECT_ROW_COLUMNS)
 				.order("updated_at", { ascending: false }),
 			listProviderKeys(user),
 		]);
 		if (error) throw error;
 		return (
 			<UserProvider user={user} providerKeys={providerKeys}>
-				<ProjectsList initialProjects={projects ?? []} />
+				<ProjectsList
+					initialProjects={ProjectRowSchema.array().parse(projects)}
+				/>
 			</UserProvider>
 		);
 	}

--- a/lib/api/__tests__/asset-bundle.test.ts
+++ b/lib/api/__tests__/asset-bundle.test.ts
@@ -25,9 +25,6 @@ describe("AssetBundle", () => {
 			const bundle = new AssetBundle(
 				"https://blob.example.com/assets/image/runware/abc",
 				{
-					version: 1,
-					type: "image",
-					createdAt: "",
 					result: { image: "output.png" },
 				},
 			);
@@ -40,9 +37,6 @@ describe("AssetBundle", () => {
 			const bundle = new AssetBundle(
 				"https://blob.example.com/assets/video/mock/xyz",
 				{
-					version: 1,
-					type: "video",
-					createdAt: "",
 					result: { video: "https://cdn.example.com/video.mp4" },
 				},
 			);
@@ -51,9 +45,6 @@ describe("AssetBundle", () => {
 
 		it("throws for unknown key", () => {
 			const bundle = new AssetBundle("https://blob.example.com/x", {
-				version: 1,
-				type: "image",
-				createdAt: "",
 				result: {},
 			});
 			expect(() => bundle.resolve("missing")).toThrow('No file "missing"');
@@ -76,8 +67,6 @@ describe("AssetBundle", () => {
 			expect(bundle.resolve("image")).toBe(
 				"https://blob.example.com/assets/image/runware/abc/output.png",
 			);
-			expect(bundle.manifest.type).toBe("image");
-			expect(bundle.manifest.version).toBe(1);
 		});
 	});
 
@@ -101,9 +90,6 @@ describe("AssetBundle", () => {
 			const bundle = new AssetBundle(
 				"https://blob.example.com/assets/tts/cartesia/abc",
 				{
-					version: 1,
-					type: "tts",
-					createdAt: "",
 					result: { timestamps: "timestamps.json" },
 				},
 			);
@@ -130,9 +116,6 @@ describe("AssetBundle", () => {
 			const bundle = new AssetBundle(
 				"https://blob.example.com/assets/tts/cartesia/abc",
 				{
-					version: 1,
-					type: "tts",
-					createdAt: "",
 					result: { timestamps: "timestamps.json" },
 				},
 			);

--- a/lib/api/asset-bundle.ts
+++ b/lib/api/asset-bundle.ts
@@ -1,4 +1,5 @@
 import { nanoid } from "nanoid";
+import { z } from "zod";
 
 async function fetchOk(url: string, label: string): Promise<Response> {
 	const res = await fetch(url);
@@ -13,13 +14,16 @@ async function fetchJson<T>(url: string, label: string): Promise<T> {
 	return res.json() as Promise<T>;
 }
 
-export type AssetManifest = {
+type AssetManifest = {
 	version: number;
 	type: string;
 	createdAt: string;
 	result: Record<string, string>;
 	metadata?: Record<string, unknown>;
 };
+
+/** The parts of a manifest a bundle is read through. */
+type BundleContents = Pick<AssetManifest, "result" | "metadata">;
 
 type BundleFileBase = {
 	key: string;
@@ -50,20 +54,22 @@ async function sourceOf(
 	return { body: res.body, multipart: true };
 }
 
-export type BundleResponse = {
-	id: string;
-	type: string;
-	provider: string;
-	result: Record<string, string>;
-	metadata?: Record<string, unknown>;
-};
+export const BundleResponseSchema = z.object({
+	id: z.string(),
+	type: z.string(),
+	provider: z.string(),
+	result: z.record(z.string(), z.string()),
+	metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type BundleResponse = z.infer<typeof BundleResponseSchema>;
 
 export class AssetBundle {
 	static baseUrl = process.env.NEXT_PUBLIC_BLOB_URL ?? "";
 
 	constructor(
 		readonly url: string,
-		readonly manifest: AssetManifest,
+		readonly manifest: BundleContents,
 	) {}
 
 	resolve(key: string): string {
@@ -87,13 +93,7 @@ export class AssetBundle {
 			response.provider,
 			response.id,
 		);
-		return new AssetBundle(url, {
-			version: 1,
-			type: response.type,
-			createdAt: "",
-			result: response.result,
-			metadata: response.metadata,
-		});
+		return new AssetBundle(url, response);
 	}
 
 	static async upload(

--- a/lib/api/handlers/video.ts
+++ b/lib/api/handlers/video.ts
@@ -31,7 +31,7 @@ export const videoHandler: JobHandler<
 		if (upstream.kind === "ready") {
 			return { kind: "completed", result: upstream.asset };
 		}
-		if (upstream.metadata?.status === "failed") {
+		if (upstream.metadata.status === "failed") {
 			throw new Error(upstream.metadata.error ?? "Video generation failed");
 		}
 		return { kind: "pending", metadata: { providerJobId } };

--- a/lib/api/jobs.ts
+++ b/lib/api/jobs.ts
@@ -1,27 +1,33 @@
 import { send } from "@vercel/queue";
 import isUndefined from "lodash/isUndefined";
 import omitBy from "lodash/omitBy";
-import type { BundleResponse } from "@/lib/api/asset-bundle";
-import type { ConnectorType } from "@/lib/connectors/types";
-import type { JobStatus } from "@/lib/gateway/base";
+import { z } from "zod";
+import {
+	BundleResponseSchema,
+	type BundleResponse,
+} from "@/lib/api/asset-bundle";
+import { CONNECTOR_TYPES, type ConnectorType } from "@/lib/connectors/types";
+import { JOB_STATUSES, type JobStatus } from "@/lib/gateway/base";
 import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/service";
 
 const ASSET_QUEUE_TOPIC = "asset-generate";
 
-export type JobRow = {
-	id: string;
-	user_id: string;
-	project_id: string | null;
-	connector_type: ConnectorType;
-	status: JobStatus;
-	request: Record<string, unknown>;
-	result: BundleResponse | null;
-	metadata: Record<string, unknown>;
-	error: string | null;
-	created_at: string;
-	updated_at: string;
-};
+const JobRowSchema = z.object({
+	id: z.string(),
+	user_id: z.string(),
+	project_id: z.string().nullable(),
+	connector_type: z.enum(CONNECTOR_TYPES),
+	status: z.enum(JOB_STATUSES),
+	request: z.record(z.string(), z.unknown()),
+	result: BundleResponseSchema.nullable(),
+	metadata: z.record(z.string(), z.unknown()),
+	error: z.string().nullable(),
+	created_at: z.string(),
+	updated_at: z.string(),
+});
+
+export type JobRow = z.infer<typeof JobRowSchema>;
 
 export type AssetQueueMessage = {
 	jobId: string;
@@ -61,7 +67,7 @@ export async function getJob(
 		.eq("user_id", userId)
 		.maybeSingle();
 	if (error) throw new Error(`Failed to load job: ${error.message}`);
-	return (data as JobRow) ?? null;
+	return data ? JobRowSchema.parse(data) : null;
 }
 
 export async function loadJobForProcessing(jobId: string): Promise<JobRow> {
@@ -72,7 +78,7 @@ export async function loadJobForProcessing(jobId: string): Promise<JobRow> {
 		.eq("id", jobId)
 		.single();
 	if (error) throw new Error(`Job ${jobId} not found: ${error.message}`);
-	return data as JobRow;
+	return JobRowSchema.parse(data);
 }
 
 export async function updateJob(

--- a/lib/connectors/__tests__/asset-base.test.ts
+++ b/lib/connectors/__tests__/asset-base.test.ts
@@ -77,9 +77,6 @@ describe("BaseAssetConnector", () => {
 			const bundle = new AssetBundle(
 				"https://blob.example.com/assets/image/runware/abc",
 				{
-					version: 1,
-					type: "image",
-					createdAt: "",
 					result: { image: "output.png" },
 					metadata: { durationSec: 10 },
 				},
@@ -98,9 +95,6 @@ describe("BaseAssetConnector", () => {
 			const bundle = new AssetBundle(
 				"https://blob.example.com/assets/image/mock/xyz",
 				{
-					version: 1,
-					type: "image",
-					createdAt: "",
 					result: { image: "output.jpg" },
 				},
 			);
@@ -114,9 +108,6 @@ describe("BaseAssetConnector", () => {
 			const bundle = new AssetBundle(
 				"https://blob.example.com/assets/image/mock/xyz",
 				{
-					version: 1,
-					type: "image",
-					createdAt: "",
 					result: { image: "output.jpg" },
 					metadata: { otherField: "value" },
 				},

--- a/lib/gateway/base.ts
+++ b/lib/gateway/base.ts
@@ -4,7 +4,14 @@ export abstract class GatewayClient<TParams = unknown, TResult = unknown> {
 	abstract generate(params: TParams): Promise<TResult>;
 }
 
-export type JobStatus = "pending" | "processing" | "completed" | "failed";
+export const JOB_STATUSES = [
+	"pending",
+	"processing",
+	"completed",
+	"failed",
+] as const;
+
+export type JobStatus = (typeof JOB_STATUSES)[number];
 
 /**
  * How long an asset job may run before both sides give up: the queue worker

--- a/lib/generation/snapshots.ts
+++ b/lib/generation/snapshots.ts
@@ -45,8 +45,12 @@ const settled = (state: Record<string, ElementSnapshot>) =>
 		]),
 	);
 
+export type ActiveGenerationStatus = Exclude<GenerationStatus, "idle">;
+
 /** A generation is active from the moment it is queued until it settles. */
-export const isGenerationActive = (status: GenerationStatus) =>
+export const isGenerationActive = (
+	status: GenerationStatus,
+): status is ActiveGenerationStatus =>
 	status === "queued" || status === "generating";
 
 /**

--- a/lib/project/api.ts
+++ b/lib/project/api.ts
@@ -3,7 +3,7 @@ import { createClient } from "@/lib/supabase/client";
 import type { ElementSnapshot } from "@/lib/generation/snapshots";
 import type { ProjectStoreSnapshot } from "./storeSnapshot";
 
-const ProjectRowSchema = z.object({
+export const ProjectRowSchema = z.object({
 	id: z.string(),
 	name: z.string(),
 	thumbnail_url: z.string().nullable(),
@@ -11,6 +11,11 @@ const ProjectRowSchema = z.object({
 });
 
 export type ProjectRow = z.infer<typeof ProjectRowSchema>;
+
+/** Selected wherever a project row is read, so the query cannot drift from the schema. */
+export const PROJECT_ROW_COLUMNS = Object.keys(ProjectRowSchema.shape).join(
+	", ",
+);
 
 export type SaveProjectInput = {
 	name: string;
@@ -29,7 +34,7 @@ export async function createProject(): Promise<ProjectRow> {
 	const { data, error } = await supabase
 		.from("projects")
 		.insert({ user_id: user.id })
-		.select("id, name, thumbnail_url, updated_at")
+		.select(PROJECT_ROW_COLUMNS)
 		.single();
 	if (error) throw error;
 	return ProjectRowSchema.parse(data);

--- a/lib/providers/video/base.ts
+++ b/lib/providers/video/base.ts
@@ -1,6 +1,6 @@
 import type { VideoGenerateParams } from "@/lib/connectors/types";
 import type { BundleFile, BundleResponse } from "@/lib/api/asset-bundle";
-import type { ProviderContract, WithMetadata } from "../base";
+import type { ProviderContract } from "../base";
 import { BaseProvider } from "../base";
 
 export type VideoJobStatus = "queued" | "processing" | "completed" | "failed";
@@ -18,7 +18,8 @@ export type VideoJobMetadata = {
 export type VideoJob = {
 	url?: string;
 	progress?: number;
-} & WithMetadata<VideoJobMetadata>;
+	metadata: VideoJobMetadata;
+};
 
 export type VideoProviderResponse = BundleResponse & {
 	metadata?: VideoJobMetadata;
@@ -26,7 +27,7 @@ export type VideoProviderResponse = BundleResponse & {
 
 /** A provider that is still working has no asset to hand back yet. */
 export type VideoPoll =
-	| { kind: "pending"; metadata?: VideoJobMetadata }
+	| { kind: "pending"; metadata: VideoJobMetadata }
 	| { kind: "ready"; asset: VideoProviderResponse };
 
 export interface VideoProvider extends ProviderContract {
@@ -59,10 +60,9 @@ export abstract class BaseVideoProvider
 			return { kind: "pending", metadata: result.metadata };
 		}
 		const metadata = {
-			jobId,
 			...result.metadata,
 			durationSec:
-				result.metadata?.durationSec ??
+				result.metadata.durationSec ??
 				request.duration ??
 				DEFAULT_VIDEO_DURATION_SEC,
 		};

--- a/lib/providers/video/mock.ts
+++ b/lib/providers/video/mock.ts
@@ -21,7 +21,7 @@ export class MockVideo extends BaseVideoProvider {
 
 	protected async store(result: VideoJob): Promise<VideoProviderResponse> {
 		return {
-			id: result.metadata?.jobId ?? "",
+			id: result.metadata.jobId,
 			type: this.blobConfig.type,
 			provider: this.blobConfig.provider,
 			result: {

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -1,6 +1,6 @@
 import type { VideoGenerateParams } from "@/lib/connectors/types";
 import { RUNWARE_VIDEO_MODELS } from "@/lib/connectors/video/runware/models";
-import type { VideoJob, VideoJobMetadata, VideoJobStatus } from "./base";
+import type { VideoJob, VideoJobStatus } from "./base";
 import { BaseVideoProvider, DEFAULT_VIDEO_DURATION_SEC } from "./base";
 import { validateRunwareKey, withRunware } from "../runware";
 import {
@@ -13,7 +13,7 @@ function toVideoJob(video: {
 	taskUUID: string;
 	status: string;
 	videoURL?: string;
-}): VideoJob & { metadata: VideoJobMetadata } {
+}): VideoJob {
 	return {
 		url: video.videoURL,
 		metadata: {


### PR DESCRIPTION
## Summary

Nightly maintainability pass for 2026-09-05. This takes the items the 2026-09-03 pass listed as blocked behind #701, now that it and the rest of the BYOK stack have merged.

- **Job rows are parsed, not cast.** `JobRowSchema` in `lib/api/jobs.ts` is now the one description of the `jobs` table. It is backed by a `BundleResponseSchema` beside the type it already described (`BundleResponse` is now `z.infer` of it) and a `JOB_STATUSES` list that `JobStatus` derives from. `getJob` and `loadJobForProcessing` return parsed rows, matching how `createProject` and `listProviderKeys` already read theirs.
- **`AssetBundle` takes only what it reads.** The constructor accepts the two manifest fields `resolve` and `resolveBundle` use, so `fromResponse` hands the response straight through instead of fabricating `version: 1` and an empty `createdAt`. Eight test fixtures drop the same filler, and the `fromResponse` test stops asserting on it.
- **`GenerationIndicator` only knows active statuses.** `isGenerationActive` is a type predicate over a new `ActiveGenerationStatus`. Every caller already renders the indicator behind that check, so the prop narrows and the idle icon, animation and "Generate" label rows, which no caller could reach, are gone. The three per-status tables and the label function fold into one `STATUS` table.
- **`VideoJob.metadata` is required.** Every producer (`toVideoJob`, both mocks) already sets it, so the optional chains in `BaseVideoProvider.poll`, `MockVideo.store` and the video job handler go, along with the leading `jobId` in `poll` that the spread always overwrote. `VideoPoll`'s pending branch carries the metadata unconditionally.
- **Project columns come from the schema.** `PROJECT_ROW_COLUMNS` is derived from `ProjectRowSchema.shape` and used by both reads, and the home page parses its rows through the same schema instead of handing an untyped array to `ProjectsList`.

No behavior change. Lint, format, typecheck, knip, build and the full test suite (176 files, 1589 tests) pass.

## Not taken

- `render-client.ts` still casts the progress response via `apiJson<RenderProgress>`. #723 settled that own-API responses cross HTTP as casts everywhere; parsing this one alone would be the odd one out.
- The hosted and BYOK vendor tables still each name the six real provider classes. Folding them trades a compile-time guarantee in the hosted table for a runtime lookup, for about ten net lines. Sub-nightly on its own.
- `HANDLERS` stays a `Partial` with the "No job handler registered" throw. Keying it by a narrower connector type would need `JobRow.connector_type` to exclude `llm` and `animated_image`, which is an architecture call rather than a cleanup.

## Merge-conflict guard

```
PR #729: clean
OK: no file overlap or merge conflict with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
