### PR TITLE
fix: raise Remotion Lambda timeout to 900s for 4K exports

### DIFF
--- a/app/api/render/progress/__tests__/progress.test.ts
+++ b/app/api/render/progress/__tests__/progress.test.ts
@@ -68,10 +68,23 @@ describe("POST /api/render/progress", () => {
 		expect(mockGetRenderProgress).not.toHaveBeenCalled();
 	});
 
-	it("reports fatal errors with the first error message", async () => {
+	it("reports the fatal error's message, skipping retried chunks", async () => {
 		mockGetRenderProgress.mockResolvedValue({
 			fatalErrorEncountered: true,
-			errors: [{ message: "lambda exploded" }],
+			errors: [
+				{
+					name: "Error",
+					message: "chunk flaked",
+					isFatal: true,
+					willRetry: true,
+				},
+				{
+					name: "Error",
+					message: "lambda exploded",
+					isFatal: true,
+					willRetry: false,
+				},
+			],
 		});
 
 		const res = await POST(makeRequest(validBody));
@@ -80,6 +93,28 @@ describe("POST /api/render/progress", () => {
 		expect(await res.json()).toEqual({
 			type: "error",
 			message: "lambda exploded",
+		});
+	});
+
+	it("maps the stitcher timeout to an actionable message", async () => {
+		mockGetRenderProgress.mockResolvedValue({
+			fatalErrorEncountered: true,
+			errors: [
+				{
+					name: "TimeoutError",
+					message: "The main function timed out. ▸ Visit the logs",
+					isFatal: true,
+					willRetry: false,
+				},
+			],
+		});
+
+		const res = await POST(makeRequest(validBody));
+
+		expect(await res.json()).toEqual({
+			type: "error",
+			message:
+				"The export took too long to finish. Try a lower resolution or a shorter video.",
 		});
 	});
 

--- a/app/api/render/progress/__tests__/progress.test.ts
+++ b/app/api/render/progress/__tests__/progress.test.ts
@@ -72,18 +72,8 @@ describe("POST /api/render/progress", () => {
 		mockGetRenderProgress.mockResolvedValue({
 			fatalErrorEncountered: true,
 			errors: [
-				{
-					name: "Error",
-					message: "chunk flaked",
-					isFatal: true,
-					willRetry: true,
-				},
-				{
-					name: "Error",
-					message: "lambda exploded",
-					isFatal: true,
-					willRetry: false,
-				},
+				{ message: "chunk flaked", isFatal: true, willRetry: true },
+				{ message: "lambda exploded", isFatal: true, willRetry: false },
 			],
 		});
 
@@ -93,28 +83,6 @@ describe("POST /api/render/progress", () => {
 		expect(await res.json()).toEqual({
 			type: "error",
 			message: "lambda exploded",
-		});
-	});
-
-	it("maps the stitcher timeout to an actionable message", async () => {
-		mockGetRenderProgress.mockResolvedValue({
-			fatalErrorEncountered: true,
-			errors: [
-				{
-					name: "TimeoutError",
-					message: "The main function timed out. ▸ Visit the logs",
-					isFatal: true,
-					willRetry: false,
-				},
-			],
-		});
-
-		const res = await POST(makeRequest(validBody));
-
-		expect(await res.json()).toEqual({
-			type: "error",
-			message:
-				"The export took too long to finish. Try a lower resolution or a shorter video.",
 		});
 	});
 

--- a/app/api/render/progress/route.ts
+++ b/app/api/render/progress/route.ts
@@ -4,6 +4,7 @@ import { createSessionRouteHandler } from "@/lib/api/route-handler";
 import { getFunctionName, REGION } from "@/lib/video/lambda-config";
 import {
 	RenderHandleRequest,
+	renderFailureMessage,
 	type RenderProgress,
 } from "@/lib/video/render-api";
 
@@ -21,7 +22,7 @@ export const POST = createSessionRouteHandler({
 		if (progress.fatalErrorEncountered) {
 			return NextResponse.json<RenderProgress>({
 				type: "error",
-				message: progress.errors[0]?.message ?? "Render failed",
+				message: renderFailureMessage(progress.errors),
 			});
 		}
 		if (progress.done) {

--- a/app/api/render/progress/route.ts
+++ b/app/api/render/progress/route.ts
@@ -4,7 +4,6 @@ import { createSessionRouteHandler } from "@/lib/api/route-handler";
 import { getFunctionName, REGION } from "@/lib/video/lambda-config";
 import {
 	RenderHandleRequest,
-	renderFailureMessage,
 	type RenderProgress,
 } from "@/lib/video/render-api";
 
@@ -20,9 +19,10 @@ export const POST = createSessionRouteHandler({
 		});
 
 		if (progress.fatalErrorEncountered) {
+			const fatal = progress.errors.find((e) => e.isFatal && !e.willRetry);
 			return NextResponse.json<RenderProgress>({
 				type: "error",
-				message: renderFailureMessage(progress.errors),
+				message: fatal?.message ?? "Render failed",
 			});
 		}
 		if (progress.done) {

--- a/lib/video/lambda-config.ts
+++ b/lib/video/lambda-config.ts
@@ -3,7 +3,7 @@ import { type AwsRegion, speculateFunctionName } from "@remotion/lambda/client";
 export const REGION: AwsRegion = "us-east-1";
 const RAM = 3008;
 const DISK = 10240;
-const TIMEOUT = 240;
+const TIMEOUT = 900;
 
 /** The deployed function is named from this spec, so deploys and callers share it. */
 export const LAMBDA_FUNCTION_SPEC = {

--- a/lib/video/render-api.ts
+++ b/lib/video/render-api.ts
@@ -1,4 +1,3 @@
-import type { EnhancedErrorInfo } from "@remotion/lambda/client";
 import { z } from "zod";
 
 /** Wire contract for `/api/render` and `/api/render/progress`. */
@@ -23,13 +22,3 @@ export type RenderProgress =
 	| { type: "progress"; progress: number }
 	| { type: "done"; url: string; size: number }
 	| { type: "error"; message: string };
-
-/** Remotion's stitcher timeout text is written for the deployer (CloudWatch links, deploy flags). */
-export function renderFailureMessage(errors: EnhancedErrorInfo[]): string {
-	const fatal = errors.find((error) => error.isFatal && !error.willRetry);
-	if (fatal == null) return "Render failed";
-	if (fatal.name === "TimeoutError") {
-		return "The export took too long to finish. Try a lower resolution or a shorter video.";
-	}
-	return fatal.message;
-}

--- a/lib/video/render-api.ts
+++ b/lib/video/render-api.ts
@@ -1,3 +1,4 @@
+import type { EnhancedErrorInfo } from "@remotion/lambda/client";
 import { z } from "zod";
 
 /** Wire contract for `/api/render` and `/api/render/progress`. */
@@ -22,3 +23,13 @@ export type RenderProgress =
 	| { type: "progress"; progress: number }
 	| { type: "done"; url: string; size: number }
 	| { type: "error"; message: string };
+
+/** Remotion's stitcher timeout text is written for the deployer (CloudWatch links, deploy flags). */
+export function renderFailureMessage(errors: EnhancedErrorInfo[]): string {
+	const fatal = errors.find((error) => error.isFatal && !error.willRetry);
+	if (fatal == null) return "Render failed";
+	if (fatal.name === "TimeoutError") {
+		return "The export took too long to finish. Try a lower resolution or a shorter video.";
+	}
+	return fatal.message;
+}


### PR DESCRIPTION
Closes #736

## What

- `TIMEOUT` in `lib/video/lambda-config.ts` goes from 240s to 900s (the AWS Lambda ceiling, and Remotion's `MAX_TIMEOUT`). The function name derives from the spec, so this is a new function: `remotion-render-4-0-481-mem3008mb-disk10240mb-900sec`.
- The progress route picks the fatal error with Remotion's own predicate (`isFatal && !willRetry`, the same one that drives `fatalErrorEncountered`), so a retried chunk flake ahead of the real failure is no longer reported as the cause. The Remotion message itself is passed through unchanged, CloudWatch links included.

## Deploy state

- **Already deployed**: the 900s function was created with `npm run deploy:remotion-function` and is listed by `remotion lambda functions ls`. Callers pick it up via `getFunctionName()` the moment this merges.
- **Not done, do after merge**: delete the old functions (`...-4-0-481-...-240sec`, plus the stale `4-0-459` and `4-0-477` ones still listed). Deleting before merge would break production exports.

## Not taken (from the issue)

- Rewording the timeout error for users. Deliberately kept raw: the project is open source and the CloudWatch links are useful.
- `framesPerLambda` as a function of `scale`, and raising `RAM` so the stitch finishes faster. The issue asks for measurement on a real 4K export before committing to numbers, and there is no measurement yet. These are the levers if 900s still is not enough.

## Checks

Lint, format, typecheck, knip, build, and the full vitest suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BJCsSS3VjjPRAZckCLRgu
