### PR TITLE
fix: open the Export popover from the export toast's View control

### DIFF
--- a/app/components/video/RenderProvider.tsx
+++ b/app/components/video/RenderProvider.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+	type ReactNode,
+} from "react";
 import { toast } from "sonner";
 import { createRequiredContext } from "@/lib/components/createRequiredContext";
 import { ExportDoneToast, ExportProgressToast } from "./ExportToast";
@@ -24,7 +30,19 @@ const TOAST_OPTIONS = {
 
 export function RenderProvider({ children }: { children: ReactNode }) {
 	const { state, render, reset } = useRendering();
-	const [open, setOpen] = useState(false);
+	const [open, setOpenState] = useState(false);
+
+	// The toasts open the popover from inside sonner's list. Sonner returns focus
+	// to whatever had it before the toast as soon as focus leaves the list, and
+	// Radix reads that restored focus as a focus-outside and dismisses the popover
+	// it just opened. Dropping focus first lets the restore run while nothing is
+	// listening.
+	const setOpen = useCallback((next: boolean) => {
+		if (next && document.activeElement instanceof HTMLElement) {
+			document.activeElement.blur();
+		}
+		setOpenState(next);
+	}, []);
 
 	useEffect(() => {
 		if (open || state.status === "idle") {
@@ -63,7 +81,7 @@ export function RenderProvider({ children }: { children: ReactNode }) {
 			id: TOAST_ID,
 			position: "bottom-right",
 		});
-	}, [state, open]);
+	}, [state, open, setOpen]);
 
 	useEffect(() => {
 		return () => {
@@ -73,7 +91,7 @@ export function RenderProvider({ children }: { children: ReactNode }) {
 
 	const value = useMemo(
 		() => ({ state, render, reset, open, setOpen }),
-		[state, render, reset, open],
+		[state, render, reset, open, setOpen],
 	);
 	return <RenderContext value={value}>{children}</RenderContext>;
 }

--- a/app/components/video/RenderProvider.tsx
+++ b/app/components/video/RenderProvider.tsx
@@ -32,11 +32,8 @@ export function RenderProvider({ children }: { children: ReactNode }) {
 	const { state, render, reset } = useRendering();
 	const [open, setOpenState] = useState(false);
 
-	// The toasts open the popover from inside sonner's list. Sonner returns focus
-	// to whatever had it before the toast as soon as focus leaves the list, and
-	// Radix reads that restored focus as a focus-outside and dismisses the popover
-	// it just opened. Dropping focus first lets the restore run while nothing is
-	// listening.
+	// Sonner restores focus when it leaves the toast list, and Radix treats that
+	// as a focus-outside that dismisses the popover. Blur first so nothing listens.
 	const setOpen = useCallback((next: boolean) => {
 		if (next && document.activeElement instanceof HTMLElement) {
 			document.activeElement.blur();


### PR DESCRIPTION
## Summary

Clicking **View** on the in-progress export toast, or **Export ready** on the finished toast, did nothing: the popover opened and closed in the same interaction.

Root cause, confirmed by reading the sonner and Radix sources in `node_modules`:

1. Clicking View focuses the button inside sonner's toast list. Sonner's list `onFocus` records the previously focused element (typically the canvas editor).
2. `setOpen(true)` mounts the Radix popover, whose `FocusScope` auto-focuses its first control.
3. Focus leaving the toast list fires sonner's `onBlur`, which restores focus to the recorded element.
4. Radix's `DismissableLayer` sees a document `focusin` outside the popover, the non-modal popover's `onInteractOutside` does not exempt it (it is neither the trigger nor preceded by a pointer-down outside), and `onDismiss` sets `open` back to false.

The flow works only when the previously focused element was `body` or the Export trigger, which is why it looked intermittent.

## Fix

`RenderProvider` owns the popover's `open` state, so the fix lives there: `setOpen(true)` drops focus from the active element before flipping the state. Sonner's restore then runs while no popover is listening, and the popover's own auto-focus lands as normal. The toasts stay plain callers of `onView`, and any future caller of `setOpen(true)` gets the same behavior.

Alternatives considered and not taken:
- `onFocusOutside={(e) => e.preventDefault()}` on the popover content: one line, but focus then ends up back in the editor after the popover opens (sonner's restore still fires), and Tab-out no longer closes the popover.
- Making the popover modal: blocks the canvas while an export runs.

## Selected issue

#735, `size: S`, `priority: medium`, `bug`. Highest-priority non-newcomer S issue open tonight. Single-file change in a component with one owner of the state.

## Validation

- `npm run lint` — pass, 0 warnings
- `npm run format:check` — pass
- `npm run typecheck` — pass
- `npm run knip` — pass
- `npm run build` — pass
- `npm run test:coverage` — 178 files, 1612 tests pass, thresholds met
- `npm run test:e2e` — skipped (unchanged smoke surface, needs a browser install and Supabase env)

Not verified in a browser (repo rule: CI checks are the verification). There is no DOM test environment in this repo (no jsdom/happy-dom), so no focused test was added; the acceptance criteria depend on real browser focus semantics that jsdom would not model faithfully anyway.

## Merge-conflict guard

```
PR #747: clean
PR #746: clean
PR #745: clean
OK: no file overlap or merge conflict with any open PR
```

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)