### PR TITLE
refactor: rethink architecture 2026-09-11

### DIFF
--- a/app/components/canvas/elements/AssetsSection.tsx
+++ b/app/components/canvas/elements/AssetsSection.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { memo, useState } from "react";
-import { useProject } from "@/lib/project/useProject";
 import {
 	AddCharacterTile,
 	ArtStyleAssetTile,
@@ -12,10 +11,7 @@ import { CollapsibleHeader } from "./CollapsibleHeader";
 import { ReferenceImages } from "./ReferenceImages";
 
 function AssetsSectionComponent() {
-	const hydrated = useProject((s) => s.hydrated);
 	const [collapsed, setCollapsed] = useState(false);
-
-	if (!hydrated) return null;
 
 	return (
 		<section className="group/collapsible mb-4 select-none" aria-label="Assets">

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -89,11 +89,6 @@ function CharacterEditDialogBody({
 	const update = (partial: Partial<MetadataCharacter>) =>
 		updateCharacter(name, partial);
 
-	const regenerateAvatar = () => {
-		if (character.avatarUploaded) update({ avatarUploaded: false });
-		avatar.generate();
-	};
-
 	const avatarModel = resolveModel("image", character.avatarModel);
 	const isStale = avatar.staleReason !== null;
 
@@ -169,7 +164,7 @@ function CharacterEditDialogBody({
 									status={avatar.status}
 									hasResult={Boolean(avatarUrl)}
 									disabled={generateDisabled}
-									onGenerate={regenerateAvatar}
+									onGenerate={avatar.generate}
 								/>
 							</div>
 						</div>
@@ -185,14 +180,13 @@ function CharacterEditDialogBody({
 						/>
 						<UploadImageButton
 							className="absolute left-2 top-2 z-10 bg-card shadow-sm ring-1 ring-border"
-							onUpload={(url) => {
+							onUpload={(url) =>
 								queue.commitResult(
 									avatar.node,
 									{ imageUrl: url, durationSec: 0 },
 									{ pinned: true },
-								);
-								update({ avatarUploaded: true });
-							}}
+								)
+							}
 						/>
 					</div>
 				</div>
@@ -224,7 +218,7 @@ function CharacterEditDialogBody({
 				characterName={name}
 				onLeaveStale={onClose}
 				onRegenerate={() => {
-					regenerateAvatar();
+					avatar.generate();
 					onClose();
 				}}
 			/>

--- a/app/components/canvas/hooks/useAutosave.ts
+++ b/app/components/canvas/hooks/useAutosave.ts
@@ -26,7 +26,6 @@ export function useAutosave(
 		() =>
 			createAutosaver({
 				projectId,
-				store,
 				read,
 				onSaved: () => toast("Saved", TOAST_OPTIONS),
 				onError: (err) =>
@@ -35,7 +34,7 @@ export function useAutosave(
 						duration: 4000,
 					}),
 			}),
-		[projectId, store, read],
+		[projectId, read],
 	);
 
 	// Runs after the rehydration effect above it in useEditorSession, so the

--- a/app/projects/[id]/ProjectEditor.tsx
+++ b/app/projects/[id]/ProjectEditor.tsx
@@ -9,10 +9,7 @@ import { UserProvider } from "@/lib/user/UserProvider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { createProjectStore } from "@/lib/project/store";
 import { ProjectStoreProvider } from "@/lib/project/ProjectStoreProvider";
-import {
-	applyStoreSnapshot,
-	parseStoreSnapshot,
-} from "@/lib/project/storeSnapshot";
+import { parseStoreSnapshot } from "@/lib/project/storeSnapshot";
 import type { ElementSnapshot } from "@/lib/generation/snapshots";
 import { GenerationQueueProvider } from "@/lib/generation/GenerationQueueProvider";
 import { ElementHistoryProvider } from "@/lib/generation/ElementHistoryProvider";
@@ -34,11 +31,9 @@ export default function ProjectEditor({
 	user: User;
 	providerKeys: ProviderKeyRecord[];
 }): ReactNode {
-	const [store] = useState(() => {
-		const created = createProjectStore();
-		applyStoreSnapshot(created, parseStoreSnapshot(initialStore));
-		return created;
-	});
+	const [store] = useState(() =>
+		createProjectStore(parseStoreSnapshot(initialStore)),
+	);
 
 	return (
 		<TooltipProvider>

--- a/lib/agent/__tests__/elementState.test.ts
+++ b/lib/agent/__tests__/elementState.test.ts
@@ -8,7 +8,6 @@ import { staleReason } from "@/lib/generation/staleReason";
 import { elementState } from "../elementState";
 
 const EMPTY_STATE = {
-	hydrated: true,
 	metadata: MetadataSchema.parse({}),
 	referenceImages: [],
 };

--- a/lib/agent/projectContext.ts
+++ b/lib/agent/projectContext.ts
@@ -32,7 +32,7 @@ function toAgentContext(
 			([name, character]) => ({
 				name,
 				hasAppearance: character.appearance.trim().length > 0,
-				avatar: characterAvatarState(results, name, character.avatarUploaded),
+				avatar: characterAvatarState(results, name),
 			}),
 		),
 		referenceImageCount: state.referenceImages.length,

--- a/lib/connectors/__tests__/_node-results.ts
+++ b/lib/connectors/__tests__/_node-results.ts
@@ -14,12 +14,12 @@ const EMPTY: ElementSnapshot = {
 
 /** Stands in for the queue when a plugin only reads committed avatar results. */
 export function stubAvatarResults(
-	avatars: Record<string, string>,
+	avatars: Record<string, { imageUrl: string; pinned?: boolean }>,
 ): NodeResults {
 	const byId = new Map(
-		Object.entries(avatars).map(([name, imageUrl]) => [
+		Object.entries(avatars).map(([name, { imageUrl, pinned = false }]) => [
 			characterAvatarElementId(name),
-			{ ...EMPTY, result: { imageUrl, durationSec: 0 } },
+			{ ...EMPTY, result: { imageUrl, durationSec: 0 }, pinned },
 		]),
 	);
 	return {

--- a/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
+++ b/lib/connectors/animated_image/plugins/__tests__/still-frame.test.ts
@@ -97,7 +97,6 @@ describe("still-frame plugin", () => {
 describe("stillSnapshot", () => {
 	const registry = DEFAULT_CONNECTOR_REGISTRY;
 	const state = {
-		hydrated: true,
 		metadata: MetadataSchema.parse({}),
 		referenceImages: [],
 	};
@@ -158,7 +157,6 @@ describe("stillSnapshot", () => {
 describe("duplicated animation", () => {
 	const registry = DEFAULT_CONNECTOR_REGISTRY;
 	const state = {
-		hydrated: true,
 		metadata: MetadataSchema.parse({}),
 		referenceImages: [],
 	};
@@ -206,7 +204,6 @@ describe("duplicated animation", () => {
 describe("uploaded still lifetime", () => {
 	const registry = DEFAULT_CONNECTOR_REGISTRY;
 	const state = {
-		hydrated: true,
 		metadata: MetadataSchema.parse({}),
 		referenceImages: [],
 	};
@@ -266,7 +263,6 @@ describe("uploaded still lifetime", () => {
 describe("an element's picture", () => {
 	const registry = DEFAULT_CONNECTOR_REGISTRY;
 	const state = {
-		hydrated: true,
 		metadata: MetadataSchema.parse({}),
 		referenceImages: [],
 	};

--- a/lib/generation/__tests__/generateForElement.test.ts
+++ b/lib/generation/__tests__/generateForElement.test.ts
@@ -21,7 +21,6 @@ import { generateForElement } from "../generateForElement";
 import { createConnector } from "@/lib/connectors/factory";
 
 const EMPTY_STATE = {
-	hydrated: true,
 	metadata: MetadataSchema.parse({}),
 	referenceImages: [],
 };

--- a/lib/generation/__tests__/graph.test.ts
+++ b/lib/generation/__tests__/graph.test.ts
@@ -16,7 +16,6 @@ import {
 import { GenerationQueue } from "../queue";
 
 const EMPTY_STATE = {
-	hydrated: true,
 	metadata: MetadataSchema.parse({}),
 	referenceImages: [],
 };

--- a/lib/generation/__tests__/queue.test.ts
+++ b/lib/generation/__tests__/queue.test.ts
@@ -17,7 +17,6 @@ import { GenerationQueue } from "../queue";
 import type { CommittedVersion } from "../versions";
 
 const EMPTY_STATE = {
-	hydrated: true,
 	metadata: MetadataSchema.parse({}),
 	referenceImages: [],
 };

--- a/lib/generation/__tests__/queueDependencies.test.ts
+++ b/lib/generation/__tests__/queueDependencies.test.ts
@@ -6,7 +6,6 @@ import { isNodeStale, type GenerationJob, type GenerationNode } from "../graph";
 import { GenerationQueue } from "../queue";
 
 const EMPTY_STATE = {
-	hydrated: true,
 	metadata: MetadataSchema.parse({}),
 	referenceImages: [],
 };

--- a/lib/generation/__tests__/scriptEdit.test.ts
+++ b/lib/generation/__tests__/scriptEdit.test.ts
@@ -19,7 +19,6 @@ const STILL_ID = stillElementId(ID);
 const IMAGE_URL = "https://example.com/frame.png";
 
 const state = {
-	hydrated: true,
 	metadata: MetadataSchema.parse({}),
 	referenceImages: [],
 };

--- a/lib/generation/__tests__/staleReason.test.ts
+++ b/lib/generation/__tests__/staleReason.test.ts
@@ -12,7 +12,6 @@ import { GenerationQueue } from "../queue";
 import { staleReason } from "../staleReason";
 
 const EMPTY_STATE = {
-	hydrated: true,
 	metadata: MetadataSchema.parse({}),
 	referenceImages: [],
 };

--- a/lib/project/__tests__/autosave.test.ts
+++ b/lib/project/__tests__/autosave.test.ts
@@ -14,11 +14,12 @@ import {
 	createAutosaver,
 } from "../autosave";
 import type { ProjectContent } from "../projectDocument";
-import { createProjectStore, type ProjectStore } from "../store";
 import {
-	extractStoreSnapshot,
-	type ProjectStoreSnapshot,
-} from "../storeSnapshot";
+	createProjectStore,
+	type ProjectData,
+	type ProjectStore,
+} from "../store";
+import { extractStoreSnapshot } from "../storeSnapshot";
 
 const saveProject = vi.hoisted(() => vi.fn());
 vi.mock("../api", () => ({ saveProject }));
@@ -34,18 +35,18 @@ const imageSnapshot = (imageUrl: string): ElementSnapshot => ({
 });
 
 const content = (
-	store: ProjectStoreSnapshot,
+	store: ProjectData,
 	script: string,
 	generation: ProjectContent["generation"] = {},
 ): ProjectContent => ({ script, store, generation });
 
-const snapshot = (title: string): ProjectStoreSnapshot => ({
+const snapshot = (title: string): ProjectData => ({
 	metadata: {
 		title,
 		style: "",
 		narration: {},
 		characters: {},
-	} as ProjectStoreSnapshot["metadata"],
+	} as ProjectData["metadata"],
 	referenceImages: [],
 });
 
@@ -78,7 +79,6 @@ describe("createAutosaver", () => {
 	const build = () =>
 		createAutosaver({
 			projectId,
-			store,
 			read: () => content(extractStoreSnapshot(store), "<osml/>"),
 			onSaved,
 			onError,
@@ -100,9 +100,8 @@ describe("createAutosaver", () => {
 		vi.restoreAllMocks();
 	});
 
-	const hydrate = () => {
+	const setTitle = () => {
 		store.getState().updateMetadata({ title: "Moon Rabbit" });
-		store.setState({ hydrated: true });
 	};
 
 	let refCount = 0;
@@ -116,7 +115,7 @@ describe("createAutosaver", () => {
 	};
 
 	it("coalesces a burst of changes into one save", async () => {
-		hydrate();
+		setTitle();
 		const autosaver = build();
 		edit();
 		autosaver.schedule();
@@ -137,7 +136,7 @@ describe("createAutosaver", () => {
 	});
 
 	it("flush runs a pending save immediately", async () => {
-		hydrate();
+		setTitle();
 		const autosaver = build();
 		edit();
 		autosaver.schedule();
@@ -147,17 +146,8 @@ describe("createAutosaver", () => {
 		expect(saveProject).toHaveBeenCalledTimes(1);
 	});
 
-	it("skips the save until the store is hydrated", async () => {
-		const autosaver = build();
-		autosaver.schedule();
-		await vi.advanceTimersByTimeAsync(AUTOSAVE_DEBOUNCE_MS);
-
-		expect(saveProject).not.toHaveBeenCalled();
-		expect(onSaved).not.toHaveBeenCalled();
-	});
-
-	it("does not save when the hydrated state is unchanged", async () => {
-		hydrate();
+	it("does not save when the loaded state is unchanged", async () => {
+		setTitle();
 		const autosaver = build();
 		autosaver.markSaved();
 		// The echo a real open produces: metadata written back with identical content.
@@ -170,12 +160,11 @@ describe("createAutosaver", () => {
 	});
 
 	it("does not save the document it was handed as already saved", async () => {
-		hydrate();
+		setTitle();
 		// Slate is filled in an effect, so the editor is empty until markSaved.
 		let script = "";
 		const autosaver = createAutosaver({
 			projectId,
-			store,
 			read: () => content(extractStoreSnapshot(store), script),
 			onSaved,
 			onError,
@@ -190,7 +179,7 @@ describe("createAutosaver", () => {
 	});
 
 	it("saves an edit made after the baseline was taken", async () => {
-		hydrate();
+		setTitle();
 		const autosaver = build();
 		autosaver.markSaved();
 
@@ -202,7 +191,7 @@ describe("createAutosaver", () => {
 	});
 
 	it("saves the first real edit after an unchanged open", async () => {
-		hydrate();
+		setTitle();
 		const autosaver = build();
 		autosaver.markSaved();
 		store.getState().updateMetadata({ title: "Moon Rabbit" });
@@ -219,7 +208,7 @@ describe("createAutosaver", () => {
 	});
 
 	it("skips a repeat of a payload it just saved", async () => {
-		hydrate();
+		setTitle();
 		const autosaver = build();
 		edit();
 		autosaver.schedule();
@@ -235,11 +224,10 @@ describe("createAutosaver", () => {
 	});
 
 	it("still saves when only the generation snapshot changed", async () => {
-		hydrate();
+		setTitle();
 		let generation: ProjectContent["generation"] = {};
 		const autosaver = createAutosaver({
 			projectId,
-			store,
 			read: () => content(extractStoreSnapshot(store), "<osml/>", generation),
 			onSaved,
 			onError,
@@ -257,7 +245,7 @@ describe("createAutosaver", () => {
 	});
 
 	it("holds saves while suspended and takes them again on resume", async () => {
-		hydrate();
+		setTitle();
 		const autosaver = build();
 		autosaver.markSaved();
 		autosaver.suspend();
@@ -274,7 +262,7 @@ describe("createAutosaver", () => {
 	});
 
 	it("stays quiet on resume when nothing was held", async () => {
-		hydrate();
+		setTitle();
 		const autosaver = build();
 		autosaver.markSaved();
 		edit();
@@ -290,7 +278,7 @@ describe("createAutosaver", () => {
 	});
 
 	it("persists a pending edit before suspending", async () => {
-		hydrate();
+		setTitle();
 		const autosaver = build();
 		autosaver.markSaved();
 		edit();
@@ -303,7 +291,7 @@ describe("createAutosaver", () => {
 	});
 
 	it("saves the document as it stood when suspend was called", async () => {
-		hydrate();
+		setTitle();
 		let script = "live";
 		let release = () => {};
 		saveProject.mockImplementationOnce(
@@ -311,7 +299,6 @@ describe("createAutosaver", () => {
 		);
 		const autosaver = createAutosaver({
 			projectId,
-			store,
 			read: () => content(extractStoreSnapshot(store), script),
 			onSaved,
 			onError,
@@ -339,7 +326,7 @@ describe("createAutosaver", () => {
 	});
 
 	it("reports every save to its subscribers until they unsubscribe", async () => {
-		hydrate();
+		setTitle();
 		const autosaver = build();
 		const seen: string[] = [];
 		const stop = autosaver.onProjectSaved(({ script }) => seen.push(script));
@@ -359,7 +346,7 @@ describe("createAutosaver", () => {
 	});
 
 	it("reports a failed save instead of throwing", async () => {
-		hydrate();
+		setTitle();
 		const boom = new Error("offline");
 		saveProject.mockRejectedValue(boom);
 		const autosaver = build();

--- a/lib/project/__tests__/characterAvatar.test.ts
+++ b/lib/project/__tests__/characterAvatar.test.ts
@@ -48,7 +48,6 @@ describe("characterFromAvatarInputs", () => {
 			),
 		).toEqual({
 			appearance: "blue hair",
-			avatarUploaded: false,
 			avatarModel: RUNWARE,
 		});
 	});

--- a/lib/project/__tests__/deriveArtStyle.test.ts
+++ b/lib/project/__tests__/deriveArtStyle.test.ts
@@ -21,21 +21,15 @@ beforeEach(() => {
 describe("artStyleReferences", () => {
 	it("combines reference images with uploaded avatars, excluding generated ones", () => {
 		project().setReferenceImages(["https://example.com/reference.jpg"]);
-		project().setCharacter("Mira", {
-			appearance: "blue hair",
-			avatarUploaded: true,
-		});
-		project().setCharacter("Generated", {
-			appearance: "green hair",
-			avatarUploaded: false,
-		});
+		project().setCharacter("Mira", { appearance: "blue hair" });
+		project().setCharacter("Generated", { appearance: "green hair" });
 
 		expect(
 			artStyleReferences(
 				project(),
 				stubAvatarResults({
-					Mira: "https://example.com/uploaded.jpg",
-					Generated: "https://example.com/generated.jpg",
+					Mira: { imageUrl: "https://example.com/uploaded.jpg", pinned: true },
+					Generated: { imageUrl: "https://example.com/generated.jpg" },
 				}),
 			),
 		).toEqual([
@@ -52,15 +46,14 @@ describe("artStyleReferences", () => {
 describe("uploadedAvatarUrls", () => {
 	it("leaves out reference images, which the project store owns", () => {
 		project().setReferenceImages(["https://example.com/reference.jpg"]);
-		project().setCharacter("Mira", {
-			appearance: "blue hair",
-			avatarUploaded: true,
-		});
+		project().setCharacter("Mira", { appearance: "blue hair" });
 
 		expect(
 			uploadedAvatarUrls(
 				project(),
-				stubAvatarResults({ Mira: "https://example.com/uploaded.jpg" }),
+				stubAvatarResults({
+					Mira: { imageUrl: "https://example.com/uploaded.jpg", pinned: true },
+				}),
 			),
 		).toEqual(["https://example.com/uploaded.jpg"]);
 	});

--- a/lib/project/__tests__/store.test.ts
+++ b/lib/project/__tests__/store.test.ts
@@ -29,16 +29,16 @@ describe("project store updateMetadata", () => {
 			characters: { Alice: { appearance: "A girl" } },
 		});
 		store.getState().updateMetadata({
-			characters: { Alice: { avatarUploaded: true } },
+			characters: { Alice: { accent: "british" } },
 		});
 
 		expect(store.getState().metadata.characters["Alice"]).toEqual({
 			appearance: "A girl",
-			avatarUploaded: true,
+			accent: "british",
 		});
 	});
 
-	it("reset returns the store to initial state", () => {
+	it("reset returns the store to a blank project", () => {
 		const store = createProjectStore();
 		store.getState().updateMetadata({
 			title: "My Project",
@@ -91,19 +91,19 @@ describe("project store updateMetadata", () => {
 		store
 			.getState()
 			.setCharacter("Alice", { appearance: "A girl", accent: "british" });
-		store.getState().updateCharacter("Alice", { avatarUploaded: true });
+		store.getState().updateCharacter("Alice", { age: "adult" });
 
 		expect(store.getState().metadata.characters["Alice"]).toEqual({
 			appearance: "A girl",
 			accent: "british",
-			avatarUploaded: true,
+			age: "adult",
 		});
 	});
 
 	it("updateCharacter throws for an unknown character", () => {
 		const store = createProjectStore();
 		expect(() =>
-			store.getState().updateCharacter("Nobody", { avatarUploaded: true }),
+			store.getState().updateCharacter("Nobody", { age: "adult" }),
 		).toThrow(/Nobody/);
 	});
 

--- a/lib/project/__tests__/storeSnapshot.test.ts
+++ b/lib/project/__tests__/storeSnapshot.test.ts
@@ -3,12 +3,7 @@ import { DEFAULT_CAPTION_STYLE } from "@/lib/video/captionStyle";
 import { DEFAULT_VIDEO_LENGTH } from "@/lib/video/videoLength";
 import { createProjectStore } from "../store";
 import { MetadataSchema } from "../types";
-import {
-	applyStoreSnapshot,
-	extractStoreSnapshot,
-	parseStoreSnapshot,
-	replaceStoreSnapshot,
-} from "../storeSnapshot";
+import { extractStoreSnapshot, parseStoreSnapshot } from "../storeSnapshot";
 
 describe("storeSnapshot", () => {
 	it("extracts a method-free snapshot", () => {
@@ -25,7 +20,7 @@ describe("storeSnapshot", () => {
 		}
 	});
 
-	it("round-trips through apply", () => {
+	it("round-trips through createProjectStore", () => {
 		const src = createProjectStore();
 		src.getState().updateMetadata({
 			title: "T",
@@ -34,22 +29,17 @@ describe("storeSnapshot", () => {
 		});
 		src.getState().setReferenceImages(["x", "y"]);
 
-		const snap = extractStoreSnapshot(src);
-		const dest = createProjectStore();
-		applyStoreSnapshot(dest, snap);
-
-		const after = dest.getState();
+		const after = createProjectStore(extractStoreSnapshot(src)).getState();
 		expect(after.metadata.title).toBe("T");
 		expect(after.metadata.style).toBe("noir");
 		expect(after.metadata.narration.age).toBe("adult");
 		expect(after.referenceImages).toEqual(["x", "y"]);
 	});
 
-	it("no-ops on an empty parsed snapshot", () => {
-		const store = createProjectStore();
-		const before = JSON.stringify(extractStoreSnapshot(store));
-		applyStoreSnapshot(store, parseStoreSnapshot(null));
-		expect(JSON.stringify(extractStoreSnapshot(store))).toBe(before);
+	it("creates the same store from an empty parsed snapshot as from nothing", () => {
+		expect(
+			extractStoreSnapshot(createProjectStore(parseStoreSnapshot(null))),
+		).toEqual(extractStoreSnapshot(createProjectStore()));
 	});
 });
 
@@ -92,22 +82,5 @@ describe("parseStoreSnapshot", () => {
 	it("throws on a structurally invalid row", () => {
 		expect(() => parseStoreSnapshot({ metadata: { title: 42 } })).toThrow();
 		expect(() => parseStoreSnapshot({ referenceImages: "a.png" })).toThrow();
-	});
-
-	it("swaps a hydrated store's contents wholesale", () => {
-		const store = createProjectStore();
-		applyStoreSnapshot(
-			store,
-			parseStoreSnapshot({ metadata: { title: "One" } }),
-		);
-		store.getState().setReferenceImages(["https://cdn/a.png"]);
-
-		replaceStoreSnapshot(
-			store,
-			parseStoreSnapshot({ metadata: { title: "Two" } }),
-		);
-
-		expect(store.getState().metadata.title).toBe("Two");
-		expect(store.getState().referenceImages).toEqual([]);
 	});
 });

--- a/lib/project/api.ts
+++ b/lib/project/api.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { createClient } from "@/lib/supabase/client";
 import type { ElementSnapshot } from "@/lib/generation/snapshots";
-import type { ProjectStoreSnapshot } from "./storeSnapshot";
+import type { ProjectData } from "./store";
 
 export const ProjectRowSchema = z.object({
 	id: z.string(),
@@ -20,7 +20,7 @@ export const PROJECT_ROW_COLUMNS = Object.keys(ProjectRowSchema.shape).join(
 export type SaveProjectInput = {
 	name: string;
 	script: string;
-	store: ProjectStoreSnapshot;
+	store: ProjectData;
 	generation: Record<string, ElementSnapshot>;
 	thumbnail_url: string | null;
 };

--- a/lib/project/autosave.ts
+++ b/lib/project/autosave.ts
@@ -5,7 +5,6 @@ import { createEmitter } from "@/lib/store/emitter";
 import { saveProject, type SaveProjectInput } from "./api";
 import type { ProjectContent } from "./projectDocument";
 import { deriveProjectName } from "./projectName";
-import type { ProjectStore } from "./store";
 import { pickThumbnailUrl } from "./thumbnail";
 
 export const AUTOSAVE_DEBOUNCE_MS = 2000;
@@ -20,7 +19,6 @@ export function buildProjectSave(content: ProjectContent): SaveProjectInput {
 
 export interface AutosaverOptions {
 	projectId: string;
-	store: ProjectStore;
 	/**
 	 * Produces the content for the next save. Called when the debounce fires, so
 	 * serializing stays off the per-keystroke path.
@@ -54,7 +52,6 @@ export interface Autosaver {
  */
 export function createAutosaver({
 	projectId,
-	store,
 	read,
 	onSaved,
 	onError,
@@ -87,10 +84,6 @@ export function createAutosaver({
 	 */
 	const schedule = debounce(() => {
 		if (suspended) return;
-		if (!store.getState().hydrated) {
-			console.error("Autosave aborted: store not hydrated", { projectId });
-			return;
-		}
 		const input = buildInput();
 		queue.clear();
 		void queue.add(() => persist(input));

--- a/lib/project/characterAvatar.ts
+++ b/lib/project/characterAvatar.ts
@@ -12,23 +12,30 @@ export const characterAvatarElementId = (name: string) =>
 export const isCharacterAvatarId = (id: string) =>
 	id.startsWith(characterAvatarElementId(""));
 
+const avatarSnapshot = (results: NodeResults, name: string) =>
+	results.getElementSnapshot(characterAvatarElementId(name));
+
 /** A character's avatar is whatever its node last produced. */
 export const characterAvatarUrl = (results: NodeResults, name: string) =>
-	getPrimaryUrl(
-		results.getElementSnapshot(characterAvatarElementId(name)).result,
-		"image",
-	);
+	getPrimaryUrl(avatarSnapshot(results, name).result, "image");
+
+/** The avatar's url only when the user supplied it: a pinned result. */
+export function uploadedAvatarUrl(
+	results: NodeResults,
+	name: string,
+): string | undefined {
+	const { result, pinned } = avatarSnapshot(results, name);
+	return pinned ? getPrimaryUrl(result, "image") : undefined;
+}
 
 export type CharacterAvatarState = "none" | "generated" | "uploaded";
 
-/** The uploaded flag only means something once an avatar image exists. */
 export function characterAvatarState(
 	results: NodeResults,
 	name: string,
-	uploaded: boolean | undefined,
 ): CharacterAvatarState {
 	if (!characterAvatarUrl(results, name)) return "none";
-	return uploaded ? "uploaded" : "generated";
+	return uploadedAvatarUrl(results, name) ? "uploaded" : "generated";
 }
 
 export function characterFromAvatarInputs(
@@ -36,7 +43,6 @@ export function characterFromAvatarInputs(
 ): Partial<MetadataCharacter> {
 	return {
 		appearance: String(version.inputs.attributes.appearance ?? ""),
-		avatarUploaded: version.pinned,
 		avatarModel: modelRefSchema.safeParse(version.inputs.attributes).data,
 	};
 }

--- a/lib/project/deriveArtStyle.ts
+++ b/lib/project/deriveArtStyle.ts
@@ -2,7 +2,7 @@ import dedent from "dedent";
 import compact from "lodash/compact";
 import type { LLMConnector } from "@/lib/connectors/types";
 import type { NodeResults } from "@/lib/generation/graph";
-import { characterAvatarUrl } from "./characterAvatar";
+import { uploadedAvatarUrl } from "./characterAvatar";
 import type { ProjectData } from "./store";
 
 const DERIVE_PROMPT = dedent`Vividly and concisely describe the visual art style of the attached reference image(s) in 1–2 concise sentences. Include ultra specific detail on character art style and overall art style. Only respond with the style description written as if it's a preamble for an image model prompt, no other text. This description should be generic enough to prepend to any image prompt, scene, or setting in this style.`;
@@ -13,8 +13,8 @@ export function uploadedAvatarUrls(
 	results: NodeResults,
 ): string[] {
 	return compact(
-		Object.entries(state.metadata.characters).map(([name, character]) =>
-			character.avatarUploaded ? characterAvatarUrl(results, name) : undefined,
+		Object.keys(state.metadata.characters).map((name) =>
+			uploadedAvatarUrl(results, name),
 		),
 	);
 }

--- a/lib/project/projectDocument.ts
+++ b/lib/project/projectDocument.ts
@@ -5,16 +5,12 @@ import type { ElementSnapshot } from "@/lib/generation/snapshots";
 import { resolveDefaultModels } from "@/lib/connectors/models";
 import type { AccountStore } from "@/lib/user/accountStore";
 import { applyScriptToEditor } from "./applyScript";
-import type { ProjectStore } from "./store";
-import {
-	extractStoreSnapshot,
-	replaceStoreSnapshot,
-	type ProjectStoreSnapshot,
-} from "./storeSnapshot";
+import type { ProjectData, ProjectStore } from "./store";
+import { extractStoreSnapshot } from "./storeSnapshot";
 
 export type ProjectContent = {
 	script: string;
-	store: ProjectStoreSnapshot;
+	store: ProjectData;
 	generation: Record<string, ElementSnapshot>;
 };
 
@@ -51,7 +47,7 @@ export function createProjectDocument({
 				account: accountStore.getState().models,
 			});
 			applyScriptToEditor(editor, content.script, defaultModels);
-			replaceStoreSnapshot(store, content.store);
+			store.setState(content.store);
 			queue.replaceSnapshots(content.generation);
 		},
 	};

--- a/lib/project/store.ts
+++ b/lib/project/store.ts
@@ -9,15 +9,10 @@ import {
 	type MetadataVoice,
 } from "./types";
 
-/** What gets saved to the project row. */
-export type ProjectPersisted = {
+/** What a project holds and what its row saves. Generation reads this; only the UI calls the setters. */
+export type ProjectData = {
 	metadata: Metadata;
 	referenceImages: string[];
-};
-
-/** What a project holds. Generation reads this; only the UI calls the setters. */
-export type ProjectData = ProjectPersisted & {
-	hydrated: boolean;
 };
 
 export type ProjectContext = ProjectData & {
@@ -35,16 +30,17 @@ export type ProjectContext = ProjectData & {
 
 export type ProjectStore = StoreApi<ProjectContext>;
 
-const freshPersisted = (): ProjectPersisted => ({
+const freshProject = (): ProjectData => ({
 	metadata: MetadataSchema.parse({}),
 	referenceImages: [],
 });
 
-export function createProjectStore(): ProjectStore {
+export function createProjectStore(
+	initial: ProjectData = freshProject(),
+): ProjectStore {
 	return createStore<ProjectContext>()(
 		immer((set) => ({
-			hydrated: false,
-			...freshPersisted(),
+			...initial,
 			updateMetadata: (partial) =>
 				set((state) => {
 					merge(state.metadata, partial);
@@ -84,7 +80,7 @@ export function createProjectStore(): ProjectStore {
 				set((state) => {
 					state.referenceImages.splice(index, 1);
 				}),
-			reset: () => set(freshPersisted()),
+			reset: () => set(freshProject()),
 		})),
 	);
 }

--- a/lib/project/storeSnapshot.ts
+++ b/lib/project/storeSnapshot.ts
@@ -1,18 +1,14 @@
 import { z } from "zod";
-import type { ProjectPersisted, ProjectStore } from "./store";
+import type { ProjectData, ProjectStore } from "./store";
 import { MetadataSchema } from "./types";
 
-/** A new field on `ProjectPersisted` will not compile until it is added here too. */
+/** A new field on `ProjectData` will not compile until it is added here too. */
 const ProjectStoreSnapshotSchema = z.object({
 	metadata: z.preprocess((value) => value ?? {}, MetadataSchema),
 	referenceImages: z.array(z.string()).default([]),
-}) satisfies z.ZodType<ProjectPersisted>;
+}) satisfies z.ZodType<ProjectData>;
 
-export type ProjectStoreSnapshot = ProjectPersisted;
-
-export function extractStoreSnapshot(
-	store: ProjectStore,
-): ProjectStoreSnapshot {
+export function extractStoreSnapshot(store: ProjectStore): ProjectData {
 	const { metadata, referenceImages } = store.getState();
 	return structuredClone({ metadata, referenceImages });
 }
@@ -21,21 +17,6 @@ export function extractStoreSnapshot(
  * The `store` column is untyped JSON. Parse it into a complete snapshot once
  * here so callers can trust the types; a structurally wrong row throws.
  */
-export function parseStoreSnapshot(raw: unknown): ProjectStoreSnapshot {
+export function parseStoreSnapshot(raw: unknown): ProjectData {
 	return ProjectStoreSnapshotSchema.parse(raw ?? {});
-}
-
-export function applyStoreSnapshot(
-	store: ProjectStore,
-	snapshot: ProjectStoreSnapshot,
-): void {
-	if (store.getState().hydrated) return;
-	store.setState({ ...snapshot, hydrated: true });
-}
-
-export function replaceStoreSnapshot(
-	store: ProjectStore,
-	snapshot: ProjectStoreSnapshot,
-): void {
-	store.setState(snapshot);
 }

--- a/lib/project/types.ts
+++ b/lib/project/types.ts
@@ -97,8 +97,6 @@ export const voiceOnModel = <V extends MetadataVoice>(
 
 export const MetadataCharacterSchema = MetadataVoiceSchema.extend({
 	appearance: z.string(),
-	/** Whether the avatar node's result came from an upload rather than generation. */
-	avatarUploaded: z.boolean().optional().catch(undefined),
 	avatarModel: modelRefSchema.optional().catch(undefined),
 });
 

--- a/lib/script/prompt/__tests__/build.test.ts
+++ b/lib/script/prompt/__tests__/build.test.ts
@@ -113,12 +113,10 @@ describe("buildScriptPrompt", () => {
 		expect(system).toContain("a small grey rabbit");
 	});
 
-	it("carries a described appearance for a character with an uploaded avatar", () => {
+	it("lists a character's appearance as its own line", () => {
 		const { system } = buildScriptPrompt(
 			metadata({
-				characters: {
-					Mira: { appearance: "a freckled girl", avatarUploaded: true },
-				},
+				characters: { Mira: { appearance: "a freckled girl" } },
 			}),
 			{ kind: "brief", brief: "a brief" },
 		);


### PR DESCRIPTION
## The app

OpenSlop is a script-to-video editor. A Slate canvas holds the script, a Zustand store holds project metadata, and a generation queue holds each element's snapshot (result, inputs, `pinned` for a result the user supplied). The three persist together as one `ProjectContent` and restore together through `ProjectDocument.write`.

## From scratch

Each fact has one home. The queue's snapshot already says whether an avatar was supplied (`pinned`), so the store never records it again. A store is built from the row it loads, so nothing has to ask whether it has been loaded yet.

## What changed

Two booleans mirrored facts that already lived elsewhere. Both are gone.

**`avatarUploaded` on a character duplicated the avatar snapshot's `pinned`.** Both were written at the same call sites (the upload button, the regenerate button, a version restore), and they had drifted: `applyTemplate` seeds avatars with `pinned: true` but never set `avatarUploaded`, so template avatars were left out of art-style references and reported to Sloppy as generated. Now `characterAvatarState(results, name)` reads the snapshot, `uploadedAvatarUrls` and the agent context derive from it, `characterFromAvatarInputs` restores only appearance and model, and the modal's `regenerateAvatar` wrapper is gone (a regenerated result commits unpinned already).

One visible effect, by design: avatars a template supplied now count as supplied. They join the art-style references and Sloppy hears "avatar uploaded by the user" for them.

**`hydrated` on the project store was true by construction.** `createProjectStore` had one caller, which applied the parsed snapshot in the same `useState` initializer, so the flag could never be observed false. The store now takes its initial data: `createProjectStore(parseStoreSnapshot(initialStore))`. Deleted with it: `applyStoreSnapshot`, the `ProjectPersisted` twin of `ProjectData`, `AutosaverOptions.store` (its only use was the hydrated check), the autosave abort branch and its test, and the `if (!hydrated) return null` gate in `AssetsSection`. Ten test fixtures lost a `hydrated: true` line.

28 files, +96 / -203.

## What I ran

`npm run lint && npm run typecheck && npm run format:check && npm run test:run && npm run build`, all green (185 files, 1633 tests). `/simplify` over the diff; the repo has no `simplify` skill of its own, so the built-in one ran. The three Vercel skills in `.claude/skills` had nothing to apply: every TSX change here is a deletion. `knip` and a clone scan are clean.

## Skipped

- Folding `useProjectRehydrate` (the script applied in an effect) into `ProjectDocument.write` so all three columns load through one path. It changes when `markSaved` sees the loaded document; separate change.
- Parsing the `generation` column on `app/projects/[id]/page.tsx` (ledger flag 769a). Rows saved before `pinned`/`connectorType` existed would throw without defaults; human call.
- The route files restating one table (`connectorType`, `fields`, `label`, `models`) twice per asset type across `app/api/v1` and `app/api/third-party`, and `AttributeSchema`'s `hideModel` option threaded through for one TTS schema. Both are next-night candidates.
- Relocating vendor-response interpretation out of the four bespoke routes (render progress, validate-code, upload). Relocation, not simplification.
- Renaming `storeSnapshot.ts` and its helpers now that the alias is gone. The `store` column is still a snapshot of the store, and the rename touches five importers for no structural gain.
- A shared `resultSource(snapshot)` for the "has a result, pinned decides" predicate that `characterAvatarState`, `UploadedBadge` and `elementState` each spell out. Real, third reader now, follow-up.

## Merge-conflict guard

```
PR #781: clean
PR #780: clean
PR #779: clean
PR #778: clean
OK: no shared files or merge conflicts with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
