### PR TITLE
docs: list supported providers as logo chips in the README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,7 @@ Test behavior not internals. Pure helpers and module boundaries. Vitest for unit
 - Title says what, description says why
 - Link the issue
 - Read your own diff before pushing
+- Adding or removing an adapter in `lib/providers/`? Update the **Supported providers** chips in [README.md](README.md#supported-providers) in the same PR
 
 ## AI
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ Open-source, free forever.
 - Runs in your browser, nothing to install
 - Built by engineers from Meta, Google, Stripe, and Dropbox
 
+## Supported providers
+
+Bring your own accounts. A provider whose key is unset falls back to a mock, so none of them is required to run the app.
+
+<p>
+  <a href="https://runware.ai"><kbd><img src="https://www.google.com/s2/favicons?domain=runware.ai&amp;sz=64" alt="Runware logo" width="16" valign="middle"> Runware &middot; image, video</kbd></a> &nbsp;
+  <a href="https://elevenlabs.io"><kbd><img src="https://www.google.com/s2/favicons?domain=elevenlabs.io&amp;sz=64" alt="ElevenLabs logo" width="16" valign="middle"> ElevenLabs &middot; music, SFX</kbd></a> &nbsp;
+  <a href="https://cartesia.ai"><kbd><img src="https://www.google.com/s2/favicons?domain=cartesia.ai&amp;sz=64" alt="Cartesia logo" width="16" valign="middle"> Cartesia &middot; text-to-speech</kbd></a> &nbsp;
+  <a href="https://www.anthropic.com"><kbd><img src="https://www.google.com/s2/favicons?domain=anthropic.com&amp;sz=64" alt="Anthropic logo" width="16" valign="middle"> Anthropic &middot; LLM</kbd></a> &nbsp;
+  <a href=".env.example"><kbd>+ more, see .env.example</kbd></a>
+</p>
+
 ## Getting started
 
 ### Prerequisites


### PR DESCRIPTION
## What

Adds a **Supported providers** section to the README, placed between **Key capabilities** and **Getting started**, in the same shape as the Nightshift README's supported-agents block: one `<kbd>` chip per adapter in `lib/providers/`, each with a favicon from Google's favicon service and a link to the provider's site, plus a tail chip linking to `.env.example`.

- Runware (image, video)
- ElevenLabs (music, SFX)
- Cartesia (text-to-speech)
- Anthropic (LLM)

Each chip names the asset types the adapter serves, matching the `api/v1/` split, so the list stays one row and does not need grouping yet. The intro states the mock fallback so a missing key does not read as a blocker.

`CONTRIBUTING.md` gains one bullet under **PRs** asking adapter changes to keep the chips in sync.

## Why

The README says "Talk to a bunch of AI providers in one place" but never names them, and the provider list is the first thing someone checks before trying the app. See #777.

## Verified

- All four favicon URLs resolve to 64x64 PNGs and all four provider sites return 200.
- `npm run lint && npm run typecheck && npm run format:check && npm run test:run && npm run build` all pass (1635 tests).

## Merge-conflict guard

```
PR #782: clean
PR #781: clean
PR #780: clean
PR #779: clean
PR #778: clean
OK: no shared files or merge conflicts with any open PR
```

Closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)
