### PR TITLE
refactor: nightly conventions sweep 2026-09-07, dead guards and one canonical read in the post-#731 delta

### DIFF
--- a/app/components/canvas/elements/GenerationIndicator.tsx
+++ b/app/components/canvas/elements/GenerationIndicator.tsx
@@ -34,7 +34,7 @@ export function GenerationIndicator({
 	status,
 	seconds = 0,
 	size = "md",
-	className = "",
+	className,
 }: {
 	status: ActiveGenerationStatus;
 	seconds?: number;
@@ -58,7 +58,7 @@ export function GenerationIndicator({
 				)}
 				disabled
 			>
-				<Icon className={cn(sizes.icon, "text-foreground", animation)} />
+				<Icon className={cn(sizes.icon, animation)} />
 			</button>
 		</SimpleTooltip>
 	);

--- a/lib/api/asset-bundle.ts
+++ b/lib/api/asset-bundle.ts
@@ -9,11 +9,6 @@ async function fetchOk(url: string, label: string): Promise<Response> {
 	return res;
 }
 
-async function fetchJson<T>(url: string, label: string): Promise<T> {
-	const res = await fetchOk(url, label);
-	return res.json() as Promise<T>;
-}
-
 type AssetManifest = {
 	version: number;
 	type: string;
@@ -80,7 +75,8 @@ export class AssetBundle {
 	}
 
 	async fetchJson<T>(key: string): Promise<T> {
-		return fetchJson<T>(this.resolve(key), `Failed to fetch "${key}"`);
+		const res = await fetchOk(this.resolve(key), `Failed to fetch "${key}"`);
+		return res.json() as Promise<T>;
 	}
 
 	static buildUrl(type: string, provider: string, id: string): string {

--- a/lib/connectors/animated_image/plugins/still-frame.ts
+++ b/lib/connectors/animated_image/plugins/still-frame.ts
@@ -13,6 +13,7 @@ import {
 import { buildImagePlugins } from "@/lib/connectors/image/plugins/imageChain";
 import { resolveModel } from "@/lib/connectors/models";
 import { ELEMENT_MODEL } from "@/lib/connectors/attributes/model";
+import { formatDef } from "@/lib/connectors/attributes/common";
 import { STILL_MODEL } from "../attributes";
 import {
 	derivedDependency,
@@ -36,7 +37,7 @@ const VIDEO_ONLY_KEYS = [
 const STILL_MODEL_KEYS = Object.values(STILL_MODEL);
 
 /** Attributes of the still, which the animation's video generation has no use for. */
-const STILL_ONLY_KEYS = ["format", ...STILL_MODEL_KEYS];
+const STILL_ONLY_KEYS = [formatDef.key, ...STILL_MODEL_KEYS];
 
 const STILL = "still";
 
@@ -97,9 +98,6 @@ export function pictureNode(node: GenerationNode): JobNode | null {
 	return makesPicture(target.job.elementType) ? target : null;
 }
 
-/**
- * The snapshot of the still a node depends on
- */
 export const stillSnapshot = (
 	node: GenerationNode,
 	queue: GenerationQueue,

--- a/lib/connectors/image/plugins/character-references.ts
+++ b/lib/connectors/image/plugins/character-references.ts
@@ -3,7 +3,7 @@ import {
 	CHARACTERS_ATTR,
 	parseCharacterNames,
 } from "@/lib/canvas/characterNames";
-import type { ConnectorPlugin, PluginContext } from "@/lib/connectors/types";
+import type { ConnectorPlugin } from "@/lib/connectors/types";
 import { characterAvatarElementId } from "@/lib/project/characterAvatar";
 import { forCharacterAvatar } from "./characterAvatarNode";
 
@@ -20,7 +20,7 @@ export function createCharacterReferencesPlugin(): ConnectorPlugin<ParamsWithCha
 			parseCharacterNames(element.generationAttributes?.[CHARACTERS_ATTR]).map(
 				forCharacterAvatar,
 			),
-		beforeGenerate(params, ctx: PluginContext<ParamsWithCharacters>) {
+		beforeGenerate(params, ctx) {
 			const { [CHARACTERS_ATTR]: characters, ...rest } = params;
 			if (!characters) return params;
 

--- a/lib/connectors/plugins.ts
+++ b/lib/connectors/plugins.ts
@@ -1,16 +1,5 @@
-import type { GatewayClient } from "@/lib/gateway/base";
 import type { ProjectData } from "@/lib/project/store";
 import type { ConnectorPlugin, ModelRef, PluginContext } from "./types";
-
-/** Assert the plugin was given a gateway, returning the narrowed dependency. */
-export function requireGateway<P, R>(
-	ctx: PluginContext<P, R>,
-	plugin: string,
-): GatewayClient<P, R> {
-	if (!ctx.gateway)
-		throw new Error(`${plugin} plugin requires gateway context`);
-	return ctx.gateway;
-}
 
 /** Assert the plugin was given project state, returning it narrowed. */
 export function requireState<P, R>(

--- a/lib/generation/snapshots.ts
+++ b/lib/generation/snapshots.ts
@@ -89,8 +89,7 @@ export class SnapshotStore {
 
 	isActive = (id: string): boolean => isGenerationActive(this.get(id).status);
 
-	isBusy = (): boolean =>
-		Array.from(this.state.values()).some((s) => isGenerationActive(s.status));
+	isBusy = (): boolean => this.getActiveCount() > 0;
 
 	private count(predicate: (snap: ElementSnapshot) => boolean): number {
 		return Array.from(this.state.values()).filter(predicate).length;
@@ -115,20 +114,9 @@ export class SnapshotStore {
 
 	/** Clears in-flight progress, keeping whatever the element already had. */
 	resetToIdle(id: string) {
-		const { result, error, resultInputs, connectorType, pinned } = this.get(id);
-		if (result || error) {
-			this.state.set(id, {
-				status: "idle",
-				seconds: 0,
-				result,
-				error,
-				resultInputs,
-				connectorType,
-				pinned,
-			});
-		} else {
-			this.state.delete(id);
-		}
+		const { result, error } = this.get(id);
+		if (result || error) this.update(id, { status: "idle", seconds: 0 });
+		else this.state.delete(id);
 	}
 
 	commit(version: CommittedVersion): CommittedVersion {

--- a/lib/providers/llm/anthropic.ts
+++ b/lib/providers/llm/anthropic.ts
@@ -10,7 +10,10 @@ import {
 import type { LLMGenerateResult, LLMStreamChunk } from "@/lib/connectors/types";
 import { parseImageSource } from "@/lib/api/imageSource";
 import { stringifyError } from "@/lib/errors";
-import { DEFAULT_THINKING_LEVEL } from "@/lib/connectors/llm/enums";
+import {
+	DEFAULT_THINKING_LEVEL,
+	type ThinkingLevel,
+} from "@/lib/connectors/llm/enums";
 import { validateByProbe } from "../validate";
 import type { AgentModel } from "./agentModel";
 import type { LLMProvider, LLMRequest } from "./base";
@@ -71,7 +74,7 @@ export class AnthropicLLM implements LLMProvider {
 	 * `display` defaults to "omitted", which streams empty thinking blocks.
 	 * Summarized is what makes thoughts visible.
 	 */
-	private thinking(effort: string): SharedV3ProviderOptions {
+	private thinking(effort: ThinkingLevel): SharedV3ProviderOptions {
 		return {
 			anthropic: {
 				thinking: { type: "adaptive", display: "summarized" },
@@ -109,7 +112,7 @@ export class AnthropicLLM implements LLMProvider {
 		const response = await generateText(this.buildRequest(params));
 		return {
 			text: response.text,
-			model: response.response.modelId ?? params.model,
+			model: response.response.modelId,
 			usage: {
 				inputTokens: response.usage.inputTokens ?? 0,
 				outputTokens: response.usage.outputTokens ?? 0,

--- a/lib/providers/tts/cartesia.ts
+++ b/lib/providers/tts/cartesia.ts
@@ -6,11 +6,7 @@ import type {
 	VoiceInfo,
 	VoiceSearchParams,
 } from "@/lib/connectors/types";
-import {
-	TTS_GENDERS,
-	type TTSGender,
-	type TTSSpeed,
-} from "@/lib/connectors/tts/enums";
+import { TTS_GENDERS, type TTSSpeed } from "@/lib/connectors/tts/enums";
 import type { BundleFile } from "@/lib/api/asset-bundle";
 import { logger } from "@/lib/api/logger";
 import { BaseProvider, type WithMetadata } from "../base";
@@ -19,7 +15,10 @@ import type { VendorParams } from "@/lib/connectors/models";
 import type { TTSProvider } from "./base";
 import { fetchAllowedVoicePreview } from "./voicePreview";
 import { buildQueryText, rankBySimilarity } from "./voiceSimilarity";
-import { GenerationRequest } from "@cartesia/cartesia-js/resources/tts.mjs";
+import type {
+	GenerationRequest,
+	RawEncoding,
+} from "@cartesia/cartesia-js/resources/tts.mjs";
 import type {
 	Voice,
 	VoiceListParams,
@@ -32,7 +31,7 @@ type RawTTSResult = {
 
 const SAMPLE_RATE = 44100;
 const NUM_CHANNELS = 1;
-const ENCODING = "pcm_f32le";
+const ENCODING: RawEncoding = "pcm_f32le";
 const CARTESIA_VOLUME = 1.0;
 
 const CARTESIA_SPEED: Record<TTSSpeed, number> = {
@@ -42,7 +41,7 @@ const CARTESIA_SPEED: Record<TTSSpeed, number> = {
 };
 
 const PCM_WAV_PARAMS: Record<
-	string,
+	RawEncoding,
 	{ audioFormat: number; bitsPerSample: number }
 > = {
 	pcm_f32le: { audioFormat: 3, bitsPerSample: 32 },
@@ -175,8 +174,8 @@ export class CartesiaTTS
 	}
 
 	async search(params: VoiceSearchParams): Promise<VoiceInfo[]> {
-		const { gender, limit, language } = params;
-		const results = await this._search(gender, language);
+		const { limit } = params;
+		const results = await this._search(params);
 		const queryText = buildQueryText(params);
 		const ranked = queryText
 			? await rankBySimilarity(results, queryText).catch((err) => {
@@ -190,10 +189,10 @@ export class CartesiaTTS
 		return ranked.slice(0, limit || ranked.length);
 	}
 
-	private async _search(
-		gender?: TTSGender,
-		language?: string,
-	): Promise<VoiceInfo[]> {
+	private async _search({
+		gender,
+		language,
+	}: VoiceSearchParams): Promise<VoiceInfo[]> {
 		const voices = await collectVoicesCached(
 			this.apiKey,
 			{ gender, language, expand: ["preview_file_url"] },
@@ -235,11 +234,7 @@ export class CartesiaTTS
 			};
 			for await (const response of ws.generate(req)) {
 				if (response.type === "chunk" && response.audio) {
-					audioChunks.push(
-						Buffer.isBuffer(response.audio)
-							? response.audio
-							: Buffer.from(response.audio),
-					);
+					audioChunks.push(response.audio);
 				}
 				if (response.type === "timestamps" && response.word_timestamps) {
 					const { words, start, end } = response.word_timestamps;

--- a/lib/video/elementAttributes.ts
+++ b/lib/video/elementAttributes.ts
@@ -89,10 +89,6 @@ export function getMotion(element: CanvasContentElement): MotionEffect {
 	return isMotionEffect(raw) ? raw : DEFAULT_MOTION;
 }
 
-/**
- * Stable signature over the raw layout-affecting attribute values, in
- * `LAYOUT_ATTRIBUTE_KEYS` order. Used to build the layout memo key.
- */
 export function layoutAttributeSignature(
 	element: CanvasContentElement,
 ): string {

--- a/lib/video/transitions.ts
+++ b/lib/video/transitions.ts
@@ -18,3 +18,4 @@ export const AUDIO_FADE_SEC = 2;
 // Lead time to mount foreground video before it's visible so it decodes ahead
 // of the transition and doesn't stall the Player (which would stutter audio).
 export const VIDEO_PREMOUNT_SEC = 2;
+export const LAYER_PREMOUNT_SEC = 1;

--- a/remotion/compositions/VideoComposition.tsx
+++ b/remotion/compositions/VideoComposition.tsx
@@ -13,6 +13,7 @@ import type { VideoLayout, ResolvedElement } from "@/lib/video/types";
 import { toFrames } from "@/lib/video/frames";
 import {
 	TRANSITION_DURATION_SEC,
+	LAYER_PREMOUNT_SEC,
 	VIDEO_PREMOUNT_SEC,
 } from "@/lib/video/transitions";
 import { audioFadeSec } from "@/lib/video/audioFade";
@@ -141,7 +142,7 @@ export const VideoComposition: React.FC<VideoLayout> = ({
 						key={`${type}-${seq.element.id}-${i}`}
 						from={toFrames(seq.start, fps)}
 						durationInFrames={toFrames(seq.duration, fps)}
-						premountFor={fps}
+						premountFor={toFrames(LAYER_PREMOUNT_SEC, fps)}
 					>
 						<SequenceContent element={seq.element} />
 					</Sequence>


### PR DESCRIPTION
Nightly CONVENTIONS.md sweep. Delta-audited the 66 source files merged since the last sweep (#730, #732, #733, #737, #739, #742) and applied only no-behavior-change fixes. Repo-wide invariants unchanged: zero bare `catch {}`, zero catch-return-null, zero `as any` / non-null / provider sniffing, the same 3 discriminated-union switches.

## Fixed (no behavior change)

- `lib/connectors/plugins.ts`: `requireGateway` had zero callers. Deleted with its import.
- `lib/connectors/animated_image/plugins/still-frame.ts`: `STILL_ONLY_KEYS` read `formatDef.key` instead of re-spelling `"format"`; dropped a doc comment that restated the name.
- `lib/connectors/image/plugins/character-references.ts`: `ctx` is contextually typed by the `ConnectorPlugin<ParamsWithCharacters>` return type. Dropped the annotation and the now-unused import.
- `lib/providers/tts/cartesia.ts`: `WebsocketResponse.Chunk.audio` is `Buffer | null`, so after the `&& response.audio` narrowing the `Buffer.from` arm was unreachable. `PCM_WAV_PARAMS` is keyed by the SDK's `RawEncoding` so a typo in `ENCODING` fails at compile time instead of module load. `_search` takes the `VoiceSearchParams` instead of unpacking two optionals to repack them. `GenerationRequest` is a type-only export, so `import type`.
- `lib/providers/llm/anthropic.ts`: `response.response.modelId` is a `string` on the AI SDK type, so `?? params.model` was dead. `thinking(effort)` now takes `ThinkingLevel`, which is what both callers pass.
- `lib/generation/snapshots.ts`: `resetToIdle` rebuilt every `ElementSnapshot` field by hand; it now goes through `update` (which does not bump `resultVersion` since `result` is not in the patch, same as before). `isBusy` is `getActiveCount() > 0`.
- `lib/api/asset-bundle.ts`: inlined the single-use module `fetchJson` into `AssetBundle.fetchJson`.
- `app/components/canvas/elements/GenerationIndicator.tsx`: `className = ""` default is dead since `cn` drops `undefined`; the icon paints `currentColor` so its own `text-foreground` duplicated the wrapper's.
- `remotion/compositions/VideoComposition.tsx` + `lib/video/transitions.ts`: layered sequences premounted a bare `fps` (1s). Named as `LAYER_PREMOUNT_SEC = 1` beside `VIDEO_PREMOUNT_SEC`; `toFrames(1, fps) === fps`.
- `lib/video/elementAttributes.ts`: dropped a comment that restated the body of `layoutAttributeSignature`.

## Flagged, not fixed (design-level or behavior change)

- **`app/page.tsx:75-77` "Get Started" button is a no-op.** No handler, not inside a `<form>`, `AccessCodeInput` has no submit. Either wire it to submit the access code or remove it. Possibly a live bug.
- **`GenerationIndicator.tsx:50-62`** renders a status marker as a `disabled` `<button>`. `disabled` suppresses pointer events in Firefox/Safari, so the tooltip will not open there, and it uses one-off `disabled:cursor-not-allowed` instead of the `unavailable:` variant. A `<span role="status">` fits better.
- **`GenerationIndicator.tsx:25,28,54` and `PlayPauseFlash.tsx:15`** pair `bg-on-media/55` with `text-foreground`; DESIGN.md says scrims take `text-on-media-foreground`.
- **`lib/providers/tts/cartesia.ts:181-189`** catch-warn-continue: a failed embedding call returns unranked voices and the caller cannot tell. Rule 6 says propagate or surface. Dates from #108, so not new, but it is the only `.catch(` with a swallow left in `lib/`.
- **`lib/providers/tts/cartesia.ts:262-264`** the provider pads `durationSec` by `+1` for a downstream pause opinion; ElevenLabs reports raw duration. Policy in the mechanism. Tests encode the `+1`.
- **`lib/providers/tts/cartesia.ts:213`** `if (!params.voiceId) throw`: the route schema requires it but `TTSGenerateParams.voiceId` stays optional. Requiring it on the TTS request type defines the guard away (14 references to check).
- **`lib/api/handlers/video.ts:30-37`** sniffs `metadata.status === "failed"` inside the `pending` variant of `VideoPoll`. A `failed` variant produced in `BaseVideoProvider.poll` would let the handler switch on `kind` only. Touches `lib/providers/video/base.ts`, under open #745.
- **`lib/api/handlers/video.ts:18-23`** the no-`jobId` throw exists only because `VideoProviderResponse.metadata` is typed optional while every producer sets it. Same file as above.
- **`lib/api/providerKeys.ts:60-66`** hosted key row uses `""` sentinels for `last4`/`createdAt`; the settings UI special-cases `MANAGED_PROVIDER` in three places so they never render. A discriminated `hosted | stored` record would remove both.
- **`lib/connectors/types.ts:83`** `PluginContext.gateway` is written by `HttpLLMConnector.pluginContext()` and read by nobody now that `requireGateway` is gone. Removing the field is a contract change.
- **`lib/connectors/plugins.ts:15-31`** `requireState`/`requireModel` plus the hand-rolled guard in `voice-search.ts:23-27` are one keyed mechanism; a generic `requireContext(ctx, key, plugin)` collapses them without a cast. API change across 6 call sites.
- **`lib/connectors/tts/plugins/voice-search.ts:30`** `language || "en"` is an unnamed default inside the plugin.
- **`lib/connectors/video/openslop/models.ts`** hosted entries copy every field from the Runware table by hand (same for image). Aliasing changes dependency direction.
- **`lib/connectors/animated_image/plugins/still-frame.ts:29-39`** `VIDEO_ONLY_KEYS` names two of `clipPlaybackDefs`' five keys; deriving it from the schema changes what the still node carries.
- **`lib/connectors/types.ts:213-216`** `imageProvider`/`imageModel` are spelled here and in `STILL_MODEL`.
- **`lib/connectors/image/enums.ts:13-18`** `enum EffectType` where every sibling closed set is an `as const` array (two other enums exist, repo-wide call).
- **`lib/video/types.ts:57-64`** 1920x1080 lives in `DEFAULT_CONFIG`, `ASPECT_RATIO_DIMENSIONS["16:9"]` and `CAPTION_BASE_HEIGHT`; tying them changes what scale 1 means for portrait.
- **`lib/video/elementAttributes.ts:46-90`** `getVolume`/`getLoops`/`getDuration` read through `flatAttributes` while `getLoop`/`getMotion` read `layoutAttributes` directly.
- **`AttributeBadge.tsx:20-21` + `AttributeTrigger.tsx:21`** hand-roll the `Badge` pill tokens twice; wants a `Badge` size. (Flag #20 if-chain still standing.)
- **`lib/api/jobs.ts:93-94`** `omitBy` + empty-patch early return guard a case no caller produces; a transition union would define it away.
- **`lib/providers/music/elevenlabs.ts:32`** `params.model as "music_v1"` asserts what the catalog guarantees.
- Low: `lib/api/asset-bundle.ts:68` env default `""`, `snapshots.ts:134` `commit` returns its input for a test only, `app/page.tsx:14-17` module-scope readdir + logo strip in a route.

## Not taken on purpose

- `fitDurations.ts:86-88` empty-ops ternary: `registry.test.ts:465` throws if `editScript` is called with nothing to change, so the no-call contract is tested.
- `cartesia.ts:190` `limit || ranked.length` → `slice(0, limit)`: the route schema excludes 0 but the type does not.
- `components/ui/icon.tsx` export-list re-sort: churn only.
- `useAgentTools.ts:52-59` picture snapshot read: rewrite is no simpler.

## Checks

`npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run test:run` (178 files, 1612 tests) and `npm run build` all pass.

## Merge-conflict guard

```
PR #745: clean
OK: no file overlap or merge conflict with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
