### PR TITLE
fix: ride out dropped poll requests instead of failing the generation

### DIFF
--- a/lib/clients/__tests__/http.test.ts
+++ b/lib/clients/__tests__/http.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { apiFetch, apiJson } from "../http";
+import { apiFetch, apiJson, UnreachableError } from "../http";
 
 describe("apiFetch", () => {
 	let fetchMock: ReturnType<typeof vi.fn>;
@@ -7,6 +7,21 @@ describe("apiFetch", () => {
 	beforeEach(() => {
 		fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);
+	});
+
+	it("types a fetch that never reached the server", async () => {
+		fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+
+		await expect(apiFetch("/api/render")).rejects.toBeInstanceOf(
+			UnreachableError,
+		);
+	});
+
+	it("leaves an abort as-is", async () => {
+		const abort = new DOMException("aborted", "AbortError");
+		fetchMock.mockRejectedValue(abort);
+
+		await expect(apiFetch("/api/render")).rejects.toBe(abort);
 	});
 
 	it("defaults to GET without a body", async () => {

--- a/lib/clients/http.ts
+++ b/lib/clients/http.ts
@@ -42,6 +42,21 @@ export function buildUrl(url: string, params?: QueryParams): string {
 	return qs ? `${url}?${qs}` : url;
 }
 
+/** The request never reached the server (offline, stalled connection, DNS). */
+export class UnreachableError extends Error {
+	constructor(cause: unknown) {
+		super("Failed to reach the server", { cause });
+		this.name = "UnreachableError";
+	}
+}
+
+// fetch rejects with a TypeError only when no response came back at all;
+// an abort is a DOMException and stays as-is.
+function asUnreachable(error: unknown): never {
+	if (error instanceof TypeError) throw new UnreachableError(error);
+	throw error;
+}
+
 /** Calls one of our own API routes, surfacing its error envelope as a thrown `Error`. */
 export async function apiFetch(
 	url: string,
@@ -50,7 +65,7 @@ export async function apiFetch(
 	const res = await fetch(buildUrl(url, params), {
 		...buildInit(method, body),
 		signal,
-	});
+	}).catch(asUnreachable);
 	if (!res.ok) throw new Error(await readErrorMessage(res));
 	return res;
 }

--- a/lib/connectors/__tests__/video.test.ts
+++ b/lib/connectors/__tests__/video.test.ts
@@ -50,9 +50,13 @@ describe("BaseVideoConnector", () => {
 			},
 		]);
 
-		const result = await new HttpVideoConnector(config).generate({
+		vi.useFakeTimers();
+		const pending = new HttpVideoConnector(config).generate({
 			prompt: "a sunset",
 		});
+		await vi.runAllTimersAsync();
+		const result = await pending;
+		vi.useRealTimers();
 		expect(result.videoUrl).toBe(VIDEO_URL);
 		expect(result.durationSec).toBe(5);
 		expect(fetch).toHaveBeenCalledTimes(3);

--- a/lib/providers/__tests__/poll.test.ts
+++ b/lib/providers/__tests__/poll.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { UnreachableError } from "@/lib/clients/http";
 import { awaitCompletion } from "../poll";
 
 type Job = { status: string; url?: string };
@@ -39,8 +40,12 @@ describe("awaitCompletion", () => {
 		expect(poll).toHaveBeenCalledTimes(3);
 	});
 
-	it("throws on timeout", async () => {
+	it("throws on timeout, whether the server answers or not", async () => {
 		const poll = vi.fn().mockResolvedValue(makeJob("processing"));
+		await expect(awaitCompletion(poll, "j1", isDone, 10, 50)).rejects.toThrow(
+			"timed out",
+		);
+		poll.mockRejectedValue(new UnreachableError(new TypeError()));
 		await expect(awaitCompletion(poll, "j1", isDone, 10, 50)).rejects.toThrow(
 			"timed out",
 		);
@@ -52,10 +57,21 @@ describe("awaitCompletion", () => {
 		expect(poll).toHaveBeenCalledWith("my-job-id");
 	});
 
-	it("propagates pollFn errors", async () => {
-		const poll = vi.fn().mockRejectedValue(new Error("network error"));
+	it("propagates errors the server answered with", async () => {
+		const poll = vi.fn().mockRejectedValue(new Error("404 Not Found"));
 		await expect(awaitCompletion(poll, "j1", isDone)).rejects.toThrow(
-			"network error",
+			"404 Not Found",
 		);
+		expect(poll).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps polling when a request never reaches the server", async () => {
+		const poll = vi
+			.fn()
+			.mockRejectedValueOnce(new UnreachableError(new TypeError()))
+			.mockResolvedValueOnce(makeJob("completed"));
+		const result = await awaitCompletion(poll, "j1", isDone, 10, 5000);
+		expect(result.status).toBe("completed");
+		expect(poll).toHaveBeenCalledTimes(2);
 	});
 });

--- a/lib/providers/poll.ts
+++ b/lib/providers/poll.ts
@@ -1,17 +1,24 @@
+import { UnreachableError } from "@/lib/clients/http";
 import { JOB_TIMEOUT_MS } from "@/lib/gateway/base";
 import { sleep } from "@/lib/utils";
+
+export const POLL_INTERVAL_MS = 5000;
 
 export async function awaitCompletion<T>(
 	pollFn: (jobId: string) => Promise<T>,
 	jobId: string,
 	isDone: (result: T) => boolean,
-	intervalMs = 1000,
+	intervalMs = POLL_INTERVAL_MS,
 	timeoutMs = JOB_TIMEOUT_MS,
 ): Promise<T> {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
-		const result = await pollFn(jobId);
-		if (isDone(result)) return result;
+		try {
+			const result = await pollFn(jobId);
+			if (isDone(result)) return result;
+		} catch (error) {
+			if (!(error instanceof UnreachableError)) throw error;
+		}
 		await sleep(intervalMs);
 	}
 	throw new Error(`Job ${jobId} timed out after ${timeoutMs}ms`);

--- a/lib/upload/__tests__/uploadImage.test.ts
+++ b/lib/upload/__tests__/uploadImage.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { UnreachableError } from "@/lib/clients/http";
 import { uploadImage } from "../uploadImage";
 
 const file = new File(["x"], "x.png", { type: "image/png" });
@@ -46,6 +47,6 @@ describe("uploadImage", () => {
 
 	it("propagates network failures", async () => {
 		fetchMock.mockRejectedValue(new TypeError("network down"));
-		await expect(uploadImage(file)).rejects.toThrow("network down");
+		await expect(uploadImage(file)).rejects.toBeInstanceOf(UnreachableError);
 	});
 });

--- a/lib/video/__tests__/render-client.test.ts
+++ b/lib/video/__tests__/render-client.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { apiJson } from "@/lib/clients/http";
+import { apiJson, UnreachableError } from "@/lib/clients/http";
 import type { VideoLayout } from "../types";
 import { runRender, type RenderUpdate } from "../render-client";
 
-vi.mock("@/lib/clients/http", () => ({ apiJson: vi.fn() }));
+vi.mock("@/lib/clients/http", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/lib/clients/http")>()),
+	apiJson: vi.fn(),
+}));
 
 const apiJsonMock = vi.mocked(apiJson);
 
@@ -58,6 +61,22 @@ describe("runRender", () => {
 			method: "POST",
 			body: HANDLE,
 		});
+	});
+
+	it("keeps polling when a progress request never reaches the server", async () => {
+		apiJsonMock
+			.mockResolvedValueOnce(HANDLE)
+			.mockRejectedValueOnce(new UnreachableError(new TypeError()))
+			.mockResolvedValueOnce({ type: "done", url: "/out.mp4", size: 1024 });
+
+		const seen = await collect(runRender(LAYOUT));
+
+		expect(seen.at(-1)).toEqual({
+			status: "done",
+			url: "/out.mp4",
+			size: 1024,
+		});
+		expect(apiJsonMock).toHaveBeenCalledTimes(3);
 	});
 
 	it("stops polling once the render is done", async () => {

--- a/lib/video/render-client.ts
+++ b/lib/video/render-client.ts
@@ -1,4 +1,5 @@
-import { apiJson } from "@/lib/clients/http";
+import { apiJson, UnreachableError } from "@/lib/clients/http";
+import { POLL_INTERVAL_MS } from "@/lib/providers/poll";
 import { sleep } from "@/lib/utils";
 import type { RenderHandle, RenderProgress } from "./render-api";
 import type { VideoLayout } from "./types";
@@ -6,8 +7,6 @@ import type { VideoLayout } from "./types";
 export type RenderUpdate =
 	| { status: "rendering"; progress: number }
 	| { status: "done"; url: string; size: number };
-
-const POLL_INTERVAL_MS = 5000;
 
 /**
  * Starts a Lambda render and yields progress until the output is ready.
@@ -24,18 +23,20 @@ export async function* runRender(
 	yield { status: "rendering", progress: 0 };
 
 	for (;;) {
-		const result = await apiJson<RenderProgress>("/api/render/progress", {
-			method: "POST",
-			body: handle,
-		});
-
-		if (result.type === "error") throw new Error(result.message);
-		if (result.type === "done") {
-			yield { status: "done", url: result.url, size: result.size };
-			return;
+		try {
+			const result = await apiJson<RenderProgress>("/api/render/progress", {
+				method: "POST",
+				body: handle,
+			});
+			if (result.type === "error") throw new Error(result.message);
+			if (result.type === "done") {
+				yield { status: "done", url: result.url, size: result.size };
+				return;
+			}
+			yield { status: "rendering", progress: result.progress };
+		} catch (error) {
+			if (!(error instanceof UnreachableError)) throw error;
 		}
-
-		yield { status: "rendering", progress: result.progress };
 		await sleep(POLL_INTERVAL_MS);
 	}
 }


### PR DESCRIPTION
## Summary
- A single dropped poll request (browser `net::ERR_TIMED_OUT`, fetch rejecting with TypeError) no longer fails the whole generation. `apiFetch` classifies it as a typed `UnreachableError` at the boundary and both poll loops (asset jobs, export progress) retry on the next tick up to the existing deadline. Server-answered errors and aborts still throw immediately.
- Asset job poll interval raised from 1s to 5s; the render client shares the same constant.

## Test plan
- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, `npx vitest run` (1593 passing)
- [x] New tests: typed error at the fetch boundary, abort passthrough, retry through an unreachable poll in both loops, deadline still fires when the server never answers
- [ ] Manual: start a generation, briefly toggle the network offline in DevTools, confirm the element completes once back online

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyATdBRznz2dPH2Sg4QLZD