### PR TITLE
refactor: rethink openslop architecture 2026-09-05

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,7 +30,7 @@ Users see models and providers; developers also see connectors. Each word means 
 
 - **Connectors** (`lib/connectors/`): what the editor calls. One class per media type, plugin-pipelined, serving every provider of that type.
 - **Gateways** (`lib/gateway/`): thin HTTP clients from connectors to our own routes. The provider a model names picks the route family: `/api/v1` for models OpenSlop hosts, `/api/third-party` for models a user brings a key for.
-- **Providers** (`lib/providers/`): server-side vendor adapters (Runware, ElevenLabs, Cartesia, Anthropic). The same classes serve both families; only where the key comes from differs.
+- **Providers** (`lib/providers/`): server-side vendor adapters (Runware, ElevenLabs, Cartesia, Anthropic). The same classes serve both families; only where the key comes from differs. A provider takes the request as its vendor's API does, the model id already resolved by the route, so no vendor falls back to a model of its own.
 
 ## Models and provider keys
 

--- a/app/api/providers/[provider]/route.ts
+++ b/app/api/providers/[provider]/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import {
-	providerKeysView,
 	deleteProviderKey,
 	MissingProviderKeyError,
+	providerKeyCheck,
+	providerKeysView,
 	readProviderKey,
 } from "@/lib/api/providerKeys";
 import { verifyProviderKey } from "@/lib/api/providers/byok";
@@ -19,7 +20,7 @@ export const POST = createSessionParamRouteHandler({
 		const key = await readProviderKey(user.id, params.provider);
 		if (!key) throw new MissingProviderKeyError(params.provider);
 		const validation = await verifyProviderKey(user.id, params.provider, key);
-		return NextResponse.json(await providerKeysView(user, validation));
+		return NextResponse.json(await providerKeyCheck(user, validation));
 	},
 });
 

--- a/app/api/providers/route.ts
+++ b/app/api/providers/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { providerKeysView, saveProviderKey } from "@/lib/api/providerKeys";
+import { providerKeyCheck, saveProviderKey } from "@/lib/api/providerKeys";
 import { MIN_KEY_LENGTH } from "@/lib/connectors/providerKey";
 import { verifyProviderKey } from "@/lib/api/providers/byok";
 import { byokProviderField } from "@/lib/api/request-schema-fields";
@@ -25,6 +25,6 @@ export const POST = createSessionRouteHandler({
 		const { provider, apiKey } = input;
 		await saveProviderKey(user.id, provider, apiKey);
 		const validation = await verifyProviderKey(user.id, provider, apiKey);
-		return NextResponse.json(await providerKeysView(user, validation));
+		return NextResponse.json(await providerKeyCheck(user, validation));
 	},
 });

--- a/lib/api/providerKeys.ts
+++ b/lib/api/providerKeys.ts
@@ -156,17 +156,20 @@ export async function setKeyStatus(
 	);
 }
 
-export type ProviderKeysView = {
-	providerKeys: ProviderKeyRecord[];
-	validation?: ValidationResult;
+export type ProviderKeysView = { providerKeys: ProviderKeyRecord[] };
+
+/** A key change answered with whether that key works, beside the list it changed. */
+export type ProviderKeyCheck = ProviderKeysView & {
+	validation: ValidationResult;
 };
 
-export async function providerKeysView(
+export async function providerKeysView(user: User): Promise<ProviderKeysView> {
+	return { providerKeys: await listProviderKeys(user) };
+}
+
+export async function providerKeyCheck(
 	user: User,
-	validation?: ValidationResult,
-): Promise<ProviderKeysView> {
-	return {
-		providerKeys: await listProviderKeys(user),
-		...(validation && { validation }),
-	};
+	validation: ValidationResult,
+): Promise<ProviderKeyCheck> {
+	return { ...(await providerKeysView(user)), validation };
 }

--- a/lib/connectors/__tests__/character-avatar.test.ts
+++ b/lib/connectors/__tests__/character-avatar.test.ts
@@ -19,12 +19,12 @@ describe("character-avatar plugin", () => {
 	it("passes an image result through untouched", () => {
 		const result = { imageUrl: "https://img/alice.png", durationSec: 0 };
 		const plugin = createCharacterAvatarPlugin("Alice");
-		expect(plugin.afterGenerate?.(result)).toEqual(result);
+		expect(plugin.afterGenerate?.(result, {})).toEqual(result);
 	});
 
 	it("throws when the generation produced no image", () => {
 		const plugin = createCharacterAvatarPlugin("Alice");
-		expect(() => plugin.afterGenerate?.({ durationSec: 0 })).toThrow(
+		expect(() => plugin.afterGenerate?.({ durationSec: 0 }, {})).toThrow(
 			/imageUrl/,
 		);
 	});

--- a/lib/connectors/__tests__/plugins.test.ts
+++ b/lib/connectors/__tests__/plugins.test.ts
@@ -26,7 +26,7 @@ describe("plugins", () => {
 				},
 			},
 		];
-		const result = await runBeforeGenerate(plugins, { prompt: "hi" });
+		const result = await runBeforeGenerate(plugins, { prompt: "hi" }, {});
 		expect(order).toEqual([1, 2]);
 		expect((result as Record<string, unknown>).tag).toBe("second");
 	});
@@ -41,7 +41,7 @@ describe("plugins", () => {
 				}),
 			},
 		];
-		const result = await runAfterGenerate(plugins, { text: "hello" });
+		const result = await runAfterGenerate(plugins, { text: "hello" }, {});
 		expect((result as Record<string, string>).text).toBe("HELLO");
 	});
 
@@ -50,7 +50,7 @@ describe("plugins", () => {
 			{ name: "prefix", transformPrompt: (p) => `[prefix] ${p}` },
 			{ name: "suffix", transformPrompt: (p) => `${p} [suffix]` },
 		];
-		const result = await runTransformPrompt(plugins, "hello");
+		const result = await runTransformPrompt(plugins, "hello", {});
 		expect(result).toBe("[prefix] hello [suffix]");
 	});
 
@@ -60,13 +60,13 @@ describe("plugins", () => {
 			{ name: "a", onError: (e) => void errors.push(`a:${e}`) },
 			{ name: "b", onError: (e) => void errors.push(`b:${e}`) },
 		];
-		await runOnError(plugins, "fail");
+		await runOnError(plugins, "fail", {});
 		expect(errors).toEqual(["a:fail", "b:fail"]);
 	});
 
 	it("skips undefined hooks", async () => {
 		const plugins: ConnectorPlugin[] = [{ name: "empty" }];
-		const result = await runBeforeGenerate(plugins, { x: 1 });
+		const result = await runBeforeGenerate(plugins, { x: 1 }, {});
 		expect(result).toEqual({ x: 1 });
 	});
 
@@ -79,6 +79,8 @@ describe("plugins", () => {
 				},
 			},
 		];
-		await expect(runBeforeGenerate(plugins, {})).rejects.toThrow("hook failed");
+		await expect(runBeforeGenerate(plugins, {}, {})).rejects.toThrow(
+			"hook failed",
+		);
 	});
 });

--- a/lib/connectors/animated_image/plugins/still-frame.ts
+++ b/lib/connectors/animated_image/plugins/still-frame.ts
@@ -106,9 +106,9 @@ export const stillSnapshot = (
 ): ElementSnapshot => queue.getElementSnapshot(stillDependency(node)?.id);
 
 const stillFrame = (
-	ctx?: PluginContext<AnimatedImageGenerateParams, AssetResult>,
+	ctx: PluginContext<AnimatedImageGenerateParams, AssetResult>,
 ): string | undefined =>
-	ctx?.elementId
+	ctx.elementId
 		? ctx.dependencies?.[stillElementId(ctx.elementId)]?.imageUrl
 		: undefined;
 

--- a/lib/connectors/image/plugins/character-references.ts
+++ b/lib/connectors/image/plugins/character-references.ts
@@ -20,14 +20,14 @@ export function createCharacterReferencesPlugin(): ConnectorPlugin<ParamsWithCha
 			parseCharacterNames(element.generationAttributes?.[CHARACTERS_ATTR]).map(
 				forCharacterAvatar,
 			),
-		beforeGenerate(params, ctx?: PluginContext<ParamsWithCharacters>) {
+		beforeGenerate(params, ctx: PluginContext<ParamsWithCharacters>) {
 			const { [CHARACTERS_ATTR]: characters, ...rest } = params;
 			if (!characters) return params;
 
 			const referenceImages = compact(
 				parseCharacterNames(characters).map(
 					(name) =>
-						ctx?.dependencies?.[characterAvatarElementId(name)]?.imageUrl,
+						ctx.dependencies?.[characterAvatarElementId(name)]?.imageUrl,
 				),
 			);
 			if (referenceImages.length === 0) return rest;

--- a/lib/connectors/models.ts
+++ b/lib/connectors/models.ts
@@ -63,12 +63,11 @@ export function modelEntry<T extends ConnectorType>(
 	return entry;
 }
 
-export type VendorParams<TReq extends ModelRef> = Omit<
-	TReq,
-	"provider" | "model"
-> & { model: string };
+/** A request as the vendor's API takes it: the catalog pair swapped for the vendor's own model id. */
+export type VendorParams<TReq> = Omit<TReq, "provider" | "model"> & {
+	model: string;
+};
 
-/** A request as the provider's own API takes it: the pair swapped for the vendor's model id. */
 export function vendorParams<TReq extends ModelRef>(
 	type: ConnectorType,
 	request: TReq,

--- a/lib/connectors/plugins.ts
+++ b/lib/connectors/plugins.ts
@@ -4,36 +4,36 @@ import type { ConnectorPlugin, ModelRef, PluginContext } from "./types";
 
 /** Assert the plugin was given a gateway, returning the narrowed dependency. */
 export function requireGateway<P, R>(
-	ctx: PluginContext<P, R> | undefined,
+	ctx: PluginContext<P, R>,
 	plugin: string,
 ): GatewayClient<P, R> {
-	if (!ctx?.gateway)
+	if (!ctx.gateway)
 		throw new Error(`${plugin} plugin requires gateway context`);
 	return ctx.gateway;
 }
 
 /** Assert the plugin was given project state, returning it narrowed. */
 export function requireState<P, R>(
-	ctx: PluginContext<P, R> | undefined,
+	ctx: PluginContext<P, R>,
 	plugin: string,
 ): ProjectData {
-	if (!ctx?.state) throw new Error(`${plugin} plugin requires project state`);
+	if (!ctx.state) throw new Error(`${plugin} plugin requires project state`);
 	return ctx.state;
 }
 
 /** Assert the plugin was told the pair its connector runs on. */
 export function requireModel<P, R>(
-	ctx: PluginContext<P, R> | undefined,
+	ctx: PluginContext<P, R>,
 	plugin: string,
 ): ModelRef {
-	if (!ctx?.model) throw new Error(`${plugin} plugin requires a model`);
+	if (!ctx.model) throw new Error(`${plugin} plugin requires a model`);
 	return ctx.model;
 }
 
 export async function runBeforeGenerate<T>(
 	plugins: ConnectorPlugin[],
 	params: T,
-	ctx?: PluginContext,
+	ctx: PluginContext,
 ): Promise<T> {
 	let result = params;
 	for (const plugin of plugins) {
@@ -47,7 +47,7 @@ export async function runBeforeGenerate<T>(
 export async function runAfterGenerate<T>(
 	plugins: ConnectorPlugin[],
 	result: T,
-	ctx?: PluginContext,
+	ctx: PluginContext,
 ): Promise<T> {
 	let current = result;
 	for (const plugin of plugins) {
@@ -61,7 +61,7 @@ export async function runAfterGenerate<T>(
 export async function runTransformPrompt(
 	plugins: ConnectorPlugin[],
 	prompt: string,
-	ctx?: PluginContext,
+	ctx: PluginContext,
 ): Promise<string> {
 	let current = prompt;
 	for (const plugin of plugins) {
@@ -75,7 +75,7 @@ export async function runTransformPrompt(
 export async function runOnError(
 	plugins: ConnectorPlugin[],
 	error: string,
-	ctx?: PluginContext,
+	ctx: PluginContext,
 ): Promise<void> {
 	for (const plugin of plugins) {
 		if (plugin.onError) {

--- a/lib/connectors/tts/plugins/voice-search.ts
+++ b/lib/connectors/tts/plugins/voice-search.ts
@@ -20,7 +20,7 @@ export function createVoiceSearchPlugin(): ConnectorPlugin<TTSGenerateParams> {
 		name: "voice-search",
 		async beforeGenerate(params, ctx) {
 			if (params.voiceId) return params;
-			if (!ctx?.searchVoices) {
+			if (!ctx.searchVoices) {
 				throw new Error(
 					"voice-search plugin requires searchVoices in PluginContext",
 				);

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -112,19 +112,19 @@ export interface ConnectorPlugin<TParams = unknown, TResult = unknown> {
 	model?(element: CanvasContentElement, state: ProjectData): ModelRef;
 	beforeGenerate?(
 		params: TParams,
-		ctx?: PluginContext<TParams, TResult>,
+		ctx: PluginContext<TParams, TResult>,
 	): TParams | Promise<TParams>;
 	afterGenerate?(
 		result: TResult,
-		ctx?: PluginContext<TParams, TResult>,
+		ctx: PluginContext<TParams, TResult>,
 	): TResult | Promise<TResult>;
 	transformPrompt?(
 		prompt: string,
-		ctx?: PluginContext<TParams, TResult>,
+		ctx: PluginContext<TParams, TResult>,
 	): string | Promise<string>;
 	onError?(
 		error: string,
-		ctx?: PluginContext<TParams, TResult>,
+		ctx: PluginContext<TParams, TResult>,
 	): void | Promise<void>;
 }
 

--- a/lib/providers/__tests__/anthropic-llm.test.ts
+++ b/lib/providers/__tests__/anthropic-llm.test.ts
@@ -11,8 +11,10 @@ vi.mock("@ai-sdk/anthropic", () => ({ createAnthropic }));
 
 import { AnthropicLLM } from "../llm/anthropic";
 
+const MODEL_ID = "claude-opus-5";
+
 const model = new MockLanguageModelV3({
-	modelId: "claude-opus-5",
+	modelId: MODEL_ID,
 	// Matches what the real provider declares, so image URLs are passed through
 	// rather than downloaded and inlined.
 	supportedUrls: { "image/*": [/^https?:\/\/.*$/] },
@@ -75,7 +77,7 @@ describe("AnthropicLLM", () => {
 			respondWith("Hello world");
 
 			const provider = new AnthropicLLM("test-key");
-			const result = await provider.generate({ prompt: "hi" });
+			const result = await provider.generate({ prompt: "hi", model: MODEL_ID });
 
 			expect(result).toEqual({
 				text: "Hello world",
@@ -90,7 +92,10 @@ describe("AnthropicLLM", () => {
 		it("asks for summarized thinking, so thoughts are not empty", async () => {
 			respondWith("ok");
 
-			await new AnthropicLLM("test-key").generate({ prompt: "hi" });
+			await new AnthropicLLM("test-key").generate({
+				prompt: "hi",
+				model: MODEL_ID,
+			});
 
 			expect(lastCall().providerOptions?.anthropic).toEqual({
 				thinking: { type: "adaptive", display: "summarized" },
@@ -124,6 +129,7 @@ describe("AnthropicLLM", () => {
 
 			await new AnthropicLLM("test-key").generate({
 				prompt: "hi",
+				model: MODEL_ID,
 				temperature: 0.5,
 			});
 
@@ -135,6 +141,7 @@ describe("AnthropicLLM", () => {
 
 			await new AnthropicLLM("test-key").generate({
 				prompt: "describe",
+				model: MODEL_ID,
 				referenceImages: ["https://a/1.jpg", "https://a/2.jpg"],
 			});
 
@@ -158,6 +165,7 @@ describe("AnthropicLLM", () => {
 
 			await new AnthropicLLM("test-key").generate({
 				prompt: "describe",
+				model: MODEL_ID,
 				referenceImages: ["data:image/png;base64,iVBORw0KGgo="],
 			});
 
@@ -174,6 +182,7 @@ describe("AnthropicLLM", () => {
 			await expect(
 				provider.generate({
 					prompt: "describe",
+					model: MODEL_ID,
 					referenceImages: ["ftp://nope/img.png"],
 				}),
 			).rejects.toThrow(/must be an http\(s\) URL or a base64 data URI/);
@@ -187,6 +196,7 @@ describe("AnthropicLLM", () => {
 			await expect(
 				provider.generate({
 					prompt: "describe",
+					model: MODEL_ID,
 					referenceImages: ["data:image/svg+xml;base64,PHN2Zy8+"],
 				}),
 			).rejects.toThrow(/media type "image\/svg\+xml" is not supported/);
@@ -200,7 +210,10 @@ describe("AnthropicLLM", () => {
 
 			const provider = new AnthropicLLM("test-key");
 			const chunks: { text: string; done: boolean }[] = [];
-			for await (const chunk of provider.stream({ prompt: "hi" })) {
+			for await (const chunk of provider.stream({
+				prompt: "hi",
+				model: MODEL_ID,
+			})) {
 				chunks.push(chunk);
 			}
 
@@ -217,7 +230,10 @@ describe("AnthropicLLM", () => {
 			const provider = new AnthropicLLM("test-key");
 			const read = async () => {
 				const chunks: { text: string; done: boolean }[] = [];
-				for await (const chunk of provider.stream({ prompt: "hi" })) {
+				for await (const chunk of provider.stream({
+					prompt: "hi",
+					model: MODEL_ID,
+				})) {
 					chunks.push(chunk);
 				}
 				return chunks;

--- a/lib/providers/__tests__/cartesia-tts.test.ts
+++ b/lib/providers/__tests__/cartesia-tts.test.ts
@@ -199,6 +199,8 @@ describe("pcmDurationSec", () => {
 	});
 });
 
+const MODEL = "sonic-3.5";
+
 describe("CartesiaTTS", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -230,6 +232,7 @@ describe("CartesiaTTS", () => {
 			const result = await provider.generate({
 				prompt: "hello world",
 				voiceId: "voice-1",
+				model: MODEL,
 			});
 
 			expect(result.result.audio).toBe("url");
@@ -258,6 +261,7 @@ describe("CartesiaTTS", () => {
 			const result = await provider.generate({
 				prompt: "hello",
 				voiceId: "voice-1",
+				model: MODEL,
 			});
 
 			expect(result.metadata?.durationSec).toBe(3);
@@ -275,6 +279,7 @@ describe("CartesiaTTS", () => {
 			const result = await provider.generate({
 				prompt: "hello",
 				voiceId: "voice-1",
+				model: MODEL,
 			});
 
 			expect(result.metadata?.durationSec).toBe(4);
@@ -285,7 +290,11 @@ describe("CartesiaTTS", () => {
 
 			const provider = new CartesiaTTS("test-key");
 			await expect(
-				provider.generate({ prompt: "hello", voiceId: "voice-1" }),
+				provider.generate({
+					prompt: "hello",
+					voiceId: "voice-1",
+					model: MODEL,
+				}),
 			).rejects.toThrow("Cartesia returned no audio for voice voice-1");
 			expect(mockClose).toHaveBeenCalled();
 		});
@@ -322,6 +331,7 @@ describe("CartesiaTTS", () => {
 			await provider.generate({
 				prompt: "test",
 				voiceId: "v1",
+				model: MODEL,
 				emotion: TTSEmotion.Excited,
 			});
 
@@ -341,7 +351,7 @@ describe("CartesiaTTS", () => {
 
 			const provider = new CartesiaTTS("test-key");
 			await expect(
-				provider.generate({ prompt: "test", voiceId: "v1" }),
+				provider.generate({ prompt: "test", voiceId: "v1", model: MODEL }),
 			).rejects.toThrow("ws error");
 			expect(mockClose).toHaveBeenCalled();
 		});

--- a/lib/providers/__tests__/elevenlabs-cached.test.ts
+++ b/lib/providers/__tests__/elevenlabs-cached.test.ts
@@ -35,6 +35,9 @@ async function loadProviders() {
 	};
 }
 
+const MUSIC_MODEL = "music_v1";
+const SFX_MODEL = "eleven_text_to_sound_v2";
+
 describe("ElevenLabs providers with pinecone cache enabled", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -57,7 +60,10 @@ describe("ElevenLabs providers with pinecone cache enabled", () => {
 		});
 
 		const { music: ElevenLabsMusic } = await loadProviders();
-		const result = await new ElevenLabsMusic("k").generate({ prompt: "jazz" });
+		const result = await new ElevenLabsMusic("k").generate({
+			prompt: "jazz",
+			model: MUSIC_MODEL,
+		});
 
 		expect(result.result.audio).toBe("https://blob/cached.mp3");
 		expect(result.metadata?.cached).toBe(true);
@@ -81,6 +87,7 @@ describe("ElevenLabs providers with pinecone cache enabled", () => {
 		const result = await new ElevenLabsMusic("k").generate({
 			prompt: "jazz",
 			durationSeconds: 5,
+			model: MUSIC_MODEL,
 		});
 
 		expect(result.result.audio).toBe("url"); // mocked AssetBundle.upload
@@ -114,6 +121,7 @@ describe("ElevenLabs providers with pinecone cache enabled", () => {
 		await new ElevenLabsSFX("k").generate({
 			prompt: "boom",
 			durationSeconds: 3,
+			model: SFX_MODEL,
 		});
 
 		expect(mockEmbedText).toHaveBeenCalledWith("boom");
@@ -133,7 +141,10 @@ describe("ElevenLabs providers with pinecone cache enabled", () => {
 		);
 
 		const { music: ElevenLabsMusic } = await loadProviders();
-		const result = await new ElevenLabsMusic("k").generate({ prompt: "rock" });
+		const result = await new ElevenLabsMusic("k").generate({
+			prompt: "rock",
+			model: MUSIC_MODEL,
+		});
 		expect(result.result.audio).toBe("url"); // fresh, not "stale"
 		expect(mockCompose).toHaveBeenCalled();
 	});

--- a/lib/providers/__tests__/elevenlabs-music.test.ts
+++ b/lib/providers/__tests__/elevenlabs-music.test.ts
@@ -21,6 +21,8 @@ function mockReadableStream(data: Uint8Array) {
 	});
 }
 
+const MODEL = "music_v1";
+
 describe("ElevenLabsMusic", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -32,14 +34,14 @@ describe("ElevenLabsMusic", () => {
 		mockCompose.mockResolvedValue(mockReadableStream(audio));
 
 		const provider = new ElevenLabsMusic("test-key");
-		const result = await provider.generate({ prompt: "jazz" });
+		const result = await provider.generate({ prompt: "jazz", model: MODEL });
 
 		expect(result.result.audio).toBe("url");
 		expect(result.metadata?.durationSec).toBe(1);
 		expect(mockCompose).toHaveBeenCalledWith({
 			prompt: "jazz",
 			musicLengthMs: undefined,
-			modelId: "music_v1",
+			modelId: MODEL,
 			outputFormat: "mp3_44100_128",
 			forceInstrumental: true,
 		});
@@ -49,7 +51,11 @@ describe("ElevenLabsMusic", () => {
 		mockCompose.mockResolvedValue(mockReadableStream(new Uint8Array([0])));
 
 		const provider = new ElevenLabsMusic("test-key");
-		await provider.generate({ prompt: "rock", durationSeconds: 60 });
+		await provider.generate({
+			prompt: "rock",
+			durationSeconds: 60,
+			model: MODEL,
+		});
 
 		expect(mockCompose).toHaveBeenCalledWith(
 			expect.objectContaining({ musicLengthMs: 60000 }),

--- a/lib/providers/__tests__/elevenlabs-sfx.test.ts
+++ b/lib/providers/__tests__/elevenlabs-sfx.test.ts
@@ -21,6 +21,8 @@ function mockReadableStream(data: Uint8Array) {
 	});
 }
 
+const MODEL = "eleven_text_to_sound_v2";
+
 describe("ElevenLabsSFX", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -32,7 +34,7 @@ describe("ElevenLabsSFX", () => {
 		mockConvert.mockResolvedValue(mockReadableStream(audio));
 
 		const provider = new ElevenLabsSFX("test-key");
-		const result = await provider.generate({ prompt: "boom" });
+		const result = await provider.generate({ prompt: "boom", model: MODEL });
 
 		expect(result.result.audio).toBe("url");
 		expect(result.metadata?.durationSec).toBe(2);
@@ -47,7 +49,11 @@ describe("ElevenLabsSFX", () => {
 		mockConvert.mockResolvedValue(mockReadableStream(new Uint8Array([0])));
 
 		const provider = new ElevenLabsSFX("test-key");
-		await provider.generate({ prompt: "crash", durationSeconds: 10 });
+		await provider.generate({
+			prompt: "crash",
+			durationSeconds: 10,
+			model: MODEL,
+		});
 
 		expect(mockConvert).toHaveBeenCalledWith(
 			expect.objectContaining({ durationSeconds: 10 }),

--- a/lib/providers/__tests__/runware-image.test.ts
+++ b/lib/providers/__tests__/runware-image.test.ts
@@ -19,6 +19,8 @@ vi.mock("@runware/sdk-js", () => ({
 import { AssetBundle } from "@/lib/api/asset-bundle";
 import { RunwareImage } from "../image/runware";
 
+const MODEL = "bytedance:seedream@5.0-lite";
+
 describe("RunwareImage", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -30,12 +32,12 @@ describe("RunwareImage", () => {
 		]);
 
 		const provider = new RunwareImage("test-key");
-		const result = await provider.generate({ prompt: "a cat" });
+		const result = await provider.generate({ prompt: "a cat", model: MODEL });
 
 		expect(result.result.image).toBe("url");
 		expect(mockImageInference).toHaveBeenCalledWith({
 			positivePrompt: "a cat",
-			model: "bytedance:seedream@5.0-lite",
+			model: MODEL,
 			width: 2848,
 			height: 1600,
 			outputType: "base64Data",
@@ -51,6 +53,7 @@ describe("RunwareImage", () => {
 
 		await new RunwareImage("test-key").generate({
 			prompt: "a cat",
+			model: MODEL,
 			format: "webp",
 		});
 
@@ -94,9 +97,9 @@ describe("RunwareImage", () => {
 		mockImageInference.mockResolvedValue([{}]);
 
 		const provider = new RunwareImage("test-key");
-		await expect(provider.generate({ prompt: "test" })).rejects.toThrow(
-			"No image data returned",
-		);
+		await expect(
+			provider.generate({ prompt: "test", model: MODEL }),
+		).rejects.toThrow("No image data returned");
 		expect(mockDisconnect).toHaveBeenCalled();
 	});
 
@@ -104,9 +107,9 @@ describe("RunwareImage", () => {
 		mockImageInference.mockRejectedValue(new Error("API error"));
 
 		const provider = new RunwareImage("test-key");
-		await expect(provider.generate({ prompt: "test" })).rejects.toThrow(
-			"API error",
-		);
+		await expect(
+			provider.generate({ prompt: "test", model: MODEL }),
+		).rejects.toThrow("API error");
 		expect(mockDisconnect).toHaveBeenCalled();
 	});
 });

--- a/lib/providers/image/runware.ts
+++ b/lib/providers/image/runware.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/connectors/image/enums";
 import { BaseProvider, type WithMetadata } from "../base";
 import { validateRunwareKey, withRunware } from "../runware";
+import type { VendorParams } from "@/lib/connectors/models";
 import type { ImageProvider } from "../types";
 
 type RawImageResult = { data: string; format: ImageFormat } & WithMetadata;
@@ -14,7 +15,7 @@ type RawImageResult = { data: string; format: ImageFormat } & WithMetadata;
 const RUNWARE_FORMATS = { jpg: "JPG", png: "PNG", webp: "WEBP" } as const;
 
 export class RunwareImage
-	extends BaseProvider<ImageGenerateParams, RawImageResult>
+	extends BaseProvider<VendorParams<ImageGenerateParams>, RawImageResult>
 	implements ImageProvider
 {
 	protected readonly blobConfig = { type: "image", provider: "runware" };
@@ -40,12 +41,12 @@ export class RunwareImage
 		];
 	}
 
-	protected async _generate(params: ImageGenerateParams) {
+	protected async _generate(params: VendorParams<ImageGenerateParams>) {
 		const format = params.format ?? DEFAULT_IMAGE_FORMAT;
 		return withRunware(this.apiKey, async (runware) => {
 			const results = await runware.imageInference({
 				positivePrompt: params.prompt,
-				model: params.model || "bytedance:seedream@5.0-lite",
+				model: params.model,
 				width: params.width || 2848,
 				height: params.height || 1600,
 				outputType: "base64Data",

--- a/lib/providers/llm/anthropic.ts
+++ b/lib/providers/llm/anthropic.ts
@@ -7,18 +7,13 @@ import {
 	type LanguageModel,
 	type TextPart,
 } from "ai";
-import type {
-	LLMGenerateParams,
-	LLMGenerateResult,
-	LLMStreamChunk,
-} from "@/lib/connectors/types";
+import type { LLMGenerateResult, LLMStreamChunk } from "@/lib/connectors/types";
 import { parseImageSource } from "@/lib/api/imageSource";
 import { stringifyError } from "@/lib/errors";
 import { DEFAULT_THINKING_LEVEL } from "@/lib/connectors/llm/enums";
-import { BaseProvider } from "../base";
 import { validateByProbe } from "../validate";
 import type { AgentModel } from "./agentModel";
-import type { LLMProvider } from "./base";
+import type { LLMProvider, LLMRequest } from "./base";
 
 const SUPPORTED_IMAGE_MEDIA_TYPES = [
 	"image/jpeg",
@@ -49,18 +44,12 @@ function toImagePart(image: string): FilePart {
 	return { type: "file", mediaType: source.mediaType, data: source.data };
 }
 
-const DEFAULT_MODEL = "claude-opus-5";
 const DEFAULT_MAX_TOKENS = 65536;
 
-export class AnthropicLLM
-	extends BaseProvider<LLMGenerateParams, LLMGenerateResult, LLMGenerateResult>
-	implements LLMProvider
-{
-	protected readonly blobConfig = { type: "llm", provider: "anthropic" };
+export class AnthropicLLM implements LLMProvider {
 	private apiKey: string;
 
 	constructor(apiKey: string) {
-		super();
 		this.apiKey = apiKey;
 	}
 
@@ -72,14 +61,6 @@ export class AnthropicLLM
 				"anthropic-version": "2023-06-01",
 			},
 		});
-	}
-
-	protected toFiles() {
-		return [];
-	}
-
-	protected async store(result: LLMGenerateResult) {
-		return result;
 	}
 
 	private model(modelId: string): LanguageModel {
@@ -107,14 +88,14 @@ export class AnthropicLLM
 		};
 	}
 
-	private buildRequest(params: LLMGenerateParams) {
+	private buildRequest(params: LLMRequest) {
 		const images = params.referenceImages ?? [];
 		const content: (FilePart | TextPart)[] = [
 			...images.map(toImagePart),
 			{ type: "text", text: params.prompt },
 		];
 		return {
-			model: this.model(params.model || DEFAULT_MODEL),
+			model: this.model(params.model),
 			instructions: params.systemPrompt || undefined,
 			messages: [{ role: "user" as const, content }],
 			maxOutputTokens: params.maxTokens || DEFAULT_MAX_TOKENS,
@@ -124,11 +105,11 @@ export class AnthropicLLM
 		};
 	}
 
-	protected async _generate(params: LLMGenerateParams) {
+	async generate(params: LLMRequest): Promise<LLMGenerateResult> {
 		const response = await generateText(this.buildRequest(params));
 		return {
 			text: response.text,
-			model: response.response.modelId ?? params.model ?? DEFAULT_MODEL,
+			model: response.response.modelId ?? params.model,
 			usage: {
 				inputTokens: response.usage.inputTokens ?? 0,
 				outputTokens: response.usage.outputTokens ?? 0,
@@ -138,7 +119,7 @@ export class AnthropicLLM
 
 	// fullStream, not textStream: textStream filters error parts out, which
 	// would end a failed generation as a clean, empty success.
-	async *stream(params: LLMGenerateParams): AsyncGenerator<LLMStreamChunk> {
+	async *stream(params: LLMRequest): AsyncGenerator<LLMStreamChunk> {
 		const result = streamText(this.buildRequest(params));
 		for await (const part of result.fullStream) {
 			if (part.type === "text-delta") yield { text: part.text, done: false };

--- a/lib/providers/llm/base.ts
+++ b/lib/providers/llm/base.ts
@@ -3,11 +3,14 @@ import type {
 	LLMGenerateResult,
 	LLMStreamChunk,
 } from "@/lib/connectors/types";
+import type { VendorParams } from "@/lib/connectors/models";
 import type { ProviderContract } from "../base";
 import type { AgentModel } from "./agentModel";
 
+export type LLMRequest = VendorParams<LLMGenerateParams>;
+
 export interface LLMProvider extends ProviderContract {
-	generate(params: LLMGenerateParams): Promise<LLMGenerateResult>;
-	stream(params: LLMGenerateParams): AsyncGenerator<LLMStreamChunk>;
+	generate(params: LLMRequest): Promise<LLMGenerateResult>;
+	stream(params: LLMRequest): AsyncGenerator<LLMStreamChunk>;
 	agentModel(model: string): AgentModel;
 }

--- a/lib/providers/music/elevenlabs.ts
+++ b/lib/providers/music/elevenlabs.ts
@@ -1,4 +1,5 @@
 import type { BundleResponse } from "@/lib/api/asset-bundle";
+import type { VendorParams } from "@/lib/connectors/models";
 import type { MusicGenerateParams } from "@/lib/connectors/types";
 import {
 	audioBundleCache,
@@ -12,21 +13,23 @@ import {
 } from "../elevenlabs";
 import type { MusicProvider } from "../types";
 
+type MusicRequest = VendorParams<MusicGenerateParams>;
+
 export class ElevenLabsMusic
-	extends BaseElevenLabsAudio<MusicGenerateParams>
+	extends BaseElevenLabsAudio<MusicRequest>
 	implements MusicProvider
 {
 	protected readonly blobConfig = { type: "music", provider: "elevenlabs" };
 	protected readonly outputFormat = ELEVENLABS_AUDIO_FORMAT;
 
-	protected requestStream(params: MusicGenerateParams) {
+	protected requestStream(params: MusicRequest) {
 		return this.client.music.compose({
 			prompt: params.prompt,
 			musicLengthMs:
 				params.durationSeconds != null
 					? params.durationSeconds * 1000
 					: undefined,
-			modelId: (params.model as "music_v1") || "music_v1",
+			modelId: params.model as "music_v1",
 			outputFormat: toElevenLabsOutputFormat(this.outputFormat),
 			forceInstrumental: true,
 		});
@@ -34,7 +37,7 @@ export class ElevenLabsMusic
 }
 
 ElevenLabsMusic.prototype.generate = pineconeCache<
-	[MusicGenerateParams],
+	[MusicRequest],
 	BundleResponse
 >(ElevenLabsMusic.prototype.generate, {
 	index: process.env.PINECONE_MUSIC_INDEX || "music",

--- a/lib/providers/sfx/elevenlabs.ts
+++ b/lib/providers/sfx/elevenlabs.ts
@@ -1,4 +1,5 @@
 import type { BundleResponse } from "@/lib/api/asset-bundle";
+import type { VendorParams } from "@/lib/connectors/models";
 import type { SFXGenerateParams } from "@/lib/connectors/types";
 import {
 	audioBundleCache,
@@ -12,14 +13,16 @@ import {
 } from "../elevenlabs";
 import type { SFXProvider } from "../types";
 
+type SFXRequest = VendorParams<SFXGenerateParams>;
+
 export class ElevenLabsSFX
-	extends BaseElevenLabsAudio<SFXGenerateParams>
+	extends BaseElevenLabsAudio<SFXRequest>
 	implements SFXProvider
 {
 	protected readonly blobConfig = { type: "sfx", provider: "elevenlabs" };
 	protected readonly outputFormat = ELEVENLABS_AUDIO_FORMAT;
 
-	protected requestStream(params: SFXGenerateParams) {
+	protected requestStream(params: SFXRequest) {
 		return this.client.textToSoundEffects.convert({
 			text: params.prompt,
 			durationSeconds: params.durationSeconds,
@@ -28,12 +31,12 @@ export class ElevenLabsSFX
 	}
 }
 
-ElevenLabsSFX.prototype.generate = pineconeCache<
-	[SFXGenerateParams],
-	BundleResponse
->(ElevenLabsSFX.prototype.generate, {
-	index: process.env.PINECONE_SFX_INDEX || "sfx",
-	serialize: (p) => p.prompt,
-	rank: rankByNearestDuration,
-	...audioBundleCache("sfx"),
-});
+ElevenLabsSFX.prototype.generate = pineconeCache<[SFXRequest], BundleResponse>(
+	ElevenLabsSFX.prototype.generate,
+	{
+		index: process.env.PINECONE_SFX_INDEX || "sfx",
+		serialize: (p) => p.prompt,
+		rank: rankByNearestDuration,
+		...audioBundleCache("sfx"),
+	},
+);

--- a/lib/providers/tts/base.ts
+++ b/lib/providers/tts/base.ts
@@ -3,9 +3,12 @@ import type {
 	VoiceInfo,
 	VoiceSearchParams,
 } from "@/lib/connectors/types";
+import type { VendorParams } from "@/lib/connectors/models";
 import type { AssetProvider } from "../base";
 
-export interface TTSProvider extends AssetProvider<TTSGenerateParams> {
+export interface TTSProvider extends AssetProvider<
+	VendorParams<TTSGenerateParams>
+> {
 	search(params: VoiceSearchParams): Promise<VoiceInfo[]>;
 	fetchVoicePreview(url: string): Promise<Response>;
 }

--- a/lib/providers/tts/cartesia.ts
+++ b/lib/providers/tts/cartesia.ts
@@ -15,6 +15,7 @@ import type { BundleFile } from "@/lib/api/asset-bundle";
 import { logger } from "@/lib/api/logger";
 import { BaseProvider, type WithMetadata } from "../base";
 import { validateByProbe } from "../validate";
+import type { VendorParams } from "@/lib/connectors/models";
 import type { TTSProvider } from "./base";
 import { fetchAllowedVoicePreview } from "./voicePreview";
 import { buildQueryText, rankBySimilarity } from "./voiceSimilarity";
@@ -127,7 +128,7 @@ const collectVoicesCached = unstable_cache(
 );
 
 export class CartesiaTTS
-	extends BaseProvider<TTSGenerateParams, RawTTSResult>
+	extends BaseProvider<VendorParams<TTSGenerateParams>, RawTTSResult>
 	implements TTSProvider
 {
 	protected readonly blobConfig = { type: "tts", provider: "cartesia" };
@@ -208,7 +209,7 @@ export class CartesiaTTS
 		}));
 	}
 
-	protected async _generate(params: TTSGenerateParams) {
+	protected async _generate(params: VendorParams<TTSGenerateParams>) {
 		if (!params.voiceId) throw new Error("voiceId is required");
 		const ws = await this.client.tts.websocket();
 		await ws.connect();
@@ -217,7 +218,7 @@ export class CartesiaTTS
 			const audioChunks: Buffer[] = [];
 			const textTimestamps: TextTimestamp[] = [];
 			const req: GenerationRequest = {
-				model_id: params.model || "sonic-3.5",
+				model_id: params.model,
 				transcript: params.prompt,
 				voice: { mode: "id", id: params.voiceId },
 				output_format: {

--- a/lib/providers/types.ts
+++ b/lib/providers/types.ts
@@ -1,3 +1,4 @@
+import type { VendorParams } from "@/lib/connectors/models";
 import type {
 	ImageGenerateParams,
 	MusicGenerateParams,
@@ -8,9 +9,9 @@ import type { LLMProvider } from "./llm/base";
 import type { TTSProvider } from "./tts/base";
 import type { VideoProvider } from "./video/base";
 
-export type ImageProvider = AssetProvider<ImageGenerateParams>;
-export type SFXProvider = AssetProvider<SFXGenerateParams>;
-export type MusicProvider = AssetProvider<MusicGenerateParams>;
+export type ImageProvider = AssetProvider<VendorParams<ImageGenerateParams>>;
+export type SFXProvider = AssetProvider<VendorParams<SFXGenerateParams>>;
+export type MusicProvider = AssetProvider<VendorParams<MusicGenerateParams>>;
 
 /** What a server-side provider promises, by the modality it serves. Any vendor's class is one of these. */
 export type Providers = {

--- a/lib/user/accountStore.ts
+++ b/lib/user/accountStore.ts
@@ -1,6 +1,9 @@
 import { createStore, type StoreApi } from "zustand/vanilla";
 import { apiJson } from "@/lib/clients/http";
-import type { ProviderKeysView } from "@/lib/api/providerKeys";
+import type {
+	ProviderKeyCheck,
+	ProviderKeysView,
+} from "@/lib/api/providerKeys";
 import type {
 	ProviderKeyRecord,
 	ValidationResult,
@@ -43,9 +46,9 @@ export function createAccountStore(initial: AccountData): AccountStore {
 			await persistModels(next);
 			set({ models: next });
 		};
-		const applyView = ({ providerKeys, validation }: ProviderKeysView) => {
-			set({ providerKeys });
-			return validation ?? { ok: true as const };
+		const applyView = <T extends ProviderKeysView>(view: T): T => {
+			set({ providerKeys: view.providerKeys });
+			return view;
 		};
 
 		return {
@@ -53,18 +56,18 @@ export function createAccountStore(initial: AccountData): AccountStore {
 
 			saveKey: async (provider, apiKey) =>
 				applyView(
-					await apiJson<ProviderKeysView>("/api/providers", {
+					await apiJson<ProviderKeyCheck>("/api/providers", {
 						method: "POST",
 						body: { provider, apiKey },
 					}),
-				),
+				).validation,
 
 			testKey: async (provider) =>
 				applyView(
-					await apiJson<ProviderKeysView>(`/api/providers/${provider}`, {
+					await apiJson<ProviderKeyCheck>(`/api/providers/${provider}`, {
 						method: "POST",
 					}),
-				),
+				).validation,
 
 			removeKey: async (provider) => {
 				applyView(


### PR DESCRIPTION
## App understanding

OpenSlop is a Next.js 16 + Supabase video-storytelling editor. A Slate canvas of scenes and content elements (tts, image, animated_image, video, music, sfx) is generated through a dependency graph (`lib/generation`), each element type running through a plugin-pipelined connector (`lib/connectors`) that posts to our own routes via a gateway (`lib/gateway`). On the server, a route family (hosted `/api/v1` on our keys, BYOK `/api/third-party` on a stored user key) resolves the picked `{ provider, model }` pair to a vendor model id with `vendorParams` and hands it to a vendor adapter in `lib/providers` (Anthropic, Runware, Cartesia, ElevenLabs). Remotion renders the result; Sloppy is the tool-calling agent over the same editor ops.

## From-scratch architecture

Rebuilt today, the seam between routes and vendor adapters would be one total contract: a provider takes exactly the request its vendor's API takes, with the model id already resolved, and nothing below the route ever chooses a model. Plugin hooks would always receive a context, and a key save or test would always answer with its validation. The current code already had every piece of this in place (`vendorParams`, `VendorParams`, `contextFor`, `verifyProviderKey`) but typed the receiving side as optional, so each vendor re-declared a fallback model, every hook guarded a context that is never missing, and the client defaulted a missing validation to ok.

## Implemented

- **Providers take the vendor request.** `VendorParams<TReq>` loses its `extends ModelRef` constraint, so `ImageProvider`, `SFXProvider`, `MusicProvider`, `TTSProvider` and `LLMProvider` are typed on `VendorParams<XGenerateParams>` with a required `model: string`. That is the type the job handlers and LLM routes were already passing. The Runware image, Cartesia, ElevenLabs music and Anthropic adapters drop their hand-copied model fallbacks (`bytedance:seedream@5.0-lite`, `sonic-3.5`, `music_v1`, `claude-opus-5`), which duplicated knowledge homed in `lib/connectors/*/models.ts` and could drift from the catalog silently. Mocks are untouched: they accept the wider connector params and still satisfy the interfaces.
- **`AnthropicLLM implements LLMProvider` directly** (flag #55). It only extended `BaseProvider` to stub `toFiles()`, override `store()` to a no-op and carry a dead `blobConfig`. `MockLLM` already implemented the interface directly.
- **Plugin hooks always get a context** (flag #57). `ConnectorPlugin` hooks, the `run*` runners and the `require*` helpers take a required `PluginContext`; `BaseConnector` always built one. The `ctx?.` guards in `plugins.ts`, `still-frame.ts`, `character-references.ts` and `voice-search.ts` go away. Context fields stay optional since they vary per connector.
- **A key check answers with a required validation** (flag #61). `ProviderKeysView` is the list alone; `ProviderKeyCheck` adds `validation`. The two POST routes return `providerKeyCheck`, DELETE returns `providerKeysView`, and `accountStore` reads `.validation` off the check instead of defaulting a missing one to `{ ok: true }`, which would have told the user a key works when the server said nothing.
- ARCHITECTURE.md states the provider contract in one sentence.

Net: 27 files, +190/-132 (most of the additions are test fixtures now passing a vendor model id).

## Validation

- `npm run typecheck` clean
- `npm run lint` clean
- `npm run format:check` clean
- `npm run knip` clean
- `npm run build` succeeds
- `npx vitest run`: 176 files, 1589 tests passed
- `madge --circular lib app`: 19 cycles, same as master, all type-only

## Skipped

- `lib/providers/video/{base,runware,mock}.ts` keep their `params.model || "bytedance:seedance@2.0-fast"` fallback: all three files are changed by open PR #730. Retyping `VideoProvider` on `VendorParams<VideoGenerateParams>` is a 4-line follow-up once #730 lands.
- `HANDLERS` Partial + "No job handler registered" throw (flag #49): `lib/api/jobs.ts` is in #730.
- `static attributesFor(_model)` (flag #56): every connector ignores the model today, but `editorOps.mergeAttrs` documents it as a deliberately kept per-model seam; left for a human call.
- `lib/providers/image/runware.ts` and `video/runware.ts` still default `width`/`height`: those are dimension defaults, not model knowledge, and the video one is reserved anyway.

## Merge-conflict guard

```
PR #731: clean
PR #730: clean
PR #729: clean
OK: no file overlap or merge conflict with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
