### PR TITLE
refactor: nightly conventions follow-up 2026-09-08, onboarding and generation-status UI

### DIFF
--- a/app/components/AccessCodeInput.tsx
+++ b/app/components/AccessCodeInput.tsx
@@ -4,7 +4,9 @@ import { useRef, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { apiJson } from "@/lib/clients/http";
 import { errorMessage } from "@/lib/errors";
+import { Button } from "@/components/ui/button";
 import {
+	ACCESS_CODE_LENGTH,
 	type CodeEntry,
 	emptyAccessCode,
 	eraseBefore,
@@ -12,6 +14,8 @@ import {
 	pasteCode,
 	typeChar,
 } from "@/lib/auth/accessCode";
+
+const INCOMPLETE_CODE = `Enter all ${ACCESS_CODE_LENGTH} characters of your access code`;
 
 export default function AccessCodeInput() {
 	const router = useRouter();
@@ -78,47 +82,70 @@ export default function AccessCodeInput() {
 		apply(entry);
 	};
 
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		if (!isComplete(values)) {
+			setError(INCOMPLETE_CODE);
+			return;
+		}
+		submitCode(values.join(""));
+	};
+
 	return (
-		<div>
-			<div className="flex gap-2 justify-center">
-				{values.map((val, i) => (
-					<input
-						key={i}
-						ref={(el) => {
-							inputRefs.current[i] = el;
-						}}
-						type="text"
-						inputMode="text"
-						maxLength={1}
-						value={val}
-						onChange={(e) => handleChange(i, e.target.value)}
-						onKeyDown={(e) => handleKeyDown(i, e)}
-						onPaste={i === 0 ? handlePaste : undefined}
-						disabled={loading}
-						aria-label={`Code character ${i + 1}`}
-						spellCheck={false}
-						autoComplete="off"
-						className="h-11 w-9 rounded-md border border-border bg-input text-center text-body-lg font-semibold text-foreground outline-none transition-[border-color,box-shadow,opacity] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50 sm:h-13 sm:w-11 sm:rounded-lg sm:text-heading-sm"
-						autoFocus={i === 0}
-					/>
-				))}
+		<form
+			onSubmit={handleSubmit}
+			className="flex w-full flex-col gap-4 sm:gap-6"
+		>
+			<div>
+				<div className="flex gap-2 justify-center">
+					{values.map((val, i) => (
+						<input
+							key={i}
+							ref={(el) => {
+								inputRefs.current[i] = el;
+							}}
+							type="text"
+							inputMode="text"
+							maxLength={1}
+							value={val}
+							onChange={(e) => handleChange(i, e.target.value)}
+							onKeyDown={(e) => handleKeyDown(i, e)}
+							onPaste={i === 0 ? handlePaste : undefined}
+							disabled={loading}
+							aria-label={`Code character ${i + 1}`}
+							spellCheck={false}
+							autoComplete="off"
+							className="h-11 w-9 rounded-md border border-border bg-input text-center text-body-lg font-semibold text-foreground outline-none transition-[border-color,box-shadow,opacity] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50 sm:h-13 sm:w-11 sm:rounded-lg sm:text-heading-sm"
+							autoFocus={i === 0}
+						/>
+					))}
+				</div>
+				{error && (
+					<p
+						aria-live="polite"
+						className="mt-3 text-center text-body text-destructive"
+					>
+						{error}
+					</p>
+				)}
+				{loading && (
+					<p
+						aria-live="polite"
+						className="mt-3 text-center text-body text-muted-foreground"
+					>
+						Validating&hellip;
+					</p>
+				)}
 			</div>
-			{error && (
-				<p
-					aria-live="polite"
-					className="mt-3 text-center text-body text-destructive"
-				>
-					{error}
-				</p>
-			)}
-			{loading && (
-				<p
-					aria-live="polite"
-					className="mt-3 text-center text-body text-muted-foreground"
-				>
-					Validating&hellip;
-				</p>
-			)}
-		</div>
+			<Button
+				type="submit"
+				variant="accent"
+				size="cta"
+				disabled={loading}
+				className="mt-2 w-full"
+			>
+				Get Started
+			</Button>
+		</form>
 	);
 }

--- a/app/components/__tests__/AccessCodeInput.test.tsx
+++ b/app/components/__tests__/AccessCodeInput.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import AccessCodeInput from "../AccessCodeInput";
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: vi.fn() }),
+}));
+
+describe("AccessCodeInput", () => {
+	it("submits the code through a form owned by the Get Started button", () => {
+		const html = renderToStaticMarkup(<AccessCodeInput />);
+		expect(html).toMatch(/^<form/);
+		expect(html).toContain('aria-label="Code character 6"');
+		expect(html).toMatch(
+			/<button[^>]*type="submit"[^>]*>Get Started<\/button>/,
+		);
+	});
+});

--- a/app/components/canvas/elements/GenerationIndicator.tsx
+++ b/app/components/canvas/elements/GenerationIndicator.tsx
@@ -47,19 +47,17 @@ export function GenerationIndicator({
 
 	return (
 		<SimpleTooltip label={label}>
-			<button
-				type="button"
+			<span
+				role="status"
 				aria-label={label}
 				className={cn(
-					"relative flex items-center justify-center rounded-full overflow-hidden text-foreground",
+					"relative flex items-center justify-center rounded-full overflow-hidden text-on-media-foreground transition-[opacity,background-color]",
 					sizes.wrapper,
 					className,
-					"transition-[opacity,background-color] disabled:cursor-not-allowed",
 				)}
-				disabled
 			>
 				<Icon className={cn(sizes.icon, animation)} />
-			</button>
+			</span>
 		</SimpleTooltip>
 	);
 }

--- a/app/components/canvas/elements/__tests__/GenerationIndicator.test.tsx
+++ b/app/components/canvas/elements/__tests__/GenerationIndicator.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { GenerationIndicator } from "../GenerationIndicator";
+
+const render = (node: React.ReactNode) =>
+	renderToStaticMarkup(<TooltipProvider>{node}</TooltipProvider>);
+
+describe("GenerationIndicator", () => {
+	it("is a named status marker, not a disabled button", () => {
+		const html = render(
+			<GenerationIndicator status="generating" seconds={3} />,
+		);
+		expect(html).toContain('role="status"');
+		expect(html).toContain('aria-label="Generating 3s"');
+		expect(html).not.toContain("<button");
+		expect(html).not.toContain("disabled");
+	});
+
+	it("pairs the media scrim with the on-media foreground", () => {
+		const html = render(<GenerationIndicator status="queued" size="sm" />);
+		expect(html).toContain("bg-on-media/55");
+		expect(html).toContain("text-on-media-foreground");
+		expect(html).not.toContain("text-foreground");
+	});
+});

--- a/app/components/video/PlayPauseFlash.tsx
+++ b/app/components/video/PlayPauseFlash.tsx
@@ -12,7 +12,7 @@ export function PlayPauseFlash({
 		<div className="pointer-events-none absolute inset-0 grid place-items-center">
 			<span
 				key={flash.key}
-				className="grid h-20 w-20 place-items-center rounded-full bg-on-media/55 text-foreground animate-[flashFade_500ms_ease-out_forwards]"
+				className="grid h-20 w-20 place-items-center rounded-full bg-on-media/55 text-on-media-foreground animate-[flashFade_500ms_ease-out_forwards]"
 			>
 				{flash.playing ? (
 					<Play className="h-7 w-7 fill-current" />

--- a/app/components/video/__tests__/PlayPauseFlash.test.tsx
+++ b/app/components/video/__tests__/PlayPauseFlash.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { PlayPauseFlash } from "../PlayPauseFlash";
+
+describe("PlayPauseFlash", () => {
+	it("pairs the media scrim with the on-media foreground", () => {
+		const html = renderToStaticMarkup(
+			<PlayPauseFlash flash={{ key: 1, playing: true }} />,
+		);
+		expect(html).toContain("bg-on-media/55");
+		expect(html).toContain("text-on-media-foreground");
+		expect(html).not.toContain("text-foreground");
+	});
+
+	it("renders nothing without a flash", () => {
+		expect(renderToStaticMarkup(<PlayPauseFlash flash={null} />)).toBe("");
+	});
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,6 @@ import OnboardingCard from "./components/OnboardingCard";
 import { AuthFooterLink } from "./components/AuthFooterLink";
 import AccessCodeInput from "./components/AccessCodeInput";
 import ProjectsList from "./components/projects/ProjectsList";
-import { Button } from "@/components/ui/button";
 import { listProviderKeys } from "@/lib/api/providerKeys";
 import { PROJECT_ROW_COLUMNS, ProjectRowSchema } from "@/lib/project/api";
 import { UserProvider } from "@/lib/user/UserProvider";
@@ -71,10 +70,6 @@ export default async function Home() {
 			</p>
 
 			<AccessCodeInput />
-
-			<Button type="button" variant="accent" size="cta" className="mt-2 w-full">
-				Get Started
-			</Button>
 		</OnboardingCard>
 	);
 }


### PR DESCRIPTION
Nightly conventions follow-up. Works the design-level flags the sweep could not apply. Theme: user-facing UI defects flagged in #746 (a no-op CTA, a tooltip that cannot open, and two scrims with the wrong foreground).

## Behavior changes
- `app/components/AccessCodeInput.tsx` + `app/page.tsx`: the "Get Started" button was a `type="button"` with no handler outside any form → `AccessCodeInput` now renders a `<form>` and owns the button as `type="submit"`, disabled while validating. Submitting with a complete code validates it (same path as the existing auto-submit on the sixth character); submitting with an incomplete code shows "Enter all 6 characters of your access code" in the existing error slot. Pressing Enter in a code box now submits too. Why: flag 746a (user-validated), CONVENTIONS.md "a button that submits lives in a `<form>` or has a handler". Tests: `app/components/__tests__/AccessCodeInput.test.tsx` pins the form and the submit button; `e2e/onboarding.spec.ts` still finds the button by name.
- `app/components/canvas/elements/GenerationIndicator.tsx`: `<button disabled>` → `<span role="status">` with the same accessible name. `disabled` suppresses pointer events in Firefox/Safari so the "Generating 12s" tooltip never opened there; the one-off `disabled:cursor-not-allowed` goes with it. Why: flag 746b (user-validated), DESIGN.md "unavailable controls" and "interactive-looking non-interactive elements become semantic". Tests: `GenerationIndicator.test.tsx`.
- `GenerationIndicator.tsx` + `app/components/video/PlayPauseFlash.tsx`: `bg-on-media/55` was paired with `text-foreground`, which is near-black in light theme on a black scrim → `text-on-media-foreground`. Why: flag 746c (user-validated), DESIGN.md scrim rule. Tests: `GenerationIndicator.test.tsx`, `PlayPauseFlash.test.tsx`.

## Contract changes
- `AccessCodeInput` now renders the CTA itself; `app/page.tsx` no longer places a separate button (1 caller).

## Flags resolved
- 746a from #746: Get Started button is a no-op.
- 746b from #746: GenerationIndicator status marker is a disabled button.
- 746c from #746: `bg-on-media/55` paired with `text-foreground` in GenerationIndicator and PlayPauseFlash.

## Skipped tonight
- 746k (`requireContext` collapse): blocked by PR #754, which changes `lib/connectors/plugins.ts`.
- 746d/e/f (Cartesia TTS contract), 746g/h (video poll `failed` variant), 746i-746v: open, different subsystems; next batches. Kept out to keep this PR one idea.

## Checks
lint, typecheck, format:check, test:run (181 files, 1616 tests), build: all pass.

## Merge-conflict guard
```
PR #754: clean
OK: no file overlap or merge conflict with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)