### PR TITLE
refactor: nightly conventions sweep 2026-09-08, JobRequest derived from JobRow in the post-#746 delta

### DIFF
--- a/lib/api/job-handlers.ts
+++ b/lib/api/job-handlers.ts
@@ -12,11 +12,10 @@ import type { JobConnectorType, JobRow } from "./jobs";
 import type { ProviderType } from "@/lib/providers/types";
 import { providerForPick } from "./route-families";
 
-type JobRequest<TReq extends ModelRef = ModelRef> = {
-	user_id: string;
-	connector_type: JobConnectorType;
-	request: TReq;
-};
+type JobRequest<TReq extends ModelRef = ModelRef> = Pick<
+	JobRow,
+	"user_id" | "connector_type"
+> & { request: TReq };
 
 export const providerForJob = <K extends ProviderType>(
 	type: K,


### PR DESCRIPTION
Nightly CONVENTIONS.md sweep over everything merged after #746 (#745, #747, #748, #749, #750, #751, #752). None of those files overlap the two open PRs (#754, #755), so the whole delta was in scope. Ten non-test source files plus eight tests read in full; the icon CSS split (#749) is pure data.

## Auto-fixed (no behavior change)

- `lib/api/job-handlers.ts:15-19` `JobRequest` re-spelled `user_id` and `connector_type` from `JobRow`. It is now `Pick<JobRow, "user_id" | "connector_type"> & { request: TReq }`, so the job row shape has one home (DRY is about knowledge).

## Flagged, design-level (not taken)

- `lib/providers/video/runware.ts:32-33` `params.width || DEFAULT_SIZE.width` swaps a `0` for the preset while a negative goes to the API. `optionalCoercedNumber` in `request-schema-fields.ts` accepts any finite number. Define it away: `.positive()` at the boundary, then `??` here. Rejects `0`/negatives, so a behavior change.
- `lib/api/asset-routes.ts:25-28` `as z.ZodType<AssetBody>` erases the per-route schema type at the one place the family handler is built. Wants `RouteFamily.createHandler` generic over the schema output so the cast is not needed. Contract change on `route-handler`.
- Already on the ledger and still live, do not re-derive: `runware.ts:19` `status as VideoJobStatus` (Runware status vocabulary mismatch, flagged in #754), `base.ts:14-19,27-29` optional `status`/`metadata` (746g/746h), `jobs.ts:103-104` `omitBy` + empty-patch guard (746t), `params.duration ?? DEFAULT_VIDEO_DURATION_SEC` x3 (standing #54, real fix is a schema `.default()`).

## Clean

`RenderProvider.tsx` (the setOpen blur comment is a justified why), `process-job.ts`, `asset-routes.ts` poll handler, `cartesia/models.ts`, `openslop/models.ts`, `icon.tsx`, all twelve `icons/*.css`, all eight delta tests.

Repo-wide invariant greps unchanged: zero bare `catch {}`, zero catch-return-null, zero `as any`/non-null/provider sniffing, the same three discriminated-union switches (scene-builder:121, applyOps:25, VideoComposition:82). The only swallow-style `.catch(` in `lib/` is still `cartesia.ts:181` (746d).

## Checks

lint, typecheck, format:check, test:run (178 files / 1611 tests) and `npm run build` all pass.

## Merge-conflict guard

```
PR #755: clean
PR #754: clean
OK: no file overlap or merge conflict with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)