### PR TITLE
refactor: nightly maintainability 2026-09-08

### DIFF
--- a/app/components/canvas/elements/CharactersPicker.tsx
+++ b/app/components/canvas/elements/CharactersPicker.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { UserPlus } from "@/components/ui/icon";
-import { Editor } from "slate";
 import { useSlateStatic } from "slate-react";
 import {
 	DropdownMenu,
@@ -10,11 +9,11 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { SelectMenuItem } from "@/components/ui/select-menu";
 import { SimpleTooltip } from "@/components/ui/tooltip";
+import { getElementCharacterNames } from "@/lib/canvas/characterNames";
 import {
-	CHARACTERS_ATTR,
-	getElementCharacterNames,
-} from "@/lib/canvas/characterNames";
-import { updateElementAttrs } from "@/app/components/canvas/utils/nodeOps";
+	setCharacterName,
+	toggleCharacter,
+} from "@/app/components/canvas/utils/characterOps";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { useProject } from "@/lib/project/useProject";
 import { useShallow } from "zustand/react/shallow";
@@ -23,47 +22,6 @@ import { CharacterPill } from "./CharacterPill";
 
 function useProjectCharacterNames(): string[] {
 	return useProject(useShallow((s) => Object.keys(s.metadata.characters)));
-}
-
-function writeCharacters(
-	editor: Editor,
-	element: CanvasContentElement,
-	names: string[],
-): void {
-	const joined = names.join(", ");
-	updateElementAttrs(editor, element, { [CHARACTERS_ATTR]: joined || null });
-}
-
-export function toggleCharacter(
-	editor: Editor,
-	element: CanvasContentElement,
-	name: string,
-): void {
-	const current = getElementCharacterNames(element);
-	const next = current.includes(name)
-		? current.filter((n) => n !== name)
-		: [...current, name];
-	writeCharacters(editor, element, next);
-}
-
-export function removeCharacter(
-	editor: Editor,
-	element: CanvasContentElement,
-	name: string,
-): void {
-	writeCharacters(
-		editor,
-		element,
-		getElementCharacterNames(element).filter((n) => n !== name),
-	);
-}
-
-function setCharacterName(
-	editor: Editor,
-	element: CanvasContentElement,
-	name: string,
-): void {
-	updateElementAttrs(editor, element, { name });
 }
 
 /** Dropdown listing the project's characters with checkmarks for selected ones. */

--- a/app/components/canvas/elements/ElementCharacters.tsx
+++ b/app/components/canvas/elements/ElementCharacters.tsx
@@ -4,11 +4,8 @@ import { useSlateStatic } from "slate-react";
 import { getElementCharacterNames } from "@/lib/canvas/characterNames";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { CharacterPill } from "./CharacterPill";
-import {
-	CharacterSwitcher,
-	CharactersPicker,
-	removeCharacter,
-} from "./CharactersPicker";
+import { removeCharacter } from "@/app/components/canvas/utils/characterOps";
+import { CharacterSwitcher, CharactersPicker } from "./CharactersPicker";
 
 export function ElementCharacters({
 	element,

--- a/app/components/canvas/elements/character/AssetEditProvider.tsx
+++ b/app/components/canvas/elements/character/AssetEditProvider.tsx
@@ -15,6 +15,13 @@ type AssetEditors = {
 	openArtStyle: () => void;
 };
 
+/** The one asset dialog open at a time, so two can never stack. */
+type AssetEdit =
+	| { kind: "create" }
+	| { kind: "character"; name: string }
+	| { kind: "narrator" }
+	| { kind: "style" };
+
 const [AssetEditContext, useAssetEditors] =
 	createRequiredContext<AssetEditors>("AssetEditProvider");
 export { useAssetEditors };
@@ -24,17 +31,18 @@ export { useAssetEditors };
  * than each view wiring the same four openers down to the tiles that use them.
  */
 export function AssetEditProvider({ children }: { children: ReactNode }) {
-	const [creating, setCreating] = useState(false);
-	const [editingName, setEditingName] = useState<string | undefined>();
-	const [editingNarrator, setEditingNarrator] = useState(false);
-	const [editingArtStyle, setEditingArtStyle] = useState(false);
+	const [editing, setEditing] = useState<AssetEdit | null>(null);
+	const onOpenChange = (open: boolean) => {
+		if (!open) setEditing(null);
+	};
+	const character = editing?.kind === "character" ? editing : undefined;
 
 	const editors = useMemo<AssetEditors>(
 		() => ({
-			openCreateCharacter: () => setCreating(true),
-			editCharacter: (name) => setEditingName(name),
-			openNarrator: () => setEditingNarrator(true),
-			openArtStyle: () => setEditingArtStyle(true),
+			openCreateCharacter: () => setEditing({ kind: "create" }),
+			editCharacter: (name) => setEditing({ kind: "character", name }),
+			openNarrator: () => setEditing({ kind: "narrator" }),
+			openArtStyle: () => setEditing({ kind: "style" }),
 		}),
 		[],
 	);
@@ -43,23 +51,23 @@ export function AssetEditProvider({ children }: { children: ReactNode }) {
 		<AssetEditContext value={editors}>
 			{children}
 			<NewCharacterDialog
-				open={creating}
-				onOpenChange={setCreating}
-				onCreated={(name) => {
-					setCreating(false);
-					setEditingName(name);
-				}}
+				open={editing?.kind === "create"}
+				onOpenChange={onOpenChange}
+				onCreated={editors.editCharacter}
 			/>
 			<CharacterEditModal
-				open={editingName !== undefined}
-				onOpenChange={(open) => !open && setEditingName(undefined)}
-				name={editingName}
+				open={character !== undefined}
+				onOpenChange={onOpenChange}
+				name={character?.name}
 			/>
 			<NarratorEditModal
-				open={editingNarrator}
-				onOpenChange={setEditingNarrator}
+				open={editing?.kind === "narrator"}
+				onOpenChange={onOpenChange}
 			/>
-			<ArtStyleModal open={editingArtStyle} onOpenChange={setEditingArtStyle} />
+			<ArtStyleModal
+				open={editing?.kind === "style"}
+				onOpenChange={onOpenChange}
+			/>
 		</AssetEditContext>
 	);
 }

--- a/app/components/canvas/utils/characterOps.ts
+++ b/app/components/canvas/utils/characterOps.ts
@@ -1,0 +1,52 @@
+import type { Editor } from "slate";
+import without from "lodash/without";
+import xor from "lodash/xor";
+import {
+	CHARACTERS_ATTR,
+	formatCharacterNames,
+	getElementCharacterNames,
+} from "@/lib/canvas/characterNames";
+import type { CanvasContentElement } from "@/lib/canvas/types";
+import { updateElementAttrs } from "./nodeOps";
+
+function writeCharacters(
+	editor: Editor,
+	element: CanvasContentElement,
+	names: string[],
+): void {
+	updateElementAttrs(editor, element, {
+		[CHARACTERS_ATTR]: formatCharacterNames(names),
+	});
+}
+
+export function toggleCharacter(
+	editor: Editor,
+	element: CanvasContentElement,
+	name: string,
+): void {
+	writeCharacters(
+		editor,
+		element,
+		xor(getElementCharacterNames(element), [name]),
+	);
+}
+
+export function removeCharacter(
+	editor: Editor,
+	element: CanvasContentElement,
+	name: string,
+): void {
+	writeCharacters(
+		editor,
+		element,
+		without(getElementCharacterNames(element), name),
+	);
+}
+
+export function setCharacterName(
+	editor: Editor,
+	element: CanvasContentElement,
+	name: string,
+): void {
+	updateElementAttrs(editor, element, { name });
+}

--- a/lib/api/error-envelope.ts
+++ b/lib/api/error-envelope.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+/** The body every internal route answers a failure with. */
+export const ApiErrorEnvelope = z.object({ error: z.string().min(1) });
+export type ApiErrorEnvelope = z.infer<typeof ApiErrorEnvelope>;

--- a/lib/api/response.ts
+++ b/lib/api/response.ts
@@ -1,27 +1,30 @@
 import { NextResponse } from "next/server";
+import type { ApiErrorEnvelope } from "./error-envelope";
+
+function errorResponse(error: string, status: number) {
+	const body: ApiErrorEnvelope = { error };
+	return NextResponse.json(body, { status });
+}
 
 export function badRequest(message: string) {
-	return NextResponse.json({ error: message }, { status: 400 });
+	return errorResponse(message, 400);
 }
 
 export function notFound() {
-	return NextResponse.json({ error: "Not found" }, { status: 404 });
+	return errorResponse("Not found", 404);
 }
 
 export function serverError(message: string) {
-	return NextResponse.json({ error: message }, { status: 500 });
+	return errorResponse(message, 500);
 }
 
 export function unauthorized() {
-	return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	return errorResponse("Unauthorized", 401);
 }
 
 export function forbidden() {
-	return NextResponse.json(
-		{
-			error:
-				"Forbidden, your API access has been revoked. Please contact hi@openslop.ai or post on our Discord server for help.",
-		},
-		{ status: 403 },
+	return errorResponse(
+		"Forbidden, your API access has been revoked. Please contact hi@openslop.ai or post on our Discord server for help.",
+		403,
 	);
 }

--- a/lib/canvas/__tests__/characterNames.test.ts
+++ b/lib/canvas/__tests__/characterNames.test.ts
@@ -4,6 +4,7 @@ import type {
 	CanvasElementType,
 } from "@/lib/canvas/types";
 import {
+	formatCharacterNames,
 	getElementCharacterNames,
 	parseCharacterNames,
 } from "../characterNames";
@@ -22,6 +23,19 @@ describe("parseCharacterNames", () => {
 		expect(parseCharacterNames(undefined)).toEqual([]);
 		expect(parseCharacterNames("")).toEqual([]);
 		expect(parseCharacterNames("  ,  ")).toEqual([]);
+	});
+});
+
+describe("formatCharacterNames", () => {
+	it("round-trips through parseCharacterNames", () => {
+		const names = ["Alice", "Bob"];
+		expect(parseCharacterNames(formatCharacterNames(names) ?? "")).toEqual(
+			names,
+		);
+	});
+
+	it("clears the attribute for an empty list", () => {
+		expect(formatCharacterNames([])).toBeNull();
 	});
 });
 

--- a/lib/canvas/characterNames.ts
+++ b/lib/canvas/characterNames.ts
@@ -15,6 +15,11 @@ export function parseCharacterNames(value: string | undefined): string[] {
 		.filter(Boolean);
 }
 
+/** Inverse of `parseCharacterNames`; an empty list clears the attribute. */
+export function formatCharacterNames(names: string[]): string | null {
+	return names.join(", ") || null;
+}
+
 const CHARACTER_NAME_EXTRACTORS: Record<string, (value: string) => string[]> = {
 	name: (v) => [v.trim()],
 	[CHARACTERS_ATTR]: parseCharacterNames,

--- a/lib/clients/http.ts
+++ b/lib/clients/http.ts
@@ -1,6 +1,7 @@
 import isUndefined from "lodash/isUndefined";
 import mapValues from "lodash/mapValues";
 import omitBy from "lodash/omitBy";
+import { ApiErrorEnvelope } from "@/lib/api/error-envelope";
 
 export type QueryParams = Record<string, string | number | undefined>;
 
@@ -11,17 +12,12 @@ type RequestOptions = {
 	signal?: AbortSignal;
 };
 
-/** Every internal route answers failures with `{ error }` (see `lib/api/response.ts`). */
 async function readErrorMessage(res: Response): Promise<string> {
-	const fallback = `${res.status} ${res.statusText}`;
-	const detail = await res.json().then(
-		(body: unknown) =>
-			typeof body === "object" && body !== null && "error" in body
-				? body.error
-				: undefined,
-		() => undefined,
+	const body: unknown = await res.json().catch(() => undefined);
+	return (
+		ApiErrorEnvelope.safeParse(body).data?.error ??
+		`${res.status} ${res.statusText}`
 	);
-	return (typeof detail === "string" && detail) || fallback;
 }
 
 function buildInit(method: string, body: unknown): RequestInit {

--- a/lib/connectors/plugins.ts
+++ b/lib/connectors/plugins.ts
@@ -19,46 +19,47 @@ export function requireModel<P, R>(
 	return ctx.model;
 }
 
-export async function runBeforeGenerate<T>(
+type TransformHook = "beforeGenerate" | "afterGenerate" | "transformPrompt";
+
+/** Threads a value through every plugin that implements the hook, in order. */
+async function fold<T>(
+	plugins: ConnectorPlugin[],
+	hook: TransformHook,
+	value: T,
+	ctx: PluginContext,
+): Promise<T> {
+	let current = value;
+	for (const plugin of plugins) {
+		const step = plugin[hook] as
+			| ((value: T, ctx: PluginContext) => T | Promise<T>)
+			| undefined;
+		if (step) current = await step(current, ctx);
+	}
+	return current;
+}
+
+export function runBeforeGenerate<T>(
 	plugins: ConnectorPlugin[],
 	params: T,
 	ctx: PluginContext,
 ): Promise<T> {
-	let result = params;
-	for (const plugin of plugins) {
-		if (plugin.beforeGenerate) {
-			result = (await plugin.beforeGenerate(result, ctx)) as T;
-		}
-	}
-	return result;
+	return fold(plugins, "beforeGenerate", params, ctx);
 }
 
-export async function runAfterGenerate<T>(
+export function runAfterGenerate<T>(
 	plugins: ConnectorPlugin[],
 	result: T,
 	ctx: PluginContext,
 ): Promise<T> {
-	let current = result;
-	for (const plugin of plugins) {
-		if (plugin.afterGenerate) {
-			current = (await plugin.afterGenerate(current, ctx)) as T;
-		}
-	}
-	return current;
+	return fold(plugins, "afterGenerate", result, ctx);
 }
 
-export async function runTransformPrompt(
+export function runTransformPrompt(
 	plugins: ConnectorPlugin[],
 	prompt: string,
 	ctx: PluginContext,
 ): Promise<string> {
-	let current = prompt;
-	for (const plugin of plugins) {
-		if (plugin.transformPrompt) {
-			current = await plugin.transformPrompt(current, ctx);
-		}
-	}
-	return current;
+	return fold(plugins, "transformPrompt", prompt, ctx);
 }
 
 export async function runOnError(


### PR DESCRIPTION
## Summary
- `lib/api/error-envelope.ts` declares the `{ error }` body every route answers failures with; `lib/api/response.ts` builds through it and `lib/clients/http.ts` parses it with `safeParse` instead of hand-rolled typeof checks.
- `lib/connectors/plugins.ts`: the three identical hook folds (`runBeforeGenerate`, `runAfterGenerate`, `runTransformPrompt`) share one private `fold` with a single boundary cast. Exported names and call sites unchanged.
- `AssetEditProvider`: four dialog flags become one `AssetEdit | null` union, so two asset dialogs can never be open at once by construction. The `AssetEditors` interface is unchanged.
- Character attribute writes move out of `CharactersPicker.tsx` into `app/components/canvas/utils/characterOps.ts` (lodash `xor`/`without`), and the comma-join for the `characters` attribute lands in `lib/canvas/characterNames.ts` as `formatCharacterNames`, the inverse of the existing parser, with a round-trip test.

No behavior change.

## Skipped (for a human call)
- `lib/providers/video/runware.ts` casts the vendor status to `VideoJobStatus` (`queued|processing|completed|failed`) but the Runware SDK compares against `"success"`, `"ready"` and `"error"`. The `status === "failed"` branch in `lib/api/handlers/video.ts` may never fire. Making the parse fail loudly would break live generation until the real vocabulary is confirmed, so it was left alone.
- `VOLUME_OPTIONS` (0-10) and `LOOPS_OPTIONS` (1-8) in `lib/connectors/attributes/common.ts` vs `VOLUME_MAX`/`LOOPS_MAX` (10 / 1000) in `lib/video/elementAttributes.ts`: loops disagree, so unifying is a behavior decision.
- Voice trait field lists are declared in four places (`lib/project/types.ts`, `lib/agent/tools/inputs.ts`, `lib/connectors/tts/plugins/voice-search.ts`, `lib/providers/tts/voiceSimilarity.ts`); deriving them from `voiceTraitsSchema` changes `.catch` semantics on the agent tool input.
- `AttributeBadge` type-switch to registry: TypeScript already narrows the enum branch, so the "silent fallthrough" cost is not real; left as is.
- `runScript` + `clearEditor` ordering in `useAgentTools.ts`, and a `useVoiceSearch` hook extraction from `VoicePicker`: real seams, deferred to keep this PR coherent.

## Merge-conflict guard
```
OK: no file overlap or merge conflict with any open PR
```

## Test plan
- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run knip`
- [x] `npm run build`
- [x] `npm run test:run` (178 files, 1613 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)