### PR TITLE
refactor: nightly maintainability 2026-09-11

### DIFF
--- a/app/components/copilot/ComposerAssets.tsx
+++ b/app/components/copilot/ComposerAssets.tsx
@@ -23,11 +23,6 @@ export function ComposerAssets({ uploadingCount }: { uploadingCount: number }) {
 
 	const hasNarration = Object.keys(narration).length > 0;
 
-	const confirmDelete = () => {
-		if (deletingName) deleteCharacter(store, queue, deletingName);
-		setDeletingName(undefined);
-	};
-
 	return (
 		<div className="flex flex-wrap gap-2 pb-2">
 			{hasArtStyle && <ArtStyleAssetTile />}
@@ -41,14 +36,12 @@ export function ComposerAssets({ uploadingCount }: { uploadingCount: number }) {
 				/>
 			))}
 			<ConfirmDeleteDialog
-				open={deletingName !== undefined}
-				onOpenChange={(open) => {
-					if (!open) setDeletingName(undefined);
-				}}
-				title={`Delete ${deletingName}?`}
+				target={deletingName}
+				onClose={() => setDeletingName(undefined)}
+				title={(name) => `Delete ${name}?`}
 				description="This permanently removes the character and its avatar. It can't be undone."
 				actionLabel="Delete character"
-				onConfirm={confirmDelete}
+				onConfirm={(name) => deleteCharacter(store, queue, name)}
 			/>
 		</div>
 	);

--- a/app/components/projects/ProjectsList.tsx
+++ b/app/components/projects/ProjectsList.tsx
@@ -80,17 +80,12 @@ export default function ProjectsList({
 				</div>
 			</div>
 			<ConfirmDeleteDialog
-				open={deleting !== undefined}
-				onOpenChange={(open) => {
-					if (!open) setDeleting(undefined);
-				}}
-				title={`Delete ${deleting?.name}?`}
+				target={deleting}
+				onClose={() => setDeleting(undefined)}
+				title={(project) => `Delete ${project.name}?`}
 				description="This permanently deletes the project and everything generated in it. It can't be undone."
 				actionLabel="Delete project"
-				onConfirm={() => {
-					if (deleting) handleDelete(deleting.id);
-					setDeleting(undefined);
-				}}
+				onConfirm={(project) => void handleDelete(project.id)}
 			/>
 		</TooltipProvider>
 	);

--- a/app/components/settings/ProviderCard.tsx
+++ b/app/components/settings/ProviderCard.tsx
@@ -73,7 +73,7 @@ export function ProviderCard({
 
 	const [editing, setEditing] = useState(selected || !key);
 	const [testing, setTesting] = useState(false);
-	const [confirmingRemoval, setConfirmingRemoval] = useState(false);
+	const [removing, setRemoving] = useState<BYOKProvider>();
 	const card = useRef<HTMLDivElement>(null);
 
 	const done = () => {
@@ -139,7 +139,7 @@ export function ProviderCard({
 							size="sm"
 							variant="destructive"
 							className="ml-auto"
-							onClick={() => setConfirmingRemoval(true)}
+							onClick={() => setRemoving(provider)}
 						>
 							<Trash2 />
 							Delete key
@@ -149,13 +149,13 @@ export function ProviderCard({
 			)}
 
 			<ConfirmDeleteDialog
-				open={confirmingRemoval}
-				onOpenChange={setConfirmingRemoval}
-				title={`Delete your ${meta.name} key?`}
+				target={removing}
+				onClose={() => setRemoving(undefined)}
+				title={() => `Delete your ${meta.name} key?`}
 				description={`Models served by ${meta.name} stop being available until you add a new key.`}
 				actionLabel="Delete key"
-				onConfirm={() =>
-					void removeKey(provider).then(onDismissed).catch(toastError)
+				onConfirm={(target) =>
+					void removeKey(target).then(onDismissed).catch(toastError)
 				}
 			/>
 		</Tile>

--- a/app/components/video/storyboard/Storyboard.tsx
+++ b/app/components/video/storyboard/Storyboard.tsx
@@ -20,7 +20,7 @@ export function Storyboard() {
 	const { layout, segments, scenes } = useLayout();
 	const selectScene = useSelectScene();
 	const defaultModels = useResolveDefaultModels();
-	const [deleting, setDeleting] = useState<StoryboardSceneData | null>(null);
+	const [deleting, setDeleting] = useState<StoryboardSceneData>();
 
 	const items = useMemo(
 		() => buildStoryboardScenes(scenes, segments),
@@ -55,17 +55,12 @@ export function Storyboard() {
 			))}
 			<SceneInsertHandle onInsert={() => addSceneBefore(items.length)} />
 			<ConfirmDeleteDialog
-				open={deleting !== null}
-				onOpenChange={(open) => {
-					if (!open) setDeleting(null);
-				}}
-				title={`Delete scene ${deleting?.sceneIndex}?`}
+				target={deleting}
+				onClose={() => setDeleting(undefined)}
+				title={(item) => `Delete scene ${item.sceneIndex}?`}
 				description="This removes the scene and everything in it. Undo from the canvas to bring it back."
 				actionLabel="Delete scene"
-				onConfirm={() => {
-					if (deleting) removeElement(editor, deleting.scene);
-					setDeleting(null);
-				}}
+				onConfirm={(item) => removeElement(editor, item.scene)}
 			/>
 		</section>
 	);

--- a/components/ui/confirm-delete-dialog.tsx
+++ b/components/ui/confirm-delete-dialog.tsx
@@ -11,51 +11,55 @@ import {
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 
-/** Confirmation gate for destructive actions. */
-export function ConfirmDeleteDialog({
-	open,
-	onOpenChange,
+/**
+ * Confirmation gate for destructive actions. It is open while there is a
+ * target, and confirming hands that target back, so the caller never has to
+ * guard against confirming nothing.
+ */
+export function ConfirmDeleteDialog<T>({
+	target,
+	onClose,
 	title,
 	description,
 	actionLabel,
 	onConfirm,
 }: {
-	open: boolean;
-	onOpenChange: (open: boolean) => void;
-	title: string;
+	target: T | undefined;
+	onClose: () => void;
+	title: (target: T) => string;
 	description: string;
 	actionLabel: string;
-	onConfirm: () => void;
+	onConfirm: (target: T) => void;
 }) {
-	// Radix keeps the dialog mounted through its exit animation; latch the
-	// content so it doesn't flash cleared values after the caller resets state.
-	const [latched, setLatched] = useState({ title, description, actionLabel });
-	if (
-		open &&
-		(latched.title !== title ||
-			latched.description !== description ||
-			latched.actionLabel !== actionLabel)
-	) {
-		setLatched({ title, description, actionLabel });
-	}
+	// Radix keeps the dialog mounted through its exit animation; keep the last
+	// target so the content doesn't flash empty after the caller clears it.
+	const [latched, setLatched] = useState(target);
+	if (target !== undefined && target !== latched) setLatched(target);
 
 	return (
-		<AlertDialog open={open} onOpenChange={onOpenChange}>
-			<AlertDialogContent>
-				<AlertDialogTitle>{latched.title}</AlertDialogTitle>
-				<AlertDialogDescription>{latched.description}</AlertDialogDescription>
-				<AlertDialogFooter>
-					<AlertDialogCancel className="rounded-md px-2.5 py-1 text-label text-muted-foreground transition-colors hover:text-foreground">
-						Cancel
-					</AlertDialogCancel>
-					<AlertDialogAction
-						onClick={onConfirm}
-						className="rounded-md bg-destructive px-3 py-1 text-label font-medium text-destructive-foreground shadow-elevation-5 transition hover:brightness-110"
-					>
-						{latched.actionLabel}
-					</AlertDialogAction>
-				</AlertDialogFooter>
-			</AlertDialogContent>
+		<AlertDialog
+			open={target !== undefined}
+			onOpenChange={(open) => {
+				if (!open) onClose();
+			}}
+		>
+			{latched !== undefined && (
+				<AlertDialogContent>
+					<AlertDialogTitle>{title(latched)}</AlertDialogTitle>
+					<AlertDialogDescription>{description}</AlertDialogDescription>
+					<AlertDialogFooter>
+						<AlertDialogCancel className="rounded-md px-2.5 py-1 text-label text-muted-foreground transition-colors hover:text-foreground">
+							Cancel
+						</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={() => onConfirm(latched)}
+							className="rounded-md bg-destructive px-3 py-1 text-label font-medium text-destructive-foreground shadow-elevation-5 transition hover:brightness-110"
+						>
+							{actionLabel}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			)}
 		</AlertDialog>
 	);
 }

--- a/lib/connectors/animated_image/connector.ts
+++ b/lib/connectors/animated_image/connector.ts
@@ -22,7 +22,7 @@ export class HttpAnimatedImageConnector extends BaseAssetConnector<
 	readonly assetKey = "video" as const;
 
 	constructor(config: ResolvedConnectorConfig) {
-		super(new HttpAssetGateway(config.model, "video", config.baseUrl), config);
+		super(new HttpAssetGateway(config.model, "video"), config);
 	}
 
 	static attributesFor(model: ModelRef): AttributeSchema {

--- a/lib/connectors/image/connector.ts
+++ b/lib/connectors/image/connector.ts
@@ -17,7 +17,7 @@ export class HttpImageConnector extends BaseAssetConnector<
 	readonly assetKey = "image" as const;
 
 	constructor(config: ResolvedConnectorConfig) {
-		super(new HttpAssetGateway(config.model, "image", config.baseUrl), config);
+		super(new HttpAssetGateway(config.model, "image"), config);
 	}
 
 	static attributesFor(_model: ModelRef): AttributeSchema {

--- a/lib/connectors/llm/connector.ts
+++ b/lib/connectors/llm/connector.ts
@@ -19,7 +19,7 @@ export class HttpLLMConnector
 
 	constructor(config: ResolvedConnectorConfig) {
 		super(config);
-		this.gateway = new HttpLLMGateway(config.model, config.baseUrl);
+		this.gateway = new HttpLLMGateway(config.model);
 	}
 
 	protected async _generate(

--- a/lib/connectors/music/connector.ts
+++ b/lib/connectors/music/connector.ts
@@ -17,7 +17,7 @@ export class HttpMusicConnector extends BaseAssetConnector<
 	readonly assetKey = "audio" as const;
 
 	constructor(config: ResolvedConnectorConfig) {
-		super(new HttpAssetGateway(config.model, "music", config.baseUrl), config);
+		super(new HttpAssetGateway(config.model, "music"), config);
 	}
 
 	static attributesFor(_model: ModelRef): AttributeSchema {

--- a/lib/connectors/sfx/connector.ts
+++ b/lib/connectors/sfx/connector.ts
@@ -17,7 +17,7 @@ export class HttpSFXConnector extends BaseAssetConnector<
 	readonly assetKey = "audio" as const;
 
 	constructor(config: ResolvedConnectorConfig) {
-		super(new HttpAssetGateway(config.model, "sfx", config.baseUrl), config);
+		super(new HttpAssetGateway(config.model, "sfx"), config);
 	}
 
 	static attributesFor(_model: ModelRef): AttributeSchema {

--- a/lib/connectors/tts/connector.ts
+++ b/lib/connectors/tts/connector.ts
@@ -24,7 +24,7 @@ export class HttpTTSConnector
 	readonly assetKey = "audio" as const;
 
 	constructor(config: ResolvedConnectorConfig) {
-		super(new HttpTTSGateway(config.model, config.baseUrl), config);
+		super(new HttpTTSGateway(config.model), config);
 	}
 
 	static attributesFor(_model: ModelRef): AttributeSchema {

--- a/lib/connectors/types.ts
+++ b/lib/connectors/types.ts
@@ -126,7 +126,6 @@ export interface ConnectorPlugin<TParams = unknown, TResult = unknown> {
 }
 
 export interface ConnectorConfig {
-	baseUrl?: string;
 	plugins?: ConnectorPlugin[];
 }
 

--- a/lib/connectors/video/connector.ts
+++ b/lib/connectors/video/connector.ts
@@ -17,7 +17,7 @@ export class HttpVideoConnector extends BaseAssetConnector<
 	readonly assetKey = "video" as const;
 
 	constructor(config: ResolvedConnectorConfig) {
-		super(new HttpAssetGateway(config.model, "video", config.baseUrl), config);
+		super(new HttpAssetGateway(config.model, "video"), config);
 	}
 
 	static attributesFor(model: ModelRef): AttributeSchema {

--- a/lib/gateway/__tests__/http-gateways.test.ts
+++ b/lib/gateway/__tests__/http-gateways.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { HttpAssetGateway, HttpLLMGateway, HttpTTSGateway } from "../http";
 
-const BASE = "https://api.test.com";
+/** Routes are app-relative, so they parse against any origin. */
+const parseUrl = (url: string) => new URL(url, "http://localhost");
 
 function jsonResponse(data: unknown) {
 	return new Response(JSON.stringify(data), {
@@ -44,11 +45,11 @@ describe("HTTP gateways", () => {
 			const submission = { jobId: "job-1", status: "pending" };
 			fetchMock.mockResolvedValue(jsonResponse(submission));
 
-			const gw = new HttpAssetGateway(model, "image", BASE);
+			const gw = new HttpAssetGateway(model, "image");
 
 			expect(await gw.generate({ prompt: "a cat" })).toEqual(submission);
 			expect(fetchMock).toHaveBeenCalledWith(
-				`${BASE}${prefix}/image`,
+				`${prefix}/image`,
 				expect.objectContaining({ method: "POST" }),
 			);
 		});
@@ -62,11 +63,11 @@ describe("HTTP gateways", () => {
 			};
 			fetchMock.mockResolvedValue(jsonResponse(poll));
 
-			const gw = new HttpAssetGateway(HOSTED_VIDEO, "video", BASE);
+			const gw = new HttpAssetGateway(HOSTED_VIDEO, "video");
 
 			expect(await gw.poll("job-1")).toEqual(poll);
 			expect(fetchMock).toHaveBeenCalledWith(
-				`${BASE}/api/v1/video/job-1`,
+				`/api/v1/video/job-1`,
 				expect.objectContaining({ method: "GET" }),
 			);
 		});
@@ -82,13 +83,10 @@ describe("HTTP gateways", () => {
 			);
 			const { signal } = new AbortController();
 
-			await new HttpAssetGateway(HOSTED_VIDEO, "video", BASE).poll(
-				"job-1",
-				signal,
-			);
+			await new HttpAssetGateway(HOSTED_VIDEO, "video").poll("job-1", signal);
 
 			expect(fetchMock).toHaveBeenCalledWith(
-				`${BASE}/api/v1/video/job-1`,
+				`/api/v1/video/job-1`,
 				expect.objectContaining({ signal }),
 			);
 		});
@@ -99,12 +97,12 @@ describe("HTTP gateways", () => {
 			const voices = [{ id: "v1", name: "Alice", gender: "feminine" }];
 			fetchMock.mockResolvedValue(jsonResponse({ voices }));
 
-			const gw = new HttpTTSGateway(HOSTED_TTS, BASE);
+			const gw = new HttpTTSGateway(HOSTED_TTS);
 
 			expect(await gw.searchVoices({ gender: "feminine", limit: 5 })).toEqual(
 				voices,
 			);
-			const url = new URL(fetchMock.mock.calls[0][0] as string);
+			const url = parseUrl(fetchMock.mock.calls[0][0] as string);
 			expect(url.pathname).toBe("/api/v1/tts/voices");
 			expect(url.searchParams.get("gender")).toBe("feminine");
 			expect(url.searchParams.get("limit")).toBe("5");
@@ -122,12 +120,9 @@ describe("HTTP gateways", () => {
 				}),
 			);
 
-			const [alice, bob] = await new HttpTTSGateway(
-				BYOK_TTS,
-				BASE,
-			).searchVoices({});
+			const [alice, bob] = await new HttpTTSGateway(BYOK_TTS).searchVoices({});
 
-			const preview = new URL(alice?.previewUrl ?? "", BASE);
+			const preview = parseUrl(alice?.previewUrl ?? "");
 			expect(preview.pathname).toBe("/api/third-party/tts/voices/preview");
 			expect(preview.searchParams.get("url")).toBe("https://vendor/a.mp3");
 			expect(preview.searchParams.get("provider")).toBe("cartesia");
@@ -140,11 +135,11 @@ describe("HTTP gateways", () => {
 		it("names its model when the key is the user's own", async () => {
 			fetchMock.mockResolvedValue(jsonResponse({ voices: [] }));
 
-			await new HttpTTSGateway(BYOK_TTS, BASE).searchVoices({
+			await new HttpTTSGateway(BYOK_TTS).searchVoices({
 				query: undefined,
 			});
 
-			const url = new URL(fetchMock.mock.calls[0][0] as string);
+			const url = parseUrl(fetchMock.mock.calls[0][0] as string);
 			expect(url.pathname).toBe("/api/third-party/tts/voices");
 			expect(url.searchParams.get("provider")).toBe("cartesia");
 			expect(url.searchParams.get("model")).toBe("Sonic 3.6");
@@ -157,11 +152,11 @@ describe("HTTP gateways", () => {
 			const response = { text: "Hello!", model: "claude-3" };
 			fetchMock.mockResolvedValue(jsonResponse(response));
 
-			const gw = new HttpLLMGateway(HOSTED_LLM, BASE);
+			const gw = new HttpLLMGateway(HOSTED_LLM);
 
 			expect(await gw.generate({ prompt: "hi" })).toEqual(response);
 			expect(fetchMock).toHaveBeenCalledWith(
-				`${BASE}/api/v1/llm`,
+				`/api/v1/llm`,
 				expect.objectContaining({ method: "POST" }),
 			);
 		});
@@ -173,14 +168,14 @@ describe("HTTP gateways", () => {
 			];
 			fetchMock.mockResolvedValue(sseResponse(chunks));
 
-			const gw = new HttpLLMGateway(BYOK_LLM, BASE);
+			const gw = new HttpLLMGateway(BYOK_LLM);
 			const results: unknown[] = [];
 			for await (const chunk of gw.stream({ prompt: "hi" })) {
 				results.push(chunk);
 			}
 
 			expect(results).toEqual(chunks);
-			expect(fetchMock.mock.calls[0][0]).toBe(`${BASE}/api/third-party/llm`);
+			expect(fetchMock.mock.calls[0][0]).toBe(`/api/third-party/llm`);
 			const body = JSON.parse(
 				fetchMock.mock.calls[0][1].body as string,
 			) as Record<string, unknown>;
@@ -192,7 +187,7 @@ describe("HTTP gateways", () => {
 				new Response(null, { status: 200, headers: {} }),
 			);
 
-			const gw = new HttpLLMGateway(HOSTED_LLM, BASE);
+			const gw = new HttpLLMGateway(HOSTED_LLM);
 			await expect(async () => {
 				for await (const _ of gw.stream({ prompt: "hi" })) {
 					// consume

--- a/lib/gateway/http.ts
+++ b/lib/gateway/http.ts
@@ -25,10 +25,9 @@ export class HttpAssetGateway<TParams> extends AssetGateway<TParams> {
 	constructor(
 		protected readonly model: ModelRef,
 		path: string,
-		baseUrl = "",
 	) {
 		super();
-		this.route = `${baseUrl}${apiPrefixFor(model.provider)}/${path}`;
+		this.route = `${apiPrefixFor(model.provider)}/${path}`;
 	}
 
 	async generate(params: TParams): Promise<JobSubmission> {
@@ -47,9 +46,9 @@ export class HttpLLMGateway extends GatewayClient<
 > {
 	private readonly route: string;
 
-	constructor(model: ModelRef, baseUrl = "") {
+	constructor(model: ModelRef) {
 		super();
-		this.route = `${baseUrl}${apiPrefixFor(model.provider)}/llm`;
+		this.route = `${apiPrefixFor(model.provider)}/llm`;
 	}
 
 	async generate(params: LLMGenerateParams): Promise<LLMGenerateResult> {
@@ -71,8 +70,8 @@ export class HttpLLMGateway extends GatewayClient<
 }
 
 export class HttpTTSGateway extends HttpAssetGateway<TTSGenerateParams> {
-	constructor(model: ModelRef, baseUrl?: string) {
-		super(model, "tts", baseUrl);
+	constructor(model: ModelRef) {
+		super(model, "tts");
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Two deletion-shaped simplifications the last two maintainability passes named as follow-ups and that were blocked on PRs that have since merged.

**`ConnectorConfig.baseUrl` is gone.** No caller ever set it: the registry configs carry only plugins, and `createConnector` spreads the config as-is. The three HTTP gateways now build their route from the model's prefix alone, the seven connector classes stop threading a positional arg, and the interface has one field left. The gateway test parses app-relative routes against a fixed origin instead of prepending one.

**`ConfirmDeleteDialog` owns its target.** It takes `target: T | undefined` and is open while there is one. `title` and `onConfirm` receive the target, so the four call sites (`ProjectsList`, `Storyboard`, `ComposerAssets`, `ProviderCard`) drop their `onOpenChange` plumbing and the `if (deleting)` guards that could never fail. The dialog latches one value through the Radix exit animation instead of comparing three strings. Confirming still closes via `AlertDialogAction`, so the explicit reset after confirm went too.

No behaviour change. +92 / -107 across 15 files.

## Checks

`npm run lint && npm run typecheck && npm run format:check && npm run test:run && npm run build` all pass (185 test files, 1635 tests).

## Skipped

- `ElementHistory.record` toasting from `lib/generation/history.ts` (a lib module reaching for UI). Deliberate UX choice from an earlier PR; a product call, not a refactor.
- The rest of the surface merged since #758 (error boundaries, provider search, account store, element history storage, video poll contract) read clean.

## Merge-conflict guard

```
PR #779: clean
PR #778: clean
OK: no shared files or merge conflicts with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)