### PR TITLE
refactor: nightly maintainability 2026-09-07

### DIFF
--- a/lib/providers/__tests__/runware-video.test.ts
+++ b/lib/providers/__tests__/runware-video.test.ts
@@ -20,6 +20,8 @@ vi.mock("@runware/sdk-js", () => ({
 
 import { RunwareVideo } from "../video/runware";
 
+const MODEL = "bytedance:seedance@2.0-fast";
+
 describe("RunwareVideo", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -34,7 +36,10 @@ describe("RunwareVideo", () => {
 			});
 
 			const provider = new RunwareVideo("test-key");
-			const result = await provider.submit({ prompt: "a sunset" });
+			const result = await provider.submit({
+				prompt: "a sunset",
+				model: MODEL,
+			});
 
 			expect(result).toEqual({
 				url: undefined,
@@ -66,6 +71,7 @@ describe("RunwareVideo", () => {
 			const provider = new RunwareVideo("test-key");
 			await provider.submit({
 				prompt: "animate this",
+				model: MODEL,
 				referenceImages: ["data:image/png;base64,ref"],
 				frameImages: ["data:image/png;base64,frame"],
 			});
@@ -130,7 +136,7 @@ describe("RunwareVideo", () => {
 			]);
 
 			const provider = new RunwareVideo("test-key");
-			const result = await provider.submit({ prompt: "test" });
+			const result = await provider.submit({ prompt: "test", model: MODEL });
 
 			expect(result.metadata?.jobId).toBe("job-arr");
 			expect(result.url).toBe("https://v.mp4");
@@ -142,7 +148,10 @@ describe("RunwareVideo", () => {
 				status: "processing",
 			});
 
-			await new RunwareVideo("test-key").submit({ prompt: "test" });
+			await new RunwareVideo("test-key").submit({
+				prompt: "test",
+				model: MODEL,
+			});
 
 			expect(mockVideoInference).toHaveBeenCalledWith(
 				expect.objectContaining({ skipResponse: true }),
@@ -153,7 +162,7 @@ describe("RunwareVideo", () => {
 			mockVideoInference.mockResolvedValue({});
 
 			await expect(
-				new RunwareVideo("test-key").submit({ prompt: "test" }),
+				new RunwareVideo("test-key").submit({ prompt: "test", model: MODEL }),
 			).rejects.toThrow("returned no task");
 		});
 
@@ -161,7 +170,9 @@ describe("RunwareVideo", () => {
 			mockVideoInference.mockRejectedValue(new Error("fail"));
 
 			const provider = new RunwareVideo("test-key");
-			await expect(provider.submit({ prompt: "test" })).rejects.toThrow("fail");
+			await expect(
+				provider.submit({ prompt: "test", model: MODEL }),
+			).rejects.toThrow("fail");
 			expect(mockDisconnect).toHaveBeenCalled();
 		});
 	});
@@ -174,7 +185,10 @@ describe("RunwareVideo", () => {
 			});
 
 			const provider = new RunwareVideo("test-key");
-			const result = await provider.generate({ prompt: "a sunset" });
+			const result = await provider.generate({
+				prompt: "a sunset",
+				model: MODEL,
+			});
 
 			expect(result.provider).toBe("runware");
 			expect(result.metadata).toEqual({
@@ -193,6 +207,7 @@ describe("RunwareVideo", () => {
 			const provider = new RunwareVideo("test-key");
 			const result = await provider.generate({
 				prompt: "test",
+				model: MODEL,
 				duration: 10,
 			});
 
@@ -209,6 +224,7 @@ describe("RunwareVideo", () => {
 			const provider = new RunwareVideo("test-key");
 			const poll = await provider.poll("job-1", {
 				prompt: "test",
+				model: MODEL,
 				duration: 8,
 			});
 
@@ -226,7 +242,10 @@ describe("RunwareVideo", () => {
 			]);
 
 			const provider = new RunwareVideo("test-key");
-			const result = await provider.poll("job-1", { prompt: "test" });
+			const result = await provider.poll("job-1", {
+				prompt: "test",
+				model: MODEL,
+			});
 
 			expect(result).toMatchObject({
 				kind: "ready",
@@ -244,7 +263,10 @@ describe("RunwareVideo", () => {
 			]);
 
 			const provider = new RunwareVideo("test-key");
-			const result = await provider.poll("job-1", { prompt: "test" });
+			const result = await provider.poll("job-1", {
+				prompt: "test",
+				model: MODEL,
+			});
 
 			expect(result).toEqual({
 				kind: "pending",
@@ -257,7 +279,7 @@ describe("RunwareVideo", () => {
 
 			const provider = new RunwareVideo("test-key");
 			await expect(
-				provider.poll("missing", { prompt: "test" }),
+				provider.poll("missing", { prompt: "test", model: MODEL }),
 			).rejects.toThrow("Job not found");
 			expect(mockDisconnect).toHaveBeenCalled();
 		});

--- a/lib/providers/video/base.ts
+++ b/lib/providers/video/base.ts
@@ -1,9 +1,12 @@
-import type { VideoGenerateParams } from "@/lib/connectors/types";
 import type { BundleFile, BundleResponse } from "@/lib/api/asset-bundle";
+import type { VendorParams } from "@/lib/connectors/models";
+import type { VideoGenerateParams } from "@/lib/connectors/types";
 import type { ProviderContract } from "../base";
 import { BaseProvider } from "../base";
 
 export type VideoJobStatus = "queued" | "processing" | "completed" | "failed";
+
+export type VideoRequest = VendorParams<VideoGenerateParams>;
 
 /** What a video runs for when the request names no duration, for asking and for reporting. */
 export const DEFAULT_VIDEO_DURATION_SEC = 5;
@@ -31,12 +34,12 @@ export type VideoPoll =
 	| { kind: "ready"; asset: VideoProviderResponse };
 
 export interface VideoProvider extends ProviderContract {
-	generate(params: VideoGenerateParams): Promise<VideoProviderResponse>;
-	poll(jobId: string, request: VideoGenerateParams): Promise<VideoPoll>;
+	generate(params: VideoRequest): Promise<VideoProviderResponse>;
+	poll(jobId: string, request: VideoRequest): Promise<VideoPoll>;
 }
 
 export abstract class BaseVideoProvider
-	extends BaseProvider<VideoGenerateParams, VideoJob, VideoProviderResponse>
+	extends BaseProvider<VideoRequest, VideoJob, VideoProviderResponse>
 	implements VideoProvider
 {
 	protected toFiles(r: VideoJob): BundleFile[] {
@@ -54,7 +57,7 @@ export abstract class BaseVideoProvider
 
 	protected abstract _poll(jobId: string): Promise<VideoJob>;
 
-	async poll(jobId: string, request: VideoGenerateParams): Promise<VideoPoll> {
+	async poll(jobId: string, request: VideoRequest): Promise<VideoPoll> {
 		const result = await this._poll(jobId);
 		if (this.toFiles(result).length === 0) {
 			return { kind: "pending", metadata: result.metadata };

--- a/lib/providers/video/runware.ts
+++ b/lib/providers/video/runware.ts
@@ -1,6 +1,4 @@
-import type { VideoGenerateParams } from "@/lib/connectors/types";
-import { RUNWARE_VIDEO_MODELS } from "@/lib/connectors/video/runware/models";
-import type { VideoJob, VideoJobStatus } from "./base";
+import type { VideoJob, VideoJobStatus, VideoRequest } from "./base";
 import { BaseVideoProvider, DEFAULT_VIDEO_DURATION_SEC } from "./base";
 import { validateRunwareKey, withRunware } from "../runware";
 import {
@@ -23,13 +21,11 @@ function toVideoJob(video: {
 	};
 }
 
-const DEFAULT_MODEL = RUNWARE_VIDEO_MODELS["Seedance 2 Fast"].id;
-
 const DEFAULT_SIZE =
 	ASPECT_RATIO_DIMENSIONS[DEFAULT_ASPECT_RATIO].video[DEFAULT_VIDEO_RESOLUTION];
 
 /** A frame-conditioned video takes its aspect from the frame, so it is sized by preset. */
-const sizeFor = (params: VideoGenerateParams) =>
+const sizeFor = (params: VideoRequest) =>
 	params.frameImages && params.resolution
 		? { resolution: params.resolution }
 		: {
@@ -50,11 +46,11 @@ export class RunwareVideo extends BaseVideoProvider {
 		return validateRunwareKey(this.apiKey);
 	}
 
-	async submit(params: VideoGenerateParams) {
+	async submit(params: VideoRequest) {
 		return withRunware(this.apiKey, async (runware) => {
 			const result = await runware.videoInference({
 				positivePrompt: params.prompt,
-				model: params.model || DEFAULT_MODEL,
+				model: params.model,
 				...sizeFor(params),
 				duration: params.duration ?? DEFAULT_VIDEO_DURATION_SEC,
 				outputType: "URL",
@@ -74,7 +70,7 @@ export class RunwareVideo extends BaseVideoProvider {
 		});
 	}
 
-	protected async _generate(params: VideoGenerateParams): Promise<VideoJob> {
+	protected async _generate(params: VideoRequest): Promise<VideoJob> {
 		const job = await this.submit(params);
 		return {
 			...job,


### PR DESCRIPTION
## Summary

Completes the server-side provider contract for video. The video provider was the last one whose `generate`/`poll` took an optional `model` and, in `RunwareVideo`, quietly fell back to Seedance when it was missing. ARCHITECTURE.md already states that a provider takes the request as its vendor's API does with the model id resolved by the route, and #732 moved the image, TTS, SFX, music and LLM providers to that contract. This PR does the same for video.

- `lib/providers/video/base.ts`: `VideoRequest = VendorParams<VideoGenerateParams>`; `VideoProvider`, `BaseVideoProvider` and `poll` are typed on it, so `model: string` is required.
- `lib/providers/video/runware.ts`: drops the `DEFAULT_MODEL` fallback and the import of the connector-layer Runware model table. The provider no longer knows any catalog name.
- `lib/providers/__tests__/runware-video.test.ts`: every request names its model, as the job handler already does in production.

No behavior change: the video job handler always passes `jobVendorParams(job)`, which carries the resolved id, so the fallback was unreachable on the real path.

## Skipped

- `HANDLERS` Partial + throw in `lib/api/job-handlers.ts`: needs `JobRow.connector_type` narrowed past `llm`/`animated_image`, an architecture call for the arch job.
- Runware image `width`/`height` defaults: dimension knowledge rather than model knowledge, previously reviewed and kept.
- Everything merged since the last pass (#733, #737, #739, #742, #744) was read and is clean.

## Checks

lint, format:check, typecheck, knip, `npm run build`, `vitest run` (178 files, 1612 tests) all pass.

## Merge-conflict guard

```
OK: no file overlap or merge conflict with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)