### PR TITLE
refactor: nightly maintainability 2026-09-12

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,7 +36,7 @@ Users see models and providers; developers also see connectors. Each word means 
 
 A model is a `{ provider, model }` pair, never a bare name. `MODELS[type][provider][name]` in `lib/connectors/models.ts` is the whole table, and nothing anywhere derives a provider from a name. Every element stores its own pair as attributes, speech included. A voice in project metadata stores the pair it was picked on, and its narration and character elements speak with that pair, falling back to their own until the voice picks one. A plugin declares where such an inherited model comes from, the same way it declares what it reads. Defaults resolve element, then project, then account, then the recommendation.
 
-Everything that differs between the two route families is one object each in `lib/api/route-families.ts`. `HOSTED` is API-access gated, takes only a model name, and runs on our keys. `BYOK` is session gated, takes the pair, and runs on the account's key. A route file picks a family and the models it serves. A job stores the pair, and the worker builds the provider from it at the last moment, which is the one place the server branches on the family.
+Everything that differs between the two route families is one object each in `lib/api/route-families.ts`. `HOSTED` is API-access gated, takes only a model name, and runs on our keys. `BYOK` is session gated, takes the pair, and runs on the account's key. A route file picks a family and a connector type; the family reads that type's models from the table. A job stores the pair, and the worker builds the provider from it at the last moment, which is the one place the server branches on the family.
 
 User keys live in Supabase Vault, one per provider, read by the service role for the single request about to use them and never returned to a client. A key is verified by asking the vendor.
 
@@ -71,4 +71,4 @@ Generated assets live in Vercel Blob as public CDN URLs.
 
 ## Adding a provider or asset type
 
-A hosted model is a row in its type's `openslop/models.ts` plus a row naming its class in `lib/api/providers/openslop.ts`. A BYOK provider is a brand entry in the provider catalog, a models map under `lib/connectors/<type>/<provider>/`, a class per type in the vendor table, and a `validate()` on those classes. A new asset type is a connector, a provider, a models map and two route files. Tests live in `__tests__` folders next to the code.
+A hosted model is a row in its type's `openslop/models.ts` plus a row naming its class in `lib/api/providers/openslop.ts`. A BYOK provider is a brand entry in the provider catalog, a models map under `lib/connectors/<type>/<provider>/`, a class per type in the vendor table, and a `validate()` on those classes. A new asset type is a connector, a provider, a models map, a row in `lib/api/asset-routes.ts` and two route files. Tests live in `__tests__` folders next to the code.

--- a/app/api/third-party/agent/route.ts
+++ b/app/api/third-party/agent/route.ts
@@ -1,5 +1,4 @@
 import { createAgentRouteHandler } from "@/lib/api/llm-routes";
 import { BYOK } from "@/lib/api/route-families";
-import { BYOK_LLM_MODELS } from "@/lib/connectors/llm/models";
 
-export const POST = createAgentRouteHandler(BYOK, BYOK_LLM_MODELS);
+export const POST = createAgentRouteHandler(BYOK);

--- a/app/api/third-party/image/route.ts
+++ b/app/api/third-party/image/route.ts
@@ -1,11 +1,4 @@
 import { createAssetRouteHandler } from "@/lib/api/asset-routes";
-import { IMAGE_FIELDS } from "@/lib/api/generation-schema";
 import { BYOK } from "@/lib/api/route-families";
-import { BYOK_IMAGE_MODELS } from "@/lib/connectors/image/models";
 
-export const POST = createAssetRouteHandler(BYOK, {
-	connectorType: "image",
-	models: BYOK_IMAGE_MODELS,
-	fields: IMAGE_FIELDS,
-	label: "Image generation",
-});
+export const POST = createAssetRouteHandler(BYOK, "image");

--- a/app/api/third-party/llm/route.ts
+++ b/app/api/third-party/llm/route.ts
@@ -1,5 +1,4 @@
 import { createLLMRouteHandler } from "@/lib/api/llm-routes";
 import { BYOK } from "@/lib/api/route-families";
-import { BYOK_LLM_MODELS } from "@/lib/connectors/llm/models";
 
-export const POST = createLLMRouteHandler(BYOK, BYOK_LLM_MODELS);
+export const POST = createLLMRouteHandler(BYOK);

--- a/app/api/third-party/music/route.ts
+++ b/app/api/third-party/music/route.ts
@@ -1,11 +1,4 @@
 import { createAssetRouteHandler } from "@/lib/api/asset-routes";
-import { AUDIO_FIELDS } from "@/lib/api/generation-schema";
 import { BYOK } from "@/lib/api/route-families";
-import { BYOK_MUSIC_MODELS } from "@/lib/connectors/music/models";
 
-export const POST = createAssetRouteHandler(BYOK, {
-	connectorType: "music",
-	models: BYOK_MUSIC_MODELS,
-	fields: AUDIO_FIELDS,
-	label: "Music generation",
-});
+export const POST = createAssetRouteHandler(BYOK, "music");

--- a/app/api/third-party/sfx/route.ts
+++ b/app/api/third-party/sfx/route.ts
@@ -1,11 +1,4 @@
 import { createAssetRouteHandler } from "@/lib/api/asset-routes";
-import { AUDIO_FIELDS } from "@/lib/api/generation-schema";
 import { BYOK } from "@/lib/api/route-families";
-import { BYOK_SFX_MODELS } from "@/lib/connectors/sfx/models";
 
-export const POST = createAssetRouteHandler(BYOK, {
-	connectorType: "sfx",
-	models: BYOK_SFX_MODELS,
-	fields: AUDIO_FIELDS,
-	label: "SFX generation",
-});
+export const POST = createAssetRouteHandler(BYOK, "sfx");

--- a/app/api/third-party/tts/route.ts
+++ b/app/api/third-party/tts/route.ts
@@ -1,11 +1,4 @@
 import { createAssetRouteHandler } from "@/lib/api/asset-routes";
-import { TTS_FIELDS } from "@/lib/api/generation-schema";
 import { BYOK } from "@/lib/api/route-families";
-import { BYOK_TTS_MODELS } from "@/lib/connectors/tts/models";
 
-export const POST = createAssetRouteHandler(BYOK, {
-	connectorType: "tts",
-	models: BYOK_TTS_MODELS,
-	fields: TTS_FIELDS,
-	label: "TTS generation",
-});
+export const POST = createAssetRouteHandler(BYOK, "tts");

--- a/app/api/third-party/tts/voices/preview/route.ts
+++ b/app/api/third-party/tts/voices/preview/route.ts
@@ -1,5 +1,4 @@
 import { BYOK } from "@/lib/api/route-families";
 import { createVoicePreviewHandler } from "@/lib/api/voice-routes";
-import { BYOK_TTS_MODELS } from "@/lib/connectors/tts/models";
 
-export const GET = createVoicePreviewHandler(BYOK, BYOK_TTS_MODELS);
+export const GET = createVoicePreviewHandler(BYOK);

--- a/app/api/third-party/tts/voices/route.ts
+++ b/app/api/third-party/tts/voices/route.ts
@@ -1,5 +1,4 @@
 import { BYOK } from "@/lib/api/route-families";
 import { createVoiceSearchHandler } from "@/lib/api/voice-routes";
-import { BYOK_TTS_MODELS } from "@/lib/connectors/tts/models";
 
-export const GET = createVoiceSearchHandler(BYOK, BYOK_TTS_MODELS);
+export const GET = createVoiceSearchHandler(BYOK);

--- a/app/api/third-party/video/route.ts
+++ b/app/api/third-party/video/route.ts
@@ -1,11 +1,4 @@
 import { createAssetRouteHandler } from "@/lib/api/asset-routes";
-import { VIDEO_FIELDS } from "@/lib/api/generation-schema";
 import { BYOK } from "@/lib/api/route-families";
-import { BYOK_VIDEO_MODELS } from "@/lib/connectors/video/models";
 
-export const POST = createAssetRouteHandler(BYOK, {
-	connectorType: "video",
-	models: BYOK_VIDEO_MODELS,
-	fields: VIDEO_FIELDS,
-	label: "Video submission",
-});
+export const POST = createAssetRouteHandler(BYOK, "video");

--- a/app/api/v1/agent/route.ts
+++ b/app/api/v1/agent/route.ts
@@ -7,9 +7,8 @@ import {
 import { createAgentRouteHandler } from "@/lib/api/llm-routes";
 import { HOSTED } from "@/lib/api/route-families";
 import { createApiQueryRouteHandler } from "@/lib/api/route-handler";
-import { OPENSLOP_LLM_MODELS } from "@/lib/connectors/llm/openslop/models";
 
-export const POST = createAgentRouteHandler(HOSTED, OPENSLOP_LLM_MODELS);
+export const POST = createAgentRouteHandler(HOSTED);
 
 export const GET = createApiQueryRouteHandler({
 	schema: z.object({ projectId: z.uuid() }),

--- a/app/api/v1/image/route.ts
+++ b/app/api/v1/image/route.ts
@@ -1,11 +1,4 @@
 import { createAssetRouteHandler } from "@/lib/api/asset-routes";
-import { IMAGE_FIELDS } from "@/lib/api/generation-schema";
 import { HOSTED } from "@/lib/api/route-families";
-import { OPENSLOP_IMAGE_MODELS } from "@/lib/connectors/image/openslop/models";
 
-export const POST = createAssetRouteHandler(HOSTED, {
-	connectorType: "image",
-	models: OPENSLOP_IMAGE_MODELS,
-	fields: IMAGE_FIELDS,
-	label: "Image generation",
-});
+export const POST = createAssetRouteHandler(HOSTED, "image");

--- a/app/api/v1/llm/route.ts
+++ b/app/api/v1/llm/route.ts
@@ -1,5 +1,4 @@
 import { createLLMRouteHandler } from "@/lib/api/llm-routes";
 import { HOSTED } from "@/lib/api/route-families";
-import { OPENSLOP_LLM_MODELS } from "@/lib/connectors/llm/openslop/models";
 
-export const POST = createLLMRouteHandler(HOSTED, OPENSLOP_LLM_MODELS);
+export const POST = createLLMRouteHandler(HOSTED);

--- a/app/api/v1/music/route.ts
+++ b/app/api/v1/music/route.ts
@@ -1,11 +1,4 @@
 import { createAssetRouteHandler } from "@/lib/api/asset-routes";
-import { AUDIO_FIELDS } from "@/lib/api/generation-schema";
 import { HOSTED } from "@/lib/api/route-families";
-import { OPENSLOP_MUSIC_MODELS } from "@/lib/connectors/music/openslop/models";
 
-export const POST = createAssetRouteHandler(HOSTED, {
-	connectorType: "music",
-	models: OPENSLOP_MUSIC_MODELS,
-	fields: AUDIO_FIELDS,
-	label: "Music generation",
-});
+export const POST = createAssetRouteHandler(HOSTED, "music");

--- a/app/api/v1/sfx/route.ts
+++ b/app/api/v1/sfx/route.ts
@@ -1,11 +1,4 @@
 import { createAssetRouteHandler } from "@/lib/api/asset-routes";
-import { AUDIO_FIELDS } from "@/lib/api/generation-schema";
 import { HOSTED } from "@/lib/api/route-families";
-import { OPENSLOP_SFX_MODELS } from "@/lib/connectors/sfx/openslop/models";
 
-export const POST = createAssetRouteHandler(HOSTED, {
-	connectorType: "sfx",
-	models: OPENSLOP_SFX_MODELS,
-	fields: AUDIO_FIELDS,
-	label: "SFX generation",
-});
+export const POST = createAssetRouteHandler(HOSTED, "sfx");

--- a/app/api/v1/tts/route.ts
+++ b/app/api/v1/tts/route.ts
@@ -1,11 +1,4 @@
 import { createAssetRouteHandler } from "@/lib/api/asset-routes";
-import { TTS_FIELDS } from "@/lib/api/generation-schema";
 import { HOSTED } from "@/lib/api/route-families";
-import { OPENSLOP_TTS_MODELS } from "@/lib/connectors/tts/openslop/models";
 
-export const POST = createAssetRouteHandler(HOSTED, {
-	connectorType: "tts",
-	models: OPENSLOP_TTS_MODELS,
-	fields: TTS_FIELDS,
-	label: "TTS generation",
-});
+export const POST = createAssetRouteHandler(HOSTED, "tts");

--- a/app/api/v1/tts/voices/preview/route.ts
+++ b/app/api/v1/tts/voices/preview/route.ts
@@ -1,5 +1,4 @@
 import { HOSTED } from "@/lib/api/route-families";
 import { createVoicePreviewHandler } from "@/lib/api/voice-routes";
-import { OPENSLOP_TTS_MODELS } from "@/lib/connectors/tts/openslop/models";
 
-export const GET = createVoicePreviewHandler(HOSTED, OPENSLOP_TTS_MODELS);
+export const GET = createVoicePreviewHandler(HOSTED);

--- a/app/api/v1/tts/voices/route.ts
+++ b/app/api/v1/tts/voices/route.ts
@@ -1,5 +1,4 @@
 import { HOSTED } from "@/lib/api/route-families";
 import { createVoiceSearchHandler } from "@/lib/api/voice-routes";
-import { OPENSLOP_TTS_MODELS } from "@/lib/connectors/tts/openslop/models";
 
-export const GET = createVoiceSearchHandler(HOSTED, OPENSLOP_TTS_MODELS);
+export const GET = createVoiceSearchHandler(HOSTED);

--- a/app/api/v1/video/route.ts
+++ b/app/api/v1/video/route.ts
@@ -1,11 +1,4 @@
 import { createAssetRouteHandler } from "@/lib/api/asset-routes";
-import { VIDEO_FIELDS } from "@/lib/api/generation-schema";
 import { HOSTED } from "@/lib/api/route-families";
-import { OPENSLOP_VIDEO_MODELS } from "@/lib/connectors/video/openslop/models";
 
-export const POST = createAssetRouteHandler(HOSTED, {
-	connectorType: "video",
-	models: OPENSLOP_VIDEO_MODELS,
-	fields: VIDEO_FIELDS,
-	label: "Video submission",
-});
+export const POST = createAssetRouteHandler(HOSTED, "video");

--- a/lib/api/__tests__/generation-schema.test.ts
+++ b/lib/api/__tests__/generation-schema.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { BYOK_IMAGE_MODELS } from "@/lib/connectors/image/models";
-import { OPENSLOP_IMAGE_MODELS } from "@/lib/connectors/image/openslop/models";
 import { bodySchema, byokModel, hostedModel } from "../generation-schema";
 
 describe("bodySchema with a hosted model", () => {
-	const schema = bodySchema(hostedModel(OPENSLOP_IMAGE_MODELS), {});
+	const schema = bodySchema(hostedModel("image"), {});
 
 	it("takes the model alone and records the provider as ours", () => {
 		expect(schema.parse({ prompt: "a cat", model: "Slop Image v1" })).toEqual({
@@ -36,7 +34,7 @@ describe("bodySchema with a hosted model", () => {
 });
 
 describe("bodySchema with BYOK models", () => {
-	const schema = bodySchema(byokModel(BYOK_IMAGE_MODELS), {});
+	const schema = bodySchema(byokModel("image"), {});
 
 	it("takes the provider and model pair as named", () => {
 		expect(

--- a/lib/api/__tests__/route-handler.test.ts
+++ b/lib/api/__tests__/route-handler.test.ts
@@ -4,7 +4,6 @@ import { z } from "zod";
 import { imageFile } from "../request-schema-fields";
 import { createJobPollHandler } from "../asset-routes";
 import { HOSTED } from "../route-families";
-import { OPENSLOP_IMAGE_MODELS } from "@/lib/connectors/image/openslop/models";
 import { bodySchema, hostedModel } from "../generation-schema";
 import {
 	createApiRouteHandler,
@@ -46,7 +45,7 @@ function makeRequest(body: unknown) {
 	});
 }
 
-const schema = bodySchema(hostedModel(OPENSLOP_IMAGE_MODELS), {});
+const schema = bodySchema(hostedModel("image"), {});
 
 function makeHandler(
 	handle?: Parameters<typeof createApiRouteHandler>[0]["handle"],

--- a/lib/api/asset-routes.ts
+++ b/lib/api/asset-routes.ts
@@ -3,45 +3,55 @@ import { z } from "zod";
 import type { JobPoll } from "@/lib/gateway/base";
 import type { ModelRef } from "@/lib/connectors/types";
 import { createJob, enqueueJob, getJob, type JobConnectorType } from "./jobs";
-import { bodySchema } from "./generation-schema";
+import {
+	AUDIO_FIELDS,
+	bodySchema,
+	IMAGE_FIELDS,
+	TTS_FIELDS,
+	VIDEO_FIELDS,
+} from "./generation-schema";
 import { notFound } from "./response";
 import type { RouteFamily } from "./route-families";
 
 type AssetBody = ModelRef & { projectId?: string } & Record<string, unknown>;
 
-type AssetRoute<TModels> = {
-	connectorType: JobConnectorType;
-	models: TModels;
-	fields: z.ZodRawShape;
-	label: string;
+/** What each asset route takes beyond the prompt and model, and how the log names it. */
+const ASSET_ROUTES: Record<
+	JobConnectorType,
+	{ fields: z.ZodRawShape; label: string }
+> = {
+	image: { fields: IMAGE_FIELDS, label: "Image generation" },
+	video: { fields: VIDEO_FIELDS, label: "Video submission" },
+	tts: { fields: TTS_FIELDS, label: "TTS generation" },
+	music: { fields: AUDIO_FIELDS, label: "Music generation" },
+	sfx: { fields: AUDIO_FIELDS, label: "SFX generation" },
 };
 
-export const createAssetRouteHandler = <TModels, TPicked extends ModelRef>(
-	family: RouteFamily<TModels, TPicked>,
-	route: AssetRoute<TModels>,
-) =>
-	family.createHandler({
+export const createAssetRouteHandler = <TPicked extends ModelRef>(
+	family: RouteFamily<TPicked>,
+	type: JobConnectorType,
+) => {
+	const { fields, label } = ASSET_ROUTES[type];
+	return family.createHandler({
 		// Every route's body is this shape; the fields only add optional keys.
-		schema: bodySchema(
-			family.model(route.models),
-			route.fields,
-		) as z.ZodType<AssetBody>,
-		label: route.label,
+		schema: bodySchema(family.model(type), fields) as z.ZodType<AssetBody>,
+		label,
 		handle: async ({ user, input }) => {
 			const { projectId, ...request } = input;
 			const { id } = await createJob({
 				userId: user.id,
 				projectId,
-				connectorType: route.connectorType,
+				connectorType: type,
 				request,
 			});
-			await enqueueJob(id, route.connectorType);
+			await enqueueJob(id, type);
 			return NextResponse.json({ jobId: id, status: "pending" });
 		},
 	});
+};
 
 export const createJobPollHandler = (
-	family: Pick<RouteFamily<never, ModelRef>, "createParamHandler">,
+	family: Pick<RouteFamily<ModelRef>, "createParamHandler">,
 ) =>
 	family.createParamHandler({
 		// A malformed id makes Postgres throw on the cast; guid() matches every

--- a/lib/api/generation-schema.ts
+++ b/lib/api/generation-schema.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 import { IMAGE_FORMATS } from "@/lib/connectors/image/enums";
 import { THINKING_LEVELS } from "@/lib/connectors/llm/enums";
+import { hasModel, listModels } from "@/lib/connectors/models";
 import {
+	isByokProvider,
 	MANAGED_PROVIDER,
 	type BYOKProvider,
 } from "@/lib/connectors/providerCatalog";
 import { TTS_SPEEDS } from "@/lib/connectors/tts/enums";
-import type { ModelRef, ModelTable } from "@/lib/connectors/types";
+import type { ConnectorType, ModelRef } from "@/lib/connectors/types";
 import {
 	byokProviderField,
 	optionalDurationSeconds,
@@ -18,32 +20,33 @@ import {
 	requiredVoiceId,
 } from "./request-schema-fields";
 
-const modelName = (table: ModelTable) => {
-	const names = Object.keys(table);
-	return z.enum(names, {
-		error: `Invalid model. Supported: ${names.join(", ")}`,
+const hostedModelNames = (type: ConnectorType) =>
+	listModels(type)
+		.filter(({ provider }) => !isByokProvider(provider))
+		.map(({ model }) => model);
+
+const byokModelNames = (type: ConnectorType) =>
+	listModels(type)
+		.filter(({ provider }) => isByokProvider(provider))
+		.map(({ provider, model }) => `${provider}/${model}`);
+
+export const hostedModel = (type: ConnectorType) => {
+	const names = hostedModelNames(type);
+	return z.object({
+		provider: z.literal(MANAGED_PROVIDER).default(MANAGED_PROVIDER),
+		model: z.enum(names, {
+			error: `Invalid model. Supported: ${names.join(", ")}`,
+		}),
 	});
 };
 
-export const hostedModel = (table: ModelTable) =>
-	z.object({
-		provider: z.literal(MANAGED_PROVIDER).default(MANAGED_PROVIDER),
-		model: modelName(table),
-	});
-
 export type BYOKModelRef = ModelRef & { provider: BYOKProvider };
 
-export const byokModel = (
-	tables: Partial<Record<BYOKProvider, ModelTable>>,
-): z.ZodType<BYOKModelRef> =>
+export const byokModel = (type: ConnectorType): z.ZodType<BYOKModelRef> =>
 	z
 		.object({ provider: byokProviderField, model: z.string() })
-		.refine(({ provider, model }) => model in (tables[provider] ?? {}), {
-			message: `Invalid model. Supported: ${Object.entries(tables)
-				.flatMap(([provider, table]) =>
-					Object.keys(table).map((name) => `${provider}/${name}`),
-				)
-				.join(", ")}`,
+		.refine((pick) => hasModel(type, pick), {
+			message: `Invalid model. Supported: ${byokModelNames(type).join(", ")}`,
 		});
 
 export const bodySchema = <

--- a/lib/api/llm-routes.ts
+++ b/lib/api/llm-routes.ts
@@ -9,12 +9,11 @@ import { badRequest } from "./response";
 import { createSSEStreamResponse } from "./sse";
 import type { RouteFamily } from "./route-families";
 
-export const createLLMRouteHandler = <TModels, TPicked extends ModelRef>(
-	family: RouteFamily<TModels, TPicked>,
-	models: TModels,
+export const createLLMRouteHandler = <TPicked extends ModelRef>(
+	family: RouteFamily<TPicked>,
 ) =>
 	family.createHandler({
-		schema: bodySchema(family.model(models), LLM_FIELDS),
+		schema: bodySchema(family.model("llm"), LLM_FIELDS),
 		label: "LLM generation",
 		handle: async ({ user, input }) => {
 			const llm = await family.providerFor(user.id, "llm", input);
@@ -25,12 +24,11 @@ export const createLLMRouteHandler = <TModels, TPicked extends ModelRef>(
 		},
 	});
 
-export const createAgentRouteHandler = <TModels, TPicked extends ModelRef>(
-	family: RouteFamily<TModels, TPicked>,
-	models: TModels,
+export const createAgentRouteHandler = <TPicked extends ModelRef>(
+	family: RouteFamily<TPicked>,
 ) =>
 	family.createHandler({
-		schema: agentTurnSchema(family.model(models)),
+		schema: agentTurnSchema(family.model("llm")),
 		label: "Sloppy turn",
 		handle: async ({ user, input }) => {
 			const message = await parseSloppyMessage(input.message);

--- a/lib/api/route-families.ts
+++ b/lib/api/route-families.ts
@@ -1,9 +1,6 @@
 import type { z } from "zod";
-import {
-	isByokProvider,
-	type BYOKProvider,
-} from "@/lib/connectors/providerCatalog";
-import type { ModelRef, ModelTable } from "@/lib/connectors/types";
+import { isByokProvider } from "@/lib/connectors/providerCatalog";
+import type { ConnectorType, ModelRef } from "@/lib/connectors/types";
 import type { ProviderType, Providers } from "@/lib/providers/types";
 import { byokModel, hostedModel, type BYOKModelRef } from "./generation-schema";
 import { byokProviderFor } from "./providers/byok";
@@ -20,13 +17,13 @@ import {
 /**
  * Everything that differs between the two route families, in one place: who a
  * route lets in, how it names its models, and whose key a picked model runs
- * on. A route picks a family and its models; nothing else about it varies.
+ * on. A route picks a family and a connector type; nothing else about it varies.
  */
-export type RouteFamily<TModels, TPicked extends ModelRef> = {
+export type RouteFamily<TPicked extends ModelRef> = {
 	createHandler: typeof createApiRouteHandler;
 	createQueryHandler: typeof createApiQueryRouteHandler;
 	createParamHandler: typeof createApiParamRouteHandler;
-	model: (models: TModels) => z.ZodType<TPicked>;
+	model: (type: ConnectorType) => z.ZodType<TPicked>;
 	providerFor: <K extends ProviderType>(
 		userId: string,
 		type: K,
@@ -34,7 +31,7 @@ export type RouteFamily<TModels, TPicked extends ModelRef> = {
 	) => Promise<Providers[K]>;
 };
 
-export const HOSTED: RouteFamily<ModelTable, ModelRef> = {
+export const HOSTED: RouteFamily<ModelRef> = {
 	createHandler: createApiRouteHandler,
 	createQueryHandler: createApiQueryRouteHandler,
 	createParamHandler: createApiParamRouteHandler,
@@ -43,10 +40,7 @@ export const HOSTED: RouteFamily<ModelTable, ModelRef> = {
 		hostedProviderFor(type, picked.model),
 };
 
-export const BYOK: RouteFamily<
-	Partial<Record<BYOKProvider, ModelTable>>,
-	BYOKModelRef
-> = {
+export const BYOK: RouteFamily<BYOKModelRef> = {
 	createHandler: createSessionRouteHandler,
 	createQueryHandler: createSessionQueryRouteHandler,
 	createParamHandler: createSessionParamRouteHandler,

--- a/lib/api/voice-routes.ts
+++ b/lib/api/voice-routes.ts
@@ -5,12 +5,11 @@ import type { ModelRef } from "@/lib/connectors/types";
 import { voiceSearchParamsSchema } from "@/lib/project/types";
 import type { RouteFamily } from "./route-families";
 
-export const createVoiceSearchHandler = <TModels, TPicked extends ModelRef>(
-	family: RouteFamily<TModels, TPicked>,
-	models: TModels,
+export const createVoiceSearchHandler = <TPicked extends ModelRef>(
+	family: RouteFamily<TPicked>,
 ) =>
 	family.createQueryHandler({
-		schema: voiceSearchParamsSchema.and(family.model(models)),
+		schema: voiceSearchParamsSchema.and(family.model("tts")),
 		label: "Voice search",
 		handle: async ({ user, input }) => {
 			const tts = await family.providerFor(user.id, "tts", input);
@@ -21,12 +20,11 @@ export const createVoiceSearchHandler = <TModels, TPicked extends ModelRef>(
 
 const previewParamsSchema = z.object({ url: z.url() });
 
-export const createVoicePreviewHandler = <TModels, TPicked extends ModelRef>(
-	family: RouteFamily<TModels, TPicked>,
-	models: TModels,
+export const createVoicePreviewHandler = <TPicked extends ModelRef>(
+	family: RouteFamily<TPicked>,
 ) =>
 	family.createQueryHandler({
-		schema: previewParamsSchema.and(family.model(models)),
+		schema: previewParamsSchema.and(family.model("tts")),
 		label: "Voice preview fetch",
 		handle: async ({ user, input }) => {
 			const tts = await family.providerFor(user.id, "tts", input);

--- a/lib/connectors/image/models.ts
+++ b/lib/connectors/image/models.ts
@@ -2,13 +2,9 @@ import type { ModelRef, ModelsByProvider } from "../types";
 import { OPENSLOP_IMAGE_MODELS } from "./openslop/models";
 import { RUNWARE_IMAGE_MODELS } from "./runware/models";
 
-export const BYOK_IMAGE_MODELS = {
-	runware: RUNWARE_IMAGE_MODELS,
-} satisfies ModelsByProvider;
-
 export const IMAGE_MODELS = {
 	openslop: OPENSLOP_IMAGE_MODELS,
-	...BYOK_IMAGE_MODELS,
+	runware: RUNWARE_IMAGE_MODELS,
 } satisfies ModelsByProvider;
 
 export const DEFAULT_IMAGE_MODEL: ModelRef = {

--- a/lib/connectors/llm/models.ts
+++ b/lib/connectors/llm/models.ts
@@ -2,13 +2,9 @@ import type { ModelRef, ModelsByProvider } from "../types";
 import { ANTHROPIC_LLM_MODELS } from "./anthropic/models";
 import { OPENSLOP_LLM_MODELS } from "./openslop/models";
 
-export const BYOK_LLM_MODELS = {
-	anthropic: ANTHROPIC_LLM_MODELS,
-} satisfies ModelsByProvider;
-
 export const LLM_MODELS = {
 	openslop: OPENSLOP_LLM_MODELS,
-	...BYOK_LLM_MODELS,
+	anthropic: ANTHROPIC_LLM_MODELS,
 } satisfies ModelsByProvider;
 
 export const DEFAULT_LLM_MODEL: ModelRef = {

--- a/lib/connectors/music/models.ts
+++ b/lib/connectors/music/models.ts
@@ -2,13 +2,9 @@ import type { ModelRef, ModelsByProvider } from "../types";
 import { ELEVENLABS_MUSIC_MODELS } from "./elevenlabs/models";
 import { OPENSLOP_MUSIC_MODELS } from "./openslop/models";
 
-export const BYOK_MUSIC_MODELS = {
-	elevenlabs: ELEVENLABS_MUSIC_MODELS,
-} satisfies ModelsByProvider;
-
 export const MUSIC_MODELS = {
 	openslop: OPENSLOP_MUSIC_MODELS,
-	...BYOK_MUSIC_MODELS,
+	elevenlabs: ELEVENLABS_MUSIC_MODELS,
 } satisfies ModelsByProvider;
 
 export const DEFAULT_MUSIC_MODEL: ModelRef = {

--- a/lib/connectors/sfx/models.ts
+++ b/lib/connectors/sfx/models.ts
@@ -2,13 +2,9 @@ import type { ModelRef, ModelsByProvider } from "../types";
 import { ELEVENLABS_SFX_MODELS } from "./elevenlabs/models";
 import { OPENSLOP_SFX_MODELS } from "./openslop/models";
 
-export const BYOK_SFX_MODELS = {
-	elevenlabs: ELEVENLABS_SFX_MODELS,
-} satisfies ModelsByProvider;
-
 export const SFX_MODELS = {
 	openslop: OPENSLOP_SFX_MODELS,
-	...BYOK_SFX_MODELS,
+	elevenlabs: ELEVENLABS_SFX_MODELS,
 } satisfies ModelsByProvider;
 
 export const DEFAULT_SFX_MODEL: ModelRef = {

--- a/lib/connectors/tts/models.ts
+++ b/lib/connectors/tts/models.ts
@@ -2,13 +2,9 @@ import type { ModelRef, ModelsByProvider } from "../types";
 import { CARTESIA_TTS_MODELS } from "./cartesia/models";
 import { OPENSLOP_TTS_MODELS } from "./openslop/models";
 
-export const BYOK_TTS_MODELS = {
-	cartesia: CARTESIA_TTS_MODELS,
-} satisfies ModelsByProvider;
-
 export const TTS_MODELS = {
 	openslop: OPENSLOP_TTS_MODELS,
-	...BYOK_TTS_MODELS,
+	cartesia: CARTESIA_TTS_MODELS,
 } satisfies ModelsByProvider;
 
 export const DEFAULT_TTS_MODEL: ModelRef = {

--- a/lib/connectors/video/models.ts
+++ b/lib/connectors/video/models.ts
@@ -2,13 +2,9 @@ import type { ModelRef, ModelsByProvider, VideoModelEntry } from "../types";
 import { OPENSLOP_VIDEO_MODELS } from "./openslop/models";
 import { RUNWARE_VIDEO_MODELS } from "./runware/models";
 
-export const BYOK_VIDEO_MODELS = {
-	runware: RUNWARE_VIDEO_MODELS,
-} satisfies ModelsByProvider<VideoModelEntry>;
-
 export const VIDEO_MODELS = {
 	openslop: OPENSLOP_VIDEO_MODELS,
-	...BYOK_VIDEO_MODELS,
+	runware: RUNWARE_VIDEO_MODELS,
 } satisfies ModelsByProvider<VideoModelEntry>;
 
 export const DEFAULT_VIDEO_MODEL: ModelRef = {


### PR DESCRIPTION
## What changed

A route file now picks a route family and a connector type. The family reads that type's models from the catalog (`listModels` / `hasModel` in `lib/connectors/models.ts`), so nothing else about a route varies.

- `lib/api/route-families.ts`: `RouteFamily<TPicked>` drops the `TModels` parameter. `model(type)` replaces `model(models)`.
- `lib/api/generation-schema.ts`: `hostedModel(type)` and `byokModel(type)` take a connector type. BYOK membership is `hasModel`, the one catalog reader, instead of a hand-rolled `model in table` check.
- `lib/api/asset-routes.ts`: an `ASSET_ROUTES` table holds each job type's request fields and log label. `createAssetRouteHandler(family, type)` reads it.
- `lib/api/llm-routes.ts`, `lib/api/voice-routes.ts`: the four factories lose their `models` argument.
- 18 route files under `app/api/v1` and `app/api/third-party` each shrink to one call and lose a models import. The `v1` and `third-party` twins can no longer drift.
- `lib/connectors/<type>/models.ts` (6 files): the `BYOK_*_MODELS` projections are gone. Each full table lists its providers directly.
- Two tests build schemas from a type instead of a table.
- `ARCHITECTURE.md`: two owner-authored sentences reworded to match ("A route file picks a family and a connector type"; a new asset type also adds a row to `ASSET_ROUTES`).

No behaviour change. Same schemas, same error messages, same labels.

+99 / -201 over 32 files.

## Not taken

- Deriving the log label from the type. Four rows are `<Type> generation` but video is `Video submission`, so deriving would rename a log line.
- Inlining the single-use `*_FIELDS` exports into the table. Pure move churn; the shapes stay in the schema module.
- One registry per job type carrying fields, label and handler, so `JOB_CONNECTOR_TYPES`, `ASSET_ROUTES` and `HANDLERS` stop being three hand-kept lists. Needs `lib/api/job-handlers.ts`; a separate night.
- Dropping the `as z.ZodType<AssetBody>` cast (ledger 756b). `projectId` still comes through the raw field shape as `unknown`; needs the generic handler contract change.

## Checks

`npm run lint && npm run typecheck && npm run format:check && npm run test:run && npm run build` all pass (185 test files, 1635 tests).

## Merge-conflict guard

```
PR #786: clean
PR #785: clean
OK: no shared files or merge conflicts with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)