### PR TITLE
fix: stop a cancelled generation's poll loop

### DIFF
--- a/lib/agent/client.ts
+++ b/lib/agent/client.ts
@@ -16,7 +16,7 @@ export async function loadAgentTranscript(
 ): Promise<SloppyMessage[]> {
 	const { messages } = await client.get<{ messages: SloppyMessage[] }>(
 		AGENT_PATH,
-		{ projectId },
+		{ params: { projectId } },
 	);
 	return messages;
 }

--- a/lib/clients/__tests__/apiClient.test.ts
+++ b/lib/clients/__tests__/apiClient.test.ts
@@ -39,7 +39,9 @@ describe("ApiClient", () => {
 				json: () => Promise.resolve({ voices: [] }),
 			});
 
-			await client.get("/api/v1/tts/voices", { gender: "feminine" });
+			await client.get("/api/v1/tts/voices", {
+				params: { gender: "feminine" },
+			});
 
 			expect(fetchMock).toHaveBeenCalledWith(
 				"https://api.test.com/api/v1/tts/voices?gender=feminine",
@@ -61,6 +63,21 @@ describe("ApiClient", () => {
 			);
 		});
 
+		it("hands the abort signal to fetch", async () => {
+			fetchMock.mockResolvedValue({
+				ok: true,
+				json: () => Promise.resolve({}),
+			});
+			const { signal } = new AbortController();
+
+			await client.get("/api/v1/video/job-1", { signal });
+
+			expect(fetchMock).toHaveBeenCalledWith(
+				"https://api.test.com/api/v1/video/job-1",
+				expect.objectContaining({ method: "GET", signal }),
+			);
+		});
+
 		it("filters out undefined param values", async () => {
 			fetchMock.mockResolvedValue({
 				ok: true,
@@ -68,8 +85,7 @@ describe("ApiClient", () => {
 			});
 
 			await client.get("/api/v1/tts/voices", {
-				gender: "masculine",
-				age: undefined as unknown as string,
+				params: { gender: "masculine", age: undefined as unknown as string },
 			});
 
 			const url = fetchMock.mock.calls[0][0] as string;

--- a/lib/clients/apiClient.ts
+++ b/lib/clients/apiClient.ts
@@ -11,8 +11,11 @@ export class ApiClient {
 		return apiJson<T>(`${this.baseUrl}${path}`, { method: "POST", body });
 	}
 
-	async get<T>(path: string, params?: QueryParams): Promise<T> {
-		return apiJson<T>(`${this.baseUrl}${path}`, { params });
+	async get<T>(
+		path: string,
+		options: { params?: QueryParams; signal?: AbortSignal } = {},
+	): Promise<T> {
+		return apiJson<T>(`${this.baseUrl}${path}`, options);
 	}
 
 	async postStream(

--- a/lib/connectors/__tests__/asset-base.test.ts
+++ b/lib/connectors/__tests__/asset-base.test.ts
@@ -151,6 +151,24 @@ describe("BaseAssetConnector", () => {
 			);
 		});
 
+		it("polls with the caller's abort signal", async () => {
+			const connector = new TestAssetConnector(
+				config,
+				vi.fn().mockResolvedValue({
+					id: "abc",
+					type: "image",
+					provider: "mock",
+					result: { image: "output.png" },
+				}),
+			);
+			const poll = vi.spyOn(connector["gateway"], "poll");
+			const { signal } = new AbortController();
+
+			await connector.generate({ prompt: "test" }, { signal });
+
+			expect(poll).toHaveBeenCalledWith("abc", signal);
+		});
+
 		it("handles external urls in bundle response", async () => {
 			const response: BundleResponse = {
 				id: "xyz",

--- a/lib/connectors/asset-base.ts
+++ b/lib/connectors/asset-base.ts
@@ -27,10 +27,13 @@ export abstract class BaseAssetConnector<
 		} as TResult;
 	}
 
-	protected async _generate(params: TParams): Promise<TResult> {
+	protected async _generate(
+		params: TParams,
+		signal?: AbortSignal,
+	): Promise<TResult> {
 		const { jobId } = await this.gateway.generate(params);
 		const completed = await awaitCompletion(
-			(id) => this.gateway.poll(id),
+			(id) => this.gateway.poll(id, signal),
 			jobId,
 			(p) => isTerminal(p.status),
 		);

--- a/lib/connectors/base.ts
+++ b/lib/connectors/base.ts
@@ -67,7 +67,7 @@ export abstract class BaseConnector<
 		const ctx = this.contextFor(context);
 		try {
 			const prepared = await this.prepareParams(params, ctx);
-			let result = await this._generate(prepared);
+			let result = await this._generate(prepared, ctx.signal);
 			result = await runAfterGenerate(this.plugins, result, ctx);
 			return result;
 		} catch (error) {
@@ -76,5 +76,8 @@ export abstract class BaseConnector<
 		}
 	}
 
-	protected abstract _generate(params: TParams): Promise<TResult>;
+	protected abstract _generate(
+		params: TParams,
+		signal?: AbortSignal,
+	): Promise<TResult>;
 }

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -90,12 +90,14 @@ export interface PluginContext<TParams = unknown, TResult = unknown> {
 	state?: ProjectData;
 	/** The pair the connector runs on. */
 	model?: ModelRef;
+	/** Aborts when the caller cancels the generation. */
+	signal?: AbortSignal;
 }
 
 /** The parts of a plugin context the caller supplies per generation. */
 export type GenerationContext = Pick<
 	PluginContext,
-	"elementId" | "dependencies" | "state"
+	"elementId" | "dependencies" | "state" | "signal"
 >;
 
 export interface ConnectorPlugin<TParams = unknown, TResult = unknown> {

--- a/lib/gateway/__tests__/http-gateways.test.ts
+++ b/lib/gateway/__tests__/http-gateways.test.ts
@@ -70,6 +70,28 @@ describe("HTTP gateways", () => {
 				expect.objectContaining({ method: "GET" }),
 			);
 		});
+
+		it("hands the abort signal to the poll request", async () => {
+			fetchMock.mockResolvedValue(
+				jsonResponse({
+					jobId: "job-1",
+					status: "processing",
+					result: null,
+					error: null,
+				}),
+			);
+			const { signal } = new AbortController();
+
+			await new HttpAssetGateway(HOSTED_VIDEO, "video", BASE).poll(
+				"job-1",
+				signal,
+			);
+
+			expect(fetchMock).toHaveBeenCalledWith(
+				`${BASE}/api/v1/video/job-1`,
+				expect.objectContaining({ signal }),
+			);
+		});
 	});
 
 	describe("HttpTTSGateway", () => {

--- a/lib/gateway/base.ts
+++ b/lib/gateway/base.ts
@@ -37,5 +37,5 @@ export abstract class AssetGateway<TParams> extends GatewayClient<
 	TParams,
 	JobSubmission
 > {
-	abstract poll(jobId: string): Promise<JobPoll>;
+	abstract poll(jobId: string, signal?: AbortSignal): Promise<JobPoll>;
 }

--- a/lib/gateway/http.ts
+++ b/lib/gateway/http.ts
@@ -38,8 +38,8 @@ export class HttpAssetGateway<TParams> extends AssetGateway<TParams> {
 		return this.client.post<JobSubmission>(this.route, params);
 	}
 
-	async poll(jobId: string): Promise<JobPoll> {
-		return this.client.get<JobPoll>(`${this.route}/${jobId}`);
+	async poll(jobId: string, signal?: AbortSignal): Promise<JobPoll> {
+		return this.client.get<JobPoll>(`${this.route}/${jobId}`, { signal });
 	}
 }
 
@@ -88,7 +88,7 @@ export class HttpTTSGateway extends HttpAssetGateway<TTSGenerateParams> {
 	async searchVoices(params: VoiceSearchParams): Promise<VoiceInfo[]> {
 		const result = await this.client.get<{ voices: VoiceInfo[] }>(
 			`${this.route}/voices`,
-			{ ...params, ...this.model },
+			{ params: { ...params, ...this.model } },
 		);
 		return result.voices.map((voice) => ({
 			...voice,

--- a/lib/generation/__tests__/generateForElement.test.ts
+++ b/lib/generation/__tests__/generateForElement.test.ts
@@ -128,6 +128,18 @@ describe("generateForElement", () => {
 		});
 	});
 
+	it("forwards the abort signal in the generation context", async () => {
+		mockGenerate.mockResolvedValue({ imageUrl: "x", durationSec: 0 });
+		const { signal } = new AbortController();
+
+		await generateForElement(makeJob("image"), inputs("test"), {}, signal);
+
+		expect(mockGenerate).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ signal }),
+		);
+	});
+
 	it("propagates errors from connector.generate", async () => {
 		mockGenerate.mockRejectedValue(new Error("generation failed"));
 

--- a/lib/generation/__tests__/queue.test.ts
+++ b/lib/generation/__tests__/queue.test.ts
@@ -308,6 +308,16 @@ describe("GenerationQueue", () => {
 			expect(listener).not.toHaveBeenCalled();
 		});
 
+		it("aborts the signal handed to the job so its poll stops", () => {
+			generateMock.mockReturnValue(new Promise(() => {}));
+			generationQueue.enqueueGraph([makeJob("c3")]);
+			const signal = generateMock.mock.calls[0]?.[3] as AbortSignal;
+			expect(signal.aborted).toBe(false);
+
+			generationQueue.cancel("c3");
+			expect(signal.aborted).toBe(true);
+		});
+
 		it("promotes queued jobs when a generating job is cancelled", () => {
 			generateMock.mockReturnValue(new Promise(() => {}));
 			generationQueue.enqueueGraph([
@@ -347,6 +357,18 @@ describe("GenerationQueue", () => {
 			expect(generationQueue.getElementSnapshot("a3").status).toBe("idle");
 			// a4 was queued (not generating), so it had no result/error — state deleted
 			expect(generationQueue.getElementSnapshot("a4").status).toBe("idle");
+		});
+
+		it("aborts every in-flight job's signal", () => {
+			generateMock.mockReturnValue(new Promise(() => {}));
+			generationQueue.enqueueGraph([makeJob("a5"), makeJob("a6")]);
+			const signals = generateMock.mock.calls.map(
+				(call) => call[3] as AbortSignal,
+			);
+			expect(signals).toHaveLength(2);
+
+			generationQueue.cancelAll();
+			expect(signals.every((signal) => signal.aborted)).toBe(true);
 		});
 	});
 

--- a/lib/generation/generateForElement.ts
+++ b/lib/generation/generateForElement.ts
@@ -7,10 +7,11 @@ export async function generateForElement(
 	job: GenerationJob,
 	inputs: GenerationInputs,
 	dependencies: Record<NodeId, AssetResult>,
+	signal?: AbortSignal,
 ): Promise<AssetResult> {
 	const connector = createConnector(job.connectorType, job.model, job.config);
 	return connector.generate(
 		{ prompt: inputs.prompt, ...inputs.attributes },
-		{ elementId: job.elementId, dependencies, state: job.state },
+		{ elementId: job.elementId, dependencies, state: job.state, signal },
 	);
 }

--- a/lib/generation/queue.ts
+++ b/lib/generation/queue.ts
@@ -264,7 +264,12 @@ export class GenerationQueue implements NodeResults {
 		this.ticker.start(elementId);
 
 		const inputs = nodeInputs(node, this);
-		generateForElement(job, inputs, this.dependencyResults(node))
+		generateForElement(
+			job,
+			inputs,
+			this.dependencyResults(node),
+			controller.signal,
+		)
 			.then((result) => this.handleJobSuccess(job, inputs, result, controller))
 			.catch((err) => this.handleJobError(elementId, err, controller))
 			.finally(() => this.finalizeJob(elementId, controller));


### PR DESCRIPTION
## Summary

Cancelling, discarding, or unmounting a canvas generation left its poll loop running until the job finished or hit the 15-minute timeout. The per-job `AbortController` was only read as an "ignore the result" flag; its signal never reached the connector.

This threads the existing signal through the layers that already had a slot for it:

- `queue.runJob` passes `controller.signal` to `generateForElement`, which puts it on the `GenerationContext`.
- `PluginContext` gains `signal`, so `BaseConnector.generate` hands it to `_generate` (mirroring `LLMConnector.stream(params, signal?)`).
- `BaseAssetConnector._generate` forwards it to every `gateway.poll(jobId, signal)`.
- `HttpAssetGateway.poll` and `ApiClient.get` pass it to `fetch`. `ApiClient.get` now takes `{ params, signal }` so the poll can name its signal without a positional placeholder.

An aborted fetch rejects with a `DOMException`, which `awaitCompletion` already rethrows (it only swallows `UnreachableError`), so the loop ends with no further requests for that job. The existing `signal.aborted` guards in the queue's terminal handlers stay in place and swallow the resulting `AbortError` for a job that completes in the same tick as the cancel. No new cancellation machinery.

## Selected issue

#694, size M, priority medium, labelled `bug`. It names the exact seam where the signal is lost and lists acceptance criteria, so the outcome was unambiguous. Every file it needed was free of open-PR overlap tonight.

## Validation

- `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run knip`: pass
- `npm run build`: pass
- `npm run test:coverage`: 178 files, 1617 tests pass
- New seam tests: queue `cancel` / `cancelAll` abort the signal handed to the job, `generateForElement` forwards it in the context, the asset connector polls with it, `HttpAssetGateway.poll` and `ApiClient.get` hand it to `fetch`.
- Skipped: `npm run test:e2e`. The Playwright smoke suite covers only the public onboarding routes, which this change does not touch. CI runs it.

## Merge-conflict guard

```
PR #757: clean
PR #756: clean
PR #755: clean
PR #754: clean
OK: no file overlap or merge conflict with any open PR
```

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)
