### PR TITLE
refactor: rethink openslop architecture 2026-09-08

### DIFF
--- a/app/components/models/useProviderKeys.ts
+++ b/app/components/models/useProviderKeys.ts
@@ -12,7 +12,3 @@ export function useProviderKeyLookup(): (
 	return (provider) =>
 		providerKeys.find((row) => row.provider === provider) ?? null;
 }
-
-export function useProviderKey(provider: Provider): ProviderKeyRecord | null {
-	return useProviderKeyLookup()(provider);
-}

--- a/app/components/settings/ModelsTab.tsx
+++ b/app/components/settings/ModelsTab.tsx
@@ -11,7 +11,10 @@ import {
 	differsFromRecommended,
 	modelEntry,
 } from "@/lib/connectors/models";
-import { MANAGED_PROVIDER } from "@/lib/connectors/providerCatalog";
+import {
+	isByokProvider,
+	MANAGED_PROVIDER,
+} from "@/lib/connectors/providerCatalog";
 import type { Provider } from "@/lib/connectors/types";
 import { toastError } from "@/lib/toastError";
 import { useSettings } from "@/lib/settings/useSettings";
@@ -33,11 +36,15 @@ export function ModelsTab({
 	const providerKeys = useAccount((state) => state.providerKeys);
 	const settings = useSettings();
 
-	const stored = providerKeys.map((row) => row.provider);
 	// A link that named a provider leads here: it goes first, so what the link
-	// was about is the first thing read.
-	const shown =
-		selected && !stored.includes(selected) ? [selected, ...stored] : stored;
+	// was about is the first thing read, even before it has a key.
+	const pending =
+		selected &&
+		isByokProvider(selected) &&
+		!providerKeys.some((row) => row.provider === selected)
+			? selected
+			: null;
+	const dismiss = () => settings.open("models");
 
 	return (
 		<div className="flex flex-col gap-6">
@@ -52,27 +59,29 @@ export function ModelsTab({
 					</Button>
 				}
 			>
-				{shown.length === 0 ? (
-					<p className="rounded-xl border border-dashed border-border p-6 text-center text-label text-muted-foreground">
-						No providers connected yet. Add one to generate on your own key.
-					</p>
-				) : (
-					<div className="flex flex-col gap-2">
-						{shown.map((provider) =>
-							provider === MANAGED_PROVIDER ? (
-								<HostedProviderCard key={provider} />
-							) : (
-								<ProviderCard
-									key={provider}
-									provider={provider}
-									selected={provider === selected}
-									// A link pointing at a row that is gone has nothing to open.
-									onDismissed={() => settings.open("models")}
-								/>
-							),
-						)}
-					</div>
-				)}
+				<div className="flex flex-col gap-2">
+					{pending && (
+						<ProviderCard
+							provider={pending}
+							providerKey={null}
+							selected
+							onDismissed={dismiss}
+						/>
+					)}
+					{providerKeys.map((row) =>
+						row.provider === MANAGED_PROVIDER ? (
+							<HostedProviderCard key={row.provider} status={row.status} />
+						) : (
+							<ProviderCard
+								key={row.provider}
+								provider={row.provider}
+								providerKey={row}
+								selected={row.provider === selected}
+								onDismissed={dismiss}
+							/>
+						),
+					)}
+				</div>
 			</SettingsSection>
 
 			<Separator />

--- a/app/components/settings/ProviderCard.tsx
+++ b/app/components/settings/ProviderCard.tsx
@@ -8,7 +8,10 @@ import { Spinner } from "@/components/ui/spinner";
 import { Tile } from "@/components/ui/tile";
 import { KeyStatusBadge } from "@/app/components/models/KeyStatusBadge";
 import { ProviderIcon } from "@/app/components/models/ProviderIcon";
-import { useProviderKey } from "@/app/components/models/useProviderKeys";
+import type {
+	KeyStatus,
+	StoredProviderKey,
+} from "@/lib/connectors/providerKey";
 import {
 	MANAGED_PROVIDER,
 	PROVIDER_CATALOG,
@@ -40,8 +43,7 @@ function ProviderHeading({
 	);
 }
 
-export function HostedProviderCard() {
-	const status = useProviderKey(MANAGED_PROVIDER)?.status ?? "invalid";
+export function HostedProviderCard({ status }: { status: KeyStatus }) {
 	return (
 		<Tile>
 			<ProviderHeading provider={MANAGED_PROVIDER}>
@@ -58,16 +60,18 @@ export function HostedProviderCard() {
 
 export function ProviderCard({
 	provider,
+	providerKey: key,
 	selected = false,
 	onDismissed,
 }: {
 	provider: BYOKProvider;
+	/** Null until a key is stored: the card opens on its form. */
+	providerKey: StoredProviderKey | null;
 	selected?: boolean;
 	/** The row is gone: removed, or backed out of before a key was ever stored. */
 	onDismissed: () => void;
 }) {
 	const meta = PROVIDER_CATALOG[provider];
-	const key = useProviderKey(provider);
 	const testKey = useAccount((state) => state.testKey);
 	const removeKey = useAccount((state) => state.removeKey);
 

--- a/lib/api/__tests__/providerKeys.test.ts
+++ b/lib/api/__tests__/providerKeys.test.ts
@@ -29,8 +29,16 @@ describe("listProviderKeys", () => {
 			},
 		]);
 		const keys = await listProviderKeys(user(true));
-		expect(keys.map((row) => row.provider)).toEqual(["openslop", "anthropic"]);
-		expect(keys[1]).toMatchObject({ last4: "abcd", createdAt: "2026-01-01" });
+		expect(keys).toEqual([
+			{ provider: "openslop", status: "valid" },
+			{
+				provider: "anthropic",
+				last4: "abcd",
+				status: "valid",
+				verifiedAt: null,
+				createdAt: "2026-01-01",
+			},
+		]);
 	});
 
 	it("marks the hosted provider by whether the account has API access", async () => {

--- a/lib/api/jobs.ts
+++ b/lib/api/jobs.ts
@@ -1,6 +1,4 @@
 import { send } from "@vercel/queue";
-import isUndefined from "lodash/isUndefined";
-import omitBy from "lodash/omitBy";
 import { z } from "zod";
 import {
 	BundleResponseSchema,
@@ -91,19 +89,24 @@ export async function loadJobForProcessing(jobId: string): Promise<JobRow> {
 	return JobRowSchema.parse(data);
 }
 
+type Status<S extends JobStatus> = { status: S };
+
+/** The writes a job's life makes, each carrying exactly what that step knows. */
+export type JobTransition =
+	| Status<"processing">
+	| (Status<"completed"> & { result: BundleResponse })
+	| (Status<"failed"> & { error: string })
+	| { metadata: Record<string, unknown> };
+
 export async function updateJob(
 	jobId: string,
-	patch: {
-		status?: JobStatus;
-		result?: BundleResponse;
-		error?: string;
-		metadata?: Record<string, unknown>;
-	},
+	transition: JobTransition,
 ): Promise<void> {
-	const update = omitBy(patch, isUndefined);
-	if (Object.keys(update).length === 0) return;
 	const supabase = createServiceClient();
-	const { error } = await supabase.from("jobs").update(update).eq("id", jobId);
+	const { error } = await supabase
+		.from("jobs")
+		.update(transition)
+		.eq("id", jobId);
 	if (error) throw new Error(`Failed to update job: ${error.message}`);
 }
 

--- a/lib/api/providerKeys.ts
+++ b/lib/api/providerKeys.ts
@@ -2,8 +2,10 @@ import type { User } from "@supabase/supabase-js";
 import { z } from "zod";
 import {
 	KEY_STATUSES,
+	type HostedProviderKey,
 	type KeyStatus,
 	type ProviderKeyRecord,
+	type StoredProviderKey,
 	type ValidationResult,
 } from "@/lib/connectors/providerKey";
 import {
@@ -40,7 +42,7 @@ const ProviderKeyRowsSchema = z.array(
 
 const toRecord = (
 	row: z.infer<typeof ProviderKeyRowsSchema>[number],
-): ProviderKeyRecord => ({
+): StoredProviderKey => ({
 	provider: row.provider,
 	last4: row.last4,
 	status: row.status,
@@ -51,18 +53,9 @@ const toRecord = (
 export const hasApiAccess = (user: User): boolean =>
 	Boolean(user.app_metadata.api_access);
 
-/**
- * The hosted provider has a key row like any other, so nothing downstream asks
- * which provider needs a key. Every account has it; API access is what makes
- * it valid today, and when it takes a key of its own it will be stored like
- * the rest.
- */
-const hostedKey = (user: User): ProviderKeyRecord => ({
+const hostedKey = (user: User): HostedProviderKey => ({
 	provider: MANAGED_PROVIDER,
-	last4: "",
 	status: hasApiAccess(user) ? "valid" : "invalid",
-	verifiedAt: null,
-	createdAt: "",
 });
 
 /**

--- a/lib/connectors/providerKey.ts
+++ b/lib/connectors/providerKey.ts
@@ -1,4 +1,4 @@
-import type { Provider } from "./types";
+import { MANAGED_PROVIDER, type BYOKProvider } from "./providerCatalog";
 
 /** Whether a stored key has been seen to work since it was last written. */
 export const KEY_STATUSES = ["unverified", "valid", "invalid"] as const;
@@ -10,13 +10,25 @@ export type KeyStatus = (typeof KEY_STATUSES)[number];
  * never appears here: only its last four characters, so a user can tell which
  * key they stored without it being readable again.
  */
-export type ProviderKeyRecord = {
-	provider: Provider;
+export type StoredProviderKey = {
+	provider: BYOKProvider;
 	last4: string;
 	status: KeyStatus;
 	verifiedAt: string | null;
 	createdAt: string;
 };
+
+/** The hosted provider has no key to show; the account's API access is what makes it valid. */
+export type HostedProviderKey = {
+	provider: typeof MANAGED_PROVIDER;
+	status: KeyStatus;
+};
+
+/**
+ * A provider the account can generate on. The hosted one is a row like any
+ * other, so nothing downstream asks which provider needs a key.
+ */
+export type ProviderKeyRecord = HostedProviderKey | StoredProviderKey;
 
 export type ValidationResult = { ok: true } | { ok: false; error: string };
 

--- a/lib/user/__tests__/accountStore.test.ts
+++ b/lib/user/__tests__/accountStore.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ProviderKeyRecord } from "@/lib/connectors/providerKey";
+import type {
+	HostedProviderKey,
+	StoredProviderKey,
+} from "@/lib/connectors/providerKey";
 import { createAccountStore } from "../accountStore";
 
-const key = (provider: ProviderKeyRecord["provider"]): ProviderKeyRecord => ({
+const hosted: HostedProviderKey = { provider: "openslop", status: "valid" };
+
+const key = (provider: StoredProviderKey["provider"]): StoredProviderKey => ({
 	provider,
 	last4: "abcd",
 	status: "valid",
@@ -24,7 +29,7 @@ describe("createAccountStore", () => {
 	it("starts from the rows the server read", () => {
 		const store = createAccountStore({
 			models: {},
-			providerKeys: [key("openslop")],
+			providerKeys: [hosted],
 		});
 		expect(providers(store)).toEqual(["openslop"]);
 	});
@@ -33,7 +38,7 @@ describe("createAccountStore", () => {
 	it("replaces the rows with each answer and reports the validation", async () => {
 		const store = createAccountStore({ models: {}, providerKeys: [] });
 		apiJson.mockResolvedValueOnce({
-			providerKeys: [key("openslop"), key("anthropic")],
+			providerKeys: [hosted, key("anthropic")],
 			validation: { ok: false, error: "nope" },
 		});
 


### PR DESCRIPTION
## App understanding

OpenSlop is a script-first AI video maker. A project is a Slate canvas of scenes and content elements (image, animated image, video, TTS, music, SFX). A generation graph turns elements into queued jobs that run through connectors and gateways to either the hosted provider or a user's own vendor key (BYOK), results land in Blob, and Remotion renders the cut. Sloppy is the in-app agent that edits the script. Supabase holds auth, projects, jobs and the key vault. Settings expose the provider keys and per-type default models.

## From-scratch architecture

The current layering (routes → `lib/api` handlers → connectors → gateways → providers) already matches what a rebuild would look like, and it has been audited clean over the last weeks. What a rebuild would still do differently is refuse to let one record type serve two kinds of row, and refuse to let a write take a patch that can be empty. Both cases were handled at runtime with sentinels and guards; the type system can carry them instead.

## Implemented simplifications

- **Provider key records are a `hosted | stored` union.** `HostedProviderKey` carries only `provider` and `status`; `StoredProviderKey` carries the key metadata. The server no longer builds the hosted row with `""` for `last4` and `createdAt`, and the shape that reaches the client is what it says it is.
- **Settings render from the records.** `ModelsTab` maps the key rows straight to cards, narrowing on `provider`: the hosted card takes its `status` as a prop instead of looking itself up and falling back to `"invalid"`, and `ProviderCard` takes its stored row instead of re-finding it in the store. A linked provider with no row yet is the one card built without a record. The "No providers connected yet" branch was unreachable, since the hosted row is always present, and is gone.
- **`useProviderKey` is gone; `useProviderKeyLookup` stays** as the one existence check used by the model menu and the add-providers list.
- **Job updates take a `JobTransition` union.** `processing`, `completed` with its result, `failed` with its error, or a metadata write. Each variant is non-empty by construction, so the lodash `omitBy` and the empty-patch early return are deleted, and the statuses are anchored to `JobStatus` so they cannot drift from the row schema.

Behavior is unchanged: the same rows, cards, order and writes.

## Validation

- `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run knip`: pass
- `npm run test:run`: 178 files, 1611 tests pass
- `npm run build`: pass
- `/simplify` ran with four review agents; applied: stored row passed into the card (dropping the generic lookup), transition statuses tied to `JobStatus`, duplicate comments removed.

## Merge-conflict guard

```
PR #756: clean
PR #755: clean
PR #754: clean
OK: no file overlap or merge conflict with any open PR
```

## Skipped items

- **`PluginContext.gateway` (ledger 746j).** Removing the unread field leaves `PluginContext<TParams, TResult>` with phantom type parameters across 8 files including `lib/connectors/plugins.ts`, which PR #754 changes. It should go together with the de-genericization, once #754 merges.
- **Cartesia TTS contract (746d/e/f) and the video poll `failed` variant (746g/h)** are the next two batches of the conventions follow-up job and were left to it.
- **`params.model as "music_v1"` (746u).** Typing the vendor params on the catalog needs a mapped id type over both model tables for one cast; sub-nightly on its own.
- `JobTransition` deliberately has no variant that writes a terminal status and metadata in one call; no caller does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
