### PR TITLE
refactor: nightly readability 2026-09-11

### DIFF
--- a/app/components/video/BottomTransportBar.tsx
+++ b/app/components/video/BottomTransportBar.tsx
@@ -31,14 +31,14 @@ function BottomTransportBarComponent() {
 	const canPlay = ready && segments.length > 0;
 	const canSeek = canPlay && player !== null;
 
-	const seekToAdjacentScene = (dir: -1 | 1) => {
+	const seekToAdjacentScene = (direction: -1 | 1) => {
 		if (!player || segments.length === 0) return;
 		const current = findSegmentIndexAtFrame(
 			segments,
 			player.getCurrentFrame(),
 			layout.fps,
 		);
-		const target = segments[current + dir];
+		const target = segments[current + direction];
 		if (target) player.seekTo(toFrames(target.start, layout.fps));
 	};
 

--- a/app/components/video/PlayerControls.tsx
+++ b/app/components/video/PlayerControls.tsx
@@ -20,7 +20,7 @@ export function TimeDisplay() {
 	const { layout } = useLayout();
 	const seconds = usePlayerValue(
 		FRAME_EVENTS,
-		(p) => Math.floor(toSeconds(p.getCurrentFrame(), layout.fps)),
+		(player) => Math.floor(toSeconds(player.getCurrentFrame(), layout.fps)),
 		0,
 	);
 	return (

--- a/app/components/video/ScrubBar.tsx
+++ b/app/components/video/ScrubBar.tsx
@@ -112,17 +112,17 @@ export function ScrubBar({
 	const drag = usePointerDrag({
 		onStart: onScrubStart,
 		onMove: (e) => {
-			const p = hoverFrom(e);
-			if (p) onScrub(p.ratio);
+			const hover = hoverFrom(e);
+			if (hover) onScrub(hover.ratio);
 		},
 		onEnd: onScrubEnd,
 	});
 
 	const onPointerMove = (e: PointerEvent<HTMLDivElement>) => {
-		const p = hoverFrom(e);
-		if (p) {
-			setHoverRatio(p.ratio);
-			onHoverChange?.(p);
+		const hover = hoverFrom(e);
+		if (hover) {
+			setHoverRatio(hover.ratio);
+			onHoverChange?.(hover);
 		}
 		drag.onPointerMove(e);
 	};

--- a/app/components/video/VideoPreview.tsx
+++ b/app/components/video/VideoPreview.tsx
@@ -75,7 +75,7 @@ export function VideoPreview({ layout, restoreFrameRef }: VideoPreviewProps) {
 		if (!player) return;
 		const willPlay = !player.isPlaying();
 		player.toggle();
-		setFlash((f) => ({ key: (f?.key ?? 0) + 1, playing: willPlay }));
+		setFlash((prev) => ({ key: (prev?.key ?? 0) + 1, playing: willPlay }));
 	};
 	return (
 		<div className={`relative h-full w-full ${styles.player}`}>

--- a/app/components/video/useAssetPrefetch.ts
+++ b/app/components/video/useAssetPrefetch.ts
@@ -7,10 +7,10 @@ type PrefetchHandle = ReturnType<typeof PrefetchFn>;
 let prefetchPromise: Promise<typeof PrefetchFn> | null = null;
 const loadPrefetch = () =>
 	(prefetchPromise ??= import("remotion")
-		.then((m) => m.prefetch)
-		.catch((err) => {
+		.then((remotion) => remotion.prefetch)
+		.catch((error) => {
 			prefetchPromise = null;
-			throw err;
+			throw error;
 		}));
 
 export function collectUrls(layout: VideoLayout): Set<string> {
@@ -47,7 +47,7 @@ export function reconcilePrefetch(
 }
 
 export async function awaitPrefetch(handles: PrefetchHandle[]): Promise<void> {
-	await Promise.allSettled(handles.map((h) => h.waitUntilDone()));
+	await Promise.allSettled(handles.map((handle) => handle.waitUntilDone()));
 }
 
 export function useAssetPrefetch(layout: VideoLayout): boolean {
@@ -67,9 +67,9 @@ export function useAssetPrefetch(layout: VideoLayout): boolean {
 				await awaitPrefetch([...active.values()]);
 				if (!cancelled) setReady(true);
 			})
-			.catch((err) => {
+			.catch((error) => {
 				if (cancelled) return;
-				console.error("Failed to load remotion for prefetch", err);
+				console.error("Failed to load remotion for prefetch", error);
 				setReady(true);
 			});
 

--- a/app/components/video/usePlayerState.ts
+++ b/app/components/video/usePlayerState.ts
@@ -18,7 +18,7 @@ const MUTE_EVENTS: readonly PlayerEvent[] = ["mutechange"];
 
 export function usePlayerValue<T>(
 	events: readonly PlayerEvent[],
-	read: (p: PlayerRef) => T,
+	read: (player: PlayerRef) => T,
 	fallback: T,
 ): T {
 	const { player } = usePlayerControl();
@@ -40,17 +40,17 @@ export function usePlayerValue<T>(
 }
 
 export function usePlayerFrame() {
-	return usePlayerValue(FRAME_EVENTS, (p) => p.getCurrentFrame(), 0);
+	return usePlayerValue(FRAME_EVENTS, (player) => player.getCurrentFrame(), 0);
 }
 
 export function usePlayerPlaying() {
-	return usePlayerValue(PLAY_EVENTS, (p) => p.isPlaying(), false);
+	return usePlayerValue(PLAY_EVENTS, (player) => player.isPlaying(), false);
 }
 
 export function usePlayerVolume() {
-	return usePlayerValue(VOLUME_EVENTS, (p) => p.getVolume(), 1);
+	return usePlayerValue(VOLUME_EVENTS, (player) => player.getVolume(), 1);
 }
 
 export function usePlayerMuted() {
-	return usePlayerValue(MUTE_EVENTS, (p) => p.isMuted(), false);
+	return usePlayerValue(MUTE_EVENTS, (player) => player.isMuted(), false);
 }

--- a/app/components/video/useRendering.ts
+++ b/app/components/video/useRendering.ts
@@ -18,8 +18,8 @@ export function useRendering() {
 		setState({ status: "invoking" });
 		try {
 			for await (const update of runRender(layout, scale)) setState(update);
-		} catch (err) {
-			setState({ status: "error", message: errorMessage(err) });
+		} catch (error) {
+			setState({ status: "error", message: errorMessage(error) });
 		}
 	}, []);
 

--- a/lib/video/fadeRamp.ts
+++ b/lib/video/fadeRamp.ts
@@ -17,15 +17,15 @@ export function fadeRamp(
 	fadeFrames: number,
 ): FadeRamp | null {
 	if (durationInFrames <= 1 || fadeFrames <= 0) return null;
-	const f = Math.min(fadeFrames, Math.floor((durationInFrames - 1) / 2));
-	if (f <= 0) {
+	const edge = Math.min(fadeFrames, Math.floor((durationInFrames - 1) / 2));
+	if (edge <= 0) {
 		return {
 			input: [0, durationInFrames / 2, durationInFrames],
 			output: [0, 1, 0],
 		};
 	}
 	return {
-		input: [0, f, durationInFrames - f, durationInFrames],
+		input: [0, edge, durationInFrames - edge, durationInFrames],
 		output: [0, 1, 1, 0],
 	};
 }

--- a/lib/video/layoutKey.ts
+++ b/lib/video/layoutKey.ts
@@ -17,8 +17,8 @@ export function getLayoutKey(
 		.filter(isSceneElement)
 		.flatMap((scene) =>
 			scene.children.map(
-				(el) =>
-					`${scene.id}:${el.id}:${el.type}:${layoutAttributeSignature(el)}`,
+				(element) =>
+					`${scene.id}:${element.id}:${element.type}:${layoutAttributeSignature(element)}`,
 			),
 		)
 		.join("|");

--- a/lib/video/motionEffects.ts
+++ b/lib/video/motionEffects.ts
@@ -17,9 +17,9 @@ const ZERO: Components = { tx: 0, ty: 0, rotation: 0, extraScale: 0 };
 
 const easeInOut = Easing.inOut(Easing.ease);
 
-function ramp(frame: number, d: number, a: number, b: number): number {
-	if (d <= 0) return b;
-	return interpolate(frame, [0, d], [a, b], {
+function ramp(frame: number, duration: number, from: number, to: number) {
+	if (duration <= 0) return to;
+	return interpolate(frame, [0, duration], [from, to], {
 		extrapolateLeft: "clamp",
 		extrapolateRight: "clamp",
 		easing: easeInOut,
@@ -106,10 +106,10 @@ export function motionTransform(
 	aspectRatio: number = 16 / 9,
 ): string {
 	if (effect === "none") return "none";
-	const d = Math.max(1, durationInFrames);
-	const ar = Math.max(1, aspectRatio);
-	const c = SPECS[effect](frame, d);
+	const duration = Math.max(1, durationInFrames);
+	const aspect = Math.max(1, aspectRatio);
+	const { tx, ty, rotation, extraScale } = SPECS[effect](frame, duration);
 	const scale =
-		coverScale(c.tx, c.ty, c.rotation, ar) + COVER_HEADROOM + c.extraScale;
-	return `translate(${c.tx.toFixed(3)}%, ${c.ty.toFixed(3)}%) scale(${scale.toFixed(4)}) rotate(${c.rotation.toFixed(3)}deg)`;
+		coverScale(tx, ty, rotation, aspect) + COVER_HEADROOM + extraScale;
+	return `translate(${tx.toFixed(3)}%, ${ty.toFixed(3)}%) scale(${scale.toFixed(4)}) rotate(${rotation.toFixed(3)}deg)`;
 }

--- a/lib/video/resolve.ts
+++ b/lib/video/resolve.ts
@@ -18,11 +18,11 @@ export function resolveElements(
 		if (!isSceneElement(scene)) continue;
 		sceneNumber += 1;
 
-		for (const el of scene.children) {
-			const snapshot = getSnapshot(el.id);
+		for (const element of scene.children) {
+			const snapshot = getSnapshot(element.id);
 			if (!snapshot.result) continue;
 
-			const spec = ELEMENT_TYPES[el.type];
+			const spec = ELEMENT_TYPES[element.type];
 			const url = getPrimaryUrl(snapshot.result, spec.outputKind);
 			if (!url) continue;
 
@@ -31,19 +31,19 @@ export function resolveElements(
 				captionsEnabled && timestamps?.length ? timestamps : undefined;
 
 			resolved.push({
-				id: el.id,
-				type: el.type,
+				id: element.id,
+				type: element.type,
 				role: spec.role,
 				layer: spec.layer,
 				sceneId: scene.id,
 				sceneNumber,
-				prompt: getPromptText(el),
+				prompt: getPromptText(element),
 				url,
 				durationSec: snapshot.result.durationSec,
-				loops: getLoops(el),
-				loop: getLoop(el),
-				volume: getVolume(el),
-				motion: getMotion(el),
+				loops: getLoops(element),
+				loop: getLoop(element),
+				volume: getVolume(element),
+				motion: getMotion(element),
 				captionTimestamps,
 			});
 		}

--- a/lib/video/scene-builder.ts
+++ b/lib/video/scene-builder.ts
@@ -66,15 +66,9 @@ function pushSequence(
 
 function trimSequencesAt(list: Sequence[] | undefined, cutoff: number) {
 	if (!list) return;
-	while (list.length > 0) {
-		const last = list[list.length - 1];
-		if (last.start >= cutoff) {
-			list.pop();
-			continue;
-		}
-		last.duration = Math.min(last.duration, cutoff - last.start);
-		return;
-	}
+	while (list.length > 0 && list[list.length - 1].start >= cutoff) list.pop();
+	const last = list.at(-1);
+	if (last) last.duration = Math.min(last.duration, cutoff - last.start);
 }
 
 function getForegroundCursor(current: Sequence | undefined, cursor: number) {

--- a/lib/video/sceneSegments.ts
+++ b/lib/video/sceneSegments.ts
@@ -21,18 +21,15 @@ export type SequenceIndex = ReadonlyMap<string, Sequence>;
  * the render payload carries the ordered `series`, not this projection of it.
  */
 export function buildSequenceIndex(series: Sequence[]): SequenceIndex {
-	const index = new Map<string, Sequence>();
-	for (const seq of series) index.set(seq.element.id, seq);
-	return index;
+	return new Map(series.map((seq) => [seq.element.id, seq]));
 }
 
 export function findSceneSequence(
 	scene: SceneElement,
 	index: SequenceIndex,
 ): Sequence | undefined {
-	const fg = scene.children.find(isForeground);
-	if (!fg) return undefined;
-	return index.get(fg.id);
+	const foreground = scene.children.find(isForeground);
+	return foreground ? index.get(foreground.id) : undefined;
 }
 
 /**
@@ -48,11 +45,10 @@ export function findSegmentIndexAtFrame(
 	fps: number,
 ): number {
 	if (segments.length === 0) return -1;
-	for (let i = 0; i < segments.length; i++) {
-		const seg = segments[i];
-		if (frame < toFrames(seg.start + seg.duration, fps)) return i;
-	}
-	return segments.length - 1;
+	const index = segments.findIndex(
+		(seg) => frame < toFrames(seg.start + seg.duration, fps),
+	);
+	return index === -1 ? segments.length - 1 : index;
 }
 
 function toThumbnail(element: ResolvedElement): SeekThumbnail | null {

--- a/lib/video/timestamps.ts
+++ b/lib/video/timestamps.ts
@@ -4,9 +4,8 @@ function floorSeconds(seconds: number): number {
 
 export function formatTime(seconds: number): string {
 	const total = floorSeconds(seconds);
-	const m = Math.floor(total / 60);
-	const s = total % 60;
-	return `${m}:${s.toString().padStart(2, "0")}`;
+	const minutes = Math.floor(total / 60);
+	return `${minutes}:${String(total % 60).padStart(2, "0")}`;
 }
 
 export function formatTimeRange(start: number, duration: number): string {


### PR DESCRIPTION
## Summary

First run of the nightly readability job. One area: the video pipeline, `lib/video` and `app/components/video`. Names say what things are, flow is straightened, and no behavior changes. Every touched file ends the same size or smaller.

**Lines: +58 / -69 across 14 files.**

### Renames

| File | Old | New |
| --- | --- | --- |
| `lib/video/motionEffects.ts` | `ramp(frame, d, a, b)` | `ramp(frame, duration, from, to)` |
| `lib/video/motionEffects.ts` | `d`, `ar`, `c` in `motionTransform` | `duration`, `aspect`, destructured `{ tx, ty, rotation, extraScale }` |
| `lib/video/fadeRamp.ts` | `f` | `edge` |
| `lib/video/timestamps.ts` | `m`, `s` | `minutes`, inlined `total % 60` |
| `lib/video/sceneSegments.ts` | `fg` | `foreground` |
| `lib/video/resolve.ts` | `el` | `element` |
| `lib/video/layoutKey.ts` | `el` | `element` |
| `app/components/video/ScrubBar.tsx` | `p` | `hover` |
| `app/components/video/usePlayerState.ts`, `PlayerControls.tsx` | `p` | `player` |
| `app/components/video/useAssetPrefetch.ts` | `m`, `h`, `err` | `remotion`, `handle`, `error` |
| `app/components/video/useRendering.ts` | `err` | `error` |
| `app/components/video/VideoPreview.tsx` | `f` | `prev` |
| `app/components/video/BottomTransportBar.tsx` | `dir` | `direction` |

### Straightened flow

- `buildSequenceIndex`: `new Map(series.map(...))` instead of a mutable loop.
- `findSceneSequence`: one guarded expression instead of an early-return pair.
- `findSegmentIndexAtFrame`: `findIndex` instead of an indexed loop; the explicit empty-list `-1` guard stays.
- `trimSequencesAt` (scene-builder): a pop-while plus one clamp instead of a while/continue/return loop.

### Skipped

- `lib/components/Waveform.tsx` has the densest short-name cluster (`a` for the audio element, six times) but is outside the video folder pair, so it is a candidate for the next pass.
- `useActiveSegmentIndex.ts` keeps its `(p)` callback: renaming it wraps the line and grows the file.
- The `SPECS` lambdas in `motionEffects.ts` keep `(f, d)`; renaming all thirteen would grow the file, so the type signature keeps `d` too for consistency.
- Moving the `Math.max(1, aspectRatio)` clamp into `coverScale` was suggested by review but changes an exported function's behavior.

### Checks

`npm run lint && npm run typecheck && npm run format:check && npm run test:run && npm run build` all pass (185 test files, 1635 tests). `/simplify` ran with four review agents; four findings applied, the rest skipped as line-budget or behavior conflicts. Composition, web-design, and React best-practice passes had nothing applicable: no JSX or component API changed.

## Merge-conflict guard

```
OK: no shared files or merge conflicts with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)