### PR TITLE
refactor: nightly conventions follow-up 2026-09-11, parse at the boundary

### DIFF
--- a/app/components/canvas/elements/AssetTile.tsx
+++ b/app/components/canvas/elements/AssetTile.tsx
@@ -38,7 +38,7 @@ export function AssetTile({
 	removeAffordance = "overlay",
 	fallback = "initial",
 }: {
-	name?: string;
+	name: string;
 	previewUrl?: string;
 	Icon: IconComponent;
 	elementId?: string;
@@ -51,9 +51,12 @@ export function AssetTile({
 	const status = useQueueSelector(
 		(q) => q.getElementSnapshot(elementId).status,
 	);
-	const initial = name?.trim().charAt(0).toUpperCase();
 	const fallbackContent =
-		fallback === "icon" || !initial ? <Icon className="h-5 w-5" /> : initial;
+		fallback === "icon" ? (
+			<Icon className="h-5 w-5" />
+		) : (
+			name.trim().charAt(0).toUpperCase()
+		);
 	return (
 		<div className="group/tile relative flex w-16 flex-col gap-1 sm:w-20">
 			<div className="relative aspect-square overflow-hidden rounded-md border border-border bg-card">
@@ -61,7 +64,7 @@ export function AssetTile({
 					<ImageWithShimmer
 						key={previewUrl}
 						src={previewUrl}
-						alt={name ?? ""}
+						alt={name}
 						fill
 						unoptimized
 						className="object-cover"
@@ -92,7 +95,7 @@ export function AssetTile({
 				{onEdit && (
 					<OverlayButton
 						icon={Pencil}
-						label={`Edit ${name ?? "asset"}`}
+						label={`Edit ${name}`}
 						onClick={onEdit}
 					/>
 				)}
@@ -101,26 +104,21 @@ export function AssetTile({
 					status !== "generating" && (
 						<OverlayButton
 							icon={X}
-							label={`Remove ${name ?? "asset"}`}
+							label={`Remove ${name}`}
 							onClick={onRemove}
 						/>
 					)}
 			</div>
 			{onRemove && removeAffordance === "corner" && status !== "generating" && (
 				<RemoveCrossButton
-					label={`Remove ${name ?? "asset"}`}
+					label={`Remove ${name}`}
 					onClick={onRemove}
 					className="z-10 opacity-0 group-hover/tile:opacity-100"
 				/>
 			)}
-			{name && (
-				<span
-					className="truncate text-badge text-muted-foreground"
-					title={name}
-				>
-					{name}
-				</span>
-			)}
+			<span className="truncate text-badge text-muted-foreground" title={name}>
+				{name}
+			</span>
 		</div>
 	);
 }

--- a/app/components/canvas/panel/CaptionTextStyleFields.tsx
+++ b/app/components/canvas/panel/CaptionTextStyleFields.tsx
@@ -49,7 +49,7 @@ export function CaptionTextStyleFields({
 					label="Fill color"
 					value={value.fill}
 					swatches={CAPTION_PALETTE}
-					onChange={(fill) => onChange({ ...value, fill: fill ?? value.fill })}
+					onChange={(fill) => onChange({ ...value, fill })}
 				/>
 			</PanelField>
 
@@ -70,13 +70,14 @@ export function CaptionTextStyleFields({
 						label="Border color"
 						value={border?.color ?? null}
 						swatches={CAPTION_PALETTE}
-						emptyLabel="No border"
+						empty={{
+							label: "No border",
+							onSelect: () => onChange({ ...value, border: null }),
+						}}
 						onChange={(color) =>
 							onChange({
 								...value,
-								border: color
-									? { width: border?.width ?? DEFAULT_BORDER_WIDTH, color }
-									: null,
+								border: { width: border?.width ?? DEFAULT_BORDER_WIDTH, color },
 							})
 						}
 					/>
@@ -88,7 +89,10 @@ export function CaptionTextStyleFields({
 					label="Background color"
 					value={value.background}
 					swatches={CAPTION_PALETTE}
-					emptyLabel="No background"
+					empty={{
+						label: "No background",
+						onSelect: () => onChange({ ...value, background: null }),
+					}}
 					onChange={(background) => onChange({ ...value, background })}
 				/>
 			</PanelField>

--- a/components/ui/color-field.tsx
+++ b/components/ui/color-field.tsx
@@ -65,22 +65,21 @@ function SwatchButton({
 
 /**
  * Color picker in a popover: a saturation field with hue and opacity sliders,
- * hex entry, and the palette. Layers that can be switched off also offer a
- * "none" swatch, which yields `null`.
+ * hex entry, and the palette. A layer that can be switched off also gets a
+ * "none" swatch.
  */
 export function ColorField({
 	value,
 	onChange,
 	swatches,
 	label,
-	emptyLabel,
+	empty,
 }: {
 	value: string | null;
-	onChange: (value: string | null) => void;
+	onChange: (value: string) => void;
 	swatches: readonly string[];
 	label: string;
-	/** When set, the picker offers a "none" choice that yields `null`. */
-	emptyLabel?: string;
+	empty?: { label: string; onSelect: () => void };
 }) {
 	const [open, setOpen] = useState(false);
 	const color = value ?? "#ffffff";
@@ -129,13 +128,13 @@ export function ColorField({
 				</div>
 
 				<div className="mt-3 grid grid-cols-7 gap-1.5 border-t border-border pt-3">
-					{emptyLabel && (
+					{empty && (
 						<SwatchButton
 							color={null}
-							label={emptyLabel}
+							label={empty.label}
 							selected={value === null}
 							onSelect={() => {
-								onChange(null);
+								empty.onSelect();
 								setOpen(false);
 							}}
 						/>

--- a/lib/project/__tests__/serialize.test.ts
+++ b/lib/project/__tests__/serialize.test.ts
@@ -56,6 +56,17 @@ describe("deserializeWithScenes", () => {
 		expect(scenes[0].children[0].type).toBe("narration");
 	});
 
+	it("keeps metadata tags out of the scene", () => {
+		const scenes = deserializeWithScenes(
+			'<metadata_character name="Red" gender="feminine" age="child" pitch="high" accent="american" description="bright" language="en">A girl</metadata_character><narration>hello</narration>',
+		);
+
+		expect(scenes).toHaveLength(1);
+		expect(scenes[0].children.map((child) => child.type)).toEqual([
+			"narration",
+		]);
+	});
+
 	it("round-trips quotes and angle brackets in attributes and text", () => {
 		const original = [
 			makeScene([

--- a/lib/project/serialize.ts
+++ b/lib/project/serialize.ts
@@ -1,6 +1,7 @@
-import type { CanvasContentElement, SceneElement } from "@/lib/canvas/types";
+import type { SceneElement } from "@/lib/canvas/types";
 import { SCENE_TYPE } from "@/lib/canvas/types";
 import { SCENE_MARKER_PATTERN } from "@/lib/canvas/constants";
+import { isParsedContentElement } from "@/lib/canvas/guards";
 import { parseOSML } from "@/lib/canvas/osmlStreamParser";
 import { makeNodeId } from "@/lib/canvas/nodeUtils";
 import type { ConnectorModels } from "@/lib/connectors/models";
@@ -24,6 +25,8 @@ export function deserializeWithScenes(
 	return splitScenes(osml).map((sceneOsml) => ({
 		id: makeNodeId(),
 		type: SCENE_TYPE,
-		children: parseOSML(sceneOsml, defaultModels) as CanvasContentElement[],
+		children: parseOSML(sceneOsml, defaultModels).filter(
+			isParsedContentElement,
+		),
 	}));
 }

--- a/lib/providers/__tests__/cache.test.ts
+++ b/lib/providers/__tests__/cache.test.ts
@@ -485,6 +485,16 @@ describe("audioBundleCache", () => {
 		expect(cache.fromMetadata({ url: "", duration: 5 })).toBe(undefined);
 	});
 
+	it("fromMetadata forces a miss when the row has no description", async () => {
+		const { audioBundleCache } = await loadCache();
+		expect(
+			audioBundleCache("music").fromMetadata({
+				url: "https://a/audio.mp3",
+				duration: 5,
+			}),
+		).toBe(undefined);
+	});
+
 	it("fromMetadata forces a miss when the row has no usable duration", async () => {
 		const { audioBundleCache } = await loadCache();
 		const cache = audioBundleCache("music");

--- a/lib/providers/cache.ts
+++ b/lib/providers/cache.ts
@@ -1,13 +1,12 @@
 import { randomUUID } from "node:crypto";
 import minBy from "lodash/minBy";
-import { Pinecone } from "@pinecone-database/pinecone";
+import { Pinecone, type RecordMetadata } from "@pinecone-database/pinecone";
+import { z } from "zod";
 import { AssetBundle, type BundleResponse } from "@/lib/api/asset-bundle";
 import { logger } from "@/lib/api/logger";
 import { embedText } from "./embed";
 
-type Metadata = Record<string, string | number | boolean>;
-
-export type CacheMatch = { score?: number; metadata?: Metadata };
+export type CacheMatch = { score?: number; metadata?: RecordMetadata };
 
 const DEFAULT_THRESHOLD = 0.8;
 const RANKED_TOP_K = 5;
@@ -15,9 +14,9 @@ const defaultSerialize = (...args: unknown[]): string => JSON.stringify(args);
 
 type PineconeCacheOptions<Args extends unknown[], Result> = {
 	index: string;
-	toMetadata: (result: Result, description: string) => Metadata;
+	toMetadata: (result: Result, description: string) => RecordMetadata;
 	/** Return `undefined` when the stored row can't be rehydrated, forcing a miss. */
-	fromMetadata: (metadata: Metadata) => Result | undefined;
+	fromMetadata: (metadata: RecordMetadata) => Result | undefined;
 	threshold?: number;
 	serialize?: (...args: Args) => string;
 	namespace?: string;
@@ -59,7 +58,7 @@ export function pineconeCache<Args extends unknown[], Result, This = unknown>(
 			});
 			const eligible: CacheMatch[] = (matches ?? [])
 				.filter((m) => (m.score ?? 0) >= threshold)
-				.map((m) => ({ score: m.score, metadata: m.metadata as Metadata }));
+				.map((m) => ({ score: m.score, metadata: m.metadata }));
 			const hit = opts.rank ? opts.rank(eligible, ...args) : eligible[0];
 			if (hit?.metadata) {
 				const cached = opts.fromMetadata(hit.metadata);
@@ -104,33 +103,34 @@ export const rankByNearestDuration = <P extends { durationSeconds?: number }>(
 	);
 };
 
+const audioRow = z.object({
+	url: z.string().min(1),
+	duration: z.number(),
+	description: z.string(),
+});
+
 /**
  * Reusable strategy for any method returning an audio BundleResponse. Stores
  * the *resolved* absolute URL so cache hits round-trip through
- * `AssetBundle.resolve` without reconstructing a bogus path. `audioUrl` is the
- * legacy key for rows written before the rename.
+ * `AssetBundle.resolve` without reconstructing a bogus path.
  */
 export const audioBundleCache = (type: string) => ({
-	toMetadata: (r: BundleResponse, description: string): Metadata => ({
+	toMetadata: (r: BundleResponse, description: string): RecordMetadata => ({
 		url: AssetBundle.fromResponse(r).resolve("audio"),
 		duration: Number(r.metadata?.durationSec ?? 0),
 		description,
 	}),
-	fromMetadata: (m: Metadata): BundleResponse | undefined => {
-		const url = m.url || m.audioUrl;
-		if (typeof url !== "string" || url === "") return undefined;
-		const durationSec = Number(m.duration);
-		if (!Number.isFinite(durationSec)) return undefined;
+	fromMetadata: (m: RecordMetadata): BundleResponse | undefined => {
+		// `audioUrl` is the legacy key for rows written before the rename.
+		const row = audioRow.safeParse({ ...m, url: m.url ?? m.audioUrl });
+		if (!row.success) return undefined;
+		const { url, duration, description } = row.data;
 		return {
 			id: url,
 			type,
 			provider: "pinecone-cache",
 			result: { audio: url },
-			metadata: {
-				durationSec,
-				cached: true,
-				description: String(m.description),
-			},
+			metadata: { durationSec: duration, cached: true, description },
 		};
 	},
 });


### PR DESCRIPTION
Nightly conventions follow-up. Theme: parse at the boundary, delete the guard the type made unnecessary.

## Behavior changes
- `lib/project/serialize.ts`: `deserializeWithScenes` cast every parsed OSML node to a canvas element; now it keeps only nodes that pass `isParsedContentElement`, the same split `withOSMLClipboard` and `useScriptSync` already make. A stored script carrying a `metadata_*` tag no longer lands in Slate as a scene child no renderer handles. Why: CONVENTIONS.md "Parse, don't validate" and "Define errors out of existence"; flag 910i. Tests: `serialize.test.ts` "keeps metadata tags out of the scene".
- `lib/providers/cache.ts`: `audioBundleCache.fromMetadata` rehydrated a Pinecone row through hand-rolled `typeof`/`Number.isFinite` checks and `String(m.description)` (a missing description became the string `"undefined"`); now a zod object parses the row and any shape we did not write is a cache miss, as before. Why: "Parse, don't validate" at an external boundary; flag 910k. Tests: `cache.test.ts` legacy `audioUrl`, no-URL and no-duration misses kept, "forces a miss when the row has no description" added.

## Contract changes
- `lib/providers/cache.ts`: the local `Metadata` alias is gone; `CacheMatch`, `toMetadata` and `fromMetadata` use Pinecone's own `RecordMetadata`, which deletes the `m.metadata as Metadata` cast (1 reference).
- `components/ui/color-field.tsx`: `onChange` is `(value: string) => void`; a layer that can be switched off passes `empty: { label, onSelect }` instead of `emptyLabel`. The picker can no longer hand a caller `null` it did not ask for, so `CaptionTextStyleFields` drops the `fill ?? value.fill` guard and each cleared layer names its own null (2 call sites). Flag 910g.
- `app/components/canvas/elements/AssetTile.tsx`: `name` is required (all four `AssetTiles` callers pass one); the five `name ?? ...` / `name &&` fallbacks and the `!initial` icon fallback are deleted. Flag 910f.

## Flags resolved
- 910i: serialize cast replaced by the shared narrow, test added.
- 910k: cache row parsed with zod, hand guards deleted.
- 910g: ColorField cannot emit null unless asked; consumer guard deleted.
- 910f: AssetTile.name required; dead fallbacks deleted.

## Skipped tonight
- 910j (`emotion` parsed as `z.enum(TTSEmotion)` at the TTS route): rejected, needs product call. The hosted LLM falls back to `MockLLM` without an Anthropic key, and that mock script writes `cheerful`, `warm`, `gentle`, `delighted`, `kind`, `hearty`, `wonder`, none of which the catalog names; enforcing the catalog at the route would 400 those lines, and Cartesia currently takes the string as-is. Question for the owner: is the emotion catalog a hard contract (then the mock script and the OSML parse boundary should enforce it), or a prompt hint (then the route stays a string)?
- 746f (`voiceId` required on `TTSGenerateParams`): blocked by PR #780 (`lib/connectors/types.ts`).
- 746o: blocked by PR #780 (`lib/connectors/types.ts`).
- 746d, 746e: rejected by the owner on #768 ("this is actually desired, since ranking is best-effort only"); ledger updated.
- 746m: already shipped by #767 (the hosted video and image tables alias the Runware rows).
- 746l, 746n: each too small to carry a night on its own; wait for 746o to free so the connector group ships together.
- 746q: the "what scale 1 means for portrait" half lives in `useRendering.ts`, reserved by PR #778; tying three literals alone is trivial.
- 746r, 910b: off theme; batched next as "element attribute bounds". Note for that batch: the LLM prompt tells the writer `loops` is any integer while the picker offers 1..8, so clamping the render to the picker is a product call.
- 910a (`readSSE` swallow): off theme, and the owner's #768 comment makes a swallow removal a question to ask first.
- 910d, 910e: `confirm-delete-dialog.tsx` is reserved by PR #780.
- 910c: visual change, waits for its own batch with DESIGN.md read.

## Checks
lint, typecheck, format:check, test:run (185 files, 1637 tests), build, knip: all pass. `/simplify`, composition, web-design and react-best-practices reviews applied (flat cache schema, dead `!initial` branch, `empty` capability instead of a props union).

## Merge-conflict guard
```
PR #780: clean
PR #779: clean
PR #778: clean
OK: no shared files or merge conflicts with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
