### PR TITLE
refactor: nightly conventions follow-up 2026-09-12, dialogs and fields ship the primitives

### DIFF
--- a/app/components/canvas/elements/attributes/TextAttributePopover.tsx
+++ b/app/components/canvas/elements/attributes/TextAttributePopover.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useRef, useState } from "react";
 import { useSlateStatic } from "slate-react";
 import { Popover, PopoverContent } from "@/components/ui/popover";
+import { Textarea } from "@/components/ui/textarea";
 import type { CanvasContentElement } from "@/lib/canvas/types";
 import { updateElementAttrs } from "@/app/components/canvas/utils/nodeOps";
 import { AttributeTrigger } from "./AttributeTrigger";
@@ -66,7 +67,8 @@ export function TextAttributePopover({
 				}}
 				className="w-72 p-1.5"
 			>
-				<textarea
+				<Textarea
+					size="sm"
 					autoFocus
 					rows={rows}
 					value={draft}
@@ -79,7 +81,7 @@ export function TextAttributePopover({
 							setOpen(false);
 						}
 					}}
-					className="w-full resize-none rounded-lg border border-border bg-card px-2 py-1.5 font-body text-label text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-accent/50"
+					className="resize-none"
 				/>
 				<div className="mt-1 px-1 text-badge text-muted-foreground">
 					⌘↵ to save · esc to cancel

--- a/app/components/canvas/elements/character/CharacterEditModal.tsx
+++ b/app/components/canvas/elements/character/CharacterEditModal.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
-import { cn } from "@/lib/utils";
 import { Trash2 } from "@/components/ui/icon";
 import { Button } from "@/components/ui/button";
 import { CloseButton } from "@/components/ui/close-button";
+import { ConfirmDeleteDialog } from "@/components/ui/confirm-delete-dialog";
 import {
 	DialogBody,
 	DialogContent,
@@ -105,15 +105,6 @@ function CharacterEditDialogBody({
 		}
 	};
 
-	const handleDelete = () => {
-		if (!confirmDelete) {
-			setConfirmDelete(true);
-			return;
-		}
-		deleteCharacter(store, queue, name);
-		onClose();
-	};
-
 	return (
 		<DialogContent
 			className="max-w-2xl"
@@ -196,22 +187,30 @@ function CharacterEditDialogBody({
 			<DialogFooter className="shrink-0">
 				<Button
 					type="button"
-					variant={confirmDelete ? "destructive" : "outline"}
+					variant="outline"
 					size="sm"
-					onClick={handleDelete}
-					className={cn(
-						"sm:mr-auto",
-						!confirmDelete && "text-muted-foreground",
-					)}
+					onClick={() => setConfirmDelete(true)}
+					className="text-muted-foreground sm:mr-auto"
 				>
 					<Trash2 />
-					{confirmDelete ? "Confirm delete" : "Delete"}
+					Delete
 				</Button>
 				<Button type="button" size="sm" onClick={requestClose}>
 					Done
 				</Button>
 			</DialogFooter>
 
+			<ConfirmDeleteDialog
+				target={confirmDelete ? name : undefined}
+				onClose={() => setConfirmDelete(false)}
+				title={(target) => `Delete ${target}?`}
+				description="This permanently removes the character and its avatar. It can't be undone."
+				actionLabel="Delete character"
+				onConfirm={() => {
+					deleteCharacter(store, queue, name);
+					onClose();
+				}}
+			/>
 			<StaleAvatarCloseDialog
 				open={closeConfirm}
 				onOpenChange={setCloseConfirm}

--- a/app/components/canvas/elements/character/NewCharacterDialog.tsx
+++ b/app/components/canvas/elements/character/NewCharacterDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
 	DialogContent,
 	DialogDescription,
@@ -12,7 +13,6 @@ import {
 } from "@/components/ui/dialog";
 import { useResolveDefaultModels } from "@/lib/connectors/useDefaultModels";
 import { normalizeCharacterName } from "@/lib/project/characterName";
-import { FIELD_CLS } from "./fields";
 import { useProject } from "@/lib/project/useProject";
 
 export function NewCharacterDialog({
@@ -65,14 +65,13 @@ function NewCharacterDialogBody({
 					</DialogDescription>
 				</DialogHeader>
 
-				<input
-					type="text"
+				<Input
+					size="sm"
 					autoFocus
 					value={name}
 					onChange={(e) => setName(e.target.value)}
 					placeholder="Character name"
 					aria-label="Character name"
-					className={FIELD_CLS}
 				/>
 
 				{collision && (

--- a/app/components/canvas/elements/character/StaleAvatarCloseDialog.tsx
+++ b/app/components/canvas/elements/character/StaleAvatarCloseDialog.tsx
@@ -32,19 +32,11 @@ export function StaleAvatarCloseDialog({
 					Your edits are already saved.
 				</AlertDialogDescription>
 				<AlertDialogFooter>
-					<AlertDialogCancel className="rounded-md px-2.5 py-1 text-label text-muted-foreground transition-colors hover:text-foreground">
-						Keep editing
-					</AlertDialogCancel>
-					<AlertDialogAction
-						onClick={onLeaveStale}
-						className="rounded-md border border-border px-2.5 py-1 text-label text-muted-foreground transition-colors hover:bg-muted"
-					>
+					<AlertDialogCancel>Keep editing</AlertDialogCancel>
+					<AlertDialogAction variant="outline" onClick={onLeaveStale}>
 						Leave stale
 					</AlertDialogAction>
-					<AlertDialogAction
-						onClick={onRegenerate}
-						className="rounded-md bg-accent px-3 py-1 text-label font-medium text-foreground shadow-elevation-5 transition hover:brightness-110"
-					>
+					<AlertDialogAction onClick={onRegenerate}>
 						Regenerate
 					</AlertDialogAction>
 				</AlertDialogFooter>

--- a/app/components/canvas/elements/character/__tests__/fields.test.tsx
+++ b/app/components/canvas/elements/character/__tests__/fields.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { EnumField, TextAreaField, TextField } from "../fields";
+
+const noop = () => {};
+
+describe("character fields", () => {
+	it("TextField labels its input and passes the placeholder through", () => {
+		const html = renderToStaticMarkup(
+			<TextField
+				label="Description"
+				value={undefined}
+				onChange={noop}
+				placeholder="Free-text"
+			/>,
+		);
+		expect(html).toContain("Description");
+		expect(html).toContain('placeholder="Free-text"');
+	});
+
+	it("TextAreaField labels its textarea and shows the value", () => {
+		const html = renderToStaticMarkup(
+			<TextAreaField label="Appearance" value="tall" onChange={noop} />,
+		);
+		expect(html).toContain("Appearance");
+		expect(html).toContain(">tall</textarea>");
+	});
+
+	it("EnumField's trigger is a button named after the label, empty as a dash", () => {
+		const html = renderToStaticMarkup(
+			<EnumField
+				label="Gender"
+				options={["male", "female"]}
+				value={undefined}
+				onChange={noop}
+			/>,
+		);
+		const trigger = html.match(/<button[^>]*>/)?.[0] ?? "";
+		expect(trigger).toContain('type="button"');
+		expect(trigger).toContain('aria-label="Gender"');
+		expect(html).toContain("—");
+	});
+});

--- a/app/components/canvas/elements/character/fields.tsx
+++ b/app/components/canvas/elements/character/fields.tsx
@@ -1,16 +1,15 @@
 "use client";
 
 import { type ReactNode } from "react";
-import { ChevronDown } from "@/components/ui/icon";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { SelectMenuItem } from "@/components/ui/select-menu";
-
-export const FIELD_CLS =
-	"w-full rounded-md border border-border bg-card px-2 py-1.5 font-body text-label text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-accent/50";
+import { Input } from "@/components/ui/input";
+import { SelectMenuItem, SelectMenuTrigger } from "@/components/ui/select-menu";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 
 export function FieldLabel({ children }: { children: ReactNode }) {
 	return (
@@ -34,12 +33,11 @@ export function TextField({
 	return (
 		<label className="flex flex-col gap-1">
 			<FieldLabel>{label}</FieldLabel>
-			<input
-				type="text"
+			<Input
+				size="sm"
 				value={value ?? ""}
 				onChange={(e) => onChange(e.target.value)}
 				placeholder={placeholder}
-				className={FIELD_CLS}
 			/>
 		</label>
 	);
@@ -51,7 +49,7 @@ export function TextAreaField({
 	onChange,
 	placeholder,
 	rows = 4,
-	className = "",
+	className,
 }: {
 	label: string;
 	value: string;
@@ -61,14 +59,15 @@ export function TextAreaField({
 	className?: string;
 }) {
 	return (
-		<label className={`flex flex-col gap-1 ${className}`}>
+		<label className={cn("flex flex-col gap-1", className)}>
 			<FieldLabel>{label}</FieldLabel>
-			<textarea
+			<Textarea
+				size="sm"
 				rows={rows}
 				value={value}
 				onChange={(e) => onChange(e.target.value)}
 				placeholder={placeholder}
-				className={`${FIELD_CLS} grow resize-none`}
+				className="grow resize-none"
 			/>
 		</label>
 	);
@@ -89,14 +88,14 @@ export function EnumField<T extends string>({
 		<div className="flex flex-col gap-1">
 			<FieldLabel>{label}</FieldLabel>
 			<DropdownMenu modal={false}>
-				<DropdownMenuTrigger
-					aria-label={label}
-					className={`${FIELD_CLS} flex items-center justify-between text-left`}
-				>
-					<span className={value ? "text-foreground" : "text-muted-foreground"}>
-						{value ?? "—"}
-					</span>
-					<ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+				<DropdownMenuTrigger asChild>
+					<SelectMenuTrigger aria-label={label} className="w-full">
+						<span
+							className={value ? "text-foreground" : "text-muted-foreground"}
+						>
+							{value ?? "—"}
+						</span>
+					</SelectMenuTrigger>
 				</DropdownMenuTrigger>
 				<DropdownMenuContent
 					align="start"

--- a/app/components/canvas/elements/style/ArtStyleModal.tsx
+++ b/app/components/canvas/elements/style/ArtStyleModal.tsx
@@ -25,7 +25,8 @@ import {
 } from "@/lib/project/deriveArtStyle";
 import { useProjectStoreHandle } from "@/lib/project/ProjectStoreProvider";
 import { useProject } from "@/lib/project/useProject";
-import { FIELD_CLS, FieldLabel } from "../character/fields";
+import { Textarea } from "@/components/ui/textarea";
+import { FieldLabel } from "../character/fields";
 import { ReferenceImages } from "../ReferenceImages";
 import { ArtStylePresets } from "./ArtStylePresets";
 
@@ -114,13 +115,14 @@ function ArtStyleDialogBody({ onClose }: { onClose: () => void }) {
 						{deriving && <Spinner className="text-current" />}
 						Use references
 					</Button>
-					<textarea
+					<Textarea
+						size="sm"
 						id={DESCRIPTION_ID}
 						rows={5}
 						value={style}
 						onChange={(e) => setStyle(e.target.value)}
 						placeholder="Describe the look of every image, or paste a full image prompt"
-						className={`${FIELD_CLS} resize-none`}
+						className="resize-none"
 					/>
 				</div>
 

--- a/components/ui/__tests__/confirm-delete-dialog.test.tsx
+++ b/components/ui/__tests__/confirm-delete-dialog.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { ConfirmDeleteDialog } from "../confirm-delete-dialog";
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const container = document.body.appendChild(document.createElement("div"));
+let root: Root;
+const onClose = vi.fn();
+const onConfirm = vi.fn();
+
+beforeEach(() => {
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	vi.clearAllMocks();
+});
+
+const render = (target: string | undefined) =>
+	act(() =>
+		root.render(
+			<ConfirmDeleteDialog
+				target={target}
+				onClose={onClose}
+				title={(name) => `Delete ${name}?`}
+				description="It can't be undone."
+				actionLabel="Delete character"
+				onConfirm={onConfirm}
+			/>,
+		),
+	);
+
+const dialog = () => document.querySelector("[role=alertdialog]");
+const button = (label: string) =>
+	Array.from(dialog()?.querySelectorAll("button") ?? []).find(
+		(b) => b.textContent === label,
+	);
+
+describe("ConfirmDeleteDialog", () => {
+	it("stays closed without a target", () => {
+		render(undefined);
+		expect(dialog()).toBeNull();
+	});
+
+	it("names the target and hands it back on confirm", () => {
+		render("Ada");
+		expect(dialog()?.textContent).toContain("Delete Ada?");
+		act(() => button("Delete character")?.click());
+		expect(onConfirm).toHaveBeenCalledExactlyOnceWith("Ada");
+	});
+
+	it("cancel closes without confirming", () => {
+		render("Ada");
+		act(() => button("Cancel")?.click());
+		expect(onClose).toHaveBeenCalledOnce();
+		expect(onConfirm).not.toHaveBeenCalled();
+	});
+});

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -2,8 +2,10 @@
 
 import * as React from "react";
 import { AlertDialog as AlertDialogPrimitive } from "radix-ui";
+import type { VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
 
 function AlertDialog({
 	...props
@@ -86,18 +88,34 @@ function AlertDialogFooter({
 }
 
 function AlertDialogAction({
+	className,
+	variant,
 	...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> & {
+	variant?: VariantProps<typeof buttonVariants>["variant"];
+}) {
 	return (
-		<AlertDialogPrimitive.Action data-slot="alert-dialog-action" {...props} />
+		<AlertDialogPrimitive.Action
+			data-slot="alert-dialog-action"
+			className={cn(buttonVariants({ variant, size: "sm" }), className)}
+			{...props}
+		/>
 	);
 }
 
 function AlertDialogCancel({
+	className,
 	...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
 	return (
-		<AlertDialogPrimitive.Cancel data-slot="alert-dialog-cancel" {...props} />
+		<AlertDialogPrimitive.Cancel
+			data-slot="alert-dialog-cancel"
+			className={cn(
+				buttonVariants({ variant: "ghost", size: "sm" }),
+				className,
+			)}
+			{...props}
+		/>
 	);
 }
 

--- a/components/ui/confirm-delete-dialog.tsx
+++ b/components/ui/confirm-delete-dialog.tsx
@@ -48,12 +48,10 @@ export function ConfirmDeleteDialog<T>({
 					<AlertDialogTitle>{title(latched)}</AlertDialogTitle>
 					<AlertDialogDescription>{description}</AlertDialogDescription>
 					<AlertDialogFooter>
-						<AlertDialogCancel className="rounded-md px-2.5 py-1 text-label text-muted-foreground transition-colors hover:text-foreground">
-							Cancel
-						</AlertDialogCancel>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
 						<AlertDialogAction
+							variant="destructive"
 							onClick={() => onConfirm(latched)}
-							className="rounded-md bg-destructive px-3 py-1 text-label font-medium text-destructive-foreground shadow-elevation-5 transition hover:brightness-110"
 						>
 							{actionLabel}
 						</AlertDialogAction>

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,16 +1,35 @@
 import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+const inputVariants = cva(
+	"flex w-full min-w-0 rounded-md border border-border bg-input font-body text-foreground shadow-xs transition-colors outline-none placeholder:text-muted-foreground hover:border-ring/50 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/30",
+	{
+		variants: {
+			size: {
+				default: "h-9 px-3 py-1 text-body",
+				sm: "h-8 px-2.5 py-1 text-label",
+			},
+		},
+		defaultVariants: {
+			size: "default",
+		},
+	},
+);
+
+function Input({
+	className,
+	type,
+	size,
+	...props
+}: Omit<React.ComponentProps<"input">, "size"> &
+	VariantProps<typeof inputVariants>) {
 	return (
 		<input
 			type={type}
 			data-slot="input"
-			className={cn(
-				"flex h-9 w-full min-w-0 rounded-md border border-border bg-input px-3 py-1 font-body text-body text-foreground shadow-xs transition-colors outline-none placeholder:text-muted-foreground hover:border-ring/50 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/30",
-				className,
-			)}
+			className={cn(inputVariants({ size }), className)}
 			{...props}
 		/>
 	);

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,15 +1,32 @@
 import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+const textareaVariants = cva(
+	"flex w-full rounded-md border border-border bg-input font-body text-foreground shadow-xs transition-colors outline-none placeholder:text-muted-foreground hover:border-ring/50 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/30",
+	{
+		variants: {
+			size: {
+				default: "min-h-20 px-3 py-2 text-body",
+				sm: "px-2.5 py-1.5 text-label",
+			},
+		},
+		defaultVariants: {
+			size: "default",
+		},
+	},
+);
+
+function Textarea({
+	className,
+	size,
+	...props
+}: React.ComponentProps<"textarea"> & VariantProps<typeof textareaVariants>) {
 	return (
 		<textarea
 			data-slot="textarea"
-			className={cn(
-				"flex min-h-20 w-full rounded-md border border-border bg-input px-3 py-2 font-body text-body text-foreground shadow-xs transition-colors outline-none placeholder:text-muted-foreground hover:border-ring/50 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/30",
-				className,
-			)}
+			className={cn(textareaVariants({ size }), className)}
 			{...props}
 		/>
 	);


### PR DESCRIPTION
Nightly conventions follow-up. Theme: dialogs and form fields ship the design-system primitives instead of hand-rolled classes.

## Behavior changes
- `app/components/canvas/elements/character/CharacterEditModal.tsx`: the footer's two-click "Delete" then "Confirm delete" button to a single "Delete" that opens `ConfirmDeleteDialog` (same copy and `deleteCharacter` call as the composer's character tiles). Why: one confirmation mechanism for destructive actions (CONVENTIONS "one canonical way"; the other four delete paths already use the dialog). Tests: `components/ui/__tests__/confirm-delete-dialog.test.tsx` (new) pins the dialog contract the modal now relies on: closed without a target, names the target, hands it back on confirm, cancel never confirms.
- `app/components/canvas/elements/character/StaleAvatarCloseDialog.tsx`: "Regenerate" from an accent fill (`bg-accent` paired with `text-foreground`, a token mismatch) to the `default` in-tool Button fill. Why: DESIGN.md reserves `accent` for hero/auth CTAs and names `default` for in-tool actions. "Leave stale" is `outline`, "Keep editing" is `ghost`.
- `components/ui/input.tsx`, `components/ui/textarea.tsx`: gain a cva `size` with an `sm` row (`h-8` / `text-label`, matching `SelectTrigger` size sm). The character edit fields, the new-character name input, the art-style description and the attribute popover textarea move from the hand-rolled `FIELD_CLS` look (`bg-card`, `focus:ring-1 ring-accent/50`, no hover, no `aria-invalid`) to these primitives at `sm`. Visible differences: `bg-input` surface, `focus-visible` ring instead of `focus`, hover border, and the attribute popover textarea is `rounded-md` instead of `rounded-lg` (DESIGN.md: form controls are `rounded-md`). Tests: `app/components/canvas/elements/character/__tests__/fields.test.tsx` (new) pins labels, placeholder pass-through, the enum trigger's accessible name and its empty dash.

## Contract changes
- `AlertDialogAction` wears `buttonVariants({ size: "sm" })` by default and takes `variant`; `AlertDialogCancel` is fixed at `ghost` / `sm`. Both consumers (`confirm-delete-dialog.tsx`, `StaleAvatarCloseDialog.tsx`) drop their class strings (4 hand-rolled button looks deleted). Actions now carry `focus-ring`.
- `Input` and `Textarea` take `size?: "default" | "sm"` (`Input` omits the native numeric `size` attribute). Existing callers pass nothing and render unchanged.
- `FIELD_CLS` export deleted from `character/fields.tsx` (3 consumers updated). `EnumField`'s trigger is `SelectMenuTrigger` under `DropdownMenuTrigger asChild`, so it drops its own chevron.

## Flags resolved
- 910d: CharacterEditModal two-click delete uses `ConfirmDeleteDialog`.
- 910e: `AlertDialogAction`/`AlertDialogCancel` ship the Button look; consumers pass only `variant`.
- 910c: `FIELD_CLS` and the `TextAttributePopover` near-copy replaced by `Input`/`Textarea`/`SelectMenuTrigger`.

## Skipped tonight
- 746f, 746n, 746o (connector group), 746r + 910b (attribute bounds), 746q, 746s, 910l: blocked by PR #785 (`lib/connectors/types.ts`, `still-frame.ts`, `attributes/common.ts`, `lib/video/elementAttributes.ts`, `lib/video/types.ts`, `AttributeBadge.tsx`, `editScript.ts`, `osml.ts`).
- 756b: blocked by PR #787 (`lib/api/asset-routes.ts`).
- 910h Waveform rider: blocked by PR #786; the other riders are cosmetic one-liners, below the bar alone.
- 910a (`readSSE` swallow): left open; the owner kept a catch-and-continue on purpose in #768, so this one waits for a human answer.
- 746l, 911b: one-line "name the literal" items, a different theme; batch later.
- 910m, 910j, 768a: need a product call (unchanged).
- Simplify pass, not taken: sharing one base string between `Input` and `Textarea` (pre-existing duplication, two uses); folding `EnumField` onto `SelectMenu` (needs a clear-to-undefined row on the primitive; the menu wiring predates this PR).

## Checks
`npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run test:run` (187 files, 1641 tests), `npm run build`: all pass.

## Merge-conflict guard
```
PR #787: clean
PR #786: clean
PR #785: clean
OK: no shared files or merge conflicts with any open PR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)