### PR TITLE
refactor: nightly conventions sweep 2026-09-05, dead guards in the LLM mock and serializer

### DIFF
--- a/lib/canvas/osmlSerializer.ts
+++ b/lib/canvas/osmlSerializer.ts
@@ -8,7 +8,7 @@ import { escapeXml } from "./xmlEscape";
 const sceneMarker = (n: number) => `\n--- Scene ${n} ---\n`;
 
 export function getElementText(element: ParsedElement): string {
-	return element.children.map((child) => child.text ?? "").join("");
+	return element.children.map((child) => child.text).join("");
 }
 
 /** What the user actually typed, with the caret marker leaf left behind. */

--- a/lib/providers/llm/mock.ts
+++ b/lib/providers/llm/mock.ts
@@ -7,6 +7,7 @@ import type { ValidationResult } from "@/lib/connectors/providerKey";
 import type {
 	LLMGenerateParams,
 	LLMGenerateResult,
+	LLMStreamChunk,
 } from "@/lib/connectors/types";
 import { SCENE_MARKER_PATTERN } from "@/lib/canvas/constants";
 import { OUTLINE_INSTRUCTION } from "@/lib/script/prompt/outline";
@@ -153,9 +154,7 @@ export class MockLLM implements LLMProvider {
 		};
 	}
 
-	async *stream(
-		params: LLMGenerateParams,
-	): AsyncGenerator<{ text: string; done: boolean }> {
+	async *stream(params: LLMGenerateParams): AsyncGenerator<LLMStreamChunk> {
 		await sleep(500);
 		const text = mockResponse(params);
 		let i = 0;
@@ -168,7 +167,7 @@ export class MockLLM implements LLMProvider {
 		yield { text: "", done: true };
 	}
 
-	agentModel(model = "mock"): AgentModel {
+	agentModel(model: string): AgentModel {
 		return {
 			model: mockAgentModel(),
 			modelId: model,
@@ -262,7 +261,7 @@ function mockCall(prompt: LanguageModelV3Prompt) {
 		};
 	}
 
-	const script = last.text ?? "";
+	const script = last.text;
 	const elementId =
 		scene === null
 			? ELEMENT_ID.exec(script)?.[1]


### PR DESCRIPTION
## Summary

Nightly CONVENTIONS.md sweep for 2026-09-05. The delta since the 2026-09-04 sweep (PR #725) is the eight PRs that merged on 09-04 (#711, #712, #713, #714, #715, #722, #724, #727), about 60 source files once the 13 files held by open PR #730 are excluded. All of them were read against the seven rules; the repo-wide invariant greps were re-run as well.

All changes are no-behavior-change: lint, format, typecheck, the full test suite (1589 tests) and `npm run build` pass.

## Auto-fixed (2 files)

**Rule 1, define errors out of existence**
- `lib/providers/llm/mock.ts`: `mockCall` guarded `last.text ?? ""`, but `lastToolResult` already returns `text: string` (it goes through `outputText`, which never yields undefined).
- `lib/providers/llm/mock.ts`: `agentModel(model = "mock")` kept a default the `LLMProvider` interface made required in #725; the only caller passes `request.model: string`.
- `lib/canvas/osmlSerializer.ts`: `getElementText` mapped `child.text ?? ""` over `CanvasText[]`, whose `text` is a required `string`.

**Rule 5, one canonical way**
- `lib/providers/llm/mock.ts`: `MockLLM.stream` restated `{ text: string; done: boolean }` inline; it now names `LLMStreamChunk` like `LLMProvider`, `AnthropicLLM` and the HTTP gateway do.

## Audited clean

Every other delta file reads as intended: the agent tool registry is one table with derived views, the preview registry derives from `ELEMENT_TYPES`, `motionEffects` and `ResizeHandle` are lookup tables, `autosave` and `queue` route every failure to a typed handler, and the API routes stay thin over the shared handler factories.

Repo-wide greps unchanged: zero bare `catch {}`, zero catch-return-null, zero `as any` / non-null assertions, zero provider sniffing, no hand-rolled `clamp` or `sleep`, no deprecated `z.string().url()`; the only `switch` statements are the three discriminated-union dispatches (`applyOps:25`, `scene-builder:121`, `VideoComposition:59`).

## Flagged, not changed

- `lib/project/autosave.ts:79`: `persist` both `console.error`s and calls `onError`, and the caller's `onError` already toasts. The console line is a second report of the same failure. Dropping it is a logging change, so it is left for a human call. Same for the `not hydrated` line at :91, which is standing flag #32.
- `app/components/canvas/elements/AssetTile.tsx:99-115`: the two remove affordances each re-spell `onRemove && status !== "generating"`. Two sites, so below the rule-of-three bar; noted only.

## Merge-conflict guard

```
PR #730: clean
PR #729: clean
OK: no file overlap or merge conflict with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
