### PR TITLE
refactor: nightly maintainability 2026-09-09

### DIFF
--- a/app/components/canvas/elements/character/VoicePicker.tsx
+++ b/app/components/canvas/elements/character/VoicePicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Check, Pause, Play } from "@/components/ui/icon";
 import { TooltipIconButton } from "@/components/ui/icon-button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -9,11 +9,9 @@ import {
 	ModelSelect,
 	ModelSelectTrigger,
 } from "@/app/components/models/ModelSelect";
-import { useConfig } from "@/lib/config/ConfigProvider";
-import { createConnector } from "@/lib/connectors/factory";
 import type { ModelRef, VoiceInfo } from "@/lib/connectors/types";
-import { errorMessage } from "@/lib/errors";
-import type { MetadataVoice } from "@/lib/project/types";
+import type { VoiceDescriptor } from "@/lib/connectors/tts/plugins/voice-search";
+import { useVoiceSearch } from "@/lib/connectors/tts/useVoiceSearch";
 import { FieldLabel } from "./fields";
 
 function PreviewPlayButton({ src }: { src: string }) {
@@ -49,9 +47,7 @@ function PreviewPlayButton({ src }: { src: string }) {
 	);
 }
 
-const DEBOUNCE_MS = 300;
 const SKELETON_ROWS = 5;
-const VOICE_LIMIT = 50;
 const VOICE_TAG_CLASS =
 	"shrink-0 rounded border border-border px-1 py-px text-badge-xs uppercase text-muted-foreground";
 
@@ -62,47 +58,13 @@ export function VoicePicker({
 	onSelect,
 	onModelChange,
 }: {
-	filters: MetadataVoice;
+	filters: VoiceDescriptor;
 	model: ModelRef;
 	selectedVoiceId?: string;
 	onSelect: (voice: VoiceInfo) => void;
 	onModelChange: (model: ModelRef) => void;
 }) {
-	const { connectorConfig } = useConfig();
-	const { provider, model: name } = model;
-	const ttsConnector = useMemo(
-		() =>
-			createConnector("tts", { provider, model: name }, connectorConfig.tts),
-		[connectorConfig, provider, name],
-	);
-
-	const [voices, setVoices] = useState<VoiceInfo[]>([]);
-	const [loading, setLoading] = useState(true);
-	const [error, setError] = useState<string | null>(null);
-
-	useEffect(() => {
-		let cancelled = false;
-		const handle = setTimeout(async () => {
-			setLoading(true);
-			setError(null);
-			try {
-				const result = await ttsConnector.searchVoices({
-					...filters,
-					limit: VOICE_LIMIT,
-				});
-				if (!cancelled) setVoices(result);
-			} catch (err) {
-				if (!cancelled) setError(errorMessage(err));
-			} finally {
-				if (!cancelled) setLoading(false);
-			}
-		}, DEBOUNCE_MS);
-
-		return () => {
-			cancelled = true;
-			clearTimeout(handle);
-		};
-	}, [filters, ttsConnector]);
+	const search = useVoiceSearch(filters, model);
 
 	return (
 		<div className="flex min-w-0 flex-col gap-1.5">
@@ -117,63 +79,68 @@ export function VoicePicker({
 					<ModelSelectTrigger model={model} label="Voice model" />
 				</ModelSelect>
 			</div>
-			{error && <span className="text-label-xs text-destructive">{error}</span>}
+			{search.status === "failed" && (
+				<span className="text-label-xs text-destructive">{search.message}</span>
+			)}
 			<div className="flex max-h-64 min-w-0 flex-col gap-0.5 overflow-y-auto">
-				{loading &&
+				{search.status === "loading" &&
 					Array.from({ length: SKELETON_ROWS }).map((_, i) => (
 						<Skeleton key={`skel-${i}`} className="h-12 shrink-0 rounded-md" />
 					))}
-				{!loading && voices.length === 0 && !error && (
-					<span className="px-2 py-3 text-center text-label-xs text-muted-foreground">
-						No voices match these filters.
-					</span>
-				)}
-				{!loading &&
-					voices.map((voice) => {
-						const selected = voice.id === selectedVoiceId;
-						return (
-							<div
-								key={voice.id}
-								role="button"
-								tabIndex={0}
-								onClick={() => onSelect(voice)}
-								onKeyDown={(e) => {
-									if (e.target !== e.currentTarget) return;
-									if (e.key === "Enter" || e.key === " ") {
-										e.preventDefault();
-										onSelect(voice);
-									}
-								}}
-								className={`flex min-w-0 cursor-pointer flex-col gap-1 rounded-md px-2 py-1 transition-colors ${
-									selected ? "bg-muted" : "hover:bg-voice-hover"
-								}`}
-							>
-								<div className="flex min-w-0 items-center gap-1.5">
-									<span className="min-w-0 flex-1 truncate text-label text-foreground">
-										{voice.name}
-									</span>
-									{[voice.language, voice.gender].filter(Boolean).map((tag) => (
-										<span key={tag} className={VOICE_TAG_CLASS}>
-											{tag}
+				{search.status === "ready" &&
+					(search.voices.length === 0 ? (
+						<span className="px-2 py-3 text-center text-label-xs text-muted-foreground">
+							No voices match these filters.
+						</span>
+					) : (
+						search.voices.map((voice) => {
+							const selected = voice.id === selectedVoiceId;
+							return (
+								<div
+									key={voice.id}
+									role="button"
+									tabIndex={0}
+									onClick={() => onSelect(voice)}
+									onKeyDown={(e) => {
+										if (e.target !== e.currentTarget) return;
+										if (e.key === "Enter" || e.key === " ") {
+											e.preventDefault();
+											onSelect(voice);
+										}
+									}}
+									className={`flex min-w-0 cursor-pointer flex-col gap-1 rounded-md px-2 py-1 transition-colors ${
+										selected ? "bg-muted" : "hover:bg-voice-hover"
+									}`}
+								>
+									<div className="flex min-w-0 items-center gap-1.5">
+										<span className="min-w-0 flex-1 truncate text-label text-foreground">
+											{voice.name}
 										</span>
-									))}
-									{selected && (
-										<Check className="h-3 w-3 shrink-0 text-accent" />
-									)}
-								</div>
-								{(voice.description || voice.previewUrl) && (
-									<div className="flex min-w-0 items-center justify-between gap-2">
-										<span className="min-w-0 flex-1 truncate text-label text-muted-foreground">
-											{voice.description}
-										</span>
-										{voice.previewUrl && (
-											<PreviewPlayButton src={voice.previewUrl} />
+										{[voice.language, voice.gender]
+											.filter(Boolean)
+											.map((tag) => (
+												<span key={tag} className={VOICE_TAG_CLASS}>
+													{tag}
+												</span>
+											))}
+										{selected && (
+											<Check className="h-3 w-3 shrink-0 text-accent" />
 										)}
 									</div>
-								)}
-							</div>
-						);
-					})}
+									{(voice.description || voice.previewUrl) && (
+										<div className="flex min-w-0 items-center justify-between gap-2">
+											<span className="min-w-0 flex-1 truncate text-label text-muted-foreground">
+												{voice.description}
+											</span>
+											{voice.previewUrl && (
+												<PreviewPlayButton src={voice.previewUrl} />
+											)}
+										</div>
+									)}
+								</div>
+							);
+						})
+					))}
 			</div>
 		</div>
 	);

--- a/app/components/canvas/elements/character/VoicePicker.tsx
+++ b/app/components/canvas/elements/character/VoicePicker.tsx
@@ -9,8 +9,11 @@ import {
 	ModelSelect,
 	ModelSelectTrigger,
 } from "@/app/components/models/ModelSelect";
-import type { ModelRef, VoiceInfo } from "@/lib/connectors/types";
-import type { VoiceDescriptor } from "@/lib/connectors/tts/plugins/voice-search";
+import type {
+	ModelRef,
+	VoiceInfo,
+	VoiceSearchParams,
+} from "@/lib/connectors/types";
 import { useVoiceSearch } from "@/lib/connectors/tts/useVoiceSearch";
 import { FieldLabel } from "./fields";
 
@@ -58,7 +61,7 @@ export function VoicePicker({
 	onSelect,
 	onModelChange,
 }: {
-	filters: VoiceDescriptor;
+	filters: VoiceSearchParams;
 	model: ModelRef;
 	selectedVoiceId?: string;
 	onSelect: (voice: VoiceInfo) => void;
@@ -87,60 +90,57 @@ export function VoicePicker({
 					Array.from({ length: SKELETON_ROWS }).map((_, i) => (
 						<Skeleton key={`skel-${i}`} className="h-12 shrink-0 rounded-md" />
 					))}
+				{search.status === "ready" && search.voices.length === 0 && (
+					<span className="px-2 py-3 text-center text-label-xs text-muted-foreground">
+						No voices match these filters.
+					</span>
+				)}
 				{search.status === "ready" &&
-					(search.voices.length === 0 ? (
-						<span className="px-2 py-3 text-center text-label-xs text-muted-foreground">
-							No voices match these filters.
-						</span>
-					) : (
-						search.voices.map((voice) => {
-							const selected = voice.id === selectedVoiceId;
-							return (
-								<div
-									key={voice.id}
-									role="button"
-									tabIndex={0}
-									onClick={() => onSelect(voice)}
-									onKeyDown={(e) => {
-										if (e.target !== e.currentTarget) return;
-										if (e.key === "Enter" || e.key === " ") {
-											e.preventDefault();
-											onSelect(voice);
-										}
-									}}
-									className={`flex min-w-0 cursor-pointer flex-col gap-1 rounded-md px-2 py-1 transition-colors ${
-										selected ? "bg-muted" : "hover:bg-voice-hover"
-									}`}
-								>
-									<div className="flex min-w-0 items-center gap-1.5">
-										<span className="min-w-0 flex-1 truncate text-label text-foreground">
-											{voice.name}
+					search.voices.map((voice) => {
+						const selected = voice.id === selectedVoiceId;
+						return (
+							<div
+								key={voice.id}
+								role="button"
+								tabIndex={0}
+								onClick={() => onSelect(voice)}
+								onKeyDown={(e) => {
+									if (e.target !== e.currentTarget) return;
+									if (e.key === "Enter" || e.key === " ") {
+										e.preventDefault();
+										onSelect(voice);
+									}
+								}}
+								className={`flex min-w-0 cursor-pointer flex-col gap-1 rounded-md px-2 py-1 transition-colors ${
+									selected ? "bg-muted" : "hover:bg-voice-hover"
+								}`}
+							>
+								<div className="flex min-w-0 items-center gap-1.5">
+									<span className="min-w-0 flex-1 truncate text-label text-foreground">
+										{voice.name}
+									</span>
+									{[voice.language, voice.gender].filter(Boolean).map((tag) => (
+										<span key={tag} className={VOICE_TAG_CLASS}>
+											{tag}
 										</span>
-										{[voice.language, voice.gender]
-											.filter(Boolean)
-											.map((tag) => (
-												<span key={tag} className={VOICE_TAG_CLASS}>
-													{tag}
-												</span>
-											))}
-										{selected && (
-											<Check className="h-3 w-3 shrink-0 text-accent" />
-										)}
-									</div>
-									{(voice.description || voice.previewUrl) && (
-										<div className="flex min-w-0 items-center justify-between gap-2">
-											<span className="min-w-0 flex-1 truncate text-label text-muted-foreground">
-												{voice.description}
-											</span>
-											{voice.previewUrl && (
-												<PreviewPlayButton src={voice.previewUrl} />
-											)}
-										</div>
+									))}
+									{selected && (
+										<Check className="h-3 w-3 shrink-0 text-accent" />
 									)}
 								</div>
-							);
-						})
-					))}
+								{(voice.description || voice.previewUrl) && (
+									<div className="flex min-w-0 items-center justify-between gap-2">
+										<span className="min-w-0 flex-1 truncate text-label text-muted-foreground">
+											{voice.description}
+										</span>
+										{voice.previewUrl && (
+											<PreviewPlayButton src={voice.previewUrl} />
+										)}
+									</div>
+								)}
+							</div>
+						);
+					})}
 			</div>
 		</div>
 	);

--- a/lib/connectors/__tests__/_state-ctx.ts
+++ b/lib/connectors/__tests__/_state-ctx.ts
@@ -3,7 +3,7 @@ import type { PluginContext } from "@/lib/connectors/types";
 import type { ProjectStore } from "@/lib/project/store";
 
 /** The context a tts connector runs its plugins with: state frozen at graph-resolve time, and its own pair. */
-export const stateCtx = <P, R>(store: ProjectStore): PluginContext<P, R> => ({
+export const stateCtx = (store: ProjectStore): PluginContext => ({
 	state: store.getState(),
 	model: DEFAULT_MODELS.tts,
 });

--- a/lib/connectors/__tests__/voice-hydrate.test.ts
+++ b/lib/connectors/__tests__/voice-hydrate.test.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
 	store = createProjectStore();
 });
 
-function ctxWith(voices: VoiceInfo[]): PluginContext<TTSGenerateParams> {
+function ctxWith(voices: VoiceInfo[]): PluginContext {
 	return {
 		searchVoices: vi.fn(async () => voices),
 		...stateCtx(store),
@@ -26,7 +26,7 @@ function ctxWith(voices: VoiceInfo[]): PluginContext<TTSGenerateParams> {
 
 async function runPipeline(
 	params: TTSGenerateParams,
-	ctx: PluginContext<TTSGenerateParams>,
+	ctx: PluginContext,
 ): Promise<TTSGenerateParams> {
 	const plugins = [
 		createMetadataVoicePlugin(),

--- a/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type {
-	AnimatedImageGenerateParams,
-	AssetResult,
-	PluginContext,
-} from "@/lib/connectors/types";
+import type { PluginContext } from "@/lib/connectors/types";
 import { DEFAULT_CONNECTOR_REGISTRY } from "@/lib/connectors/registry";
 import { getPrimaryUrl } from "@/lib/connectors/assetUrl";
 import {
@@ -28,9 +24,7 @@ import { splitAttributes } from "@/lib/video/elementAttributes";
 const ELEMENT_ID = "anim-1";
 const STILL_URL = "https://example.com/still.png";
 
-const ctx = (
-	imageUrl?: string,
-): PluginContext<AnimatedImageGenerateParams, AssetResult> => ({
+const ctx = (imageUrl?: string): PluginContext => ({
 	elementId: ELEMENT_ID,
 	dependencies: imageUrl
 		? { [stillElementId(ELEMENT_ID)]: { imageUrl, durationSec: 0 } }

--- a/lib/connectors/animated_image/plugins/still-frame.ts
+++ b/lib/connectors/animated_image/plugins/still-frame.ts
@@ -103,9 +103,7 @@ export const stillSnapshot = (
 	queue: GenerationQueue,
 ): ElementSnapshot => queue.getElementSnapshot(stillDependency(node)?.id);
 
-const stillFrame = (
-	ctx: PluginContext<AnimatedImageGenerateParams, AssetResult>,
-): string | undefined =>
+const stillFrame = (ctx: PluginContext): string | undefined =>
 	ctx.elementId
 		? ctx.dependencies?.[stillElementId(ctx.elementId)]?.imageUrl
 		: undefined;

--- a/lib/connectors/base.ts
+++ b/lib/connectors/base.ts
@@ -38,13 +38,9 @@ export abstract class BaseConnector<
 		this.model = config.model;
 	}
 
-	protected pluginContext(): PluginContext<TParams, TResult> {
-		return {};
-	}
-
 	protected async prepareParams(
 		params: TParams,
-		ctx: PluginContext<TParams, TResult>,
+		ctx: PluginContext,
 	): Promise<TParams> {
 		const prompt = await runTransformPrompt(this.plugins, params.prompt, ctx);
 		return runBeforeGenerate(
@@ -54,10 +50,8 @@ export abstract class BaseConnector<
 		);
 	}
 
-	protected contextFor(
-		context?: GenerationContext,
-	): PluginContext<TParams, TResult> {
-		return { ...this.pluginContext(), ...context, model: this.model };
+	protected contextFor(context?: GenerationContext): PluginContext {
+		return { ...context, model: this.model };
 	}
 
 	async generate(

--- a/lib/connectors/image/openslop/models.ts
+++ b/lib/connectors/image/openslop/models.ts
@@ -1,7 +1,5 @@
+import { RUNWARE_IMAGE_MODELS } from "../runware/models";
+
 export const OPENSLOP_IMAGE_MODELS = {
-	"Slop Image v1": {
-		id: "bytedance:seedream@5.0-lite",
-		cost: "low",
-		speed: "high",
-	},
+	"Slop Image v1": RUNWARE_IMAGE_MODELS["Seedream 5 Lite"],
 } as const;

--- a/lib/connectors/image/plugins/art-style.ts
+++ b/lib/connectors/image/plugins/art-style.ts
@@ -1,4 +1,4 @@
-import { requireState } from "@/lib/connectors/plugins";
+import { requireContext } from "@/lib/connectors/plugins";
 import type { ConnectorPlugin } from "@/lib/connectors/types";
 import { forArtStyle } from "@/lib/generation/sourceNodes";
 
@@ -7,7 +7,11 @@ export function createArtStylePlugin(): ConnectorPlugin<{ prompt: string }> {
 		name: "art-style",
 		dependencies: () => [forArtStyle],
 		transformPrompt(prompt, ctx) {
-			const style = requireState(ctx, "art-style").metadata.style.trim();
+			const style = requireContext(
+				ctx,
+				"state",
+				"art-style",
+			).metadata.style.trim();
 			if (!style) return prompt;
 			return `${style}. ${prompt}`;
 		},

--- a/lib/connectors/image/plugins/character-avatar.ts
+++ b/lib/connectors/image/plugins/character-avatar.ts
@@ -1,4 +1,4 @@
-import { requireState } from "@/lib/connectors/plugins";
+import { requireContext } from "@/lib/connectors/plugins";
 import type { AssetResult, ConnectorPlugin } from "@/lib/connectors/types";
 
 export function createCharacterAvatarPlugin(
@@ -8,8 +8,9 @@ export function createCharacterAvatarPlugin(
 		name: "character-avatar",
 		transformPrompt(_, ctx) {
 			const appearance =
-				requireState(ctx, "character-avatar").metadata.characters[name]
-					?.appearance ?? "";
+				requireContext(ctx, "state", "character-avatar").metadata.characters[
+					name
+				]?.appearance ?? "";
 			return [
 				`Character portrait of ${name}`,
 				appearance,

--- a/lib/connectors/image/plugins/reference-images.ts
+++ b/lib/connectors/image/plugins/reference-images.ts
@@ -2,7 +2,7 @@ import {
 	parseReferenceImages,
 	REFERENCE_IMAGES_ATTR,
 } from "@/lib/connectors/attributes/referenceImages";
-import { requireState } from "@/lib/connectors/plugins";
+import { requireContext } from "@/lib/connectors/plugins";
 import type { ConnectorPlugin } from "@/lib/connectors/types";
 import { forReferenceImages } from "@/lib/generation/sourceNodes";
 
@@ -33,7 +33,7 @@ export function createReferenceImagesPlugin(): ConnectorPlugin<ParamsWithReferen
 			const urls = [
 				...existing,
 				...(parseReferenceImages(override) ??
-					requireState(ctx, "reference-images").referenceImages),
+					requireContext(ctx, "state", "reference-images").referenceImages),
 			];
 			return urls.length === 0 ? rest : { ...rest, referenceImages: urls };
 		},

--- a/lib/connectors/llm/connector.ts
+++ b/lib/connectors/llm/connector.ts
@@ -22,10 +22,6 @@ export class HttpLLMConnector
 		this.gateway = new HttpLLMGateway(config.model, config.baseUrl);
 	}
 
-	protected pluginContext() {
-		return { gateway: this.gateway };
-	}
-
 	protected async _generate(
 		params: LLMGenerateParams,
 	): Promise<LLMGenerateResult> {

--- a/lib/connectors/llm/openslop/models.ts
+++ b/lib/connectors/llm/openslop/models.ts
@@ -1,3 +1,5 @@
+import { ANTHROPIC_LLM_MODELS } from "../anthropic/models";
+
 export const OPENSLOP_LLM_MODELS = {
-	"Slop LLM v1": { id: "claude-opus-5", cost: "high", speed: "low" },
+	"Slop LLM v1": ANTHROPIC_LLM_MODELS["Claude Opus 5"],
 } as const;

--- a/lib/connectors/music/openslop/models.ts
+++ b/lib/connectors/music/openslop/models.ts
@@ -1,3 +1,5 @@
+import { ELEVENLABS_MUSIC_MODELS } from "../elevenlabs/models";
+
 export const OPENSLOP_MUSIC_MODELS = {
-	"Slop Music v1": { id: "music_v1", cost: "medium", speed: "medium" },
+	"Slop Music v1": ELEVENLABS_MUSIC_MODELS["Eleven Music v1"],
 } as const;

--- a/lib/connectors/plugins.ts
+++ b/lib/connectors/plugins.ts
@@ -1,22 +1,16 @@
-import type { ProjectData } from "@/lib/project/store";
-import type { ConnectorPlugin, ModelRef, PluginContext } from "./types";
+import type { ConnectorPlugin, PluginContext } from "./types";
 
-/** Assert the plugin was given project state, returning it narrowed. */
-export function requireState<P, R>(
-	ctx: PluginContext<P, R>,
+/** Assert the plugin was given a context field, returning it narrowed. */
+export function requireContext<K extends keyof PluginContext>(
+	ctx: PluginContext,
+	key: K,
 	plugin: string,
-): ProjectData {
-	if (!ctx.state) throw new Error(`${plugin} plugin requires project state`);
-	return ctx.state;
-}
-
-/** Assert the plugin was told the pair its connector runs on. */
-export function requireModel<P, R>(
-	ctx: PluginContext<P, R>,
-	plugin: string,
-): ModelRef {
-	if (!ctx.model) throw new Error(`${plugin} plugin requires a model`);
-	return ctx.model;
+): NonNullable<PluginContext[K]> {
+	const value = ctx[key];
+	if (value === undefined) {
+		throw new Error(`${plugin} plugin requires ${key} in its context`);
+	}
+	return value;
 }
 
 type TransformHook = "beforeGenerate" | "afterGenerate" | "transformPrompt";

--- a/lib/connectors/plugins.ts
+++ b/lib/connectors/plugins.ts
@@ -1,6 +1,5 @@
 import type { ConnectorPlugin, PluginContext } from "./types";
 
-/** Assert the plugin was given a context field, returning it narrowed. */
 export function requireContext<K extends keyof PluginContext>(
 	ctx: PluginContext,
 	key: K,

--- a/lib/connectors/plugins/dimensions.ts
+++ b/lib/connectors/plugins/dimensions.ts
@@ -1,4 +1,4 @@
-import { requireState } from "@/lib/connectors/plugins";
+import { requireContext } from "@/lib/connectors/plugins";
 import { aspectDimensions, forAspectRatio } from "@/lib/generation/sourceNodes";
 import type { ConnectorPlugin } from "@/lib/connectors/types";
 import {
@@ -21,7 +21,7 @@ export function createDimensionsPlugin(
 		name: "dimensions",
 		dependencies: () => [forAspectRatio],
 		beforeGenerate(params, ctx) {
-			const dims = aspectDimensions(requireState(ctx, "dimensions"));
+			const dims = aspectDimensions(requireContext(ctx, "state", "dimensions"));
 			if (kind === "image") return { ...params, ...dims.image };
 			const resolution = params.resolution ?? DEFAULT_VIDEO_RESOLUTION;
 			return { ...params, resolution, ...dims.video[resolution] };

--- a/lib/connectors/sfx/openslop/models.ts
+++ b/lib/connectors/sfx/openslop/models.ts
@@ -1,3 +1,5 @@
+import { ELEVENLABS_SFX_MODELS } from "../elevenlabs/models";
+
 export const OPENSLOP_SFX_MODELS = {
-	"Slop SFX v1": { id: "eleven_text_to_sound_v2", cost: "low", speed: "high" },
+	"Slop SFX v1": ELEVENLABS_SFX_MODELS["Eleven Text to Sound v2"],
 } as const;

--- a/lib/connectors/tts/connector.ts
+++ b/lib/connectors/tts/connector.ts
@@ -4,6 +4,7 @@ import { BaseAssetConnector } from "../asset-base";
 import type { AttributeSchema } from "../attributes/schema";
 import { TTS_ATTRIBUTES } from "./attributes";
 import type {
+	GenerationContext,
 	PluginContext,
 	ResolvedConnectorConfig,
 	TextTimestamp,
@@ -42,7 +43,10 @@ export class HttpTTSConnector
 		};
 	}
 
-	protected pluginContext(): PluginContext<TTSGenerateParams, TTSResult> {
-		return { searchVoices: (p) => this.searchVoices(p) };
+	protected contextFor(context?: GenerationContext): PluginContext {
+		return {
+			...super.contextFor(context),
+			searchVoices: (p) => this.searchVoices(p),
+		};
 	}
 }

--- a/lib/connectors/tts/openslop/models.ts
+++ b/lib/connectors/tts/openslop/models.ts
@@ -1,3 +1,5 @@
+import { CARTESIA_TTS_MODELS } from "../cartesia/models";
+
 export const OPENSLOP_TTS_MODELS = {
-	"Slop TTS v1": { id: "sonic-3.6", cost: "low", speed: "high" },
+	"Slop TTS v1": CARTESIA_TTS_MODELS["Sonic 3.6"],
 } as const;

--- a/lib/connectors/tts/plugins/metadata-voice.ts
+++ b/lib/connectors/tts/plugins/metadata-voice.ts
@@ -1,5 +1,5 @@
 import { resolveModel } from "@/lib/connectors/models";
-import { requireModel, requireState } from "@/lib/connectors/plugins";
+import { requireContext } from "@/lib/connectors/plugins";
 import { forVoice } from "@/lib/generation/sourceNodes";
 import { declaredLanguage } from "@/lib/project/language";
 import {
@@ -41,7 +41,7 @@ export function createMetadataVoicePlugin(): ConnectorPlugin<TTSGenerateParams> 
 				)(state),
 		],
 		beforeGenerate(params, ctx) {
-			const { metadata } = requireState(ctx, "metadata-voice");
+			const { metadata } = requireContext(ctx, "state", "metadata-voice");
 			const voice = metadataVoiceFor(metadata, params.name);
 			if (!voice) return params;
 			const traits = voiceTraitsSchema.parse(voice);
@@ -49,7 +49,10 @@ export function createMetadataVoicePlugin(): ConnectorPlugin<TTSGenerateParams> 
 				...params,
 				...traits,
 				language: declaredLanguage(metadata.language) ?? traits.language,
-				voiceId: voiceIdOn(voice, requireModel(ctx, "metadata-voice")),
+				voiceId: voiceIdOn(
+					voice,
+					requireContext(ctx, "model", "metadata-voice"),
+				),
 			};
 		},
 	};

--- a/lib/connectors/tts/plugins/voice-hydrate.ts
+++ b/lib/connectors/tts/plugins/voice-hydrate.ts
@@ -1,4 +1,4 @@
-import { requireModel } from "@/lib/connectors/plugins";
+import { requireContext } from "@/lib/connectors/plugins";
 import type { ProjectStore } from "@/lib/project/store";
 import { metadataVoiceFor, voiceIdOn } from "@/lib/project/types";
 import type {
@@ -20,7 +20,7 @@ export function createVoiceHydratePlugin(
 		beforeGenerate(params, ctx) {
 			const { voiceId, name } = params;
 			if (!voiceId) return params;
-			const model = requireModel(ctx, "voice-hydrate");
+			const model = requireContext(ctx, "model", "voice-hydrate");
 			const { metadata, updateCharacter, setNarration } = store.getState();
 			const voice = metadataVoiceFor(metadata, name);
 			if (!voice || voiceIdOn(voice, model) === voiceId) return params;

--- a/lib/connectors/tts/plugins/voice-search.ts
+++ b/lib/connectors/tts/plugins/voice-search.ts
@@ -4,9 +4,7 @@ import { requireContext } from "@/lib/connectors/plugins";
 import type {
 	ConnectorPlugin,
 	TTSGenerateParams,
-	VoiceSearchParams,
 } from "@/lib/connectors/types";
-import { FALLBACK_LANGUAGE } from "@/lib/project/language";
 
 const VOICE_DESCRIPTOR_KEYS = [
 	"gender",
@@ -18,12 +16,6 @@ const VOICE_DESCRIPTOR_KEYS = [
 	"language",
 ] as const;
 
-/** How a wanted voice is described: what a search matches on. */
-export type VoiceDescriptor = Pick<
-	VoiceSearchParams,
-	(typeof VOICE_DESCRIPTOR_KEYS)[number]
->;
-
 export function createVoiceSearchPlugin(): ConnectorPlugin<TTSGenerateParams> {
 	return {
 		name: "voice-search",
@@ -32,7 +24,7 @@ export function createVoiceSearchPlugin(): ConnectorPlugin<TTSGenerateParams> {
 			const searchVoices = requireContext(ctx, "searchVoices", "voice-search");
 			const voices = await searchVoices({
 				...pick(params, VOICE_DESCRIPTOR_KEYS),
-				language: params.language || FALLBACK_LANGUAGE,
+				language: params.language || "en",
 			});
 			if (!voices.length) throw new Error("No matching voice found");
 			return { ...omit(params, VOICE_DESCRIPTOR_KEYS), voiceId: voices[0].id };

--- a/lib/connectors/tts/plugins/voice-search.ts
+++ b/lib/connectors/tts/plugins/voice-search.ts
@@ -1,9 +1,12 @@
 import omit from "lodash/omit";
 import pick from "lodash/pick";
+import { requireContext } from "@/lib/connectors/plugins";
 import type {
 	ConnectorPlugin,
 	TTSGenerateParams,
+	VoiceSearchParams,
 } from "@/lib/connectors/types";
+import { FALLBACK_LANGUAGE } from "@/lib/project/language";
 
 const VOICE_DESCRIPTOR_KEYS = [
 	"gender",
@@ -15,19 +18,21 @@ const VOICE_DESCRIPTOR_KEYS = [
 	"language",
 ] as const;
 
+/** How a wanted voice is described: what a search matches on. */
+export type VoiceDescriptor = Pick<
+	VoiceSearchParams,
+	(typeof VOICE_DESCRIPTOR_KEYS)[number]
+>;
+
 export function createVoiceSearchPlugin(): ConnectorPlugin<TTSGenerateParams> {
 	return {
 		name: "voice-search",
 		async beforeGenerate(params, ctx) {
 			if (params.voiceId) return params;
-			if (!ctx.searchVoices) {
-				throw new Error(
-					"voice-search plugin requires searchVoices in PluginContext",
-				);
-			}
-			const voices = await ctx.searchVoices({
+			const searchVoices = requireContext(ctx, "searchVoices", "voice-search");
+			const voices = await searchVoices({
 				...pick(params, VOICE_DESCRIPTOR_KEYS),
-				language: params.language || "en",
+				language: params.language || FALLBACK_LANGUAGE,
 			});
 			if (!voices.length) throw new Error("No matching voice found");
 			return { ...omit(params, VOICE_DESCRIPTOR_KEYS), voiceId: voices[0].id };

--- a/lib/connectors/tts/useVoiceSearch.ts
+++ b/lib/connectors/tts/useVoiceSearch.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useConfig } from "@/lib/config/ConfigProvider";
+import { createConnector } from "@/lib/connectors/factory";
+import type { VoiceDescriptor } from "@/lib/connectors/tts/plugins/voice-search";
+import type { ModelRef, VoiceInfo } from "@/lib/connectors/types";
+import { errorMessage } from "@/lib/errors";
+
+export type VoiceSearch =
+	| { status: "loading" }
+	| { status: "ready"; voices: VoiceInfo[] }
+	| { status: "failed"; message: string };
+
+const DEBOUNCE_MS = 300;
+const VOICE_LIMIT = 50;
+const LOADING: VoiceSearch = { status: "loading" };
+
+/** The voices a pair offers for the filters, searched again whenever either changes. */
+export function useVoiceSearch(
+	filters: VoiceDescriptor,
+	model: ModelRef,
+): VoiceSearch {
+	const { connectorConfig } = useConfig();
+	const { provider, model: name } = model;
+	const connector = useMemo(
+		() =>
+			createConnector("tts", { provider, model: name }, connectorConfig.tts),
+		[connectorConfig, provider, name],
+	);
+	const [search, setSearch] = useState<VoiceSearch>(LOADING);
+
+	useEffect(() => {
+		let cancelled = false;
+		const handle = setTimeout(async () => {
+			setSearch(LOADING);
+			try {
+				const voices = await connector.searchVoices({
+					...filters,
+					limit: VOICE_LIMIT,
+				});
+				if (!cancelled) setSearch({ status: "ready", voices });
+			} catch (err) {
+				if (!cancelled)
+					setSearch({ status: "failed", message: errorMessage(err) });
+			}
+		}, DEBOUNCE_MS);
+
+		return () => {
+			cancelled = true;
+			clearTimeout(handle);
+		};
+	}, [filters, connector]);
+
+	return search;
+}

--- a/lib/connectors/tts/useVoiceSearch.ts
+++ b/lib/connectors/tts/useVoiceSearch.ts
@@ -3,8 +3,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { useConfig } from "@/lib/config/ConfigProvider";
 import { createConnector } from "@/lib/connectors/factory";
-import type { VoiceDescriptor } from "@/lib/connectors/tts/plugins/voice-search";
-import type { ModelRef, VoiceInfo } from "@/lib/connectors/types";
+import type {
+	ModelRef,
+	VoiceInfo,
+	VoiceSearchParams,
+} from "@/lib/connectors/types";
 import { errorMessage } from "@/lib/errors";
 
 export type VoiceSearch =
@@ -16,9 +19,8 @@ const DEBOUNCE_MS = 300;
 const VOICE_LIMIT = 50;
 const LOADING: VoiceSearch = { status: "loading" };
 
-/** The voices a pair offers for the filters, searched again whenever either changes. */
 export function useVoiceSearch(
-	filters: VoiceDescriptor,
+	filters: VoiceSearchParams,
 	model: ModelRef,
 ): VoiceSearch {
 	const { connectorConfig } = useConfig();

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import type { CanvasContentElement } from "@/lib/canvas/types";
-import type { GatewayClient } from "@/lib/gateway/base";
 import type { NodeSpec } from "@/lib/generation/graph";
 import type { ProjectData } from "@/lib/project/store";
 import type { WithMetadata } from "@/lib/providers/base";
@@ -79,8 +78,7 @@ export type ModelPick = { provider?: string; model?: string };
 
 export type VoiceSearchFn = (params: VoiceSearchParams) => Promise<VoiceInfo[]>;
 
-export interface PluginContext<TParams = unknown, TResult = unknown> {
-	gateway?: GatewayClient<TParams, TResult>;
+export interface PluginContext {
 	searchVoices?: VoiceSearchFn;
 	/** Id of the node being generated. */
 	elementId?: string;
@@ -114,20 +112,17 @@ export interface ConnectorPlugin<TParams = unknown, TResult = unknown> {
 	model?(element: CanvasContentElement, state: ProjectData): ModelRef;
 	beforeGenerate?(
 		params: TParams,
-		ctx: PluginContext<TParams, TResult>,
+		ctx: PluginContext,
 	): TParams | Promise<TParams>;
 	afterGenerate?(
 		result: TResult,
-		ctx: PluginContext<TParams, TResult>,
+		ctx: PluginContext,
 	): TResult | Promise<TResult>;
 	transformPrompt?(
 		prompt: string,
-		ctx: PluginContext<TParams, TResult>,
+		ctx: PluginContext,
 	): string | Promise<string>;
-	onError?(
-		error: string,
-		ctx: PluginContext<TParams, TResult>,
-	): void | Promise<void>;
+	onError?(error: string, ctx: PluginContext): void | Promise<void>;
 }
 
 export interface ConnectorConfig {

--- a/lib/connectors/video/openslop/models.ts
+++ b/lib/connectors/video/openslop/models.ts
@@ -1,14 +1,6 @@
+import { RUNWARE_VIDEO_MODELS } from "../runware/models";
+
 export const OPENSLOP_VIDEO_MODELS = {
-	"Slop Video v1": {
-		id: "bytedance:seedance@2.0-fast",
-		cost: "high",
-		speed: "medium",
-		resolutions: ["720p"],
-	},
-	"Slop Video v1 Fast": {
-		id: "klingai:kling-video@3.0-turbo",
-		cost: "high",
-		speed: "high",
-		resolutions: ["720p", "1080p"],
-	},
+	"Slop Video v1": RUNWARE_VIDEO_MODELS["Seedance 2 Fast"],
+	"Slop Video v1 Fast": RUNWARE_VIDEO_MODELS["Kling 3 Turbo"],
 } as const;

--- a/lib/project/language.ts
+++ b/lib/project/language.ts
@@ -2,6 +2,9 @@ import { TTS_LANGUAGES, type TTSLanguage } from "@/lib/connectors/tts/enums";
 
 export const AUTO_LANGUAGE = "auto";
 
+/** What speech speaks when the project leaves the language on auto. */
+export const FALLBACK_LANGUAGE: TTSLanguage = "en";
+
 export type LanguageChoice = typeof AUTO_LANGUAGE | TTSLanguage;
 
 export const LANGUAGE_CHOICES = [AUTO_LANGUAGE, ...TTS_LANGUAGES] as const;

--- a/lib/project/language.ts
+++ b/lib/project/language.ts
@@ -2,9 +2,6 @@ import { TTS_LANGUAGES, type TTSLanguage } from "@/lib/connectors/tts/enums";
 
 export const AUTO_LANGUAGE = "auto";
 
-/** What speech speaks when the project leaves the language on auto. */
-export const FALLBACK_LANGUAGE: TTSLanguage = "en";
-
 export type LanguageChoice = typeof AUTO_LANGUAGE | TTSLanguage;
 
 export const LANGUAGE_CHOICES = [AUTO_LANGUAGE, ...TTS_LANGUAGES] as const;


### PR DESCRIPTION
Nightly maintainability pass over `lib/connectors`. No behavior change except the one noted under VoicePicker. Four of the changes are user-validated flags from the conventions follow-up ledger (746j, 746k, 746l, 746m), unblocked now that #754 has merged.

## Plugin context contract

- `PluginContext` loses its dead `gateway` field. `HttpLLMConnector` was the only writer and no plugin ever read it (`requireGateway` went away earlier). With the field gone the `<TParams, TResult>` generics carried nothing, so `PluginContext` is now plain; `ConnectorPlugin` keeps its generics, which are still load-bearing on `beforeGenerate`/`afterGenerate`. Eight files stop spelling phantom type arguments.
- `requireContext(ctx, key, plugin)` replaces `requireState`, `requireModel`, and the hand-rolled `searchVoices` guard in `voice-search.ts`. One keyed mechanism, no cast; the return type narrows from the field. Ten call sites.
- `BaseConnector.pluginContext()` is gone. It was a virtual hook returning `{}` with one override left (TTS), so `HttpTTSConnector` now overrides `contextFor` directly and adds `searchVoices` to the base context.

## Hosted model tables

Every `openslop/models.ts` table restated its vendor entry by hand (`id`, `cost`, `speed`, `resolutions`). They now alias the vendor row they serve: `"Slop Video v1": RUNWARE_VIDEO_MODELS["Seedance 2 Fast"]`, and likewise for image, TTS, LLM, SFX, and music. The ids cannot drift from the vendor tables any more, and `typeof OPENSLOP_*_MODELS` still keys `OPENSLOP_PROVIDERS` in `lib/api/providers/openslop.ts` unchanged.

## Voice search

- `useVoiceSearch(filters, model)` in `lib/connectors/tts/useVoiceSearch.ts` owns the TTS connector, the 300ms debounce, the cancellation flag, and the result limit. It returns a `loading | ready | failed` union in the shape `usePeaks` already uses. `VoicePicker` is now presentational: it calls the hook and renders the three states.

**One visible difference:** when a voice search fails, the list from the previous successful search no longer stays on screen under the error. The failed state renders the error alone.

## Not taken

- Dropping the `plugin` name argument from `requireContext` by attributing failures in the plugin runner: needs a try/rethrow around every hook call and changes every plugin error's text. Left for a human call.
- A hosted catalog that derives `OPENSLOP_PROVIDERS` from the vendor tables: the aliasing removes the id duplication; tying the provider source to the table is a larger contract change.
- Generic `AsyncState<T>` shared by `usePeaks` and `useVoiceSearch`: two uses, and the repo has rejected generic async hooks before.
- 746q (1920x1080 in three places), 746r (`getLoop`/`getMotion` read path), 746s (Badge size): off-theme for this pass and still open on the ledger.

## Checks

lint, format:check, typecheck, knip, test:coverage (181 files, 1624 tests, thresholds met), build: all pass.

## Merge-conflict guard

```
PR #766: clean
PR #765: clean
PR #764: clean
PR #763: clean
PR #762: clean
PR #761: clean
PR #760: clean
PR #759: clean
OK: no file overlap or merge conflict with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

