### PR TITLE
feat: migrate TTS to Cartesia Sonic 3.6

### DIFF
--- a/app/components/canvas/__tests__/withLayout.test.ts
+++ b/app/components/canvas/__tests__/withLayout.test.ts
@@ -21,7 +21,7 @@ describe("withLayout", () => {
 	});
 
 	it("seeds it with the model the project speaks in", () => {
-		const pinned = { provider: "cartesia", model: "Sonic 3.5" } as const;
+		const pinned = { provider: "cartesia", model: "Sonic 3.6" } as const;
 		expect(flatAttributes(seeded({ tts: pinned }))).toMatchObject(pinned);
 	});
 });

--- a/lib/canvas/__tests__/createCanvasNode.test.ts
+++ b/lib/canvas/__tests__/createCanvasNode.test.ts
@@ -67,7 +67,7 @@ describe("createCanvasNode", () => {
 	});
 
 	it("gives speech a model of its own, like every other type", () => {
-		const pinned = { provider: "cartesia", model: "Sonic 3.5" } as const;
+		const pinned = { provider: "cartesia", model: "Sonic 3.6" } as const;
 		const node = createCanvasNode("narration", {
 			defaultModels: { tts: pinned },
 		});

--- a/lib/canvas/__tests__/elementConnector.test.ts
+++ b/lib/canvas/__tests__/elementConnector.test.ts
@@ -73,7 +73,7 @@ describe("resolveElementConnector for speech", () => {
 		store.getState().updateMetadata({ narration });
 		return store.getState();
 	};
-	const own = { provider: "cartesia", model: "Sonic 3.5" };
+	const own = { provider: "cartesia", model: "Sonic 3.6" };
 
 	it("speaks with the pair its voice picked, over its own", () => {
 		expect(

--- a/lib/connectors/__tests__/metadata-voice.test.ts
+++ b/lib/connectors/__tests__/metadata-voice.test.ts
@@ -66,7 +66,7 @@ describe("createMetadataVoicePlugin", () => {
 			narration: {
 				gender: "feminine",
 				provider: "cartesia",
-				model: "Sonic 3.5",
+				model: "Sonic 3.6",
 			},
 		});
 		const { beforeGenerate } = createMetadataVoicePlugin();
@@ -107,7 +107,7 @@ describe("createMetadataVoicePlugin", () => {
 		store.getState().updateMetadata({
 			narration: {
 				provider: "cartesia",
-				model: "Sonic 3.5",
+				model: "Sonic 3.6",
 				gender: "feminine",
 				voiceId: "v-cartesia",
 				resolvedVoiceId: "v-cartesia",
@@ -213,7 +213,7 @@ describe("createMetadataVoicePlugin", () => {
 	});
 
 	describe("the model speech speaks with", () => {
-		const cartesia = { provider: "cartesia", model: "Sonic 3.5" } as const;
+		const cartesia = { provider: "cartesia", model: "Sonic 3.6" } as const;
 		const narration = (
 			attrs: Record<string, string>,
 		): CanvasContentElement => ({

--- a/lib/connectors/tts/cartesia/models.ts
+++ b/lib/connectors/tts/cartesia/models.ts
@@ -1,3 +1,3 @@
 export const CARTESIA_TTS_MODELS = {
-	"Sonic 3.5": { id: "sonic-3.5", cost: "low", speed: "high" },
+	"Sonic 3.6": { id: "sonic-3.6", cost: "low", speed: "high" },
 } as const;

--- a/lib/connectors/tts/openslop/models.ts
+++ b/lib/connectors/tts/openslop/models.ts
@@ -1,3 +1,3 @@
 export const OPENSLOP_TTS_MODELS = {
-	"Slop TTS v1": { id: "sonic-3.5", cost: "low", speed: "high" },
+	"Slop TTS v1": { id: "sonic-3.6", cost: "low", speed: "high" },
 } as const;

--- a/lib/gateway/__tests__/http-gateways.test.ts
+++ b/lib/gateway/__tests__/http-gateways.test.ts
@@ -22,7 +22,7 @@ const HOSTED_IMAGE = { provider: "openslop", model: "Slop Image v1" } as const;
 const BYOK_IMAGE = { provider: "runware", model: "Seedream 5 Lite" } as const;
 const HOSTED_VIDEO = { provider: "openslop", model: "Slop Video v1" } as const;
 const HOSTED_TTS = { provider: "openslop", model: "Slop TTS v1" } as const;
-const BYOK_TTS = { provider: "cartesia", model: "Sonic 3.5" } as const;
+const BYOK_TTS = { provider: "cartesia", model: "Sonic 3.6" } as const;
 const HOSTED_LLM = { provider: "openslop", model: "Slop LLM v1" } as const;
 const BYOK_LLM = { provider: "anthropic", model: "Claude Sonnet 5" } as const;
 
@@ -109,7 +109,7 @@ describe("HTTP gateways", () => {
 			expect(preview.pathname).toBe("/api/third-party/tts/voices/preview");
 			expect(preview.searchParams.get("url")).toBe("https://vendor/a.mp3");
 			expect(preview.searchParams.get("provider")).toBe("cartesia");
-			expect(preview.searchParams.get("model")).toBe("Sonic 3.5");
+			expect(preview.searchParams.get("model")).toBe("Sonic 3.6");
 			expect(bob?.previewUrl).toBeUndefined();
 		});
 
@@ -125,7 +125,7 @@ describe("HTTP gateways", () => {
 			const url = new URL(fetchMock.mock.calls[0][0] as string);
 			expect(url.pathname).toBe("/api/third-party/tts/voices");
 			expect(url.searchParams.get("provider")).toBe("cartesia");
-			expect(url.searchParams.get("model")).toBe("Sonic 3.5");
+			expect(url.searchParams.get("model")).toBe("Sonic 3.6");
 			expect(url.searchParams.has("query")).toBe(false);
 		});
 	});

--- a/lib/providers/__tests__/cartesia-tts.test.ts
+++ b/lib/providers/__tests__/cartesia-tts.test.ts
@@ -199,7 +199,7 @@ describe("pcmDurationSec", () => {
 	});
 });
 
-const MODEL = "sonic-3.5";
+const MODEL = "sonic-3.6";
 
 describe("CartesiaTTS", () => {
 	beforeEach(() => {


### PR DESCRIPTION
## Summary
- Repoint the BYOK Cartesia catalog entry and the hosted `Slop TTS v1` entry from `sonic-3.5` to `sonic-3.6` (renamed the catalog key `Sonic 3.5` → `Sonic 3.6`).
- Update test fixtures that named the old model.

## Why no further action is required
Per Cartesia's [Sonic 3.6 announcement](https://www.cartesia.ai/blog/sonic-3.6), [TTS models docs](https://docs.cartesia.ai/build-with-cartesia/models/tts) and [2026 changelog](https://docs.cartesia.ai/changelog/2026):
- Sonic 3.6 is fully backwards compatible with Sonic 3.5: same request shape, no parameter changes, no SDK bump needed (`@cartesia/cartesia-js` only passes `model_id` through).
- Voice IDs and instant/professional voice clones carry over unchanged.
- The only migration step is repointing `model_id`, which this PR does.
- Sonic 3.6 has been GA since 2026-08-27. The October 20 sunset only affects `sonic-3`, `sonic-turbo` and `sonic-3-2025-10-27`, none of which we use.

## Compatibility
Elements, projects or accounts that pinned `Sonic 3.5` no longer match the catalog, so `resolveModel` falls back to the default (`Slop TTS v1`, now also on 3.6). No throw path is reachable.

## Checks
lint, format, typecheck, knip, vitest (1611 passed), build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4XtDupUvvYfhRFeZY85EL