### PR TITLE
refactor: rethink openslop architecture 2026-09-07

### DIFF
--- a/lib/api/__tests__/process-job.test.ts
+++ b/lib/api/__tests__/process-job.test.ts
@@ -64,16 +64,6 @@ describe("processQueuedJob", () => {
 		expect(mockUpdateJob).not.toHaveBeenCalled();
 	});
 
-	it("throws when no handler is registered for the connector type", async () => {
-		mockLoadJobForProcessing.mockResolvedValue(pendingJob());
-		mockGetJobHandler.mockReturnValue(undefined);
-
-		await expect(processQueuedJob(JOB_ID)).rejects.toThrow(
-			"No job handler registered for image",
-		);
-		expect(mockUpdateJob).not.toHaveBeenCalled();
-	});
-
 	it("marks the job processing then completed with the handler result", async () => {
 		const job = pendingJob();
 		mockLoadJobForProcessing.mockResolvedValue(job);

--- a/lib/api/asset-routes.ts
+++ b/lib/api/asset-routes.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import type { JobPoll } from "@/lib/gateway/base";
-import type { ConnectorType, ModelRef } from "@/lib/connectors/types";
-import { createJob, enqueueJob, getJob } from "./jobs";
+import type { ModelRef } from "@/lib/connectors/types";
+import { createJob, enqueueJob, getJob, type JobConnectorType } from "./jobs";
 import { bodySchema } from "./generation-schema";
 import { notFound } from "./response";
 import type { RouteFamily } from "./route-families";
@@ -10,7 +10,7 @@ import type { RouteFamily } from "./route-families";
 type AssetBody = ModelRef & { projectId?: string } & Record<string, unknown>;
 
 type AssetRoute<TModels> = {
-	connectorType: ConnectorType;
+	connectorType: JobConnectorType;
 	models: TModels;
 	fields: z.ZodRawShape;
 	label: string;

--- a/lib/api/job-handlers.ts
+++ b/lib/api/job-handlers.ts
@@ -1,7 +1,6 @@
 import type { BundleResponse } from "@/lib/api/asset-bundle";
 import { vendorParams, type VendorParams } from "@/lib/connectors/models";
 import type {
-	ConnectorType,
 	ImageGenerateParams,
 	ModelRef,
 	MusicGenerateParams,
@@ -9,13 +8,13 @@ import type {
 	TTSGenerateParams,
 } from "@/lib/connectors/types";
 import { videoHandler } from "./handlers/video";
-import type { JobRow } from "./jobs";
+import type { JobConnectorType, JobRow } from "./jobs";
 import type { ProviderType } from "@/lib/providers/types";
 import { providerForPick } from "./route-families";
 
 type JobRequest<TReq extends ModelRef = ModelRef> = {
 	user_id: string;
-	connector_type: ConnectorType;
+	connector_type: JobConnectorType;
 	request: TReq;
 };
 
@@ -56,7 +55,7 @@ function assetHandler<TReq extends ModelRef>(
 	};
 }
 
-const HANDLERS: Partial<Record<ConnectorType, JobHandler>> = {
+const HANDLERS: Record<JobConnectorType, JobHandler> = {
 	image: assetHandler<ImageGenerateParams & ModelRef>((job) =>
 		providerForJob("image", job),
 	),
@@ -72,6 +71,5 @@ const HANDLERS: Partial<Record<ConnectorType, JobHandler>> = {
 	video: videoHandler,
 };
 
-export function getJobHandler(type: ConnectorType): JobHandler | undefined {
-	return HANDLERS[type];
-}
+export const getJobHandler = (type: JobConnectorType): JobHandler =>
+	HANDLERS[type];

--- a/lib/api/jobs.ts
+++ b/lib/api/jobs.ts
@@ -6,18 +6,28 @@ import {
 	BundleResponseSchema,
 	type BundleResponse,
 } from "@/lib/api/asset-bundle";
-import { CONNECTOR_TYPES, type ConnectorType } from "@/lib/connectors/types";
 import { JOB_STATUSES, type JobStatus } from "@/lib/gateway/base";
 import { createClient } from "@/lib/supabase/server";
 import { createServiceClient } from "@/lib/supabase/service";
 
 const ASSET_QUEUE_TOPIC = "asset-generate";
 
+/** What an asset route queues. LLM turns stream, and an animated image reaches the worker as a video job. */
+export const JOB_CONNECTOR_TYPES = [
+	"image",
+	"music",
+	"sfx",
+	"tts",
+	"video",
+] as const;
+
+export type JobConnectorType = (typeof JOB_CONNECTOR_TYPES)[number];
+
 const JobRowSchema = z.object({
 	id: z.string(),
 	user_id: z.string(),
 	project_id: z.string().nullable(),
-	connector_type: z.enum(CONNECTOR_TYPES),
+	connector_type: z.enum(JOB_CONNECTOR_TYPES),
 	status: z.enum(JOB_STATUSES),
 	request: z.record(z.string(), z.unknown()),
 	result: BundleResponseSchema.nullable(),
@@ -31,13 +41,13 @@ export type JobRow = z.infer<typeof JobRowSchema>;
 
 export type AssetQueueMessage = {
 	jobId: string;
-	connectorType: ConnectorType;
+	connectorType: JobConnectorType;
 };
 
 export async function createJob(input: {
 	userId: string;
 	projectId?: string | null;
-	connectorType: ConnectorType;
+	connectorType: JobConnectorType;
 	request: Record<string, unknown>;
 }): Promise<{ id: string }> {
 	const supabase = createServiceClient();
@@ -99,7 +109,7 @@ export async function updateJob(
 
 export async function enqueueJob(
 	jobId: string,
-	connectorType: ConnectorType,
+	connectorType: JobConnectorType,
 	options?: { delaySeconds: number },
 ): Promise<void> {
 	const message: AssetQueueMessage = { jobId, connectorType };

--- a/lib/api/process-job.ts
+++ b/lib/api/process-job.ts
@@ -18,9 +18,6 @@ export async function processQueuedJob(jobId: string): Promise<void> {
 
 	const connectorType = job.connector_type;
 	const handler = getJobHandler(connectorType);
-	if (!handler) {
-		throw new Error(`No job handler registered for ${connectorType}`);
-	}
 
 	if (job.status !== "processing") {
 		await updateJob(jobId, { status: "processing" });


### PR DESCRIPTION
## App understanding

OpenSlop is a script-to-video editor. A project is a Slate script whose elements resolve into a generation graph; the client queues stale nodes and posts each to an asset route, which records a `jobs` row and enqueues it on the Vercel Queue. A worker picks the handler for the job's connector type, uploads the result, and the client polls. Video redelivers itself to poll the vendor. LLM turns stream over SSE instead of queueing, and an animated image reaches the worker as a video job.

## From-scratch architecture

Everything that can be a queued job says so in one place, and the row schema, the queue message, the asset routes and the handler map all read that one list. A job row that reaches the worker can only name a type the worker serves, so there is no "no handler registered" branch to write or test.

## Implemented

- `JOB_CONNECTOR_TYPES` / `JobConnectorType` in `lib/api/jobs.ts`: the five types an asset route queues (image, music, sfx, tts, video). `JobRowSchema.connector_type`, `AssetQueueMessage`, `createJob` and `enqueueJob` are typed on it, so a row with any other type is rejected at the parse boundary.
- `lib/api/job-handlers.ts`: `HANDLERS` is a total `Record<JobConnectorType, JobHandler>` and `getJobHandler` always returns a handler.
- `lib/api/process-job.ts`: the runtime "No job handler registered" throw is gone, along with its test.
- `lib/api/asset-routes.ts`: `AssetRoute.connectorType` is a `JobConnectorType`, so a route cannot queue an LLM or animated-image job.

No behavior change for any valid job. An invalid `connector_type` on a row now fails at `JobRowSchema.parse` instead of one line later in the worker.

## Validation

- `npm run lint` passed
- `npm run format:check` passed
- `npm run typecheck` passed
- `npm run knip` passed
- `npm run test:run`: 178 files, 1611 tests passed
- `npm run build` passed

## Merge-conflict guard

```
PR #746: clean
PR #745: clean
OK: no file overlap or merge conflict with any open PR
```

## Skipped

- Folding the hosted and BYOK vendor tables into one (`lib/api/providers/{openslop,byok}.ts`): trades a compile-time class reference for a runtime lookup for about ten lines; left as is.
- `AssetQueueMessage.connectorType` is never read by the callback, which re-reads the row on purpose. Kept as queue-payload context rather than dropped.
- Everything merged since #732 through #744 was audited clean by the maintainability pass this morning and was not re-read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
