### PR TITLE
refactor: nightly readability 2026-09-12

### DIFF
--- a/app/components/canvas/elements/AudioPlayer.tsx
+++ b/app/components/canvas/elements/AudioPlayer.tsx
@@ -27,9 +27,9 @@ export function AudioPlayer({ src }: { src: string }) {
 				className="flex-1 basis-[160px] min-w-0 h-10"
 				onPlay={() => setPlaying(true)}
 				onPause={() => setPlaying(false)}
-				onTimeUpdate={(t, d) => {
-					setCurrentTime(t);
-					setDuration(d);
+				onTimeUpdate={(time, duration) => {
+					setCurrentTime(time);
+					setDuration(duration);
 				}}
 				onFinish={() => setPlaying(false)}
 			/>

--- a/lib/components/Waveform.tsx
+++ b/lib/components/Waveform.tsx
@@ -70,46 +70,40 @@ export function Waveform({
 	);
 
 	const setProgress = useCallback((progress: number) => {
-		const el = progressRef.current;
-		if (el)
-			el.style.clipPath = `inset(0 ${(1 - clamp(progress, 0, 1)) * 100}% 0 0)`;
+		const overlay = progressRef.current;
+		if (overlay)
+			overlay.style.clipPath = `inset(0 ${(1 - clamp(progress, 0, 1)) * 100}% 0 0)`;
 	}, []);
 
-	useImperativeHandle(
-		ref,
+	const handle = useMemo<WaveformHandle>(
 		() => ({
 			play() {
-				const a = audioRef.current;
-				if (a) startPlayback(a);
+				const audio = audioRef.current;
+				if (audio) startPlayback(audio);
 			},
 			pause() {
 				audioRef.current?.pause();
 			},
 			toggle() {
-				const a = audioRef.current;
-				if (a) {
-					if (a.paused) startPlayback(a);
-					else a.pause();
-				}
+				const audio = audioRef.current;
+				if (!audio) return;
+				if (audio.paused) startPlayback(audio);
+				else audio.pause();
 			},
 			seek(progress: number) {
-				const a = audioRef.current;
-				if (a?.duration) {
-					a.currentTime = clamp(progress, 0, 1) * a.duration;
-					setProgress(progress);
-				}
+				const audio = audioRef.current;
+				if (!audio?.duration) return;
+				audio.currentTime = clamp(progress, 0, 1) * audio.duration;
+				setProgress(progress);
 			},
 		}),
 		[setProgress],
 	);
+	useImperativeHandle(ref, () => handle, [handle]);
 
-	const handleClick = (e: MouseEvent<HTMLDivElement>) => {
-		const a = audioRef.current;
-		if (!a?.duration) return;
-		const rect = e.currentTarget.getBoundingClientRect();
-		const progress = (e.clientX - rect.left) / rect.width;
-		a.currentTime = clamp(progress, 0, 1) * a.duration;
-		setProgress(progress);
+	const handleClick = (event: MouseEvent<HTMLDivElement>) => {
+		const rect = event.currentTarget.getBoundingClientRect();
+		handle.seek((event.clientX - rect.left) / rect.width);
 	};
 
 	return (
@@ -137,20 +131,17 @@ export function Waveform({
 				crossOrigin="anonymous"
 				preload="metadata"
 				hidden
-				onTimeUpdate={() => {
-					const a = audioRef.current;
-					if (!a) return;
-					setProgress(a.duration ? a.currentTime / a.duration : 0);
-					onTimeUpdate?.(a.currentTime, a.duration || 0);
+				onTimeUpdate={(event) => {
+					const audio = event.currentTarget;
+					setProgress(audio.duration ? audio.currentTime / audio.duration : 0);
+					onTimeUpdate?.(audio.currentTime, audio.duration || 0);
 				}}
-				onLoadedMetadata={() => {
-					const a = audioRef.current;
-					if (!a) return;
+				onLoadedMetadata={(event) => {
+					const audio = event.currentTarget;
 					setProgress(0);
-					if (Number.isFinite(a.duration) && a.duration > 0) {
+					if (Number.isFinite(audio.duration) && audio.duration > 0)
 						setAudioSettledFor(src);
-					}
-					onTimeUpdate?.(0, a.duration || 0);
+					onTimeUpdate?.(0, audio.duration || 0);
 				}}
 				onError={() => setAudioSettledFor(src)}
 				onPlay={onPlay}

--- a/lib/components/peaks.ts
+++ b/lib/components/peaks.ts
@@ -1,10 +1,7 @@
 const PEAK_COUNT = 200;
 
-let sharedAudioCtx: AudioContext | null = null;
-const getAudioCtx = () => {
-	if (!sharedAudioCtx) sharedAudioCtx = new AudioContext();
-	return sharedAudioCtx;
-};
+let sharedAudioContext: AudioContext | null = null;
+const getAudioContext = () => (sharedAudioContext ??= new AudioContext());
 
 /**
  * Normalized amplitudes (0–1) from raw audio samples, one per bucket.
@@ -15,20 +12,16 @@ const getAudioCtx = () => {
 export function extractPeaks(data: Float32Array, count: number): number[] {
 	const step = Math.floor(data.length / count);
 	if (step === 0) return [];
-	const peaks: number[] = [];
-	let max = 0;
-	for (let i = 0; i < count; i++) {
-		const offset = i * step;
-		let sumOfSquares = 0;
-		for (let j = 0; j < step; j++) {
-			const sample = data[offset + j];
-			sumOfSquares += sample * sample;
-		}
-		const rms = Math.sqrt(sumOfSquares / step);
-		peaks.push(rms);
-		if (rms > max) max = rms;
-	}
-	return max > 0 ? peaks.map((p) => p / max) : peaks;
+	const peaks = Array.from({ length: count }, (_, bucket) => {
+		const samples = data.subarray(bucket * step, (bucket + 1) * step);
+		const sumOfSquares = samples.reduce(
+			(sum, sample) => sum + sample * sample,
+			0,
+		);
+		return Math.sqrt(sumOfSquares / step);
+	});
+	const max = peaks.reduce((loudest, peak) => Math.max(loudest, peak), 0);
+	return max > 0 ? peaks.map((peak) => peak / max) : peaks;
 }
 
 const decoded = new Map<string, Promise<number[]>>();
@@ -53,7 +46,7 @@ async function decodePeaks(src: string): Promise<number[]> {
 	if (!response.ok) {
 		throw new Error(`Failed to fetch audio: ${response.status}`);
 	}
-	const audio = await getAudioCtx().decodeAudioData(
+	const audio = await getAudioContext().decodeAudioData(
 		await response.arrayBuffer(),
 	);
 	return extractPeaks(audio.getChannelData(0), PEAK_COUNT);


### PR DESCRIPTION
Readability pass over the audio waveform cluster: `lib/components/Waveform.tsx`, `lib/components/peaks.ts`, and `app/components/canvas/elements/AudioPlayer.tsx`. No behavior change. +42 / -58; every file ends the same size or smaller.

## Renames

| Old | New | Where |
| --- | --- | --- |
| `a` (x6) | `audio` | `Waveform.tsx` |
| `el` | `overlay` | `Waveform.tsx` `setProgress` |
| `e` | `event` | `Waveform.tsx` `handleClick` |
| `(t, d)` | `(time, duration)` | `AudioPlayer.tsx` `onTimeUpdate` |
| `sharedAudioCtx` / `getAudioCtx` | `sharedAudioContext` / `getAudioContext` | `peaks.ts` |
| `p` | `peak` | `peaks.ts` normalize map |

## Straightened flow

- `Waveform`: the imperative handle is built once with `useMemo` and `useImperativeHandle` exposes it, so click-to-seek calls the existing `handle.seek` instead of carrying its own copy of the clamp / `currentTime` / `setProgress` lines.
- `Waveform`: `toggle` and `seek` use early returns instead of nested `if`.
- `Waveform`: the `<audio>` `onTimeUpdate` / `onLoadedMetadata` handlers read `event.currentTarget` instead of re-reading the ref and null-guarding an element that is dispatching its own event.
- `peaks.ts`: the lazy `AudioContext` getter is one `??=` line.
- `peaks.ts`: `extractPeaks` builds the buckets with `Array.from` + `subarray().reduce()` and takes the max with `reduce`, replacing two nested index loops, a `push`, and a hand-tracked `max`. Same arithmetic in the same order, so the exact-equality tests still pass.

## Skipped

- Deleting `play` / `pause` / `seek` from `WaveformHandle` (only `toggle` has a caller today): kept, shared interface.
- `h` → `height` in `soundwave.ts` `buildSoundwaveMask`: prettier wraps the line and the file grows.
- `el` → `ancestor` in `scrollIntoContainer.ts`: same, the `for` header wraps.
- `(s) => s.x` store selectors and `(e) =>` DOM handlers across `app/`: idiomatic, a repo-wide sweep for no gain.
- `lib/agent/tools/useAgentTools.ts` (deep nesting): in PR #785.
- `subarray().reduce()` is ~10x slower per sample than the fused loop (about 1.5 ms → 15 ms for 3 minutes of audio, measured on Node 22), on a one-shot decode path that already waits on `decodeAudioData`; taken as the job's "language helper over hand-rolled loop" trade.

## Checks

`npm run lint && npm run typecheck && npm run format:check && npm run test:run && npm run build` all pass (185 files, 1635 tests).

## Merge-conflict guard

```
PR #785: clean
OK: no shared files or merge conflicts with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)